### PR TITLE
docs: Document ANGLE default and SwiftShader fallback for v5

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -50,12 +50,21 @@ If you use `@remotion/eslint-config`, the minimum ESLint version is now <MinEsli
 
 ## WebGL and WebGPU during rendering are now enabled by default
 
-In Remotion 4.0, the default OpenGL renderer was `null`, which would not enable WebGL or WebGPU.
+In Remotion 4.0, the default OpenGL renderer was <code>null</code>, which would not enable WebGL or WebGPU.
 
-In Remotion 5.0, the default is `angle` with automatic fallback to `swangle`.
-Lambda and Cloud Run continue to use `swangle` by default, because they have no GPU.
+In Remotion 5.0, the default is <code>angle</code> on local renders.
+When no compatible GPU is available, Remotion opts into Chromium's automatic SwiftShader fallback via <code>--enable-unsafe-swiftshader</code>, so WebGL content can render on GPU-less machines such as GitHub Actions runners.
 
-**Required action**: If you used `--gl=angle` before, you can now remove it.
+On [Lambda](/docs/lambda), <code>swangle</code> remains the effective default (<code>angle</code> is converted to <code>swangle</code> in the Lambda handler).
+On [Cloud Run](/docs/cloudrun), <code>angle</code> is now the default in Remotion 5.0 (previously <code>null</code>, which Cloud Run mapped to <code>swangle</code>).
+
+**Required action**: Remove redundant <code>--gl=angle</code> configuration if you only added it to enable WebGL.
+Pass <code>chromiumOptions.gl: null</code> to restore the Remotion 4.x behavior and let Chrome decide.
+See [OpenGL renderer options](/docs/gl-options) for when to override the default.
+
+**Performance**: SwiftShader fallback is slower than hardware rendering but enables WebGL where it previously failed.
+
+**Security**: <code>--enable-unsafe-swiftshader</code> lowers Chromium's security guarantees and is intended for trusted rendering workloads.
 
 ## `selectComposition()` and `getCompositions()` now require `inputProps`
 
@@ -188,22 +197,6 @@ This prevents black frames that were commonly seen when a `<Sequence>` containin
 This prevents the Player from continuing while media or images are still loading.
 
 **Required action**: If you want to keep the old behavior, set `pauseWhenBuffering={false}` on video and audio components and `pauseWhenLoading={false}` on `<Img>` explicitly.
-
-## ANGLE is now the default OpenGL renderer
-
-In Remotion 4.x, the default OpenGL renderer was <code>null</code> on local renders, which lets Chrome decide.
-In Remotion 5.0, the default is <code>angle</code>.
-When no compatible GPU is available, Remotion opts into Chromium's automatic SwiftShader fallback via <code>--enable-unsafe-swiftshader</code>, so WebGL content can render on GPU-less machines such as GitHub Actions runners.
-
-On [Lambda](/docs/lambda) and [Cloud Run](/docs/cloudrun), <code>swangle</code> remains the default.
-
-**Required action**: Remove redundant <code>--gl=angle</code> configuration if you only added it to enable WebGL.
-Pass <code>chromiumOptions.gl: null</code> to restore the Remotion 4.x behavior and let Chrome decide.
-See [OpenGL renderer options](/docs/gl-options) for when to override the default.
-
-**Performance**: SwiftShader fallback is slower than hardware rendering but enables WebGL where it previously failed.
-
-**Security**: <code>--enable-unsafe-swiftshader</code> lowers Chromium's security guarantees and is intended for trusted rendering workloads.
 
 ## License changes
 

--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -189,6 +189,22 @@ This prevents the Player from continuing while media or images are still loading
 
 **Required action**: If you want to keep the old behavior, set `pauseWhenBuffering={false}` on video and audio components and `pauseWhenLoading={false}` on `<Img>` explicitly.
 
