### PR TITLE
Internal: Classify test-only PRs as internal

### DIFF
--- a/.agents/skills/pr-name/SKILL.md
+++ b/.agents/skills/pr-name/SKILL.md
@@ -19,7 +19,15 @@ If multiple packages are affected, use the one that you think is most relevant.
 
 ## Special handling
 
-For changes that match one of the categories below, use its special prefix instead of a package name.
+For changes that match one of the categories below, use its special prefix instead of a package name. Classify the change by its user-facing impact, not merely by the package directory containing the changed files.
+
+If a change only adds, fixes, or stabilizes internal tests, test fixtures, snapshots, or test infrastructure, and does not change shipped behavior, use the `Internal:` prefix. This also applies to package-local tests under a published package. Do not use that package's name as the prefix just because the test is located there. The package name may instead appear in the description when useful:
+
+```
+Internal: Stabilize registration range test in `@remotion/transitions`
+```
+
+If shipped implementation changes are accompanied by tests, use the normal affected-package prefix instead.
 
 If the change is about docs only:
 


### PR DESCRIPTION
## Summary

- classify test-only changes by their user-facing impact instead of their package directory
- use `Internal:` for package-local test stabilization work that does not change shipped behavior
- retain package prefixes when implementation changes are accompanied by tests

This avoids package-prefixed titles for internal-only work such as #9661 and #9754.

## Verification

- `bunx oxfmt .agents/skills/pr-name/SKILL.md --write`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
