### PR TITLE
`@remotion/studio`: Open properties in editor

### DIFF
--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -18,6 +18,7 @@ import {deleteStaticFileHandler} from './routes/delete-static-file';
 import {downloadRemoteAssetHandler} from './routes/download-remote-asset';
 import {duplicateEffectHandler} from './routes/duplicate-effect';
 import {duplicateJsxNodeHandler} from './routes/duplicate-jsx-node';
+import {findInFileHandler} from './routes/find-in-file';
 import {insertElementHandler} from './routes/insert-element';
 import {insertJsxElementHandler} from './routes/insert-jsx-element';
 import {handleInstallPackage} from './routes/install-dependency';
@@ -67,6 +68,7 @@ export const allApiRoutes: {
 	'/api/subscribe-to-file-existence': subscribeToFileExistence,
 	'/api/remove-render': handleRemoveRender,
 	'/api/open-in-editor': openInEditorHandler,
+	'/api/find-in-file': findInFileHandler,
 	'/api/open-in-file-explorer': handleOpenInFileExplorer,
 	'/api/register-client-render': registerClientRenderHandler,
 	'/api/unregister-client-render': unregisterClientRenderHandler,

--- a/packages/studio-server/src/preview-server/routes/find-in-file.ts
+++ b/packages/studio-server/src/preview-server/routes/find-in-file.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type {
+	FindInFileRequest,
+	FindInFileResponse,
+} from '@remotion/studio-shared';
+import type {ApiHandler} from '../api-types';
+
+export const findSearchPosition = ({
+	contents,
+	lineNumber,
+	columnNumber,
+	search,
+}: {
+	contents: string;
+	lineNumber: number;
+	columnNumber: number;
+	search: string;
+}) => {
+	const lines = contents.split(/\r?\n/);
+	const startLineIndex = Math.max(0, lineNumber - 1);
+
+	for (let lineIndex = startLineIndex; lineIndex < lines.length; lineIndex++) {
+		const startColumnIndex =
+			lineIndex === startLineIndex ? Math.max(0, columnNumber - 1) : 0;
+		const foundColumnIndex = lines[lineIndex].indexOf(search, startColumnIndex);
+
+		if (foundColumnIndex !== -1) {
+			return {
+				lineNumber: lineIndex + 1,
+				columnNumber: foundColumnIndex + 1,
+			};
+		}
+	}
+
+	return {lineNumber, columnNumber};
+};
+
+export const findInFileHandler: ApiHandler<
+	FindInFileRequest,
+	FindInFileResponse
+> = async ({input, remotionRoot}) => {
+	const {fileName, lineNumber, columnNumber, search} = input;
+	const contents = await fs.promises.readFile(
+		path.resolve(remotionRoot, fileName),
+		'utf-8',
+	);
+
+	return findSearchPosition({
+		contents,
+		lineNumber,
+		columnNumber,
+		search,
+	});
+};

--- a/packages/studio-server/src/preview-server/routes/open-in-editor.ts
+++ b/packages/studio-server/src/preview-server/routes/open-in-editor.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import type {
 	OpenInEditorRequest,
@@ -12,36 +11,6 @@ import {
 import type {ApiHandler} from '../api-types';
 
 const editorGuess = guessEditor();
-
-export const findSearchPosition = ({
-	contents,
-	lineNumber,
-	columnNumber,
-	search,
-}: {
-	contents: string;
-	lineNumber: number;
-	columnNumber: number;
-	search: string;
-}) => {
-	const lines = contents.split(/\r?\n/);
-	const startLineIndex = Math.max(0, lineNumber - 1);
-
-	for (let lineIndex = startLineIndex; lineIndex < lines.length; lineIndex++) {
-		const startColumnIndex =
-			lineIndex === startLineIndex ? Math.max(0, columnNumber - 1) : 0;
-		const foundColumnIndex = lines[lineIndex].indexOf(search, startColumnIndex);
-
-		if (foundColumnIndex !== -1) {
-			return {
-				lineNumber: lineIndex + 1,
-				columnNumber: foundColumnIndex + 1,
-			};
-		}
-	}
-
-	return {lineNumber, columnNumber};
-};
 
 export const getEditorName = async () => {
 	const [edit] = await editorGuess;
@@ -57,31 +26,13 @@ export const openInEditorHandler: ApiHandler<
 			throw new TypeError('Need to pass stack');
 		}
 
-		const {stack, search} = input;
-		const fileName = path.resolve(
-			remotionRoot,
-			stack.originalFileName as string,
-		);
-		const originalLineNumber = stack.originalLineNumber as number;
-		const originalColumnNumber = stack.originalColumnNumber as number;
-		const position =
-			search === null
-				? {
-						lineNumber: originalLineNumber,
-						columnNumber: originalColumnNumber,
-					}
-				: findSearchPosition({
-						contents: await fs.promises.readFile(fileName, 'utf-8'),
-						lineNumber: originalLineNumber,
-						columnNumber: originalColumnNumber,
-						search,
-					});
+		const {stack} = input;
 		const guess = await editorGuess;
 		const didOpen = await launchEditor({
-			colNumber: position.columnNumber,
+			colNumber: stack.originalColumnNumber as number,
 			editor: guess[0],
-			fileName,
-			lineNumber: position.lineNumber,
+			fileName: path.resolve(remotionRoot, stack.originalFileName as string),
+			lineNumber: stack.originalLineNumber as number,
 			vsCodeNewWindow: false,
 			logLevel,
 		});

--- a/packages/studio-server/src/preview-server/routes/open-in-editor.ts
+++ b/packages/studio-server/src/preview-server/routes/open-in-editor.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import type {
 	OpenInEditorRequest,
@@ -11,6 +12,36 @@ import {
 import type {ApiHandler} from '../api-types';
 
 const editorGuess = guessEditor();
+
+export const findSearchPosition = ({
+	contents,
+	lineNumber,
+	columnNumber,
+	search,
+}: {
+	contents: string;
+	lineNumber: number;
+	columnNumber: number;
+	search: string;
+}) => {
+	const lines = contents.split(/\r?\n/);
+	const startLineIndex = Math.max(0, lineNumber - 1);
+
+	for (let lineIndex = startLineIndex; lineIndex < lines.length; lineIndex++) {
+		const startColumnIndex =
+			lineIndex === startLineIndex ? Math.max(0, columnNumber - 1) : 0;
+		const foundColumnIndex = lines[lineIndex].indexOf(search, startColumnIndex);
+
+		if (foundColumnIndex !== -1) {
+			return {
+				lineNumber: lineIndex + 1,
+				columnNumber: foundColumnIndex + 1,
+			};
+		}
+	}
+
+	return {lineNumber, columnNumber};
+};
 
 export const getEditorName = async () => {
 	const [edit] = await editorGuess;
@@ -26,13 +57,31 @@ export const openInEditorHandler: ApiHandler<
 			throw new TypeError('Need to pass stack');
 		}
 
-		const {stack} = input;
+		const {stack, search} = input;
+		const fileName = path.resolve(
+			remotionRoot,
+			stack.originalFileName as string,
+		);
+		const originalLineNumber = stack.originalLineNumber as number;
+		const originalColumnNumber = stack.originalColumnNumber as number;
+		const position =
+			search === null
+				? {
+						lineNumber: originalLineNumber,
+						columnNumber: originalColumnNumber,
+					}
+				: findSearchPosition({
+						contents: await fs.promises.readFile(fileName, 'utf-8'),
+						lineNumber: originalLineNumber,
+						columnNumber: originalColumnNumber,
+						search,
+					});
 		const guess = await editorGuess;
 		const didOpen = await launchEditor({
-			colNumber: stack.originalColumnNumber as number,
+			colNumber: position.columnNumber,
 			editor: guess[0],
-			fileName: path.resolve(remotionRoot, stack.originalFileName as string),
-			lineNumber: stack.originalLineNumber as number,
+			fileName,
+			lineNumber: position.lineNumber,
 			vsCodeNewWindow: false,
 			logLevel,
 		});

--- a/packages/studio-server/src/test/open-in-editor.test.ts
+++ b/packages/studio-server/src/test/open-in-editor.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'bun:test';
+import {findSearchPosition} from '../preview-server/routes/open-in-editor';
+
+test('finds a property after the component location', () => {
+	const contents = [
+		'const MyComp = () => (',
+		'\t<Sequence',
+		'\t\tstyle={{',
+		'\t\t\topacity: 0.5,',
+		'\t\t}}',
+		'\t/>',
+		');',
+	].join('\n');
+
+	expect(
+		findSearchPosition({
+			contents,
+			lineNumber: 2,
+			columnNumber: 2,
+			search: 'opacity',
+		}),
+	).toEqual({lineNumber: 4, columnNumber: 4});
+});
+
+test('starts searching at the source column', () => {
+	const contents = 'opacity: 1; <Sequence opacity={0.5} />';
+
+	expect(
+		findSearchPosition({
+			contents,
+			lineNumber: 1,
+			columnNumber: 13,
+			search: 'opacity',
+		}),
+	).toEqual({lineNumber: 1, columnNumber: 23});
+});
+
+test('keeps the component location if the property is not found', () => {
+	expect(
+		findSearchPosition({
+			contents: '<Sequence />',
+			lineNumber: 1,
+			columnNumber: 2,
+			search: 'opacity',
+		}),
+	).toEqual({lineNumber: 1, columnNumber: 2});
+});

--- a/packages/studio-server/src/test/open-in-editor.test.ts
+++ b/packages/studio-server/src/test/open-in-editor.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {findSearchPosition} from '../preview-server/routes/open-in-editor';
+import {findSearchPosition} from '../preview-server/routes/find-in-file';
 
 test('finds a property after the component location', () => {
 	const contents = [

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -52,11 +52,22 @@ export type OpenInFileExplorerRequest = {
 
 export type OpenInEditorRequest = {
 	stack: SymbolicatedStackFrame;
-	search: string | null;
 };
 
 export type OpenInEditorResponse = {
 	success: boolean;
+};
+
+export type FindInFileRequest = {
+	fileName: string;
+	lineNumber: number;
+	columnNumber: number;
+	search: string;
+};
+
+export type FindInFileResponse = {
+	lineNumber: number;
+	columnNumber: number;
 };
 
 export type CompositionComponentInfoRequest = {
@@ -944,6 +955,7 @@ export type ApiRoutes = {
 	>;
 	'/api/remove-render': ReqAndRes<RemoveRenderRequest, undefined>;
 	'/api/open-in-editor': ReqAndRes<OpenInEditorRequest, OpenInEditorResponse>;
+	'/api/find-in-file': ReqAndRes<FindInFileRequest, FindInFileResponse>;
 	'/api/open-in-file-explorer': ReqAndRes<OpenInFileExplorerRequest, void>;
 	'/api/register-client-render': ReqAndRes<CompletedClientRender, void>;
 	'/api/unregister-client-render': ReqAndRes<{id: string}, void>;

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -52,6 +52,7 @@ export type OpenInFileExplorerRequest = {
 
 export type OpenInEditorRequest = {
 	stack: SymbolicatedStackFrame;
+	search: string | null;
 };
 
 export type OpenInEditorResponse = {

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -47,6 +47,8 @@ export {
 	DuplicateJsxNodeRequest,
 	DuplicateJsxNodeResponse,
 	ElementInstallRequest,
+	FindInFileRequest,
+	FindInFileResponse,
 	GoogleFontSourceEdit,
 	InsertElementRequest,
 	InsertElementResponse,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -8,7 +8,7 @@ import type {
 	CanUpdateSequencePropStatusKeyframed,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
-import {Internals, useVideoConfig} from 'remotion';
+import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
@@ -18,7 +18,6 @@ import {callApi} from '../call-api';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddEffectKeyframe} from './call-add-keyframe';
-import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
 import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
@@ -37,11 +36,7 @@ import {
 	TimelineFieldValue,
 	UnsupportedStatus,
 } from './TimelineSchemaField';
-import {
-	useTimelineRowSelection,
-	useTimelineSelection,
-} from './TimelineSelection';
-import {canEditEasingForInterpolationFunction} from './update-selected-easing';
+import {useTimelineRowSelection} from './TimelineSelection';
 
 const fieldRowBase: React.CSSProperties = {};
 
@@ -367,9 +362,6 @@ export const TimelineEffectPropItem: React.FC<{
 		Internals.VisualModeDragOverridesContext,
 	);
 	const selection = useTimelineRowSelection(nodePathInfo);
-	const {selectItems} = useTimelineSelection();
-	const setFrame = Internals.useTimelineSetFrame();
-	const videoConfig = useVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const sourceFrame = timelinePosition - keyframeDisplayOffset;
 	const style = useMemo((): React.CSSProperties => {
@@ -500,110 +492,24 @@ export const TimelineEffectPropItem: React.FC<{
 		];
 	}, [canShowReset, onReset]);
 
-	const seekToDisplayFrame = useCallback(
-		(frame: number) => {
-			setFrame((current) => {
-				const next = {...current, [videoConfig.id]: frame};
-				Internals.persistCurrentFrame(next);
-				return next;
-			});
-		},
-		[setFrame, videoConfig.id],
-	);
-
 	const onPropertyDoubleClick = useCallback<
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
 			if (
-				window.remotion_editorName &&
-				previewServerState.type === 'connected'
+				!window.remotion_editorName ||
+				previewServerState.type !== 'connected'
 			) {
-				event.stopPropagation();
-				openOriginalPositionInEditorAtProperty({
-					originalPosition: validatedLocation,
-					property: field.key,
-				}).catch(() => undefined);
-			}
-
-			if (propStatus === null || propStatus.status === 'computed') {
-				return;
-			}
-
-			const keyframeSelection = {
-				type: 'keyframe' as const,
-				nodePathInfo,
-				frame: sourceFrame + keyframeDisplayOffset,
-			};
-
-			if (propStatus.status === 'static') {
-				if (!keyframable || previewServerState.type !== 'connected') {
-					return;
-				}
-
-				const value = Internals.getEffectiveVisualModeValue({
-					propStatus,
-					dragOverrideValue,
-					frame: sourceFrame,
-					defaultValue: field.fieldSchema.default,
-					shouldResortToDefaultValueIfUndefined: true,
-				});
-
-				event.stopPropagation();
-				callAddEffectKeyframe({
-					fileName: validatedLocation.source,
-					nodePath,
-					effectIndex: field.effectIndex,
-					fieldKey: field.key,
-					sourceFrame,
-					value,
-					schema: field.effectSchema,
-					setPropStatuses,
-					clientId: previewServerState.clientId,
-				}).catch(() => undefined);
-				selectItems([keyframeSelection], {reveal: true});
-				seekToDisplayFrame(keyframeSelection.frame);
-				return;
-			}
-
-			const targetSelection = getAnimationItemSelectionForSourceFrame({
-				includeEasings: canEditEasingForInterpolationFunction(
-					propStatus.interpolationFunction,
-				),
-				keyframeDisplayOffset,
-				keyframes: propStatus.keyframes,
-				nodePathInfo,
-				sourceFrame,
-			});
-
-			if (targetSelection === null) {
 				return;
 			}
 
 			event.stopPropagation();
-			selectItems([targetSelection], {reveal: true});
-			if (targetSelection.type === 'keyframe') {
-				seekToDisplayFrame(targetSelection.frame);
-			}
+			openOriginalPositionInEditorAtProperty({
+				originalPosition: validatedLocation,
+				property: field.key,
+			}).catch(() => undefined);
 		},
-		[
-			dragOverrideValue,
-			field.effectIndex,
-			field.effectSchema,
-			field.fieldSchema.default,
-			field.key,
-			keyframeDisplayOffset,
-			keyframable,
-			nodePath,
-			nodePathInfo,
-			previewServerState,
-			propStatus,
-			seekToDisplayFrame,
-			selectItems,
-			setPropStatuses,
-			sourceFrame,
-			validatedLocation,
-		],
+		[field.key, previewServerState.type, validatedLocation],
 	);
 
 	const row = (

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -12,6 +12,7 @@ import {Internals, useVideoConfig} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {openOriginalPositionInEditorAtProperty} from '../../helpers/open-in-editor';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
 import {ContextMenu} from '../ContextMenu';
@@ -514,6 +515,17 @@ export const TimelineEffectPropItem: React.FC<{
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
+			if (
+				window.remotion_editorName &&
+				previewServerState.type === 'connected'
+			) {
+				event.stopPropagation();
+				openOriginalPositionInEditorAtProperty({
+					originalPosition: validatedLocation,
+					property: field.key,
+				}).catch(() => undefined);
+			}
+
 			if (propStatus === null || propStatus.status === 'computed') {
 				return;
 			}
@@ -590,7 +602,7 @@ export const TimelineEffectPropItem: React.FC<{
 			selectItems,
 			setPropStatuses,
 			sourceFrame,
-			validatedLocation.source,
+			validatedLocation,
 		],
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -11,6 +11,7 @@ import {Internals, useVideoConfig} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {openOriginalPositionInEditorAtProperty} from '../../helpers/open-in-editor';
 import type {
 	SchemaFieldInfo,
 	TimelineFieldOnDragValueChange,
@@ -469,6 +470,17 @@ export const TimelineSequencePropItem: React.FC<{
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
+			if (
+				window.remotion_editorName &&
+				previewServerState.type === 'connected'
+			) {
+				event.stopPropagation();
+				openOriginalPositionInEditorAtProperty({
+					originalPosition: validatedLocation,
+					property: field.key.split('.').at(-1) ?? field.key,
+				}).catch(() => undefined);
+			}
+
 			if (propStatus === null || propStatus.status === 'computed') {
 				return;
 			}
@@ -543,7 +555,7 @@ export const TimelineSequencePropItem: React.FC<{
 			selectItems,
 			setPropStatuses,
 			sourceFrame,
-			validatedLocation.source,
+			validatedLocation,
 		],
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -7,7 +7,7 @@ import type {
 	InteractivitySchema,
 	SequencePropsSubscriptionKey,
 } from 'remotion';
-import {Internals, useVideoConfig} from 'remotion';
+import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
@@ -21,7 +21,6 @@ import {ContextMenu} from '../ContextMenu';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
-import {getAnimationItemSelectionForSourceFrame} from './get-animation-item-selection-for-frame';
 import {saveSequenceProps} from './save-sequence-prop';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
 import {TimelineFieldRowContent} from './TimelineFieldRowContent';
@@ -37,11 +36,7 @@ import {
 	TimelineFieldValue,
 	TimelineNonEditableStatus,
 } from './TimelineSchemaField';
-import {
-	useTimelineRowSelection,
-	useTimelineSelection,
-} from './TimelineSelection';
-import {canEditEasingForInterpolationFunction} from './update-selected-easing';
+import {useTimelineRowSelection} from './TimelineSelection';
 
 const fieldRowBase: React.CSSProperties = {};
 
@@ -322,9 +317,6 @@ export const TimelineSequencePropItem: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const selection = useTimelineRowSelection(nodePathInfo);
-	const {selectItems} = useTimelineSelection();
-	const setFrame = Internals.useTimelineSetFrame();
-	const videoConfig = useVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const sourceFrame = timelinePosition - keyframeDisplayOffset;
 
@@ -455,108 +447,24 @@ export const TimelineSequencePropItem: React.FC<{
 		];
 	}, [canShowReset, onReset]);
 
-	const seekToDisplayFrame = useCallback(
-		(frame: number) => {
-			setFrame((current) => {
-				const next = {...current, [videoConfig.id]: frame};
-				Internals.persistCurrentFrame(next);
-				return next;
-			});
-		},
-		[setFrame, videoConfig.id],
-	);
-
 	const onPropertyDoubleClick = useCallback<
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
 			if (
-				window.remotion_editorName &&
-				previewServerState.type === 'connected'
+				!window.remotion_editorName ||
+				previewServerState.type !== 'connected'
 			) {
-				event.stopPropagation();
-				openOriginalPositionInEditorAtProperty({
-					originalPosition: validatedLocation,
-					property: field.key.split('.').at(-1) ?? field.key,
-				}).catch(() => undefined);
-			}
-
-			if (propStatus === null || propStatus.status === 'computed') {
-				return;
-			}
-
-			const keyframeSelection = {
-				type: 'keyframe' as const,
-				nodePathInfo,
-				frame: sourceFrame + keyframeDisplayOffset,
-			};
-
-			if (propStatus.status === 'static') {
-				if (!keyframable || previewServerState.type !== 'connected') {
-					return;
-				}
-
-				const value = Internals.getEffectiveVisualModeValue({
-					propStatus,
-					dragOverrideValue,
-					frame: sourceFrame,
-					defaultValue: field.fieldSchema.default,
-					shouldResortToDefaultValueIfUndefined: true,
-				});
-
-				event.stopPropagation();
-				callAddSequenceKeyframe({
-					fileName: validatedLocation.source,
-					nodePath,
-					fieldKey: field.key,
-					sourceFrame,
-					value,
-					schema,
-					setPropStatuses,
-					clientId: previewServerState.clientId,
-				}).catch(() => undefined);
-				selectItems([keyframeSelection], {reveal: true});
-				seekToDisplayFrame(keyframeSelection.frame);
-				return;
-			}
-
-			const targetSelection = getAnimationItemSelectionForSourceFrame({
-				includeEasings: canEditEasingForInterpolationFunction(
-					propStatus.interpolationFunction,
-				),
-				keyframeDisplayOffset,
-				keyframes: propStatus.keyframes,
-				nodePathInfo,
-				sourceFrame,
-			});
-
-			if (targetSelection === null) {
 				return;
 			}
 
 			event.stopPropagation();
-			selectItems([targetSelection], {reveal: true});
-			if (targetSelection.type === 'keyframe') {
-				seekToDisplayFrame(targetSelection.frame);
-			}
+			openOriginalPositionInEditorAtProperty({
+				originalPosition: validatedLocation,
+				property: field.key.split('.').at(-1) ?? field.key,
+			}).catch(() => undefined);
 		},
-		[
-			dragOverrideValue,
-			field.fieldSchema.default,
-			field.key,
-			keyframeDisplayOffset,
-			keyframable,
-			nodePath,
-			nodePathInfo,
-			previewServerState,
-			propStatus,
-			schema,
-			seekToDisplayFrame,
-			selectItems,
-			setPropStatuses,
-			sourceFrame,
-			validatedLocation,
-		],
+		[field.key, previewServerState.type, validatedLocation],
 	);
 
 	if (propStatus === null) {

--- a/packages/studio/src/helpers/open-in-editor.ts
+++ b/packages/studio/src/helpers/open-in-editor.ts
@@ -6,7 +6,10 @@ import {useSyncExternalStore} from 'react';
 import {callApi} from '../components/call-api';
 import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
 
-export const openInEditor = (stack: SymbolicatedStackFrame) => {
+const openInEditorWithSearch = (
+	stack: SymbolicatedStackFrame,
+	search: string | null,
+) => {
 	const {
 		originalFileName,
 		originalLineNumber,
@@ -16,6 +19,7 @@ export const openInEditor = (stack: SymbolicatedStackFrame) => {
 	} = stack;
 
 	return callApi('/api/open-in-editor', {
+		search,
 		stack: {
 			originalFileName,
 			originalLineNumber,
@@ -26,16 +30,42 @@ export const openInEditor = (stack: SymbolicatedStackFrame) => {
 	});
 };
 
+export const openInEditor = (stack: SymbolicatedStackFrame) => {
+	return openInEditorWithSearch(stack, null);
+};
+
 export const openOriginalPositionInEditor = async (
 	originalPosition: OriginalPosition,
 ) => {
-	await openInEditor({
-		originalColumnNumber: originalPosition.column,
-		originalFileName: originalPosition.source,
-		originalFunctionName: null,
-		originalLineNumber: originalPosition.line,
-		originalScriptCode: null,
-	});
+	await openInEditorWithSearch(
+		{
+			originalColumnNumber: originalPosition.column,
+			originalFileName: originalPosition.source,
+			originalFunctionName: null,
+			originalLineNumber: originalPosition.line,
+			originalScriptCode: null,
+		},
+		null,
+	);
+};
+
+export const openOriginalPositionInEditorAtProperty = async ({
+	originalPosition,
+	property,
+}: {
+	originalPosition: OriginalPosition;
+	property: string;
+}) => {
+	await openInEditorWithSearch(
+		{
+			originalColumnNumber: originalPosition.column,
+			originalFileName: originalPosition.source,
+			originalFunctionName: null,
+			originalLineNumber: originalPosition.line,
+			originalScriptCode: null,
+		},
+		property,
+	);
 };
 
 type ResolvedCompositionComponentInfo = {

--- a/packages/studio/src/helpers/open-in-editor.ts
+++ b/packages/studio/src/helpers/open-in-editor.ts
@@ -4,12 +4,12 @@ import type {
 } from '@remotion/studio-shared';
 import {useSyncExternalStore} from 'react';
 import {callApi} from '../components/call-api';
-import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
+import type {
+	CodePosition,
+	OriginalPosition,
+} from '../error-overlay/react-overlay/utils/get-source-map';
 
-const openInEditorWithSearch = (
-	stack: SymbolicatedStackFrame,
-	search: string | null,
-) => {
+export const openInEditor = (stack: SymbolicatedStackFrame) => {
 	const {
 		originalFileName,
 		originalLineNumber,
@@ -19,7 +19,6 @@ const openInEditorWithSearch = (
 	} = stack;
 
 	return callApi('/api/open-in-editor', {
-		search,
 		stack: {
 			originalFileName,
 			originalLineNumber,
@@ -30,42 +29,37 @@ const openInEditorWithSearch = (
 	});
 };
 
-export const openInEditor = (stack: SymbolicatedStackFrame) => {
-	return openInEditorWithSearch(stack, null);
-};
-
 export const openOriginalPositionInEditor = async (
 	originalPosition: OriginalPosition,
 ) => {
-	await openInEditorWithSearch(
-		{
-			originalColumnNumber: originalPosition.column,
-			originalFileName: originalPosition.source,
-			originalFunctionName: null,
-			originalLineNumber: originalPosition.line,
-			originalScriptCode: null,
-		},
-		null,
-	);
+	await openInEditor({
+		originalColumnNumber: originalPosition.column,
+		originalFileName: originalPosition.source,
+		originalFunctionName: null,
+		originalLineNumber: originalPosition.line,
+		originalScriptCode: null,
+	});
 };
 
 export const openOriginalPositionInEditorAtProperty = async ({
 	originalPosition,
 	property,
 }: {
-	originalPosition: OriginalPosition;
+	originalPosition: CodePosition;
 	property: string;
 }) => {
-	await openInEditorWithSearch(
-		{
-			originalColumnNumber: originalPosition.column,
-			originalFileName: originalPosition.source,
-			originalFunctionName: null,
-			originalLineNumber: originalPosition.line,
-			originalScriptCode: null,
-		},
-		property,
-	);
+	const position = await callApi('/api/find-in-file', {
+		fileName: originalPosition.source,
+		lineNumber: originalPosition.line,
+		columnNumber: originalPosition.column,
+		search: property,
+	});
+
+	await openOriginalPositionInEditor({
+		source: originalPosition.source,
+		line: position.lineNumber,
+		column: position.columnNumber,
+	});
 };
 
 type ResolvedCompositionComponentInfo = {


### PR DESCRIPTION
## Summary

- open sequence and effect properties in the configured editor on double-click
- use a dedicated `/api/find-in-file` request for the primitive forward text search, then pass the returned position to the unchanged `/api/open-in-editor` route
- remove the previous double-click behavior that created or selected keyframes

## Test plan

- `bun test packages/studio-server/src/test/open-in-editor.test.ts`
- `bunx turbo run make --filter='@remotion/studio' --filter='@remotion/studio-server' --filter='@remotion/studio-shared'`
- `bun run build`
- `bun run stylecheck`

Closes #9731
