### PR TITLE
Docs: Document validateFontIsLoaded default for v5

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -142,6 +142,12 @@ loadFont('normal', {
 });
 ```
 
+## `validateFontIsLoaded` is now `true` by default in `@remotion/layout-utils`
+
+[`measureText()`](/docs/layout-utils/measure-text), [`fitText()`](/docs/layout-utils/fit-text), [`fillTextBox()`](/docs/layout-utils/fill-text-box), and [`fitTextOnNLines()`](/docs/layout-utils/fit-text-on-n-lines) now default `validateFontIsLoaded` to `true`.
+
+**Required action**: Ensure custom fonts are loaded before calling these APIs, or pass `validateFontIsLoaded: false` explicitly to keep the previous behavior. See [layout utils best practices](/docs/layout-utils/best-practices).
+
 ## Sequences are automatically premounted
 
 [`<Sequence>`](/docs/sequence), [`<Series.Sequence>`](/docs/series) and [`<TransitionSeries.Sequence>`](/docs/transitions/transitionseries) components now automatically [premount](/docs/player/premounting) for 1 second (`fps` frames) before they appear.

--- a/packages/docs/docs/layout-utils/best-practices.mdx
+++ b/packages/docs/docs/layout-utils/best-practices.mdx
@@ -201,13 +201,11 @@ export const MyComp: React.FC = () => {
 
 ### Use the `validateFontIsLoaded` option<AvailableFrom v="4.0.136"/>
 
-Pass `validateFontIsLoaded: true` to any of [`measureText()`](/docs/layout-utils/measure-text), [`fitText()`](/docs/layout-utils/fit-text), and [`fillTextBox()`](/docs/layout-utils/fill-text-box) to validate that the font family you passed is actually loaded.
+[`measureText()`](/docs/layout-utils/measure-text), [`fitText()`](/docs/layout-utils/fit-text), [`fillTextBox()`](/docs/layout-utils/fill-text-box), and [`fitTextOnNLines()`](/docs/layout-utils/fit-text-on-n-lines) validate that the font family you passed is actually loaded when `validateFontIsLoaded` is enabled.
 
-This will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+Starting with Remotion 5.0, `validateFontIsLoaded` defaults to `true`. Pass `validateFontIsLoaded: false` to disable the check.
 
-:::note
-In Remotion v5, this will become the default.
-:::
+This takes a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 ## Match all font properties
 

--- a/packages/docs/docs/layout-utils/fill-text-box.mdx
+++ b/packages/docs/docs/layout-utils/fill-text-box.mdx
@@ -90,7 +90,7 @@ Same as CSS style `text-transform`.
 
 _boolean_
 
-If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+Defaults to `true` in Remotion 5.0 (previously `false`). When enabled, takes a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 #### `additionalStyles?`<AvailableFrom v="4.0.140"/>
 

--- a/packages/docs/docs/layout-utils/fit-text-on-n-lines.mdx
+++ b/packages/docs/docs/layout-utils/fit-text-on-n-lines.mdx
@@ -107,7 +107,7 @@ Same as CSS style `text-transform`.
 
 _boolean_
 
-If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+Defaults to `true` in Remotion 5.0 (previously `false`). When enabled, takes a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 ### `additionalStyles?`
 

--- a/packages/docs/docs/layout-utils/fit-text.mdx
+++ b/packages/docs/docs/layout-utils/fit-text.mdx
@@ -98,7 +98,7 @@ Same as CSS style `text-transform`.
 
 _boolean_
 
-If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+Defaults to `true` in Remotion 5.0 (previously `false`). When enabled, takes a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 ### `additionalStyles?`<AvailableFrom v="4.0.140"/>
 

--- a/packages/docs/docs/layout-utils/measure-text.mdx
+++ b/packages/docs/docs/layout-utils/measure-text.mdx
@@ -80,7 +80,7 @@ Same as CSS style `text-transform`.
 
 _boolean_
 
-If set to `true`, will take a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
+Defaults to `true` in Remotion 5.0 (previously `false`). When enabled, takes a second measurement with the fallback font and if it produces the same measurements, it assumes the fallback font was used and will throw an error.
 
 ### `additionalStyles?`<AvailableFrom v="4.0.140"/>
 


### PR DESCRIPTION
Closes #9485

## Problem

Remotion 5.0 makes `validateFontIsLoaded` default to `true` in `@remotion/layout-utils`, but the v5 migration guide and layout-utils API docs still describe the option as opt-in only. The best-practices page still says the default change is upcoming.

## Triage / Root cause

Issue #9485 tracks the documentation follow-up after the v5 masterplan decision ([#3310](https://github.com/remotion-dev/remotion/issues/3310)). The migration guide had no entry for this default change, and the four affected API pages plus best-practices still used pre-v5 wording.

## Fix

- Add a `validateFontIsLoaded` section to `packages/docs/docs/5-0-migration.mdx` with required action and opt-out guidance.
- Update `measure-text`, `fit-text`, `fill-text-box`, and `fit-text-on-n-lines` API docs to state the v5 default.
- Refresh `layout-utils/best-practices.mdx` to describe the new default instead of the old "will become the default" note.

## Verification

- `bunx oxfmt --check` on all six changed MDX files — pass.
- `python3 ../scripts/preflight_ship.py` against `remotion-dev/remotion` — clear (no duplicate PRs; upstream still missing the migration section).
- `bun run stylecheck` at repo root fails on unrelated upstream `@remotion/light-leaks#make` (`TS2307: Cannot find module '@remotion/effects/light-leak'`). No files outside `packages/docs/` were changed.

## Notes / Risks

Docs-only change. No release note expected for documentation.

Made with [Cursor](https://cursor.com)