### PR TITLE
`@remotion/studio`: Clip keyframes outside timeline padding

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -1,6 +1,9 @@
 import React, {useContext} from 'react';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {TIMELINE_ITEM_BORDER_BOTTOM} from '../../helpers/timeline-layout';
+import {
+	TIMELINE_ITEM_BORDER_BOTTOM,
+	TIMELINE_PADDING,
+} from '../../helpers/timeline-layout';
 import {getTimelineEasingSegments} from './get-timeline-easing-segments';
 import type {getTimelineKeyframes} from './get-timeline-keyframes';
 import {TimelineKeyframeDiamond} from './TimelineKeyframeDiamond';
@@ -11,8 +14,15 @@ import {
 } from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
-const row: React.CSSProperties = {
+const rowClipper: React.CSSProperties = {
+	marginLeft: -TIMELINE_PADDING,
+	marginRight: -TIMELINE_PADDING,
 	overflow: 'hidden',
+	paddingLeft: TIMELINE_PADDING,
+	paddingRight: TIMELINE_PADDING,
+};
+
+const row: React.CSSProperties = {
 	position: 'relative',
 };
 
@@ -37,33 +47,35 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 	return (
 		<>
 			{showSeparator ? <div style={rowSeparator} /> : null}
-			<div style={{...row, height}}>
-				{rowHighlightBackground && timelineWidth !== null ? (
-					<div
-						style={getTimelineSelectedTrackHighlightStyle(
-							timelineWidth,
-							rowHighlightBackground,
-						)}
-					/>
-				) : null}
-				{easingSegments.map((segment) => (
-					<TimelineKeyframeEasingLine
-						key={`${segment.segmentIndex}-${segment.fromFrame}-${segment.toFrame}`}
-						fromFrame={segment.fromFrame}
-						toFrame={segment.toFrame}
-						rowHeight={height}
-						nodePathInfo={nodePathInfo}
-						segmentIndex={segment.segmentIndex}
-					/>
-				))}
-				{keyframes.map((keyframe) => (
-					<TimelineKeyframeDiamond
-						key={keyframe.frame}
-						frame={keyframe.frame}
-						rowHeight={height}
-						nodePathInfo={nodePathInfo}
-					/>
-				))}
+			<div style={{...rowClipper, height}}>
+				<div style={{...row, height}}>
+					{rowHighlightBackground && timelineWidth !== null ? (
+						<div
+							style={getTimelineSelectedTrackHighlightStyle(
+								timelineWidth,
+								rowHighlightBackground,
+							)}
+						/>
+					) : null}
+					{easingSegments.map((segment) => (
+						<TimelineKeyframeEasingLine
+							key={`${segment.segmentIndex}-${segment.fromFrame}-${segment.toFrame}`}
+							fromFrame={segment.fromFrame}
+							toFrame={segment.toFrame}
+							rowHeight={height}
+							nodePathInfo={nodePathInfo}
+							segmentIndex={segment.segmentIndex}
+						/>
+					))}
+					{keyframes.map((keyframe) => (
+						<TimelineKeyframeDiamond
+							key={keyframe.frame}
+							frame={keyframe.frame}
+							rowHeight={height}
+							nodePathInfo={nodePathInfo}
+						/>
+					))}
+				</div>
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Summary

- clip expanded keyframe rows with a wrapper that reaches into the timeline gutters
- keep frame-zero keyframes fully visible using the shared timeline padding
- prevent out-of-range keyframes from increasing the main timeline scroll width

## Verification

- `bun run build`
- `bun run stylecheck`
- verified in Remotion Studio that an out-of-range keyframe no longer increases the main timeline scroller's `scrollWidth`
