### PR TITLE
`@remotion/studio`: Enable safe interactions in read-only mode

### DIFF
--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -43,6 +43,7 @@ type SequenceTestWrapperProps = {
 	readonly rerenderOnRegister?: boolean;
 	readonly compositionDurationInFrames?: number;
 	readonly currentFrame?: number;
+	readonly readOnlyStudio?: boolean;
 };
 
 type VisualModeOverrides = {
@@ -84,6 +85,7 @@ const SequenceTestWrapperWithVisualModeOverrides: React.FC<
 	visualModeOverrides,
 	compositionDurationInFrames,
 	currentFrame,
+	readOnlyStudio = false,
 }) => {
 	const [, setTick] = useState(0);
 
@@ -152,7 +154,7 @@ const SequenceTestWrapperWithVisualModeOverrides: React.FC<
 					isClientSideRendering: false,
 					isPlayer: false,
 					isStudio: true,
-					isReadOnlyStudio: false,
+					isReadOnlyStudio: readOnlyStudio,
 				}}
 			>
 				<OverrideIdsToNodePathsGettersContext.Provider
@@ -181,6 +183,7 @@ const SequenceTestWrapper: React.FC<SequenceTestWrapperProps> = ({
 	rerenderOnRegister = false,
 	compositionDurationInFrames,
 	currentFrame,
+	readOnlyStudio,
 }) => {
 	return (
 		<SequenceTestWrapperWithVisualModeOverrides
@@ -189,6 +192,7 @@ const SequenceTestWrapper: React.FC<SequenceTestWrapperProps> = ({
 			visualModeOverrides={null}
 			compositionDurationInFrames={compositionDurationInFrames}
 			currentFrame={currentFrame}
+			readOnlyStudio={readOnlyStudio}
 		>
 			{children}
 		</SequenceTestWrapperWithVisualModeOverrides>
@@ -359,6 +363,50 @@ test('Series.Sequence registers with its own visual controls', () => {
 		firstStack,
 		secondStack,
 	]);
+});
+
+test('read-only Studio registers visual controls without applying overrides', () => {
+	const registeredSequences: TSequence[] = [];
+	const nodePath = {
+		absolutePath: '/src/Composition.tsx',
+		nodePath: ['body', 0],
+		sequenceKeys: [],
+		effectKeys: [],
+		videoConfigValues: null,
+	};
+	const subscriptionKey = Internals.makeSequencePropsSubscriptionKey(nodePath);
+
+	render(
+		<SequenceTestWrapperWithVisualModeOverrides
+			readOnlyStudio
+			onRegisterSequence={(registeredSequence) => {
+				registeredSequences.push(registeredSequence);
+			}}
+			visualModeOverrides={{
+				overrideIdToNodePathMappings: new Proxy(
+					{},
+					{get: () => nodePath},
+				) as OverrideIdToNodePaths,
+				propStatuses: {},
+				dragOverrides: {
+					[subscriptionKey]: {
+						durationInFrames: Internals.makeStaticDragOverride(20),
+					},
+				},
+			}}
+		>
+			<Interactive.Div durationInFrames={10}>Hello</Interactive.Div>
+		</SequenceTestWrapperWithVisualModeOverrides>,
+	);
+
+	const sequence = registeredSequences.find(
+		(item) => item.displayName === '<Interactive.Div>',
+	);
+	expect(sequence?.controls).not.toBe(null);
+	expect(sequence?.controls?.componentIdentity).toBe(
+		'dev.remotion.remotion.Interactive.Div',
+	);
+	expect(sequence?.duration).toBe(10);
 });
 
 test('Series.Sequence timing overrides cascade to later sequences', async () => {

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -174,7 +174,7 @@ export const withInteractivitySchema = <
 	const Wrapped = forwardRef<unknown, Props>((props, ref) => {
 		const env = useRemotionEnvironment();
 
-		if (!env.isStudio || env.isReadOnlyStudio || env.isRendering) {
+		if (!env.isStudio || env.isRendering) {
 			return React.createElement(Component, {
 				...props,
 				controls: null,
@@ -222,8 +222,9 @@ export const withInteractivitySchema = <
 			stackToOverrideMap[stack] = newOverrideId;
 			return newOverrideId;
 		});
-		const nodePath =
-			nodePathMapping.overrideIdToNodePathMappings[overrideId] ?? null;
+		const nodePath = env.isReadOnlyStudio
+			? null
+			: (nodePathMapping.overrideIdToNodePathMappings[overrideId] ?? null);
 
 		// Read the runtime values for every flat key from the JSX props,
 		// memoized on the leaf values so the object reference is stable

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -95,6 +95,126 @@ const revealIconStyle: React.CSSProperties = {
 	color: CURRENT_COLOR,
 };
 
+export const getAssetActionAvailability = ({
+	readOnlyStudio,
+	connectionStatus,
+	publicFolderExists,
+}: {
+	readOnlyStudio: boolean;
+	connectionStatus: 'init' | 'connected' | 'disconnected';
+	publicFolderExists: string | null;
+}) => {
+	return {
+		mutationsDisabled: readOnlyStudio || connectionStatus !== 'connected',
+		fileExplorerDisabled:
+			publicFolderExists === null ||
+			readOnlyStudio ||
+			connectionStatus !== 'connected',
+	};
+};
+
+export const getCanDragAsset = ({
+	readOnlyStudio,
+	relativePath,
+}: {
+	readOnlyStudio: boolean;
+	relativePath: string;
+}) => {
+	return !readOnlyStudio && getAssetElementFromPath(relativePath) !== null;
+};
+
+export const getAssetContextMenuItems = ({
+	relativePath,
+	fileManagerName,
+	copyFileName,
+	copyStaticFilePath,
+	openAssetInExplorer,
+	renameAsset,
+	deleteAsset,
+	fileExplorerDisabled,
+	mutationsDisabled,
+}: {
+	relativePath: string;
+	fileManagerName: string;
+	copyFileName: () => void;
+	copyStaticFilePath: () => void;
+	openAssetInExplorer: () => void;
+	renameAsset: () => void;
+	deleteAsset: () => void;
+	fileExplorerDisabled: boolean;
+	mutationsDisabled: boolean;
+}): ComboboxValue[] => {
+	return [
+		getOpenInNewWindowMenuItem(`/assets/${relativePath}`),
+		{
+			type: 'divider',
+			id: 'open-in-new-window-divider',
+		},
+		{
+			id: 'copy-asset-file-name',
+			keyHint: null,
+			label: 'Copy file name',
+			leftItem: null,
+			onClick: copyFileName,
+			quickSwitcherLabel: 'Copy asset file name',
+			subMenu: null,
+			type: 'item',
+			value: 'copy-asset-file-name',
+		},
+		{
+			id: 'copy-asset-static-file-path',
+			keyHint: null,
+			label: 'Copy staticFile() path',
+			leftItem: null,
+			onClick: copyStaticFilePath,
+			quickSwitcherLabel: 'Copy staticFile() path',
+			subMenu: null,
+			type: 'item',
+			value: 'copy-asset-static-file-path',
+		},
+		{
+			type: 'divider',
+			id: 'asset-file-actions-divider',
+		},
+		{
+			id: 'open-asset-in-explorer',
+			keyHint: null,
+			label: `Show in ${fileManagerName}`,
+			leftItem: null,
+			onClick: openAssetInExplorer,
+			quickSwitcherLabel: `Show asset in ${fileManagerName}`,
+			subMenu: null,
+			type: 'item',
+			value: 'open-asset-in-explorer',
+			disabled: fileExplorerDisabled,
+		},
+		{
+			id: 'rename-asset',
+			keyHint: null,
+			label: 'Rename...',
+			leftItem: null,
+			onClick: renameAsset,
+			quickSwitcherLabel: 'Rename asset...',
+			subMenu: null,
+			type: 'item',
+			value: 'rename-asset',
+			disabled: mutationsDisabled,
+		},
+		{
+			id: 'delete-asset',
+			keyHint: null,
+			label: 'Delete...',
+			leftItem: null,
+			onClick: deleteAsset,
+			quickSwitcherLabel: 'Delete asset...',
+			subMenu: null,
+			type: 'item',
+			value: 'delete-asset',
+			disabled: mutationsDisabled,
+		},
+	];
+};
+
 const AssetFolderItem: React.FC<{
 	readonly item: AssetFolder;
 	readonly tabIndex: number;
@@ -318,7 +438,7 @@ const AssetSelectorItem: React.FC<{
 	}, [canvasContent, relativePath]);
 
 	const canDragAsset = useMemo(() => {
-		return !readOnlyStudio && getAssetElementFromPath(relativePath) !== null;
+		return getCanDragAsset({readOnlyStudio, relativePath});
 	}, [readOnlyStudio, relativePath]);
 
 	const onPointerLeave = useCallback(() => {
@@ -454,8 +574,11 @@ const AssetSelectorItem: React.FC<{
 		});
 	}, [relativePath]);
 
-	const serverActionDisabled =
-		readOnlyStudio || connectionStatus !== 'connected';
+	const {mutationsDisabled, fileExplorerDisabled} = getAssetActionAvailability({
+		readOnlyStudio,
+		connectionStatus,
+		publicFolderExists: window.remotion_publicFolderExists,
+	});
 
 	const deleteAsset = useCallback(() => {
 		confirm({
@@ -498,91 +621,35 @@ const AssetSelectorItem: React.FC<{
 			});
 	}, [confirm, relativePath]);
 
+	const renameAsset = useCallback(() => {
+		setSelectedModal({
+			type: 'rename-static-file',
+			relativePath,
+		});
+	}, [relativePath, setSelectedModal]);
+
 	const contextMenu = useMemo((): ComboboxValue[] => {
-		return [
-			getOpenInNewWindowMenuItem(`/assets/${relativePath}`),
-			{
-				type: 'divider',
-				id: 'open-in-new-window-divider',
-			},
-			{
-				id: 'copy-asset-file-name',
-				keyHint: null,
-				label: 'Copy file name',
-				leftItem: null,
-				onClick: copyFileName,
-				quickSwitcherLabel: 'Copy asset file name',
-				subMenu: null,
-				type: 'item',
-				value: 'copy-asset-file-name',
-			},
-			{
-				id: 'copy-asset-static-file-path',
-				keyHint: null,
-				label: 'Copy staticFile() path',
-				leftItem: null,
-				onClick: copyStaticFilePath,
-				quickSwitcherLabel: 'Copy staticFile() path',
-				subMenu: null,
-				type: 'item',
-				value: 'copy-asset-static-file-path',
-			},
-			{
-				type: 'divider',
-				id: 'asset-file-actions-divider',
-			},
-			{
-				id: 'open-asset-in-explorer',
-				keyHint: null,
-				label: `Show in ${fileManagerName}`,
-				leftItem: null,
-				onClick: openAssetInExplorer,
-				quickSwitcherLabel: `Show asset in ${fileManagerName}`,
-				subMenu: null,
-				type: 'item',
-				value: 'open-asset-in-explorer',
-				disabled:
-					serverActionDisabled || window.remotion_publicFolderExists === null,
-			},
-			{
-				id: 'rename-asset',
-				keyHint: null,
-				label: 'Rename...',
-				leftItem: null,
-				onClick: () => {
-					setSelectedModal({
-						type: 'rename-static-file',
-						relativePath,
-					});
-				},
-				quickSwitcherLabel: 'Rename asset...',
-				subMenu: null,
-				type: 'item',
-				value: 'rename-asset',
-				disabled: serverActionDisabled,
-			},
-			{
-				id: 'delete-asset',
-				keyHint: null,
-				label: 'Delete...',
-				leftItem: null,
-				onClick: deleteAsset,
-				quickSwitcherLabel: 'Delete asset...',
-				subMenu: null,
-				type: 'item',
-				value: 'delete-asset',
-				disabled: serverActionDisabled,
-			},
-		];
+		return getAssetContextMenuItems({
+			relativePath,
+			fileManagerName,
+			copyFileName,
+			copyStaticFilePath,
+			openAssetInExplorer,
+			renameAsset,
+			deleteAsset,
+			fileExplorerDisabled,
+			mutationsDisabled,
+		});
 	}, [
 		copyFileName,
 		copyStaticFilePath,
 		deleteAsset,
+		fileExplorerDisabled,
 		fileManagerName,
+		mutationsDisabled,
 		openAssetInExplorer,
+		renameAsset,
 		relativePath,
-		serverActionDisabled,
-		setSelectedModal,
 	]);
 
 	const revealInExplorer: React.MouseEventHandler<HTMLButtonElement> =
@@ -633,7 +700,7 @@ const AssetSelectorItem: React.FC<{
 								renderAction={renderCopyAction}
 								onClick={copyToClipboard}
 							/>
-							{serverActionDisabled ? null : (
+							{fileExplorerDisabled ? null : (
 								<>
 									<Spacing x={0.5} />
 									<InlineAction

--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals, type CanUpdateSequencePropStatus} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
+import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {AlignBottomIcon} from '../../icons/align-bottom';
 import {AlignCenterHorizontalIcon} from '../../icons/align-center-horizontal';
 import {AlignCenterVerticalIcon} from '../../icons/align-center-vertical';
@@ -93,6 +94,7 @@ export const AlignmentControls: React.FC<{
 			direction: 'left' | 'center-h' | 'right' | 'top' | 'center-v' | 'bottom',
 		) => {
 			if (
+				!isStudioInteractivityEnabled() ||
 				previewServerState.type !== 'connected' ||
 				!track.nodePathInfo ||
 				!track.sequence.controls
@@ -237,6 +239,7 @@ export const AlignmentControls: React.FC<{
 	);
 
 	if (
+		!isStudioInteractivityEnabled() ||
 		previewServerState.type !== 'connected' ||
 		!track.nodePathInfo ||
 		!track.sequence.controls ||

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -47,7 +47,9 @@ const actionIconStyle: React.CSSProperties = {
 	width: 18,
 };
 
-const CompositionActions: React.FC = () => {
+const CompositionActions: React.FC<{
+	readonly readOnlyStudio: boolean;
+}> = ({readOnlyStudio}) => {
 	const {
 		canInsertAsset,
 		canInsertSolid,
@@ -57,7 +59,7 @@ const CompositionActions: React.FC = () => {
 		insertSolid,
 	} = useCompositionActions();
 
-	if (!canShowInsertAsset && !canShowInsertSolid) {
+	if (readOnlyStudio || (!canShowInsertAsset && !canShowInsertSolid)) {
 		return null;
 	}
 
@@ -92,8 +94,9 @@ const CompositionActions: React.FC = () => {
 const CompositionDefaultPropsSection: React.FC<{
 	readonly composition: _InternalTypes['AnyComposition'];
 	readonly currentDefaultProps: Record<string, unknown>;
+	readonly readOnlyStudio: boolean;
 	readonly setDefaultProps: UpdaterFunction<Record<string, unknown>>;
-}> = ({composition, currentDefaultProps, setDefaultProps}) => {
+}> = ({composition, currentDefaultProps, readOnlyStudio, setDefaultProps}) => {
 	const z = useZodIfPossible();
 	const canSaveDefaultProps = useContext(ObserveDefaultPropsContext);
 	const [defaultPropsMode, setDefaultPropsMode] =
@@ -150,7 +153,7 @@ const CompositionDefaultPropsSection: React.FC<{
 		showCannotSaveDefaultPropsWarning: canShowDefaultPropsSection,
 	});
 
-	if (!canShowDefaultPropsSection) {
+	if (readOnlyStudio || !canShowDefaultPropsSection) {
 		return null;
 	}
 
@@ -206,9 +209,12 @@ const CompositionDefaultPropsSection: React.FC<{
 	);
 };
 
-const CompositionVisualControlsSection: React.FC = () => {
+const CompositionVisualControlsSection: React.FC<{
+	readonly readOnlyStudio: boolean;
+}> = ({readOnlyStudio}) => {
 	const {handles: visualControlHandles} = useContext(VisualControlsContext);
 	const hasVisualControls =
+		!readOnlyStudio &&
 		isStudioInteractivityEnabled() &&
 		Object.keys(visualControlHandles).length > 0;
 
@@ -247,10 +253,11 @@ export const CompositionInspector: React.FC<{
 			<CompositionDefaultPropsSection
 				composition={composition}
 				currentDefaultProps={currentDefaultProps}
+				readOnlyStudio={readOnlyStudio}
 				setDefaultProps={setDefaultProps}
 			/>
-			<CompositionVisualControlsSection />
-			<CompositionActions />
+			<CompositionVisualControlsSection readOnlyStudio={readOnlyStudio} />
+			<CompositionActions readOnlyStudio={readOnlyStudio} />
 		</div>
 	);
 };

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -287,7 +287,7 @@ export const CompositionMetadata: React.FC<{
 	);
 	const saveMetadata = useCallback(
 		(newValues: CompositionMetadataValues) => {
-			if (resolvedConfig === null) {
+			if (disabled || resolvedConfig === null) {
 				return;
 			}
 
@@ -374,6 +374,7 @@ export const CompositionMetadata: React.FC<{
 		[
 			compositionId,
 			currentValues,
+			disabled,
 			onPendingValueAccepted,
 			onPendingValueFailed,
 			pendingValues,

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -252,15 +252,17 @@ const SequenceExpandedInspector: React.FC<{
 		[selectItems, sequenceSelected, sequenceSelection],
 	);
 
-	if (previewServerState.type !== 'connected') {
+	if (
+		previewServerState.type !== 'connected' &&
+		!window.remotion_isReadOnlyStudio
+	) {
 		return <InspectorMessage>Studio server disconnected</InspectorMessage>;
 	}
 
 	if (
 		!track.nodePathInfo ||
 		sequenceSelection === null ||
-		!hasSequenceControls(track.sequence) ||
-		!validatedLocation
+		!hasSequenceControls(track.sequence)
 	) {
 		return <InspectorMessage>Sequence inspector unavailable</InspectorMessage>;
 	}
@@ -280,21 +282,27 @@ const SequenceExpandedInspector: React.FC<{
 					/>
 				</>
 			) : null}
-			<InspectorSequenceSection
-				sequence={track.sequence}
-				validatedLocation={validatedLocation}
-				nodePathInfo={track.nodePathInfo}
-				keyframeDisplayOffset={track.keyframeDisplayOffset}
-				renderTransformControls={() => <AlignmentControls track={track} />}
-			/>
-			<InspectorActionSection>
-				<SplitSequenceAction selection={sequenceSelection} track={track} />
-				<SequenceSourceActions
-					selection={sequenceSelection}
-					track={track}
-					validatedSource={validatedLocation.source}
-				/>
-			</InspectorActionSection>
+			{validatedLocation ? (
+				<>
+					<InspectorSequenceSection
+						sequence={track.sequence}
+						validatedLocation={validatedLocation}
+						nodePathInfo={track.nodePathInfo}
+						keyframeDisplayOffset={track.keyframeDisplayOffset}
+						renderTransformControls={() => <AlignmentControls track={track} />}
+					/>
+					<InspectorActionSection>
+						<SplitSequenceAction selection={sequenceSelection} track={track} />
+						<SequenceSourceActions
+							selection={sequenceSelection}
+							track={track}
+							validatedSource={validatedLocation.source}
+						/>
+					</InspectorActionSection>
+				</>
+			) : (
+				<InspectorMessage>Source controls unavailable</InspectorMessage>
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -43,6 +43,7 @@ export const useCompositionActions = () => {
 
 	const canShowInsertSolid =
 		previewInteractive &&
+		!window.remotion_isReadOnlyStudio &&
 		compositionComponentInfo?.canAddSequence === true &&
 		currentCompositionId !== null &&
 		compositionFile !== null &&

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -5,6 +5,7 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT, WHITE} from '../helpers/colors';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
 import {
 	flattenVisibleTreeNodes,
 	SCHEMA_FIELD_GROUPS,
@@ -355,6 +356,7 @@ export const InspectorSequenceSection: React.FC<{
 	const canAddEffect =
 		nodePathInfo.supportsEffects &&
 		previewServerState.type === 'connected' &&
+		isStudioInteractivityEnabled() &&
 		Boolean(validatedLocation.source);
 
 	const onAddEffect = useCallback(() => {

--- a/packages/studio/src/components/OutlineToggle.tsx
+++ b/packages/studio/src/components/OutlineToggle.tsx
@@ -3,9 +3,7 @@ import {BLUE, WHITE} from '../helpers/colors';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ControlButton} from './ControlButton';
 
-export const OutlineToggle: React.FC<{
-	readonly disabled: boolean;
-}> = ({disabled}) => {
+export const OutlineToggle: React.FC = () => {
 	const {editorShowOutlines, setEditorShowOutlines} = useContext(
 		EditorShowOutlinesContext,
 	);
@@ -23,7 +21,6 @@ export const OutlineToggle: React.FC<{
 		<ControlButton
 			title={accessibilityLabel}
 			aria-label={accessibilityLabel}
-			disabled={disabled}
 			onClick={onClick}
 		>
 			<svg

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -269,11 +269,13 @@ export const PreviewToolbar: React.FC<{
 						<CheckboardToggle />
 					</PreviewToolbarControl>
 					<PreviewToolbarControl>
-						<OutlineToggle disabled={readOnlyStudio} />
+						<OutlineToggle />
 					</PreviewToolbarControl>
-					<PreviewToolbarControl>
-						<SnappingToggle disabled={readOnlyStudio} />
-					</PreviewToolbarControl>
+					{readOnlyStudio ? null : (
+						<PreviewToolbarControl>
+							<SnappingToggle />
+						</PreviewToolbarControl>
+					)}
 				</>
 			) : null}
 			<Spacing x={1} />

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -12,6 +12,7 @@ import {
 import {formatFileLocation} from '../helpers/format-file-location';
 import {getConnectedCompositions} from '../helpers/get-connected-compositions';
 import {getSequenceDoubleClickAction} from '../helpers/get-sequence-double-click-action';
+import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
 import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ModalsContext} from '../state/modals';
@@ -1589,7 +1590,7 @@ export const SelectedOutlineElement: React.FC<{
 	);
 
 	const onContextMenuOpen = React.useCallback(async () => {
-		if (target === undefined || previewServerState.type !== 'connected') {
+		if (target === undefined) {
 			return false;
 		}
 
@@ -1614,9 +1615,13 @@ export const SelectedOutlineElement: React.FC<{
 		const canOpenInEditor = Boolean(
 			window.remotion_editorName && originalLocation,
 		);
-		const disableInteractivityDisabled = !target.sequence.showInTimeline;
+		const sourceEditingEnabled = isStudioInteractivityEnabled();
+		const disableInteractivityDisabled =
+			!sourceEditingEnabled || !target.sequence.showInTimeline;
 		const sourceEditDisabled =
-			!target.sequence.controls || !nodePath.absolutePath;
+			!sourceEditingEnabled ||
+			!target.sequence.controls ||
+			!nodePath.absolutePath;
 		const canAddEffect =
 			target.nodePathInfo.supportsEffects &&
 			!sourceEditDisabled &&
@@ -1630,7 +1635,7 @@ export const SelectedOutlineElement: React.FC<{
 			disableInteractivityDisabled,
 			duplicateDisabled: sourceEditDisabled,
 			fileLocation,
-			includeSourceEditItems: true,
+			includeSourceEditItems: sourceEditingEnabled,
 			onDeleteSequenceFromSource: async () => {
 				if (sourceEditDisabled || previewServerState.type !== 'connected') {
 					return;
@@ -1704,70 +1709,72 @@ export const SelectedOutlineElement: React.FC<{
 			originalLocation,
 			selectAsset,
 			sequence: target.sequence,
-			sourceActions: [
-				...(target.nodePathInfo.supportsEffects
-					? [
-							{
-								type: 'item' as const,
-								id: 'add-effect',
-								keyHint: null,
-								label: 'Add effect...',
-								leftItem: null,
-								disabled: !canAddEffect,
-								onClick: () => {
-									if (
-										!canAddEffect ||
-										previewServerState.type !== 'connected'
-									) {
-										return;
-									}
+			sourceActions: sourceEditingEnabled
+				? [
+						...(target.nodePathInfo.supportsEffects
+							? [
+									{
+										type: 'item' as const,
+										id: 'add-effect',
+										keyHint: null,
+										label: 'Add effect...',
+										leftItem: null,
+										disabled: !canAddEffect,
+										onClick: () => {
+											if (
+												!canAddEffect ||
+												previewServerState.type !== 'connected'
+											) {
+												return;
+											}
 
-									setSelectedModal({
-										type: 'add-effect',
-										clientId: previewServerState.clientId,
-										fileName: nodePath.absolutePath,
-										nodePath,
-									});
-								},
-								quickSwitcherLabel: null,
-								subMenu: null,
-								value: 'add-effect',
-							},
-						]
-					: []),
-				{
-					type: 'item' as const,
-					id: 'crop',
-					keyHint: null,
-					label: 'Crop',
-					leftItem: null,
-					disabled: !canCrop,
-					onClick: () => {
-						if (!canCrop) {
-							return;
-						}
+											setSelectedModal({
+												type: 'add-effect',
+												clientId: previewServerState.clientId,
+												fileName: nodePath.absolutePath,
+												nodePath,
+											});
+										},
+										quickSwitcherLabel: null,
+										subMenu: null,
+										value: 'add-effect',
+									},
+								]
+							: []),
+						{
+							type: 'item' as const,
+							id: 'crop',
+							keyHint: null,
+							label: 'Crop',
+							leftItem: null,
+							disabled: !canCrop,
+							onClick: () => {
+								if (!canCrop) {
+									return;
+								}
 
-						onSelect(
-							{
-								type: 'sequence-prop',
-								nodePathInfo: {
-									...target.nodePathInfo,
-									auxiliaryKeys: ['controls', cropFieldKeys.left],
-								},
-								key: cropFieldKeys.left,
+								onSelect(
+									{
+										type: 'sequence-prop',
+										nodePathInfo: {
+											...target.nodePathInfo,
+											auxiliaryKeys: ['controls', cropFieldKeys.left],
+										},
+										key: cropFieldKeys.left,
+									},
+									{shiftKey: false, toggleKey: false},
+								);
 							},
-							{shiftKey: false, toggleKey: false},
-						);
-					},
-					quickSwitcherLabel: null,
-					subMenu: null,
-					value: 'crop',
-				},
-				{
-					type: 'divider' as const,
-					id: 'crop-divider',
-				},
-			],
+							quickSwitcherLabel: null,
+							subMenu: null,
+							value: 'crop',
+						},
+						{
+							type: 'divider' as const,
+							id: 'crop-divider',
+						},
+					]
+				: [],
 		});
 	}, [
 		confirm,

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -16,7 +16,10 @@ import {
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
+import {
+	isStudioInteractivityEnabled,
+	isStudioSelectionEnabled,
+} from '../helpers/interactivity-enabled';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
@@ -679,6 +682,10 @@ export const SelectedOutlineOverlay: React.FC<{
 	const keyboardNudgeSessionRef =
 		useRef<SelectedOutlineKeyboardNudgeSession | null>(null);
 	const saveKeyboardNudgeSessionRef = useRef<() => void>(() => undefined);
+	const previewInteractive =
+		previewServerState.type === 'connected' && isStudioInteractivityEnabled();
+	const previewSelectionAvailable =
+		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
 
 	const onDraggingChange = React.useCallback((dragging: boolean) => {
 		setDraggingOutline(dragging);
@@ -702,7 +709,11 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 
 	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
-		if (!isStudioInteractivityEnabled() || !editorShowOutlines) {
+		if (
+			!isStudioSelectionEnabled() ||
+			!previewSelectionAvailable ||
+			!editorShowOutlines
+		) {
 			return [];
 		}
 
@@ -822,7 +833,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				(rotationPropStatus?.status === 'keyframed' &&
 					rotationPropStatus.interpolationFunction === 'interpolate');
 			const canDrag =
-				previewServerState.type === 'connected' &&
+				previewInteractive &&
 				controls !== null &&
 				fieldSchema?.type === 'translate' &&
 				canDragStatus;
@@ -831,12 +842,12 @@ export const SelectedOutlineOverlay: React.FC<{
 				(scalePropStatus?.status === 'keyframed' &&
 					scalePropStatus.interpolationFunction === 'interpolate');
 			const canScaleDrag =
-				previewServerState.type === 'connected' &&
+				previewInteractive &&
 				controls !== null &&
 				scaleFieldSchema?.type === 'scale' &&
 				canScaleDragStatus;
 			const canRotationDrag =
-				previewServerState.type === 'connected' &&
+				previewInteractive &&
 				controls !== null &&
 				rotationFieldSchema?.type === 'rotation-css' &&
 				canRotationDragStatus;
@@ -856,7 +867,7 @@ export const SelectedOutlineOverlay: React.FC<{
 				(propStatus?.status === 'keyframed' &&
 					propStatus.interpolationFunction === 'interpolate');
 			const canTransformOriginDrag =
-				previewServerState.type === 'connected' &&
+				previewInteractive &&
 				selectedForTransformOrigin &&
 				controls !== null &&
 				transformOriginFieldSchema?.type === 'transform-origin' &&
@@ -870,19 +881,15 @@ export const SelectedOutlineOverlay: React.FC<{
 					? sourceFrame
 					: selectedCropInfo.displayFrame - keyframeDisplayOffset;
 			const canCropDrag =
-				previewServerState.type === 'connected' &&
+				previewInteractive &&
 				selectedForCrop &&
 				controls !== null &&
 				cropFields !== null;
 			const canDropEffect =
-				previewServerState.type === 'connected' &&
-				controls?.supportsEffects === true;
+				previewInteractive && controls?.supportsEffects === true;
 			return {
 				key,
-				canCrop:
-					previewServerState.type === 'connected' &&
-					controls !== null &&
-					cropFields !== null,
+				canCrop: previewInteractive && controls !== null && cropFields !== null,
 				crop,
 				cropDrag: canCropDrag
 					? {
@@ -1046,6 +1053,8 @@ export const SelectedOutlineOverlay: React.FC<{
 		getScaleLockState,
 		editorShowOutlines,
 		overrideIdToNodePathMappings,
+		previewInteractive,
+		previewSelectionAvailable,
 		previewServerState,
 		selectedItems,
 		sequences,

--- a/packages/studio/src/components/SequencePropsSubscriptionProvider.tsx
+++ b/packages/studio/src/components/SequencePropsSubscriptionProvider.tsx
@@ -1,17 +1,52 @@
-import {useState, useCallback, useMemo} from 'react';
+import {useState, useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import type {
 	OverrideIdToNodePaths,
 	OverrideToNodePathGetters,
 	OverrideToNodeSetters,
 	SequencePropsSubscriptionKey,
+	TSequence,
 } from 'remotion';
+
+export const getReadOnlyOverrideIdToNodePathMappings = (
+	sequences: readonly TSequence[],
+): OverrideIdToNodePaths => {
+	return Object.fromEntries(
+		sequences.flatMap((sequence) => {
+			const overrideId = sequence.controls?.overrideId;
+			if (!overrideId) {
+				return [];
+			}
+
+			return [
+				[
+					overrideId,
+					{
+						absolutePath: '',
+						effectKeys: [],
+						nodePath: ['readonly-sequence', overrideId],
+						sequenceKeys: [],
+						videoConfigValues: null,
+					} satisfies SequencePropsSubscriptionKey,
+				],
+			];
+		}),
+	);
+};
 
 export const SequencePropsSubscriptionProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
+	const {sequences} = useContext(Internals.SequenceManager);
 	const [overrideToNodePathMap, setOverrideIdToNodePathMap] =
 		useState<OverrideIdToNodePaths>({});
+	const readOnlyOverrideToNodePathMap = useMemo(
+		() =>
+			window.remotion_isReadOnlyStudio
+				? getReadOnlyOverrideIdToNodePathMappings(sequences)
+				: null,
+		[sequences],
+	);
 
 	const setOverrideIdToNodePath = useCallback(
 		(overrideId: string, state: SequencePropsSubscriptionKey) => {
@@ -28,8 +63,11 @@ export const SequencePropsSubscriptionProvider: React.FC<{
 	);
 
 	const getters = useMemo((): OverrideToNodePathGetters => {
-		return {overrideIdToNodePathMappings: overrideToNodePathMap};
-	}, [overrideToNodePathMap]);
+		return {
+			overrideIdToNodePathMappings:
+				readOnlyOverrideToNodePathMap ?? overrideToNodePathMap,
+		};
+	}, [overrideToNodePathMap, readOnlyOverrideToNodePathMap]);
 
 	const setters = useMemo((): OverrideToNodeSetters => {
 		return {setOverrideIdToNodePath};

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -6,9 +6,7 @@ import {MagnetIcon} from '../icons/magnet';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ControlButton} from './ControlButton';
 
-export const SnappingToggle: React.FC<{
-	readonly disabled: boolean;
-}> = ({disabled}) => {
+export const SnappingToggle: React.FC = () => {
 	const {editorSnapping, setEditorSnapping} = useContext(EditorSnappingContext);
 
 	const onClick = useCallback(() => {
@@ -29,7 +27,6 @@ export const SnappingToggle: React.FC<{
 			aria-label={accessibilityLabel}
 			aria-pressed={editorSnapping}
 			aria-keyshortcuts="Shift+M"
-			disabled={disabled}
 			onClick={onClick}
 		>
 			<MagnetIcon

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -32,7 +32,10 @@ import type {
 	SequenceNodePathInfo,
 	TimelineTrackData,
 } from '../../helpers/get-timeline-sequence-sort-key';
-import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {
+	isStudioInteractivityEnabled,
+	isStudioSelectionEnabled,
+} from '../../helpers/interactivity-enabled';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
@@ -1102,9 +1105,9 @@ export const TimelineSelectionProvider: React.FC<{
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
 	const {expandParentTracks} = useContext(ExpandedTracksSetterContext);
 	const canSelect =
-		isStudioInteractivityEnabled() &&
-		previewServerState.type === 'connected' &&
-		!window.remotion_isReadOnlyStudio;
+		isStudioSelectionEnabled() &&
+		(previewServerState.type === 'connected' ||
+			window.remotion_isReadOnlyStudio);
 	const [selectedItems, setSelectedItems] = useState<
 		readonly TimelineSelection[]
 	>([]);
@@ -1138,7 +1141,9 @@ export const TimelineSelectionProvider: React.FC<{
 	}, [canSelect]);
 
 	const canSelectItem = useCallback(
-		(_item: TimelineSelection) => canSelect,
+		(item: TimelineSelection) =>
+			canSelect &&
+			(!window.remotion_isReadOnlyStudio || item.type === 'sequence'),
 		[canSelect],
 	);
 
@@ -1500,8 +1505,12 @@ export const TimelineSelectionProvider: React.FC<{
 			<TimelineSelectionContext.Provider value={value}>
 				{children}
 				<TimelineEscapeKeybindings />
-				<TimelineClipboardKeybindings />
-				<TimelineDeleteKeybindings />
+				{isStudioInteractivityEnabled() ? (
+					<>
+						<TimelineClipboardKeybindings />
+						<TimelineDeleteKeybindings />
+					</>
+				) : null}
 			</TimelineSelectionContext.Provider>
 		</CurrentTimelineSelectionContext.Provider>
 	);

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -490,10 +490,6 @@ const TimelineSequenceInner: React.FC<{
 		validatedSource: validatedLocation?.source ?? null,
 	});
 	const contextMenuValues = useMemo(() => {
-		if (!previewConnected) {
-			return [];
-		}
-
 		return getSequenceContextMenuItems({
 			assetLinkInfo,
 			canOpenInEditor,
@@ -527,7 +523,6 @@ const TimelineSequenceInner: React.FC<{
 		onDuplicateSequenceFromSource,
 		openInEditor,
 		originalLocation,
-		previewConnected,
 		s,
 		selectAsset,
 	]);
@@ -703,7 +698,7 @@ const TimelineSequenceInner: React.FC<{
 		</TimelineSequenceCurrentFrame>
 	);
 
-	return previewConnected ? (
+	return previewConnected || window.remotion_isReadOnlyStudio ? (
 		<ContextMenu values={contextMenuValues} onOpen={onContextMenuOpen}>
 			{sequence}
 		</ContextMenu>

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -965,10 +965,6 @@ export const TimelineSequenceItem: React.FC<{
 	}, [canCrop, nodePathInfo, selectItem]);
 
 	const contextMenuValues = useMemo(() => {
-		if (!previewConnected) {
-			return [];
-		}
-
 		return getSequenceContextMenuItems({
 			assetLinkInfo,
 			canOpenInEditor,
@@ -1056,7 +1052,6 @@ export const TimelineSequenceItem: React.FC<{
 		onRenameSequence,
 		openInEditor,
 		originalLocation,
-		previewConnected,
 		selectAsset,
 		sequence,
 	]);
@@ -1239,7 +1234,7 @@ export const TimelineSequenceItem: React.FC<{
 
 	return (
 		<>
-			{previewConnected ? (
+			{previewConnected || window.remotion_isReadOnlyStudio ? (
 				<ContextMenu
 					values={contextMenuValues}
 					onOpen={selectable ? onSelect : null}

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -191,18 +191,20 @@ export const getSequenceContextMenuItems = ({
 				}
 			: null,
 		...sourceActions,
-		{
-			type: 'item' as const,
-			id: 'disable-interactivity',
-			keyHint: null,
-			label: 'Disable interactivity',
-			leftItem: null,
-			disabled: disableInteractivityDisabled,
-			onClick: onDisableSequenceInteractivity,
-			quickSwitcherLabel: null,
-			subMenu: null,
-			value: 'disable-interactivity',
-		},
+		includeSourceEditItems
+			? {
+					type: 'item' as const,
+					id: 'disable-interactivity',
+					keyHint: null,
+					label: 'Disable interactivity',
+					leftItem: null,
+					disabled: disableInteractivityDisabled,
+					onClick: onDisableSequenceInteractivity,
+					quickSwitcherLabel: null,
+					subMenu: null,
+					value: 'disable-interactivity',
+				}
+			: null,
 		includeSourceEditItems
 			? {
 					type: 'item' as const,

--- a/packages/studio/src/helpers/interactivity-enabled.ts
+++ b/packages/studio/src/helpers/interactivity-enabled.ts
@@ -1,3 +1,10 @@
 import {getStudioInteractivityEnabled} from './studio-runtime-config';
 
-export const isStudioInteractivityEnabled = getStudioInteractivityEnabled;
+export const isStudioInteractivityEnabled = () => {
+	return (
+		getStudioInteractivityEnabled() &&
+		(typeof window === 'undefined' || !window.remotion_isReadOnlyStudio)
+	);
+};
+
+export const isStudioSelectionEnabled = getStudioInteractivityEnabled;

--- a/packages/studio/src/test/asset-context-menu.test.ts
+++ b/packages/studio/src/test/asset-context-menu.test.ts
@@ -1,0 +1,83 @@
+import {expect, test} from 'bun:test';
+import {
+	getAssetActionAvailability,
+	getCanDragAsset,
+	getAssetContextMenuItems,
+} from '../components/AssetSelectorItem';
+
+const noop = () => undefined;
+
+const getItem = (
+	items: ReturnType<typeof getAssetContextMenuItems>,
+	id: string,
+) => {
+	const item = items.find((candidate) => candidate.id === id);
+	if (!item || item.type !== 'item') {
+		throw new Error(`Could not find menu item ${id}`);
+	}
+
+	return item;
+};
+
+test('keeps copy and open-in-new-window asset actions enabled in read-only Studio', () => {
+	const availability = getAssetActionAvailability({
+		readOnlyStudio: true,
+		connectionStatus: 'init',
+		publicFolderExists: '/project/public',
+	});
+	const items = getAssetContextMenuItems({
+		relativePath: 'nested/video.mp4',
+		fileManagerName: 'Finder',
+		copyFileName: noop,
+		copyStaticFilePath: noop,
+		openAssetInExplorer: noop,
+		renameAsset: noop,
+		deleteAsset: noop,
+		...availability,
+	});
+
+	expect(getItem(items, 'open-in-new-window').disabled).not.toBe(true);
+	expect(getItem(items, 'copy-asset-file-name').disabled).not.toBe(true);
+	expect(getItem(items, 'copy-asset-static-file-path').disabled).not.toBe(true);
+	expect(getItem(items, 'open-asset-in-explorer').disabled).toBe(true);
+	expect(getItem(items, 'rename-asset').disabled).toBe(true);
+	expect(getItem(items, 'delete-asset').disabled).toBe(true);
+});
+
+test('only offers file-manager actions when a local public folder is available', () => {
+	const availability = getAssetActionAvailability({
+		readOnlyStudio: true,
+		connectionStatus: 'init',
+		publicFolderExists: null,
+	});
+
+	expect(availability.fileExplorerDisabled).toBe(true);
+});
+
+test('disables asset mutations while an editable Studio is disconnected', () => {
+	const availability = getAssetActionAvailability({
+		readOnlyStudio: false,
+		connectionStatus: 'disconnected',
+		publicFolderExists: '/project/public',
+	});
+
+	expect(availability).toEqual({
+		fileExplorerDisabled: true,
+		mutationsDisabled: true,
+	});
+});
+
+test('disables drag insertion in read-only Studio', () => {
+	expect(
+		getCanDragAsset({
+			readOnlyStudio: true,
+			relativePath: 'nested/video.mp4',
+		}),
+	).toBe(false);
+	expect(
+		getCanDragAsset({
+			readOnlyStudio: false,
+			relativePath: 'nested/video.mp4',
+		}),
+	).toBe(true);
+});

--- a/packages/studio/src/test/composition-menu-items.test.ts
+++ b/packages/studio/src/test/composition-menu-items.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, expect, test} from 'bun:test';
 import type {_InternalTypes} from 'remotion';
+import type {ResolvedStackLocation} from 'remotion';
 import {
 	getCompositionContextMenuItems,
 	getCompositionMenuItems,
@@ -42,6 +43,12 @@ const composition = {
 	id: 'ConnectedComposition',
 	durationInFrames: 100,
 } as _InternalTypes['AnyComposition'];
+
+const resolvedLocation: ResolvedStackLocation = {
+	column: 1,
+	line: 10,
+	source: '/project/src/Composition.tsx',
+};
 
 const commonArgs = {
 	closeMenu: () => undefined,
@@ -121,4 +128,45 @@ test('editor actions use Open labels and are adjacent', () => {
 
 	expect(compositionItem.label).toBe('Open composition in VS Code');
 	expect(componentItem.label).toBe('Open component in VS Code');
+});
+
+test('read-only composition menus keep navigation and copy actions enabled', () => {
+	installTestWindowWithEditor();
+
+	const mainMenuItems = getCompositionMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: true,
+		includeNewCompositionItem: true,
+		readOnlyStudio: true,
+		resolvedLocation,
+	});
+	const items = getCompositionContextMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: true,
+		readOnlyStudio: true,
+		resolvedLocation,
+	});
+	const itemById = (id: string) => {
+		const item = items.find((candidate) => candidate.id === id);
+		if (item?.type !== 'item') {
+			throw new Error(`Expected ${id} to be a menu item`);
+		}
+
+		return item;
+	};
+
+	expect(itemById('open-in-new-window').disabled).not.toBe(true);
+	expect(itemById('show-in-editor').disabled).toBe(false);
+	expect(itemById('open-component-in-editor').disabled).toBe(false);
+	expect(itemById('copy-file-location').disabled).toBe(false);
+	expect(itemById('copy-id').disabled).toBe(false);
+	expect(itemById('rename').disabled).toBe(true);
+	expect(itemById('duplicate').disabled).toBe(true);
+	expect(itemById('delete').disabled).toBe(true);
+	const newItem = mainMenuItems.find((item) => item.id === 'new');
+	if (newItem?.type !== 'item') {
+		throw new Error('Expected new to be a menu item');
+	}
+
+	expect(newItem.disabled).toBe(true);
 });

--- a/packages/studio/src/test/folder-menu-items.test.ts
+++ b/packages/studio/src/test/folder-menu-items.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, expect, test} from 'bun:test';
+import type {ResolvedStackLocation, _InternalTypes} from 'remotion';
+import {getFolderMenuItems} from '../components/folder-menu-items';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
+});
+
+test('read-only folder menus keep navigation and copy actions enabled', () => {
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			remotion_cwd: '/project',
+			remotion_editorName: 'VS Code',
+		},
+	});
+	const folder = {
+		name: 'Nested',
+		parent: null,
+		stack: 'stack',
+	} as _InternalTypes['TFolder'];
+	const resolvedLocation: ResolvedStackLocation = {
+		column: 1,
+		line: 10,
+		source: '/project/src/Root.tsx',
+	};
+	const items = getFolderMenuItems({
+		closeMenu: () => undefined,
+		connectionStatus: 'connected',
+		folder,
+		readOnlyStudio: true,
+		resolvedLocation,
+		setSelectedModal: () => undefined,
+	});
+	const itemById = (id: string) => {
+		const item = items.find((candidate) => candidate.id === id);
+		if (item?.type !== 'item') {
+			throw new Error(`Expected ${id} to be a menu item`);
+		}
+
+		return item;
+	};
+
+	expect(itemById('show-folder-in-editor').disabled).toBe(false);
+	expect(itemById('copy-folder-file-location').disabled).toBe(false);
+	expect(itemById('copy-folder-id').disabled).toBe(false);
+	expect(itemById('new-composition-in-folder').disabled).toBe(true);
+	expect(itemById('rename-folder').disabled).toBe(true);
+	expect(itemById('delete-folder').disabled).toBe(true);
+});

--- a/packages/studio/src/test/read-only-sequence-mappings.test.ts
+++ b/packages/studio/src/test/read-only-sequence-mappings.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'bun:test';
+import type {TSequence} from 'remotion';
+import {getReadOnlyOverrideIdToNodePathMappings} from '../components/SequencePropsSubscriptionProvider';
+
+test('read-only sequences get stable non-writable selection identities', () => {
+	const mappings = getReadOnlyOverrideIdToNodePathMappings([
+		{
+			controls: {overrideId: 'first'},
+		} as TSequence,
+		{
+			controls: null,
+		} as TSequence,
+	]);
+
+	expect(mappings).toEqual({
+		first: {
+			absolutePath: '',
+			effectKeys: [],
+			nodePath: ['readonly-sequence', 'first'],
+			sequenceKeys: [],
+			videoConfigValues: null,
+		},
+	});
+});

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -164,6 +164,42 @@ test('Interactive.Svg context menu can copy the rendered SVG', () => {
 	expect(items[copySvgIndex + 1]?.type).toBe('divider');
 });
 
+test('read-only sequence menus only contain non-mutating actions', () => {
+	installTestWindow();
+
+	const items = getSequenceContextMenuItems({
+		assetLinkInfo: null,
+		canOpenInEditor: false,
+		deleteDisabled: true,
+		disableInteractivityDisabled: true,
+		duplicateDisabled: true,
+		fileLocation: 'src/Video.tsx:10:2',
+		includeSourceEditItems: false,
+		onDeleteSequenceFromSource: noop,
+		onDisableSequenceInteractivity: noop,
+		onDuplicateSequenceFromSource: noop,
+		openInEditor: noop,
+		originalLocation: null,
+		selectAsset: noop,
+		sequence: {
+			controls: {
+				componentIdentity: 'dev.remotion.remotion.Interactive.Svg',
+			},
+			documentationLink: 'https://www.remotion.dev/docs/interactive',
+			refForOutline: {
+				current: {outerHTML: '<svg><circle /></svg>'},
+			},
+		} as unknown as TSequence,
+	});
+
+	expect(items.map((item) => item.id)).toEqual([
+		'copy-file-location',
+		'open-component-docs',
+		'sequence-link-divider',
+		'copy-svg',
+	]);
+});
+
 test('sequence freeze context menu item is hidden for audio', () => {
 	expect(shouldShowFreezeFrameMenuItem({type: 'audio'} as TSequence)).toBe(
 		false,


### PR DESCRIPTION
## Summary

- keep non-mutating composition, folder, asset, and sequence actions available in read-only Studio
- allow sequence selection, context menus, and inspectors without a Studio server connection
- disable source edits, visual controls, asset mutations, and other write actions in read-only mode
- add focused coverage for the read-only menu and sequence identity policies

## Tests

- `bun run build`
- `bun run stylecheck`
- `cd packages/studio && bun test src`

Closes #9714
