### PR TITLE
Internal: Stop publishing deprecated packages in v5

### DIFF
--- a/packages/bundler/src/shared-bundler-config.ts
+++ b/packages/bundler/src/shared-bundler-config.ts
@@ -51,12 +51,16 @@ export const getResolveConfig = () => ({
 			'index.mjs',
 		),
 
-		'@remotion/media-parser/worker': path.resolve(
-			require.resolve('@remotion/media-parser'),
-			'..',
-			'esm',
-			'worker.mjs',
-		),
+		...(NoReactInternals.ENABLE_V5_BREAKING_CHANGES
+			? {}
+			: {
+					'@remotion/media-parser/worker': path.resolve(
+						require.resolve('@remotion/media-parser'),
+						'..',
+						'esm',
+						'worker.mjs',
+					),
+				}),
 		// test visual controls before removing this
 		'@remotion/studio': require.resolve('@remotion/studio'),
 		[path.join(

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -31,6 +31,17 @@ Upgrade `remotion` and all packages starting with `@remotion` to the latest vers
 
 Run `npm i `, `yarn`, `pnpm i` or `bun i` respectively afterwards.
 
+## Four packages are no longer published
+
+The following packages stop receiving releases after the 4.x line:
+
+- Replace `@remotion/light-leaks` with [`lightLeak()` from `@remotion/effects`](/docs/effects/light-leak).
+- Replace `@remotion/starburst` with [`starburst()` from `@remotion/effects`](/docs/effects/starburst).
+- Replace `@remotion/media-parser` with [Mediabunny](/docs/mediabunny).
+- Replace `@remotion/webcodecs` with [Mediabunny](/docs/mediabunny).
+
+**Required action**: Migrate usages and remove these packages from your dependencies before upgrading. Existing 4.x versions remain available, but no 5.x versions will be published.
+
 ## Runtime requirements
 
 The minimum Node version is now <MinNodeVersion />. The minimum Bun version is <MinBunVersion />.

--- a/packages/it-tests/src/monorepo/get-all-packages.ts
+++ b/packages/it-tests/src/monorepo/get-all-packages.ts
@@ -3,6 +3,7 @@ import {readFileSync} from 'node:fs';
 import path from 'path';
 import {Pkgs, packages} from '@remotion/studio-shared';
 import {CreateVideoInternals} from 'create-video';
+import {packagesRemovedInV5} from '../../../studio-shared/src/release-package-policy';
 
 export const getAllPackages = () => {
 	const pkgDir = path.join(__dirname, '..', '..', '..');
@@ -20,14 +21,12 @@ export const getAllPackages = () => {
 		}))
 		.filter(({path}) => existsSync(path));
 
-	const packageAndTemplateNames = (
-		packages
-			.slice()
-			.sort()
-			.map((pkg) => pkg) as string[]
-	)
-		.concat(localTemplates)
-		.sort();
+	const packagesKeptForV4 = packagesRemovedInV5.map((pkg) =>
+		pkg.replace('@remotion/', ''),
+	);
+	const packageAndTemplateNames = [
+		...new Set([...packages, ...localTemplates, ...packagesKeptForV4]),
+	].sort();
 
 	const packagesAndTemplates = folders.map((pkg) => pkg.pkg).sort() as string[];
 

--- a/packages/studio-shared/src/package-info.ts
+++ b/packages/studio-shared/src/package-info.ts
@@ -1,4 +1,7 @@
-export const packages = [
+import {VERSION} from 'remotion';
+import {shouldReleasePackage} from './release-package-policy';
+
+const allPackages = [
 	'svg-3d-engine',
 	'animation-utils',
 	'animated-emoji',
@@ -102,7 +105,14 @@ export const packages = [
 	'effects',
 ] as const;
 
-export type Pkgs = (typeof packages)[number];
+export type Pkgs = (typeof allPackages)[number];
+
+export const packages = allPackages.filter((pkg) =>
+	shouldReleasePackage({
+		packageName: pkg === 'core' ? 'remotion' : `@remotion/${pkg}`,
+		releaseVersion: VERSION,
+	}),
+);
 
 export type ExtraPackage = {
 	name: string;
@@ -327,10 +337,16 @@ export const installableMap: {[key in Pkgs]: boolean} = {
 	'test-utils': false,
 	three: true,
 	transitions: true,
-	'media-parser': true,
+	'media-parser': shouldReleasePackage({
+		packageName: '@remotion/media-parser',
+		releaseVersion: VERSION,
+	}),
 	'zod-types': true,
 	'zod-types-v3': true,
-	webcodecs: true,
+	webcodecs: shouldReleasePackage({
+		packageName: '@remotion/webcodecs',
+		releaseVersion: VERSION,
+	}),
 	convert: false,
 	captions: true,
 	'openai-whisper': true,
@@ -342,9 +358,15 @@ export const installableMap: {[key in Pkgs]: boolean} = {
 	'web-renderer': false,
 	design: false,
 	'drag-and-drop': true,
-	'light-leaks': true,
+	'light-leaks': shouldReleasePackage({
+		packageName: '@remotion/light-leaks',
+		releaseVersion: VERSION,
+	}),
 	'rough-notation': true,
-	starburst: true,
+	starburst: shouldReleasePackage({
+		packageName: '@remotion/starburst',
+		releaseVersion: VERSION,
+	}),
 	vercel: true,
 	sfx: true,
 	effects: true,

--- a/packages/studio-shared/src/release-package-policy.ts
+++ b/packages/studio-shared/src/release-package-policy.ts
@@ -1,0 +1,59 @@
+export const packagesRemovedInV5 = [
+	'@remotion/light-leaks',
+	'@remotion/media-parser',
+	'@remotion/starburst',
+	'@remotion/webcodecs',
+] as const;
+
+const packagesRemovedInV5Set = new Set<string>(packagesRemovedInV5);
+
+export const shouldReleasePackage = ({
+	packageName,
+	releaseVersion,
+}: {
+	packageName: string;
+	releaseVersion: string;
+}) => {
+	const majorVersion = Number.parseInt(releaseVersion.split('.')[0], 10);
+	if (!Number.isInteger(majorVersion)) {
+		throw new Error(`Invalid release version: ${releaseVersion}`);
+	}
+
+	return majorVersion < 5 || !packagesRemovedInV5Set.has(packageName);
+};
+
+type PackageJsonWithDependencies = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+};
+
+type PackageJsonForRelease<T> = Omit<T, 'dependencies' | 'devDependencies'> &
+	PackageJsonWithDependencies;
+
+export const moveRemovedDependenciesToDevDependencies = <
+	T extends PackageJsonWithDependencies,
+>({
+	packageJson,
+	releaseVersion,
+}: {
+	packageJson: T;
+	releaseVersion: string;
+}): PackageJsonForRelease<T> => {
+	const dependencies = {...packageJson.dependencies};
+	const devDependencies = {...packageJson.devDependencies};
+	let movedDependency = false;
+
+	for (const [packageName, dependencyVersion] of Object.entries(dependencies)) {
+		if (!shouldReleasePackage({packageName, releaseVersion})) {
+			delete dependencies[packageName];
+			devDependencies[packageName] = dependencyVersion;
+			movedDependency = true;
+		}
+	}
+
+	if (!movedDependency) {
+		return packageJson as PackageJsonForRelease<T>;
+	}
+
+	return {...packageJson, dependencies, devDependencies};
+};

--- a/packages/studio-shared/src/test/release-package-policy.test.ts
+++ b/packages/studio-shared/src/test/release-package-policy.test.ts
@@ -1,0 +1,76 @@
+import {expect, test} from 'bun:test';
+import {
+	moveRemovedDependenciesToDevDependencies,
+	packagesRemovedInV5,
+	shouldReleasePackage,
+} from '../release-package-policy';
+
+test('releases the deprecated packages on the 4.x line', () => {
+	for (const packageName of packagesRemovedInV5) {
+		expect(shouldReleasePackage({packageName, releaseVersion: '4.0.500'})).toBe(
+			true,
+		);
+	}
+});
+
+test('does not release the deprecated packages starting with v5', () => {
+	for (const packageName of packagesRemovedInV5) {
+		expect(shouldReleasePackage({packageName, releaseVersion: '5.0.0'})).toBe(
+			false,
+		);
+		expect(shouldReleasePackage({packageName, releaseVersion: '6.0.0'})).toBe(
+			false,
+		);
+	}
+});
+
+test('continues to release other packages in v5', () => {
+	expect(
+		shouldReleasePackage({
+			packageName: '@remotion/effects',
+			releaseVersion: '5.0.0',
+		}),
+	).toBe(true);
+});
+
+test('rejects an invalid release version', () => {
+	expect(() =>
+		shouldReleasePackage({
+			packageName: '@remotion/effects',
+			releaseVersion: 'latest',
+		}),
+	).toThrow('Invalid release version: latest');
+});
+
+test('keeps dependencies on the 4.x line', () => {
+	const packageJson = {
+		dependencies: {
+			'@remotion/media-parser': 'workspace:*',
+			remotion: 'workspace:*',
+		},
+	};
+
+	expect(
+		moveRemovedDependenciesToDevDependencies({
+			packageJson,
+			releaseVersion: '4.0.500',
+		}),
+	).toEqual(packageJson);
+});
+
+test('does not leave a dangling v5 dependency', () => {
+	expect(
+		moveRemovedDependenciesToDevDependencies({
+			packageJson: {
+				dependencies: {
+					'@remotion/media-parser': 'workspace:*',
+					remotion: 'workspace:*',
+				},
+			},
+			releaseVersion: '5.0.0',
+		}),
+	).toEqual({
+		dependencies: {remotion: 'workspace:*'},
+		devDependencies: {'@remotion/media-parser': 'workspace:*'},
+	});
+});

--- a/publish.ts
+++ b/publish.ts
@@ -1,4 +1,3 @@
-import {$} from 'bun';
 import {
 	copyFileSync,
 	existsSync,
@@ -8,10 +7,19 @@ import {
 	unlinkSync,
 } from 'node:fs';
 import path from 'node:path';
+import {$} from 'bun';
 import limit from 'p-limit';
 import {FEATURED_TEMPLATES} from './packages/create-video/src/templates';
+import {shouldReleasePackage} from './packages/studio-shared/src/release-package-policy';
 
 const p = limit(4);
+
+const releaseVersion = JSON.parse(
+	readFileSync(
+		path.join(process.cwd(), 'packages', 'core', 'package.json'),
+		'utf-8',
+	),
+).version as string;
 
 const dirs = readdirSync('packages')
 	.filter((dir) =>
@@ -35,6 +43,15 @@ for (const dir of dirs) {
 	const packageJsonPath = path.join(packagePath, 'package.json');
 	const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 	if (packageJson.private) {
+		continue;
+	}
+
+	if (
+		!shouldReleasePackage({
+			packageName: packageJson.name,
+			releaseVersion,
+		})
+	) {
 		continue;
 	}
 

--- a/set-version.ts
+++ b/set-version.ts
@@ -10,6 +10,10 @@ import {
 } from 'fs';
 import path from 'path';
 import {FEATURED_TEMPLATES} from './packages/create-video/src/templates.ts';
+import {
+	moveRemovedDependenciesToDevDependencies,
+	shouldReleasePackage,
+} from './packages/studio-shared/src/release-package-policy';
 
 let version = process.argv[2];
 let noCommit = process.argv.includes('--no-commit');
@@ -63,7 +67,23 @@ for (const dir of [path.join('cloudrun', 'container'), ...dirs]) {
 		unlinkSync(tsconfigBuildPath);
 	}
 
-	const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+	let packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+	if (
+		!shouldReleasePackage({
+			packageName: packageJson.name,
+			releaseVersion: version,
+		})
+	) {
+		continue;
+	}
+
+	if (!packageJson.private) {
+		packageJson = moveRemovedDependenciesToDevDependencies({
+			packageJson,
+			releaseVersion: version,
+		});
+	}
+
 	packageJson.version = version;
 	writeFileSync(
 		packageJsonPath,


### PR DESCRIPTION
## Summary

- keep the four deprecated packages publishable on Remotion 4.x while excluding them from v5 releases
- remove retired packages and dangling dependencies from v5 package metadata
- gate the legacy media parser worker alias behind the v5 breaking-changes flag
- document the migration paths to `@remotion/effects` and Mediabunny

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/release-package-policy.test.ts` in `packages/studio-shared`
- Bundler and monorepo package metadata tests
- documentation production build and Twoslash validation

Closes #9667

## Preview

- [v5.0 Migration](https://remotion-git-codex-stop-publishing-deprecated-p-da613e-remotion.vercel.app/docs/5-0-migration)
