### PR TITLE
`remotion`: Reject nested HtmlInCanvas before Chrome 152

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -218,6 +218,21 @@ export const isHtmlInCanvasSupported = (): boolean => {
 export const HTML_IN_CANVAS_UNSUPPORTED_MESSAGE =
 	'HTML in Canvas is not supported. Two common causes: Chrome is older than version 148 (update Chrome), or the HTML-in-Canvas flag is disabled at chrome://flags/#canvas-draw-element (enable it and restart Chrome).';
 
+const MINIMUM_CHROME_VERSION_FOR_NESTED_HTML_IN_CANVAS = 152;
+
+const getChromeMajorVersion = (): number | null => {
+	if (typeof navigator === 'undefined') {
+		return null;
+	}
+
+	const match = navigator.userAgent.match(/\b(?:HeadlessChrome|Chrome)\/(\d+)/);
+	if (!match) {
+		return null;
+	}
+
+	return Number(match[1]);
+};
+
 export type HtmlInCanvasOnPaint = (
 	params: HtmlInCanvasOnPaintParams,
 ) => void | Promise<void>;
@@ -376,6 +391,17 @@ const HtmlInCanvasContent = forwardRef<
 	) => {
 		const ancestor = useContext(HtmlInCanvasAncestorContext);
 		assertHtmlInCanvasDimensions(width, height);
+		const chromeMajorVersion = getChromeMajorVersion();
+		if (
+			ancestor &&
+			chromeMajorVersion !== null &&
+			chromeMajorVersion < MINIMUM_CHROME_VERSION_FOR_NESTED_HTML_IN_CANVAS
+		) {
+			throw new Error(
+				`Nested <HtmlInCanvas> components require Chrome ${MINIMUM_CHROME_VERSION_FOR_NESTED_HTML_IN_CANVAS} or newer, but the current browser is Chrome ${chromeMajorVersion}. Upgrade Chrome or avoid nesting components that use <HtmlInCanvas>, such as shapes with effects.`,
+			);
+		}
+
 		const resolvedPixelDensity = resolveHtmlInCanvasPixelDensity(pixelDensity);
 		const canvasWidth = Math.ceil(width * resolvedPixelDensity);
 		const canvasHeight = Math.ceil(height * resolvedPixelDensity);

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -319,6 +319,70 @@ test('<HtmlInCanvas> exposes crop controls', () => {
 	expect(htmlInCanvasSchema.cropBottom.keyframable).toBe(true);
 });
 
+test('<HtmlInCanvas> throws when nested in Chrome older than 152', () => {
+	const originalUserAgent = Object.getOwnPropertyDescriptor(
+		window.navigator,
+		'userAgent',
+	);
+	Object.defineProperty(window.navigator, 'userAgent', {
+		configurable: true,
+		value: 'Mozilla/5.0 HeadlessChrome/151.0.0.0 Safari/537.36',
+	});
+
+	try {
+		expect(() =>
+			render(
+				<SequenceTestWrapper onRegisterSequence={() => undefined}>
+					<HtmlInCanvas width={120} height={80}>
+						<HtmlInCanvas width={60} height={40}>
+							<div>Nested</div>
+						</HtmlInCanvas>
+					</HtmlInCanvas>
+				</SequenceTestWrapper>,
+			),
+		).toThrow(
+			'Nested <HtmlInCanvas> components require Chrome 152 or newer, but the current browser is Chrome 151.',
+		);
+	} finally {
+		if (originalUserAgent) {
+			Object.defineProperty(window.navigator, 'userAgent', originalUserAgent);
+		} else {
+			Reflect.deleteProperty(window.navigator, 'userAgent');
+		}
+	}
+});
+
+test('<HtmlInCanvas> allows nesting in Chrome 152', () => {
+	const originalUserAgent = Object.getOwnPropertyDescriptor(
+		window.navigator,
+		'userAgent',
+	);
+	Object.defineProperty(window.navigator, 'userAgent', {
+		configurable: true,
+		value: 'Mozilla/5.0 Chrome/152.0.0.0 Safari/537.36',
+	});
+
+	try {
+		const {container} = render(
+			<SequenceTestWrapper onRegisterSequence={() => undefined}>
+				<HtmlInCanvas width={120} height={80}>
+					<HtmlInCanvas width={60} height={40}>
+						<div>Nested</div>
+					</HtmlInCanvas>
+				</HtmlInCanvas>
+			</SequenceTestWrapper>,
+		);
+
+		expect(container.querySelectorAll('canvas')).toHaveLength(2);
+	} finally {
+		if (originalUserAgent) {
+			Object.defineProperty(window.navigator, 'userAgent', originalUserAgent);
+		} else {
+			Reflect.deleteProperty(window.navigator, 'userAgent');
+		}
+	}
+});
+
 test('<HtmlInCanvas> keeps refs current when the canvas remounts', async () => {
 	const registeredSequences: TSequence[] = [];
 	const canvasRef = React.createRef<HTMLCanvasElement>();


### PR DESCRIPTION
## Summary

- detect the current Chrome major version when an `HtmlInCanvas` is nested
- throw an actionable error below Chrome 152 instead of waiting for a nested `paint` event that never arrives
- cover Headless Chrome 151 rejection and Chrome 152 support with regression tests

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test` in `packages/core`
- verified the effected-shape reproduction fails immediately on bundled Chrome 149 and renders on Chrome Canary 152

Related: #9399
