### PR TITLE
`@remotion/studio`: Preview sequence outlines on hover

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -24,6 +24,7 @@ import {useKeybinding} from '../helpers/use-keybinding';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
+import {TimelineSequenceHoverContext} from '../state/timeline-sequence-hover';
 import {showNotification} from './Notifications/NotificationCenter';
 import {
 	clearSelectedOutlineDragOverrides,
@@ -665,15 +666,15 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 	const {getScaleLockState} = useContext(ScaleLockContext);
 	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
+	const {hoveredSequence, setHoveredSequence} = useContext(
+		TimelineSequenceHoverContext,
+	);
 	const {editorShowGuides, guidesList} = useContext(EditorShowGuidesContext);
 	const {frameBack, frameForward, getCurrentFrame, seek} =
 		PlayerInternals.usePlayer();
 	const keybindings = useKeybinding();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
-	const [hoveredOutlineKey, setHoveredOutlineKey] = useState<string | null>(
-		null,
-	);
 	const [draggingOutline, setDraggingOutline] = useState(false);
 	const [activeSnapPoints, setActiveSnapPoints] = useState<
 		readonly SelectedOutlineSnapPoint[]
@@ -687,14 +688,31 @@ export const SelectedOutlineOverlay: React.FC<{
 	const previewSelectionAvailable =
 		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
 
-	const onDraggingChange = React.useCallback((dragging: boolean) => {
-		setDraggingOutline(dragging);
-		if (dragging) {
-			setHoveredOutlineKey(null);
-		} else {
-			setActiveSnapPoints([]);
-		}
-	}, []);
+	const onDraggingChange = React.useCallback(
+		(dragging: boolean) => {
+			setDraggingOutline(dragging);
+			if (dragging) {
+				setHoveredSequence((currentHover) =>
+					currentHover?.source === 'canvas' ? null : currentHover,
+				);
+			} else {
+				setActiveSnapPoints([]);
+			}
+		},
+		[setHoveredSequence],
+	);
+	const onHoverChange = useCallback(
+		(key: string | null) => {
+			setHoveredSequence((currentHover) => {
+				if (key !== null) {
+					return {key, source: 'canvas'};
+				}
+
+				return currentHover?.source === 'canvas' ? null : currentHover;
+			});
+		},
+		[setHoveredSequence],
+	);
 	const onSnapPointsChange = useCallback(
 		(snapPoints: readonly SelectedOutlineSnapPoint[]) => {
 			setActiveSnapPoints(snapPoints);
@@ -1064,12 +1082,14 @@ export const SelectedOutlineOverlay: React.FC<{
 
 	useEffect(() => {
 		if (
-			hoveredOutlineKey !== null &&
-			!outlineTargets.some((target) => target.key === hoveredOutlineKey)
+			hoveredSequence?.source === 'canvas' &&
+			!outlineTargets.some((target) => target.key === hoveredSequence.key)
 		) {
-			setHoveredOutlineKey(null);
+			setHoveredSequence((currentHover) =>
+				currentHover?.source === 'canvas' ? null : currentHover,
+			);
 		}
-	}, [hoveredOutlineKey, outlineTargets]);
+	}, [hoveredSequence, outlineTargets, setHoveredSequence]);
 
 	const targetsByKey = useMemo(() => {
 		return new Map(outlineTargets.map((target) => [target.key, target]));
@@ -1500,10 +1520,10 @@ export const SelectedOutlineOverlay: React.FC<{
 					allRotationDragTargets={allRotationDragTargets}
 					allScaleDragTargets={allScaleDragTargets}
 					dragging={draggingOutline}
-					hovered={hoveredOutlineKey === outline.key}
+					hovered={hoveredSequence?.key === outline.key}
 					outline={outline}
 					onDraggingChange={onDraggingChange}
-					onHoverChange={setHoveredOutlineKey}
+					onHoverChange={onHoverChange}
 					onSnapPointsChange={onSnapPointsChange}
 					onSelect={selectOutlineItem}
 					scale={scale}

--- a/packages/studio/src/components/ShowOutlinesProvider.tsx
+++ b/packages/studio/src/components/ShowOutlinesProvider.tsx
@@ -4,6 +4,10 @@ import {
 	loadEditorShowOutlinesOption,
 	persistEditorShowOutlinesOption,
 } from '../state/editor-outlines';
+import {
+	TimelineSequenceHoverContext,
+	type TimelineSequenceHover,
+} from '../state/timeline-sequence-hover';
 
 export const ShowOutlinesProvider: React.FC<{
 	readonly children: React.ReactNode;
@@ -11,6 +15,8 @@ export const ShowOutlinesProvider: React.FC<{
 	const [editorShowOutlines, setEditorShowOutlinesState] = useState(() =>
 		loadEditorShowOutlinesOption(),
 	);
+	const [hoveredSequence, setHoveredSequence] =
+		useState<TimelineSequenceHover | null>(null);
 
 	const setEditorShowOutlines = useCallback(
 		(newValue: (prevState: boolean) => boolean) => {
@@ -29,10 +35,16 @@ export const ShowOutlinesProvider: React.FC<{
 			setEditorShowOutlines,
 		};
 	}, [editorShowOutlines, setEditorShowOutlines]);
+	const timelineSequenceHoverCtx = useMemo(
+		() => ({hoveredSequence, setHoveredSequence}),
+		[hoveredSequence],
+	);
 
 	return (
 		<EditorShowOutlinesContext.Provider value={editorShowOutlinesCtx}>
-			{children}
+			<TimelineSequenceHoverContext.Provider value={timelineSequenceHoverCtx}>
+				{children}
+			</TimelineSequenceHoverContext.Provider>
 		</EditorShowOutlinesContext.Provider>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -45,6 +45,7 @@ export const TimelineRowChrome: React.FC<{
 	readonly onSelect: (interaction?: TimelineSelectionInteraction) => void;
 	readonly showSelectedBackground: boolean;
 	readonly containsSelection: boolean;
+	readonly hovered?: boolean;
 	// When set, the chrome is wrapped in an outer container of this height with a
 	// bottom track separator. The background highlight and click target span the
 	// outer (used by sequence rows whose layer is taller than the chrome row).
@@ -53,6 +54,8 @@ export const TimelineRowChrome: React.FC<{
 	readonly onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
 	readonly onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
 	readonly onDoubleClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+	readonly onPointerEnter?: () => void;
+	readonly onPointerLeave?: () => void;
 }> = ({
 	depth,
 	eye,
@@ -66,11 +69,14 @@ export const TimelineRowChrome: React.FC<{
 	onSelect,
 	showSelectedBackground,
 	containsSelection,
+	hovered = false,
 	outerHeight,
 	onDragLeave,
 	onDragOver,
 	onDrop,
 	onDoubleClick,
+	onPointerEnter,
+	onPointerLeave,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const {
@@ -128,6 +134,7 @@ export const TimelineRowChrome: React.FC<{
 		showSelectedBackground,
 		selected,
 		containsSelection,
+		hovered,
 	});
 
 	const innerRowStyle = useMemo(
@@ -190,6 +197,8 @@ export const TimelineRowChrome: React.FC<{
 				onPointerDown={selectable ? onPointerDown : undefined}
 				onContextMenu={selectable ? onContextMenu : undefined}
 				onDoubleClick={onDoubleClick}
+				onPointerEnter={onPointerEnter}
+				onPointerLeave={onPointerLeave}
 			>
 				<div style={innerRowStyle}>{chrome}</div>
 			</div>
@@ -205,6 +214,8 @@ export const TimelineRowChrome: React.FC<{
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onContextMenu={selectable ? onContextMenu : undefined}
 			onDoubleClick={onDoubleClick}
+			onPointerEnter={onPointerEnter}
+			onPointerLeave={onPointerLeave}
 			style={innerRowStyle}
 		>
 			{chrome}

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -25,6 +25,7 @@ import {
 	TIMELINE_BACKGROUND_COLOR,
 	TIMELINE_SELECTED_BACKGROUND_COLOR,
 	TIMELINE_SELECTED_LABEL_BACKGROUND_COLOR,
+	WHITE_ALPHA_05,
 	WHITE_ALPHA_10,
 	WHITE_ALPHA_80,
 } from '../../helpers/colors';
@@ -63,6 +64,7 @@ import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
 
 export const TIMELINE_SELECTED_BACKGROUND = TIMELINE_SELECTED_BACKGROUND_COLOR;
+export const TIMELINE_HOVER_BACKGROUND = WHITE_ALPHA_05;
 export const TIMELINE_SELECTED_LABEL_BACKGROUND =
 	TIMELINE_SELECTED_LABEL_BACKGROUND_COLOR;
 export const TIMELINE_SELECTED_LABEL_TEXT = BLACK;
@@ -108,14 +110,18 @@ export const getTimelineRowHighlightBackground = ({
 	showSelectedBackground,
 	selected,
 	containsSelection,
+	hovered,
 }: {
 	readonly showSelectedBackground: boolean;
 	readonly selected: boolean;
 	readonly containsSelection: boolean;
+	readonly hovered: boolean;
 }): string | undefined => {
-	return showSelectedBackground && (selected || containsSelection)
-		? TIMELINE_SELECTED_BACKGROUND
-		: undefined;
+	if (showSelectedBackground && (selected || containsSelection)) {
+		return TIMELINE_SELECTED_BACKGROUND;
+	}
+
+	return hovered ? TIMELINE_HOVER_BACKGROUND : undefined;
 };
 
 export const TIMELINE_BACKGROUND = TIMELINE_BACKGROUND_COLOR;
@@ -1862,6 +1868,7 @@ export const useTimelineRowContainsSelection = (
 
 export const useTimelineRowHighlightBackground = (
 	nodePathInfo: SequenceNodePathInfo | null,
+	hovered = false,
 ): string | undefined => {
 	const {selected} = useTimelineRowSelection(nodePathInfo);
 	const containsSelection = useTimelineRowContainsSelection(nodePathInfo);
@@ -1869,5 +1876,6 @@ export const useTimelineRowHighlightBackground = (
 		showSelectedBackground: true,
 		selected,
 		containsSelection,
+		hovered,
 	});
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../helpers/timeline-layout';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {ModalsContext} from '../../state/modals';
+import {useTimelineSequenceHover} from '../../state/timeline-sequence-hover';
 import {callApi} from '../call-api';
 import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
 import {useConfirmationDialog} from '../ConfirmationDialog';
@@ -260,6 +261,8 @@ export const TimelineSequenceItem: React.FC<{
 	siblingIndex,
 }) => {
 	const nodePath = nodePathInfo?.sequenceSubscriptionKey ?? null;
+	const {hovered, onPointerEnter, onPointerLeave} =
+		useTimelineSequenceHover(nodePathInfo);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
 	const previewInteractive = previewConnected && isStudioInteractivityEnabled();
@@ -1173,6 +1176,7 @@ export const TimelineSequenceItem: React.FC<{
 			onSelect={onSelect}
 			showSelectedBackground
 			containsSelection={containsSelection}
+			hovered={hovered}
 			outerHeight={outerHeight}
 			onDragLeave={canDropEffect ? onEffectDragLeave : undefined}
 			onDragOver={canDropEffect ? onEffectDragOver : undefined}
@@ -1180,6 +1184,8 @@ export const TimelineSequenceItem: React.FC<{
 			onDoubleClick={
 				canHandleSequenceDoubleClick ? onSequenceDoubleClick : undefined
 			}
+			onPointerEnter={onPointerEnter}
+			onPointerLeave={onPointerLeave}
 		>
 			<div style={labelContainerStyle}>
 				{connectedCompositions.length > 0 ? (

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -5,6 +5,7 @@ import {
 	getTimelineLayerHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
 } from '../../helpers/timeline-layout';
+import {useTimelineSequenceHover} from '../../state/timeline-sequence-hover';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {TimelineExpandedTrackKeyframes} from './TimelineExpandedTrackKeyframes';
 import {
@@ -21,8 +22,12 @@ const TimelineTrackUnmemoized: React.FC<{
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewServerConnected = previewServerState.type === 'connected';
 	const timelineWidth = useContext(TimelineWidthContext);
+	const {hovered, onPointerEnter, onPointerLeave} = useTimelineSequenceHover(
+		track.nodePathInfo,
+	);
 	const rowHighlightBackground = useTimelineRowHighlightBackground(
 		track.nodePathInfo,
+		hovered,
 	);
 
 	const layerStyle = useMemo(
@@ -40,7 +45,7 @@ const TimelineTrackUnmemoized: React.FC<{
 		getIsExpanded(track.nodePathInfo);
 
 	return (
-		<div>
+		<div onPointerEnter={onPointerEnter} onPointerLeave={onPointerLeave}>
 			<div style={layerStyle}>
 				{rowHighlightBackground && timelineWidth !== null ? (
 					<div

--- a/packages/studio/src/state/timeline-sequence-hover.ts
+++ b/packages/studio/src/state/timeline-sequence-hover.ts
@@ -1,0 +1,64 @@
+import type {Dispatch, SetStateAction} from 'react';
+import {createContext, useCallback, useContext, useMemo} from 'react';
+import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
+
+export type TimelineSequenceHover = {
+	readonly key: string;
+	readonly source: 'canvas' | 'timeline';
+};
+
+type TimelineSequenceHoverState = {
+	readonly hoveredSequence: TimelineSequenceHover | null;
+	readonly setHoveredSequence: Dispatch<
+		SetStateAction<TimelineSequenceHover | null>
+	>;
+};
+
+export const TimelineSequenceHoverContext =
+	createContext<TimelineSequenceHoverState>({
+		hoveredSequence: null,
+		setHoveredSequence: () => undefined,
+	});
+
+export const useTimelineSequenceHover = (
+	nodePathInfo: SequenceNodePathInfo | null,
+) => {
+	const {hoveredSequence, setHoveredSequence} = useContext(
+		TimelineSequenceHoverContext,
+	);
+	const sequenceKey = useMemo(
+		() =>
+			nodePathInfo === null
+				? null
+				: timelineNodePathInfoToKey({...nodePathInfo, auxiliaryKeys: []}),
+		[nodePathInfo],
+	);
+
+	const onPointerEnter = useCallback(() => {
+		if (sequenceKey === null) {
+			return;
+		}
+
+		setHoveredSequence({key: sequenceKey, source: 'timeline'});
+	}, [sequenceKey, setHoveredSequence]);
+
+	const onPointerLeave = useCallback(() => {
+		setHoveredSequence((currentHover) => {
+			if (
+				currentHover?.source !== 'timeline' ||
+				currentHover.key !== sequenceKey
+			) {
+				return currentHover;
+			}
+
+			return null;
+		});
+	}, [sequenceKey, setHoveredSequence]);
+
+	return {
+		hovered: sequenceKey !== null && hoveredSequence?.key === sequenceKey,
+		onPointerEnter,
+		onPointerLeave,
+	};
+};

--- a/packages/studio/src/state/timeline-sequence-hover.ts
+++ b/packages/studio/src/state/timeline-sequence-hover.ts
@@ -56,9 +56,10 @@ export const useTimelineSequenceHover = (
 		});
 	}, [sequenceKey, setHoveredSequence]);
 
-	return {
-		hovered: sequenceKey !== null && hoveredSequence?.key === sequenceKey,
-		onPointerEnter,
-		onPointerLeave,
-	};
+	const hovered = sequenceKey !== null && hoveredSequence?.key === sequenceKey;
+
+	return useMemo(
+		() => ({hovered, onPointerEnter, onPointerLeave}),
+		[hovered, onPointerEnter, onPointerLeave],
+	);
 };

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -107,6 +107,7 @@ import {
 	getSelectableTimelineItems,
 	getSelectableTimelineSequenceSelections,
 	getTimelineMarqueeSelection,
+	getTimelineRowHighlightBackground,
 	getTimelineSelectionAfterInteraction,
 	getTimelineSelectionFromNodePathInfo,
 	getTimelineSelectionKey,
@@ -114,6 +115,8 @@ import {
 	isTimelineSelectionModifierEvent,
 	shouldSelectTimelineRowOnPointerDown,
 	TIMELINE_BACKGROUND,
+	TIMELINE_HOVER_BACKGROUND,
+	TIMELINE_SELECTED_BACKGROUND,
 	TIMELINE_TICKS_BACKGROUND,
 	timelineMarqueeRectsIntersect,
 } from '../components/Timeline/TimelineSelection';
@@ -2739,6 +2742,25 @@ test('Timeline from drag removes the prop at the default value', () => {
 test('Timeline colors use the outlines palette', () => {
 	expect(TIMELINE_BACKGROUND).toBe('#0F1113');
 	expect(TIMELINE_TICKS_BACKGROUND).not.toBe(TIMELINE_BACKGROUND);
+});
+
+test('Timeline hover highlight is weaker than selection', () => {
+	expect(
+		getTimelineRowHighlightBackground({
+			showSelectedBackground: true,
+			selected: false,
+			containsSelection: false,
+			hovered: true,
+		}),
+	).toBe(TIMELINE_HOVER_BACKGROUND);
+	expect(
+		getTimelineRowHighlightBackground({
+			showSelectedBackground: true,
+			selected: true,
+			containsSelection: false,
+			hovered: true,
+		}),
+	).toBe(TIMELINE_SELECTED_BACKGROUND);
 });
 
 test('Timeline outlines visibility is enabled by default and persisted', () => {


### PR DESCRIPTION
## Summary

- share hovered sequence identity between the canvas and timeline
- preview canvas outlines when hovering timeline rows
- add a subtle timeline highlight for canvas hover while preserving the stronger selected state

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #7989
