### PR TITLE
Docs: Deprecate Starburst and Light Leaks packages

### DIFF
--- a/packages/docs/components/demos/StarburstDemo.tsx
+++ b/packages/docs/components/demos/StarburstDemo.tsx
@@ -10,7 +10,7 @@ import {
 
 export const StarburstDemoComp: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {width, height} = useVideoConfig();
+	const {width, height, durationInFrames} = useVideoConfig();
 
 	return (
 		<AbsoluteFill style={{backgroundColor: 'black'}}>
@@ -21,9 +21,7 @@ export const StarburstDemoComp: React.FC = () => {
 					starburst({
 						rays: 16,
 						colors: ['#ffdd00', '#ff8800'],
-						rotation: interpolate(frame, [0, 45, 89], [0, 180, 360]),
-						smoothness: interpolate(frame, [0, 45, 89], [0, 0.3, 0]),
-						origin: [0.5, 0.5],
+						rotation: interpolate(frame, [0, durationInFrames], [0, 360]),
 					}),
 				]}
 			/>

--- a/packages/docs/components/demos/types.ts
+++ b/packages/docs/components/demos/types.ts
@@ -1542,7 +1542,7 @@ export const starburstDemo: DemoType = {
 	comp: StarburstDemoComp,
 	compHeight: 720,
 	compWidth: 1280,
-	durationInFrames: 90,
+	durationInFrames: 180,
 	fps: 30,
 	id: 'starburst',
 	autoPlay: true,

--- a/packages/docs/docs/starburst-guide.mdx
+++ b/packages/docs/docs/starburst-guide.mdx
@@ -25,7 +25,7 @@ import {
 
 export const MyComp: React.FC = () => {
   const frame = useCurrentFrame();
-  const {width, height} = useVideoConfig();
+  const {width, height, durationInFrames} = useVideoConfig();
 
   return (
     <AbsoluteFill>
@@ -36,9 +36,7 @@ export const MyComp: React.FC = () => {
           starburst({
             rays: 16,
             colors: ['#ffdd00', '#ff8800'],
-            rotation: interpolate(frame, [0, 45, 89], [0, 180, 360]),
-            smoothness: interpolate(frame, [0, 45, 89], [0, 0.3, 0]),
-            origin: [0.5, 0.5],
+            rotation: interpolate(frame, [0, durationInFrames], [0, 360]),
           }),
         ]}
       />

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -472,15 +472,6 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
-			label: '@remotion/light-leaks',
-			link: {
-				type: 'doc',
-				id: 'light-leaks/light-leaks-api',
-			},
-			items: ['light-leaks/light-leak-effect', 'light-leaks/light-leak'],
-		},
-		{
-			type: 'category',
 			label: '@remotion/lottie',
 			link: {
 				type: 'doc',
@@ -770,15 +761,6 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
-			label: '@remotion/starburst',
-			link: {
-				type: 'doc',
-				id: 'starburst/starburst-api',
-			},
-			items: ['starburst/starburst-effect', 'starburst/starburst-component'],
-		},
-		{
-			type: 'category',
 			label: '@remotion/studio',
 			link: {
 				type: 'doc',
@@ -974,6 +956,15 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
+			label: '@remotion/light-leaks (deprecated)',
+			link: {
+				type: 'doc',
+				id: 'light-leaks/light-leaks-api',
+			},
+			items: ['light-leaks/light-leak-effect', 'light-leaks/light-leak'],
+		},
+		{
+			type: 'category',
 			label: '@remotion/media-parser (deprecated)',
 			link: {
 				type: 'doc',
@@ -998,6 +989,15 @@ const sidebars: SidebarsConfig = {
 				'media-parser/node-writer',
 				'media-parser/webcodecs-timescale',
 			],
+		},
+		{
+			type: 'category',
+			label: '@remotion/starburst (deprecated)',
+			link: {
+				type: 'doc',
+				id: 'starburst/starburst-api',
+			},
+			items: ['starburst/starburst-effect', 'starburst/starburst-component'],
 		},
 		{
 			type: 'category',


### PR DESCRIPTION
## Summary

- simplify the Starburst guide and demo to use the default smoothness and origin
- animate one full rotation over the composition duration and double the demo length
- group `@remotion/starburst` and `@remotion/light-leaks` with deprecated packages in the API sidebar

## Validation

- `bun run build`
- `bun run stylecheck`
- `REMOTION_DOCS_LOW_MEMORY_BUILD=1 REMOTION_DOCS_BUILD_HEARTBEAT_MS=30000 bun run build-docs`

Closes #9666

## Preview

- [Starburst guide](https://remotion-git-codex-deprecated-effects-docs-polish-remotion.vercel.app/docs/starburst)
