### PR TITLE
`@remotion/bundler`: Remove legacy positional signatures in v5

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -5,6 +5,7 @@ import {promisify} from 'node:util';
 import {isMainThread} from 'node:worker_threads';
 import type {GitSource, RenderDefaults} from '@remotion/studio-shared';
 import {getProjectName} from '@remotion/studio-shared';
+import {NoReactInternals} from 'remotion/no-react';
 import webpack from 'webpack';
 import {copyDir} from './copy-dir';
 import {indexHtml} from './index-html';
@@ -81,7 +82,7 @@ export const getBundleStaticHash = (publicPath: string): string => {
 	);
 };
 
-export type MandatoryLegacyBundleOptions = {
+export type MandatoryBundleInternalsOptions = {
 	bundlerOverride?: BundlerOverrideFn;
 	rspackOverride?: RspackOverrideFn;
 	webpackOverride: WebpackOverrideFn;
@@ -105,7 +106,17 @@ export type MandatoryLegacyBundleOptions = {
 	symlinkPublicDir: boolean;
 };
 
-export type LegacyBundleOptions = Partial<MandatoryLegacyBundleOptions>;
+type V4LegacyBundleOptions = Partial<MandatoryBundleInternalsOptions>;
+
+export type MandatoryLegacyBundleOptions =
+	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
+		? never
+		: MandatoryBundleInternalsOptions;
+
+export type LegacyBundleOptions =
+	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
+		? never
+		: V4LegacyBundleOptions;
 
 export const getConfig = ({
 	entryPoint,
@@ -118,7 +129,7 @@ export const getConfig = ({
 	entryPoint: string;
 	resolvedRemotionRoot: string;
 	onProgress: (progress: number) => void;
-	options: MandatoryLegacyBundleOptions;
+	options: MandatoryBundleInternalsOptions;
 }) => {
 	const configArgs = {
 		entry: path.join(
@@ -150,7 +161,6 @@ export const getConfig = ({
 };
 
 type NewBundleOptions = {
-	entryPoint: string;
 	onProgress: (progress: number) => void;
 	ignoreRegisterRootWarning: boolean;
 	onDirectoryCreated: (dir: string) => void;
@@ -164,33 +174,47 @@ type NewBundleOptions = {
 type MandatoryBundleOptions = {
 	entryPoint: string;
 } & NewBundleOptions &
-	MandatoryLegacyBundleOptions;
+	MandatoryBundleInternalsOptions;
 
 export type BundleOptions = {
 	entryPoint: string;
 } & Partial<NewBundleOptions> &
-	LegacyBundleOptions;
+	Partial<MandatoryBundleInternalsOptions>;
 
-type Arguments =
+type V4BundleArguments =
 	| [options: BundleOptions]
 	| [
 			entryPoint: string,
 			onProgress?: (progress: number) => void,
-			options?: LegacyBundleOptions,
+			options?: V4LegacyBundleOptions,
 	  ];
 
-const convertArgumentsIntoOptions = (args: Arguments): BundleOptions => {
+type BundleArguments =
+	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
+		? [options: BundleOptions]
+		: V4BundleArguments;
+
+export const convertBundleArgumentsIntoOptions = (
+	args: V4BundleArguments,
+	enableV5BreakingChanges: boolean,
+): BundleOptions => {
 	if ((args.length as number) === 0) {
 		throw new TypeError('bundle() was called without arguments');
 	}
 
 	const firstArg = args[0];
 	if (typeof firstArg === 'string') {
-		return {
-			entryPoint: firstArg,
-			onProgress: args[1],
-			...(args[2] ?? {}),
-		};
+		if (!enableV5BreakingChanges) {
+			return {
+				entryPoint: firstArg,
+				onProgress: args[1],
+				...(args[2] ?? {}),
+			};
+		}
+
+		throw new TypeError(
+			'bundle() no longer supports the legacy positional arguments. Pass an options object instead: bundle({entryPoint, onProgress, ...options}).',
+		);
 	}
 
 	if (typeof firstArg.entryPoint !== 'string') {
@@ -446,8 +470,11 @@ export const internalBundle = async (
  * @description Bundles a Remotion project and prepares it for rendering.
  * @see [Documentation](https://remotion.dev/docs/bundle)
  */
-export async function bundle(...args: Arguments): Promise<string> {
-	const actualArgs = convertArgumentsIntoOptions(args);
+export async function bundle(...args: BundleArguments): Promise<string> {
+	const actualArgs = convertBundleArgumentsIntoOptions(
+		args,
+		NoReactInternals.ENABLE_V5_BREAKING_CHANGES,
+	);
 	const result = await internalBundle({
 		bufferStateDelayInMilliseconds:
 			actualArgs.bufferStateDelayInMilliseconds ?? null,

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -28,6 +28,7 @@ export {
 	BundleOptions,
 	LegacyBundleOptions,
 	MandatoryLegacyBundleOptions,
+	MandatoryBundleInternalsOptions,
 } from './bundle';
 export type {
 	BundlerConfiguration,

--- a/packages/bundler/src/test/validate-bundle.test.ts
+++ b/packages/bundler/src/test/validate-bundle.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {bundle} from '../bundle';
+import {bundle, convertBundleArgumentsIntoOptions} from '../bundle';
 
 test('Should reject bad bundle options', () => {
 	// @ts-expect-error
@@ -8,5 +8,18 @@ test('Should reject bad bundle options', () => {
 	// @ts-expect-error
 	expect(() => bundle({})).toThrow(
 		/bundle\(\) was called without the `entryPoint` option/,
+	);
+});
+
+test('Should gate the legacy positional bundle() signature', () => {
+	expect(convertBundleArgumentsIntoOptions(['src/index.ts'], false)).toEqual({
+		entryPoint: 'src/index.ts',
+		onProgress: undefined,
+	});
+
+	expect(() =>
+		convertBundleArgumentsIntoOptions(['src/index.ts'], true),
+	).toThrow(
+		'bundle() no longer supports the legacy positional arguments. Pass an options object instead: bundle({entryPoint, onProgress, ...options}).',
 	);
 });

--- a/packages/cli/src/setup-cache.ts
+++ b/packages/cli/src/setup-cache.ts
@@ -2,7 +2,7 @@ import {existsSync} from 'fs';
 import path from 'path';
 import type {
 	BundlerOverrideFn,
-	MandatoryLegacyBundleOptions,
+	MandatoryBundleInternalsOptions,
 	RspackOverrideFn,
 	WebpackOverrideFn,
 } from '@remotion/bundler';
@@ -226,7 +226,7 @@ export const bundleOnCli = async ({
 		updateProgress(false);
 	};
 
-	const options: MandatoryLegacyBundleOptions = {
+	const options: MandatoryBundleInternalsOptions = {
 		enableCaching: shouldCache,
 		bundlerOverride: bundlerOverride ?? ConfigInternals.getBundlerOverrideFn(),
 		rspackOverride: rspackOverride ?? ConfigInternals.getRspackOverrideFn(),

--- a/packages/docs/blog/2021-08-11-remotion-2-3.mdx
+++ b/packages/docs/blog/2021-08-11-remotion-2-3.mdx
@@ -62,7 +62,7 @@ npx remotion still --props='{"custom": "data"}'  my-comp out.png
 
 If you render using the Node.JS APIs, we have a new equivalent API for rendering stills as well.
 
-```ts twoslash
+```ts
 import {bundle} from '@remotion/bundler';
 import {getCompositions, renderStill} from '@remotion/renderer';
 

--- a/packages/docs/blog/2022-11-17-remotion-3-3.mdx
+++ b/packages/docs/blog/2022-11-17-remotion-3-3.mdx
@@ -207,7 +207,7 @@ Previously, the progress for rendering and encoding was reported individually. T
 
 Previously, [`bundle()`](/docs/bundle) accepted three arguments: `entryPoint`, `onProgress` and `options`.
 
-```ts twoslash title="Old bundle() signature"
+```ts title="Old bundle() signature"
 import {bundle} from '@remotion/bundler';
 
 bundle('./src/index.ts', (progress) => console.log(progress), {

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -44,6 +44,21 @@ A common footgun was the render was not working as intended because the input pr
 
 **Required action**: Pass an empty object `{}` if you don't have any input props.
 
+## `bundle()` and `getCompositions()` now take an options object
+
+The legacy positional signatures of [`bundle()`](/docs/bundle) and [`getCompositions()`](/docs/renderer/get-compositions) have been removed.
+The return value of `bundle()` remains the output directory as a string.
+
+**Required action**: Move positional arguments into an options object:
+
+```diff title="Before and after"
+- bundle(entryPoint, onProgress, options)
++ bundle({entryPoint, onProgress, ...options})
+
+- getCompositions(serveUrl, options)
++ getCompositions({serveUrl, ...options})
+```
+
 ## `visualizeAudio()` yields different result
 
 [`optimizeFor: "speed"`](/docs/visualize-audio#optimizefor) is now the default. This will yield slightly different results.

--- a/packages/docs/docs/audio/exporting.mdx
+++ b/packages/docs/docs/audio/exporting.mdx
@@ -40,7 +40,9 @@ const compositionId = 'HelloWorld';
 // You only have to do this once, you can reuse the bundle.
 const entry = './src/index';
 console.log('Creating a Webpack bundle of the video');
-const bundleLocation = await bundle(path.resolve(entry), () => undefined, {
+const bundleLocation = await bundle({
+  entryPoint: path.resolve(entry),
+  onProgress: () => undefined,
   // If you have a Webpack override, make sure to add it here
   webpackOverride: (config) => config,
 });
@@ -52,7 +54,8 @@ const inputProps = {
 
 // Extract all the compositions you have defined in your project
 // from the webpack bundle.
-const comps = await getCompositions(bundleLocation, {
+const comps = await getCompositions({
+  serveUrl: bundleLocation,
   // You can pass custom input props that you can retrieve using getInputProps()
   // in the composition list. Use this if you want to dynamically set the duration or
   // dimensions of the video.
@@ -149,7 +152,9 @@ const compositionId = 'HelloWorld';
 // You only have to do this once, you can reuse the bundle.
 const entry = './src/index';
 console.log('Creating a Webpack bundle of the video');
-const bundleLocation = await bundle(path.resolve(entry), () => undefined, {
+const bundleLocation = await bundle({
+  entryPoint: path.resolve(entry),
+  onProgress: () => undefined,
   // If you have a Webpack override, make sure to add it here
   webpackOverride: (config) => config,
 });
@@ -161,7 +166,8 @@ const inputProps = {
 
 // Extract all the compositions you have defined in your project
 // from the webpack bundle.
-const comps = await getCompositions(bundleLocation, {
+const comps = await getCompositions({
+  serveUrl: bundleLocation,
   // You can pass custom input props that you can retrieve using getInputProps()
   // in the composition list. Use this if you want to dynamically set the duration or
   // dimensions of the video.

--- a/packages/docs/docs/bundle.mdx
+++ b/packages/docs/docs/bundle.mdx
@@ -169,7 +169,7 @@ await bundle('src/index.ts', () => console.log(progress * 100 + '% done'), {
 });
 ```
 
-It is still supported in Remotion v3, but we encourage to migrate to the new function signature.
+It is supported through Remotion v4 and removed in Remotion v5. Migrate to the options object signature before upgrading.
 
 ## Return value
 

--- a/packages/docs/docs/bundle.mdx
+++ b/packages/docs/docs/bundle.mdx
@@ -169,7 +169,7 @@ await bundle('src/index.ts', () => console.log(progress * 100 + '% done'), {
 });
 ```
 
-It is supported through Remotion v4 and removed in Remotion v5. Migrate to the options object signature before upgrading.
+It is supported through Remotion v4 and removed in Remotion 5.0. Migrate to the options object signature before upgrading.
 
 ## Return value
 

--- a/packages/docs/docs/layout-utils/best-practices.mdx
+++ b/packages/docs/docs/layout-utils/best-practices.mdx
@@ -206,7 +206,7 @@ Pass `validateFontIsLoaded: true` to any of [`measureText()`](/docs/layout-utils
 This will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 :::note
-In Remotion v5, this will become the default.
+In Remotion 5.0, this will become the default.
 :::
 
 ## Match all font properties

--- a/packages/docs/docs/player/player-integration.mdx
+++ b/packages/docs/docs/player/player-integration.mdx
@@ -197,7 +197,9 @@ In any Node.JS context, you can call [`bundle()`](/docs/bundle) to bundle your v
 import path from 'path';
 import {bundle} from '@remotion/bundler';
 
-const bundled = await bundle(path.join(process.cwd(), 'src', 'remotion', 'index.ts'));
+const bundled = await bundle({
+  entryPoint: path.join(process.cwd(), 'src', 'remotion', 'index.ts'),
+});
 ```
 
 See [Server-side rendering](/docs/ssr) for a full example.

--- a/packages/docs/docs/render-all.mdx
+++ b/packages/docs/docs/render-all.mdx
@@ -49,7 +49,10 @@ const bundled = await bundle({
   webpackOverride: (config) => config,
 });
 
-const compositions = await getCompositions(bundled);
+const compositions = await getCompositions({
+  serveUrl: bundled,
+  inputProps: {},
+});
 
 for (const composition of compositions) {
   console.log(`Rendering ${composition.id}...`);

--- a/packages/docs/docs/renderer/get-compositions.mdx
+++ b/packages/docs/docs/renderer/get-compositions.mdx
@@ -11,7 +11,7 @@ Gets a list of compositions defined in a Remotion project based on a [Remotion B
 
 For every compositions their [`calculateMetadata()`](/docs/composition#calculatemetadata) function is evaluated. If you just want to evaluate one composition that you want to render, use [`selectComposition()`](/docs/renderer/select-composition).
 
-The new signature, from [v4.0.497](https://github.com/remotion-dev/remotion/releases/v4.0.497) is:
+The options object signature is available from [v4.0.497](https://github.com/remotion-dev/remotion/releases/v4.0.497) and is the only signature in Remotion v5:
 
 ```ts twoslash title="Example"
 import {bundle} from '@remotion/bundler';
@@ -25,7 +25,7 @@ const compositions = await getCompositions({
 });
 ```
 
-Use [the old signature](#legacy-function-signature) for versions below 4.0.496. It remains supported.
+Use [the positional signature](#legacy-function-signature) for versions below v4.0.497. It remains supported through Remotion v4.
 
 ## Arguments
 
@@ -160,15 +160,17 @@ An absolute path overriding the `ffprobe` executable to use.
 
 ## Legacy function signature
 
-The positional function signature is also supported for backwards compatibility:
+The positional function signature is supported through Remotion v4 and removed in Remotion v5:
 
-```ts twoslash title="Legacy signature"
+```ts title="Legacy signature"
 import {getCompositions} from '@remotion/renderer';
 
 const compositions = await getCompositions('https://example.com', {
   inputProps: {},
 });
 ```
+
+Migrate to the options object signature before upgrading to Remotion v5.
 
 ## Return value
 

--- a/packages/docs/docs/renderer/get-compositions.mdx
+++ b/packages/docs/docs/renderer/get-compositions.mdx
@@ -11,7 +11,7 @@ Gets a list of compositions defined in a Remotion project based on a [Remotion B
 
 For every compositions their [`calculateMetadata()`](/docs/composition#calculatemetadata) function is evaluated. If you just want to evaluate one composition that you want to render, use [`selectComposition()`](/docs/renderer/select-composition).
 
-The options object signature is available from [v4.0.497](https://github.com/remotion-dev/remotion/releases/v4.0.497) and is the only signature in Remotion v5:
+The options object signature is available from [v4.0.497](https://github.com/remotion-dev/remotion/releases/v4.0.497) and is the only signature in Remotion 5.0:
 
 ```ts twoslash title="Example"
 import {bundle} from '@remotion/bundler';
@@ -160,7 +160,7 @@ An absolute path overriding the `ffprobe` executable to use.
 
 ## Legacy function signature
 
-The positional function signature is supported through Remotion v4 and removed in Remotion v5:
+The positional function signature is supported through Remotion v4 and removed in Remotion 5.0:
 
 ```ts title="Legacy signature"
 import {getCompositions} from '@remotion/renderer';
@@ -170,7 +170,7 @@ const compositions = await getCompositions('https://example.com', {
 });
 ```
 
-Migrate to the options object signature before upgrading to Remotion v5.
+Migrate to the options object signature before upgrading to Remotion 5.0.
 
 ## Return value
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -29,7 +29,8 @@ const serveUrl = await bundle({
   entryPoint: require.resolve('./src/index.ts'),
 });
 
-const comps = await getCompositions(serveUrl, {
+const comps = await getCompositions({
+  serveUrl,
   inputProps: {
     custom: 'data',
   },

--- a/packages/docs/render-cards.ts
+++ b/packages/docs/render-cards.ts
@@ -1,9 +1,9 @@
-import {bundle} from '@remotion/bundler';
-import {getCompositions, renderStill} from '@remotion/renderer';
 import {execSync} from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {bundle} from '@remotion/bundler';
+import {getCompositions, renderStill} from '@remotion/renderer';
 import {readDir} from './get-pages.mjs';
 
 const data: {
@@ -176,7 +176,10 @@ const serveUrl = await bundle({
 	entryPoint: path.join(process.cwd(), './src/remotion/entry.ts'),
 	publicDir: path.join(process.cwd(), 'static'),
 });
-const compositions = await getCompositions(serveUrl);
+const compositions = await getCompositions({
+	serveUrl,
+	inputProps: {},
+});
 
 for (const composition of compositions.filter(
 	(c) => c.id.startsWith('expert') || c.id.startsWith('template'),

--- a/packages/docs/render-element-previews.ts
+++ b/packages/docs/render-element-previews.ts
@@ -89,7 +89,10 @@ const serveUrl = await bundle({
 	entryPoint: path.join(process.cwd(), 'src', 'remotion', 'entry.ts'),
 	publicDir: path.join(process.cwd(), 'static'),
 });
-const compositions = await getCompositions(serveUrl);
+const compositions = await getCompositions({
+	serveUrl,
+	inputProps: {},
+});
 const elementCompositions = compositions.filter((composition) =>
 	composition.id.startsWith('element-'),
 );

--- a/packages/example/render-all.ts
+++ b/packages/example/render-all.ts
@@ -8,7 +8,10 @@ const start = async () => {
 		webpackOverride,
 	});
 
-	const compositions = await getCompositions(bundled);
+	const compositions = await getCompositions({
+		serveUrl: bundled,
+		inputProps: {},
+	});
 
 	for (const composition of compositions) {
 		console.log(`Rendering ${composition.id}...`);

--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -16,7 +16,8 @@ test(
 	'Legacy SSR way of rendering videos should still work',
 	async () => {
 		const puppeteerInstance = await openBrowser('chrome');
-		const compositions = await getCompositions(exampleBuild, {
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
 			puppeteerInstance,
 			inputProps: {},
 		});

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -42,7 +42,10 @@ const getSampleRateFromFile = async (filePath: string): Promise<number> => {
 test(
 	'Render video with sampleRate 44100 should produce 44100 Hz audio',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 		const comp = compositions.find((c) => c.id === 'audio-testing');
 
 		if (!comp) {
@@ -71,7 +74,10 @@ test(
 test(
 	'Render video with default sampleRate should produce 48000 Hz audio',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 		const comp = compositions.find((c) => c.id === 'audio-testing');
 
 		if (!comp) {

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -10,7 +10,8 @@ test(
 	'Render video with browser instance open',
 	async () => {
 		const puppeteerInstance = await openBrowser('chrome');
-		const compositions = await getCompositions(exampleBuild, {
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
 			puppeteerInstance,
 			inputProps: {},
 		});
@@ -42,7 +43,10 @@ test(
 );
 
 test('Render video with browser instance not open', async () => {
-	const compositions = await getCompositions(exampleBuild);
+	const compositions = await getCompositions({
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
 
 	const reactSvg = compositions.find((c) => c.id === 'react-svg');
 
@@ -109,7 +113,10 @@ test('should fail on invalid CRF', async () => {
 });
 
 test('Render video to a buffer', async () => {
-	const compositions = await getCompositions(exampleBuild);
+	const compositions = await getCompositions({
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
 
 	const reactSvg = compositions.find((c) => c.id === 'react-svg');
 

--- a/packages/it-tests/src/ssr/render-still.test.ts
+++ b/packages/it-tests/src/ssr/render-still.test.ts
@@ -46,7 +46,10 @@ test('Render video with browser instance open', async () => {
 test(
 	'Render still with browser instance not open and legacy webpack config',
 	async () => {
-		const compositions = await getCompositions(exampleBuild);
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			inputProps: {},
+		});
 
 		const reactSvg = compositions.find((c) => c.id === 'react-svg');
 

--- a/packages/lambda/src/test/mocks/mock-bundle-site.ts
+++ b/packages/lambda/src/test/mocks/mock-bundle-site.ts
@@ -1,30 +1,22 @@
 import type {bundle, BundleOptions} from '@remotion/bundler';
 
-const convertArgumentsIntoOptions = (
-	args: Parameters<typeof bundle>,
-): BundleOptions => {
-	if ((args.length as number) === 0) {
+const validateOptions = (options: BundleOptions): BundleOptions => {
+	if (!options) {
 		throw new TypeError('bundle() was called without arguments');
 	}
 
-	const firstArg = args[0];
-	if (typeof firstArg === 'string') {
-		return {
-			entryPoint: firstArg,
-			onProgress: args[1],
-			...(args[2] ?? {}),
-		};
-	}
-
-	if (typeof firstArg.entryPoint !== 'string') {
+	if (typeof options.entryPoint !== 'string') {
 		throw new TypeError('bundle() was called without the `entryPoint` option');
 	}
 
-	return firstArg;
+	return options;
 };
 
 export const mockBundleSite: typeof bundle = (...args) => {
-	const {entryPoint} = convertArgumentsIntoOptions(args);
+	const firstArg = args[0] as BundleOptions | string;
+	const options =
+		typeof firstArg === 'string' ? {entryPoint: firstArg} : firstArg;
+	const {entryPoint} = validateOptions(options);
 	if (entryPoint === 'first') {
 		return Promise.resolve('/path/to/bundle-1');
 	}

--- a/packages/renderer/src/get-compositions.ts
+++ b/packages/renderer/src/get-compositions.ts
@@ -38,7 +38,7 @@ type InternalGetCompositionsOptions = {
 	onLog: OnLog;
 } & ToOptions<typeof optionsMap.getCompositions>;
 
-export type LegacyGetCompositionsOptions = RequiredInputPropsInV5 & {
+type SharedGetCompositionsOptions = {
 	envVariables?: Record<string, string>;
 	puppeteerInstance?: HeadlessBrowser;
 	onBrowserLog?: (log: BrowserLog) => void;
@@ -47,16 +47,32 @@ export type LegacyGetCompositionsOptions = RequiredInputPropsInV5 & {
 	port?: number | null;
 } & Partial<ToOptions<typeof optionsMap.getCompositions>>;
 
-export type GetCompositionsOptions = LegacyGetCompositionsOptions & {
-	serveUrl: string;
-};
+type V4LegacyGetCompositionsOptions = {
+	inputProps?: Record<string, unknown>;
+} & SharedGetCompositionsOptions;
+
+export type LegacyGetCompositionsOptions =
+	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
+		? never
+		: V4LegacyGetCompositionsOptions;
+
+export type GetCompositionsOptions = RequiredInputPropsInV5 &
+	SharedGetCompositionsOptions & {
+		serveUrl: string;
+	};
+
+type V4GetCompositionsArguments =
+	| [options: GetCompositionsOptions]
+	| [serveUrlOrWebpackUrl: string, config?: V4LegacyGetCompositionsOptions];
 
 type GetCompositionsArguments =
-	| [options: GetCompositionsOptions]
-	| [serveUrlOrWebpackUrl: string, config?: LegacyGetCompositionsOptions];
+	typeof NoReactInternals.ENABLE_V5_BREAKING_CHANGES extends true
+		? [options: GetCompositionsOptions]
+		: V4GetCompositionsArguments;
 
-const convertGetCompositionsArgumentsToOptions = (
-	args: GetCompositionsArguments,
+export const convertGetCompositionsArgumentsToOptions = (
+	args: V4GetCompositionsArguments,
+	enableV5BreakingChanges: boolean,
 ): GetCompositionsOptions => {
 	if ((args.length as number) === 0) {
 		throw new Error(
@@ -66,10 +82,16 @@ const convertGetCompositionsArgumentsToOptions = (
 
 	const firstArg = args[0];
 	if (typeof firstArg === 'string') {
+		if (enableV5BreakingChanges) {
+			throw new TypeError(
+				'getCompositions() no longer supports the legacy positional arguments. Pass an options object instead: getCompositions({serveUrl, ...options}).',
+			);
+		}
+
 		return {
 			...(args[1] ?? {}),
 			serveUrl: firstArg,
-		};
+		} as GetCompositionsOptions;
 	}
 
 	return firstArg;
@@ -311,7 +333,11 @@ export const internalGetCompositions = wrapWithErrorHandling(
 export const getCompositions = (
 	...args: GetCompositionsArguments
 ): Promise<VideoConfig[]> => {
-	const options = convertGetCompositionsArgumentsToOptions(args);
+	const options = convertGetCompositionsArgumentsToOptions(
+		args,
+		NoReactInternals.ENABLE_V5_BREAKING_CHANGES,
+	);
+
 	if (typeof options?.serveUrl !== 'string' || !options.serveUrl) {
 		throw new Error(
 			'No serve URL or webpack bundle directory was passed to getCompositions().',

--- a/packages/renderer/src/test/get-compositions.test.ts
+++ b/packages/renderer/src/test/get-compositions.test.ts
@@ -1,0 +1,20 @@
+import {expect, test} from 'bun:test';
+import {convertGetCompositionsArgumentsToOptions} from '../get-compositions';
+
+test('Should gate the legacy positional getCompositions() signature', () => {
+	expect(
+		convertGetCompositionsArgumentsToOptions(
+			['https://example.com', {inputProps: {title: 'Hello'}}],
+			false,
+		),
+	).toEqual({
+		serveUrl: 'https://example.com',
+		inputProps: {title: 'Hello'},
+	});
+
+	expect(() =>
+		convertGetCompositionsArgumentsToOptions(['https://example.com'], true),
+	).toThrow(
+		'getCompositions() no longer supports the legacy positional arguments. Pass an options object instead: getCompositions({serveUrl, ...options}).',
+	);
+});

--- a/packages/template-skia/README.md
+++ b/packages/template-skia/README.md
@@ -42,7 +42,9 @@ npx remotion upgrade
 This template uses a [custom Webpack override](https://www.remotion.dev/docs/bundlers). If you are using server-side rendering, you need to import `enableSkia` from `@remotion/skia/enable` and pass it to [`bundle()`](https://www.remotion.dev/docs/bundle) (if using SSR) and [`deploySite()`](https://www.remotion.dev/docs/lambda/deploysite) (if using Lambda):
 
 ```ts
-bundle(entry, () => undefined, {
+bundle({
+  entryPoint: entry,
+  onProgress: () => undefined,
   webpackOverride: (config) => enableSkia(config),
 });
 // or

--- a/packages/template-still/src/server/index.ts
+++ b/packages/template-still/src/server/index.ts
@@ -22,7 +22,9 @@ dotenv.config({ quiet: true });
 const app = express();
 const port = process.env.PORT || 8000;
 
-const webpackBundling = bundle(path.join(process.cwd(), "src/index.ts"));
+const webpackBundling = bundle({
+  entryPoint: path.join(process.cwd(), "src/index.ts"),
+});
 const tmpDir = fs.promises.mkdtemp(path.join(os.tmpdir(), "remotion-"));
 
 enum Params {


### PR DESCRIPTION
## Summary

- gate the `bundle()` and `getCompositions()` public signatures and runtime validation behind `ENABLE_V5_BREAKING_CHANGES`
- preserve both positional APIs in Remotion v4 while exposing only the options-object APIs in Remotion 5.0
- keep the `bundle()` return value as the output-directory string
- migrate current callers and templates to the options-object signatures
- document the migration and add focused coverage for both compatibility paths

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/bundler/src/test/validate-bundle.test.ts packages/renderer/src/test/get-compositions.test.ts packages/it-tests/src/rendering/get-compositions.test.ts`
- temporarily enabled `ENABLE_V5_BREAKING_CHANGES` and verified the generated declarations only expose the options-object signatures
- compiled `@remotion/bundler`, `@remotion/cli`, `@remotion/lambda`, and `template-still` against the v5 declarations

Closes #9486

## Preview

- [Remotion 2.3 blog post](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/blog/2-3)
- [Remotion 3.3 blog post](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/blog/3-3)
- [v5.0 Migration](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/5-0-migration)
- [Exporting Audio](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/audio/exporting)
- [`bundle()`](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/bundle)
- [Layout utils best practices](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/layout-utils/best-practices)
- [Player code sharing](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/player/integration)
- [Render all compositions](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/render-all)
- [`getCompositions()`](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/renderer/get-compositions)
- [`renderStill()`](https://remotion-git-codex-remove-v5-legacy-bundle-signatures-remotion.vercel.app/docs/renderer/render-still)