+## ANGLE is now the default OpenGL renderer
+
+In Remotion 4.x, the default OpenGL renderer was <code>null</code> on local renders, which lets Chrome decide.
+In Remotion 5.0, the default is <code>angle</code>.
+When no compatible GPU is available, Remotion opts into Chromium's automatic SwiftShader fallback via <code>--enable-unsafe-swiftshader</code>, so WebGL content can render on GPU-less machines such as GitHub Actions runners.
+
+On [Lambda](/docs/lambda) and [Cloud Run](/docs/cloudrun), <code>swangle</code> remains the default.
+
+**Required action**: Remove redundant <code>--gl=angle</code> configuration if you only added it to enable WebGL.
+Pass <code>chromiumOptions.gl: null</code> to restore the Remotion 4.x behavior and let Chrome decide.
+See [OpenGL renderer options](/docs/gl-options) for when to override the default.
+
+**Performance**: SwiftShader fallback is slower than hardware rendering but enables WebGL where it previously failed.
+
+**Security**: <code>--enable-unsafe-swiftshader</code> lowers Chromium's security guarantees and is intended for trusted rendering workloads.
+
 ## License changes
 
 Remotion 5.0 has an updated license. View the [license](https://github.com/remotion-dev/remotion/blob/5-0-license/LICENSE.md) here or compare the [changes](https://github.com/remotion-dev/remotion/pull/3750).

--- a/packages/docs/docs/open-gl.mdx
+++ b/packages/docs/docs/open-gl.mdx
@@ -15,7 +15,7 @@ The following renderer backends are supported in Remotion:
 - <code>swiftshader</code>
 - <code>vulkan</code> (from Remotion v4.0.41)
 - <code>angle-egl</code> (from Remotion v4.0.52)
-- <code>swangle</code> - default on Lambda and Cloud Run
+- <code>swangle</code> - default on Lambda
 
 ## Remotion 5.0 default
 

--- a/packages/docs/docs/open-gl.mdx
+++ b/packages/docs/docs/open-gl.mdx
@@ -9,7 +9,7 @@ When rendering a video in Remotion, different [GL](https://en.wikipedia.org/wiki
 
 The following renderer backends are supported in Remotion:
 
-- <code>null</code> - default in Remotion 4.0, lets Chrome decide
+- <code>null</code> - default in Remotion 4.0, lets Chrome decide (opt-out in Remotion 5.0)
 - <code>angle</code> - default in Remotion 5.0
 - <code>egl</code>
 - <code>swiftshader</code>
@@ -19,20 +19,30 @@ The following renderer backends are supported in Remotion:
 
 ## Remotion 5.0 default
 
-From Remotion 5.0, `angle` is the default renderer. A compatible GPU is used when available, and Chromium automatically falls back to software rendering through SwiftShader otherwise. No renderer option is needed to make WebGL or WebGPU work.
+From Remotion 5.0, `angle` is the default renderer on local renders. A compatible GPU is used when available, and Chromium automatically falls back to software rendering through SwiftShader otherwise via <code>--enable-unsafe-swiftshader</code>. No renderer option is needed to make WebGL or WebGPU work.
 
-Lambda and Cloud Run continue to use `swangle` by default.
+This means you no longer need to pass <code>--gl=angle</code> merely to make WebGL work, and you no longer need to manually select <code>swangle</code> on machines without a GPU.
+
+:::note
+<code>--enable-unsafe-swiftshader</code> lowers Chromium's security guarantees.
+It is intended for trusted rendering workloads where you control the rendered content.
+:::
+
+To restore the Remotion 4.x behavior and let Chrome decide the renderer, pass <code>chromiumOptions.gl: null</code> in Node.js APIs or set the renderer to <code>null</code> via config or CLI.
+
+On [Lambda](/docs/lambda), <code>swangle</code> remains the effective default (<code>angle</code> is converted to <code>swangle</code> in the Lambda handler).
+On [Cloud Run](/docs/cloudrun), the v5 CLI default of <code>angle</code> is passed through; <code>swangle</code> is only used when <code>gl</code> is <code>null</code>.
 
 ## Recommended renderers in Remotion 4.0
 
 <Step>1</Step> If you use WebGL, WebGPU or Three.js:
 
-- On a desktop, `angle` is recommended
-- On a [cloud instance with a GPU](/docs/miscellaneous/cloud-gpu), `angle-egl` is recommended
-- On Lambda, use `swangle` (default on Lambda)
-- On a machine with no GPU, `swangle` is recommended. Rendering might be slow.
+- From Remotion 5.0, <code>angle</code> is already the local default (with automatic SwiftShader fallback when needed)
+- On a [cloud instance with a GPU](/docs/miscellaneous/cloud-gpu), <code>angle-egl</code> is recommended
+- On Lambda, use <code>swangle</code> (default)
+- On Cloud Run, <code>angle</code> is the v5 default (with automatic SwiftShader fallback when needed)
 
-<Step>2</Step> If you don't use WebGL, WebGPU or Three.js, the default renderer (<code>null</code> on local, <code>swangle</code> on Lambda and Cloud Run) is the best choice.<br/>
+<Step>2</Step> If you don't use WebGL, WebGPU or Three.js, the default renderer is the best choice: <code>angle</code> on local renders and Cloud Run in Remotion 5.0 (<code>null</code> in Remotion 4.x), and <code>swangle</code> on Lambda.<br/>
 
 ## Using the GPU
 
@@ -75,3 +85,4 @@ Pass [`--gl=[angle,swangle,...]`](/docs/cli) in one of the following commands: [
 ## See also
 
 - [Using the GPU](/docs/gpu)
+- [v5.0 Migration](/docs/5-0-migration)


### PR DESCRIPTION
Part of #9524

## Problem

Remotion 5.0 defaults local renders to ANGLE with automatic SwiftShader fallback (#9536), but `open-gl.mdx` still described `null` as the local default, told users to pass `--gl=angle` for WebGL, recommended manually selecting `swangle` on GPU-less machines, and claimed ANGLE fails on GitHub Actions. The v5 migration guide had no entry for this breaking change.

## Triage / Root cause

#9524 tracks the documentation follow-up after the renderer default landed in #9536. The canonical OpenGL page and migration guide were never updated.

## Fix

- Rewrite `packages/docs/docs/open-gl.mdx` to describe ANGLE as the Remotion 5.0 local default, automatic SwiftShader fallback, the `gl: null` opt-out, the `--enable-unsafe-swiftshader` security tradeoff, and unchanged Lambda/Cloud Run `swangle` defaults.
- Add an ANGLE default section to `packages/docs/docs/5-0-migration.mdx` with required action, performance, and security notes.

This PR covers the canonical documentation portion of #9524. WebGL setup guides, effect pages, error messages, and templates remain for follow-up PRs.

## Verification

- `python3 ../scripts/preflight_ship.py` — clear before edit (no open duplicate PRs; stale GHA claim still on upstream/main).
- Pre-commit docs formatter passed on commit (`docs format: Exited with code 0`).
- Docs-only change; two files touched.

## Notes / Risks

Scoped to canonical OpenGL docs + migration entry per #9524 checklist. Does not yet update `three.mdx`, effect pages, `gpu.mdx`, error messages, or agent skills — those are separate follow-ups on the same issue.
