### PR TITLE
docs: Document renderMedia licenseKey requirement for v5

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -180,6 +180,16 @@ This prevents the Player from continuing while media or images are still loading
 
 **Required action**: If you want to keep the old behavior, set `pauseWhenBuffering={false}` on video and audio components and `pauseWhenLoading={false}` on `<Img>` explicitly.
 
+## `renderMedia()` now requires `licenseKey`
+
+In Remotion 4.x, [`licenseKey`](/docs/renderer/render-media#licensekey) was optional on [`renderMedia()`](/docs/renderer/render-media).
+In Remotion 5.0, you must pass `licenseKey: string | null` explicitly.
+
+Pass your license key from [remotion.pro](https://www.remotion.pro) to report usage telemetry.
+Pass `null` to skip sending a usage event.
+
+**Required action**: Add `licenseKey` to every `renderMedia()` call. See [Licensing](/docs/licensing) for when telemetry is required and how to obtain a license key.
+
 ## License changes
 
 Remotion 5.0 has an updated license. View the [license](https://github.com/remotion-dev/remotion/blob/5-0-license/LICENSE.md) here or compare the [changes](https://github.com/remotion-dev/remotion/pull/3750).

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -493,7 +493,9 @@ An option to be used only if implementing a distributed renderer, see [Distribut
 
 <Options id="on-browser-download" />
 
-### `licenseKey?`<AvailableFrom v="4.0.409"/>
+### `licenseKey`<AvailableFrom v="4.0.409"/>
+
+Optional in v4.x, required from v5.0.
 
 <Options id="license-key" />
 


### PR DESCRIPTION
Closes #9539

## Problem

In Remotion 4.x, `licenseKey` on [`renderMedia()`](/docs/renderer/render-media) was optional. Remotion 5.0 makes `licenseKey: string | null` a required property, but the v5 migration guide had no entry for this breaking change and the API reference still labeled the option as `licenseKey?`.

## Triage / Root cause

JonnyBurger filed #9539 to track the documentation follow-up after the v5 type change landed behind `ENABLE_V5_BREAKING_CHANGES`. The migration guide and `render-media.mdx` were never updated to match.

## Fix

- Add a `renderMedia()` / `licenseKey` section to `packages/docs/docs/5-0-migration.mdx` with required action and guidance on when to pass a license key vs `null`.
- Update `packages/docs/docs/renderer/render-media.mdx` to mark `licenseKey` as optional in v4.x and required from v5.0 (same pattern as `inputProps` on `select-composition.mdx`).

## Verification

- Pre-commit docs formatter passed on commit.
- `python3 ../scripts/preflight_ship.py` against `remotion-dev/remotion` — clear before edit (no duplicate PRs; upstream still missing the migration section).
- `bun run stylecheck` at repo root fails on unrelated upstream `@remotion/starburst#make` / `@remotion/light-leaks#make` (`TS2307` missing `@remotion/effects/*` modules). No files outside `packages/docs/` were changed.

## Notes / Risks

Docs-only change scoped to `renderMedia()` as described in #9539. `renderStill()` still documents optional `licenseKey?` because the v5 required-property change applies only to `renderMedia()` in the current types.

Made with [Cursor](https://cursor.com)