### PR TITLE
Docs: Add starburst and light-leaks to v5 migration guide

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -87,6 +87,16 @@ Use [Mediabunny to get video metadata](/docs/mediabunny/metadata) instead.
 
 **Required action**: Replace calls to `getVideoMetadata()` from `@remotion/renderer` with [getting metadata using Mediabunny](/docs/mediabunny/metadata).
 
+## `@remotion/starburst` and `@remotion/light-leaks` are no longer published
+
+Both packages are deprecated and will not be published in Remotion 5.0. Their effects have moved to [`@remotion/effects`](/docs/effects/api).
+
+**Required action**:
+
+- Replace `starburst()` from `@remotion/starburst` with [`starburst()`](/docs/effects/starburst) from `@remotion/effects/starburst`.
+- Replace `lightLeak()` from `@remotion/light-leaks` with [`lightLeak()`](/docs/effects/light-leak) from `@remotion/effects/light-leak`.
+- The `<Starburst>` and `<LightLeak>` components are not available in `@remotion/effects`. Migrate to the canvas-based effect APIs above, or stay on Remotion 4.x if you still need the components.
+
 ## `diskSizeInMb` is now 10240 by default
 
 For Remotion Lambda, the default disk size is now 10240 MB.  


### PR DESCRIPTION
Fixes #9667

## Problem

The Remotion 5.0 migration guide did not mention that `@remotion/starburst` and `@remotion/light-leaks` stop publishing in v5. Individual package docs already carry deprecation notices (landed via #9677/#9712), but issue #9667 explicitly calls for a migration-guide section with replacement imports from `@remotion/effects`.

## Triage / Root cause

`packages/docs/docs/5-0-migration.mdx` lists other v5 breaking changes (e.g. `getVideoMetadata()` removal) but had no entry for the starburst/light-leaks package sunset tracked under #9659.

## Fix

Add a new section after the `getVideoMetadata()` entry documenting:

- both packages are no longer published in Remotion 5.0
- `starburst()` and `lightLeak()` migrate to `@remotion/effects/starburst` and `@remotion/effects/light-leak`
- the `<Starburst>` and `<LightLeak>` sequence components are not moving to `@remotion/effects`

## Verification

- `python3 scripts/preflight_ship.py --repo remotion-dev/remotion --local remotion --branch main --file packages/docs/docs/5-0-migration.mdx --must-not-contain '@remotion/starburst' --must-not-contain '@remotion/light-leaks' --search 'starburst light-leaks 5-0-migration' --issue 9667` → PREFLIGHT CLEAR before edit
- Pre-commit docs format hook passed on commit
- `bun run stylecheck` fails on upstream/main at `@remotion/light-leaks#make` (`Cannot find module '@remotion/effects/light-leak'`) — pre-existing, unrelated to this docs-only diff

## Notes / Risks

- Complements (does not duplicate) the per-package deprecation notices already on `main`; addresses the migration-guide task in #9667 specifically.
- Related parent issue: #9659. Deprecation notice sub-issue #9666 is effectively covered on `main` via maintainer PRs #9677/#9712.
