### PR TITLE
Internal: Add masterplan issue audit skill

### DIFF
--- a/.agents/skills/find-unplanned-issues/SKILL.md
+++ b/.agents/skills/find-unplanned-issues/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: find-unplanned-issues
+description: 'Audit and clean the Remotion GitHub masterplan hierarchy. Use when finding open issues that lack a masterplan ancestor, identifying orphaned issues that need a parent, or recursively removing closed issues from the masterplan rooted at issue #9081.'
+---
+
+# Find unplanned issues
+
+Run the bundled read-only audit from the repository root:
+
+```sh
+bun .agents/skills/find-unplanned-issues/scripts/find-unplanned-issues.ts
+```
+
+The script treats an issue as planned when its title contains `masterplan` or any
+issue in its parent chain has a title containing `masterplan`. Masterplan issues
+themselves are omitted from the report. Repository-specific exceptions are also
+omitted; currently, issue #8375 is exempt because the long-running CI flake
+tracker intentionally stands on its own. Results distinguish between:
+
+- `no parent`: the open issue has no parent at all.
+- `no masterplan ancestor`: the issue has a parent, but following the complete
+  parent chain does not reach a masterplan.
+
+Use a different repository or machine-readable output when needed:
+
+```sh
+bun .agents/skills/find-unplanned-issues/scripts/find-unplanned-issues.ts --repo owner/repo
+bun .agents/skills/find-unplanned-issues/scripts/find-unplanned-issues.ts --json
+```
+
+Pass `--check` for automation. It exits with status 1 when unplanned issues are
+found and 0 when every non-exempt open issue belongs to a masterplan.
+
+The audit requires an authenticated `gh` CLI that supports the `parent` JSON
+field. It only reads issue data. To fix findings, use the `issue-management`
+skill and verify each relationship after editing it.
+
+## Remove closed issues from the masterplan
+
+Preview all closed descendants of the root masterplan recursively:
+
+```sh
+bun .agents/skills/find-unplanned-issues/scripts/prune-closed-masterplan-issues.ts
+```
+
+The default root is <https://github.com/remotion-dev/remotion/issues/9081>.
+Override it only when intentionally auditing a different hierarchy:
+
+```sh
+bun .agents/skills/find-unplanned-issues/scripts/prune-closed-masterplan-issues.ts \
+  --root https://github.com/owner/repo/issues/123
+```
+
+The command is a dry run unless `--apply` is passed. During application, process
+closed issues deepest-first and verify every relationship after changing it. If
+a closed issue has open children, move those children to its parent before
+removing the closed issue so open work stays in the masterplan.
+
+```sh
+bun .agents/skills/find-unplanned-issues/scripts/prune-closed-masterplan-issues.ts --apply
+```
+
+Use `--json` for a machine-readable dry-run report. Never pass `--apply` merely
+to test the script; it changes live GitHub issue relationships.

--- a/.agents/skills/find-unplanned-issues/agents/openai.yaml
+++ b/.agents/skills/find-unplanned-issues/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Audit Masterplan Issues'
+  short_description: 'Audit and clean masterplan issue trees'
+  default_prompt: 'Use $find-unplanned-issues to audit masterplan coverage or prune closed issues from the Remotion masterplan tree.'

--- a/.agents/skills/find-unplanned-issues/scripts/find-unplanned-issues.ts
+++ b/.agents/skills/find-unplanned-issues/scripts/find-unplanned-issues.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env bun
+
+type IssueReference = {
+	readonly number: number;
+	readonly state: string;
+	readonly title: string;
+	readonly url: string;
+};
+
+type Issue = IssueReference & {
+	readonly parent: IssueReference | null;
+};
+
+type Finding = {
+	readonly number: number;
+	readonly parentChain: readonly IssueReference[];
+	readonly reason: 'no parent' | 'no masterplan ancestor';
+	readonly title: string;
+	readonly url: string;
+};
+
+type Options = {
+	readonly check: boolean;
+	readonly json: boolean;
+	readonly limit: number;
+	readonly repo: string | null;
+};
+
+const decoder = new TextDecoder();
+const exemptIssueUrls = new Set([
+	// This long-running CI flake tracker intentionally stands on its own.
+	'https://github.com/remotion-dev/remotion/issues/8375',
+]);
+
+const usage = `Find open issues that are not connected to a masterplan.
+
+Usage:
+  bun find-unplanned-issues.ts [options]
+
+Options:
+  --repo OWNER/REPO  Inspect another GitHub repository
+  --limit NUMBER     Maximum open issues to inspect (default: 10000)
+  --json             Print findings as JSON
+  --check            Exit 1 when findings exist
+  --help             Show this help`;
+
+const fail = (message: string): never => {
+	console.error(message);
+	process.exit(2);
+};
+
+const readValue = (
+	args: readonly string[],
+	index: number,
+	flag: string,
+): string => {
+	const value = args[index + 1];
+	if (!value || value.startsWith('--')) {
+		fail(`${flag} requires a value`);
+	}
+
+	return value;
+};
+
+const parseOptions = (): Options => {
+	const args = Bun.argv.slice(2);
+	let check = false;
+	let json = false;
+	let limit = 10000;
+	let repo: string | null = null;
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg === '--check') {
+			check = true;
+			continue;
+		}
+
+		if (arg === '--json') {
+			json = true;
+			continue;
+		}
+
+		if (arg === '--help') {
+			console.log(usage);
+			process.exit(0);
+		}
+
+		if (arg === '--repo') {
+			repo = readValue(args, index, arg);
+			index++;
+			continue;
+		}
+
+		if (arg === '--limit') {
+			const rawLimit = readValue(args, index, arg);
+			limit = Number(rawLimit);
+			if (!Number.isInteger(limit) || limit < 1) {
+				fail(`--limit must be a positive integer, received: ${rawLimit}`);
+			}
+
+			index++;
+			continue;
+		}
+
+		fail(`Unknown option: ${arg}\n\n${usage}`);
+	}
+
+	return {check, json, limit, repo};
+};
+
+const runGhJson = <T>(args: readonly string[]): T => {
+	const command = Bun.spawnSync(['gh', ...args], {
+		stderr: 'pipe',
+		stdout: 'pipe',
+	});
+
+	if (command.exitCode !== 0) {
+		const error = decoder.decode(command.stderr).trim();
+		fail(error || `gh ${args.join(' ')} failed`);
+	}
+
+	const output = decoder.decode(command.stdout);
+	try {
+		return JSON.parse(output) as T;
+	} catch {
+		fail(`gh returned invalid JSON for: gh ${args.join(' ')}`);
+	}
+};
+
+const isMasterplan = (issue: IssueReference): boolean =>
+	/masterplan/i.test(issue.title);
+
+const isExempt = (issue: IssueReference): boolean =>
+	exemptIssueUrls.has(issue.url);
+
+const options = parseOptions();
+const repoArgs = options.repo === null ? [] : ['--repo', options.repo];
+const issues = runGhJson<Issue[]>([
+	'issue',
+	'list',
+	...repoArgs,
+	'--state',
+	'open',
+	'--limit',
+	String(options.limit),
+	'--json',
+	'number,title,parent,state,url',
+]);
+
+const issuesByUrl = new Map<string, Issue>(
+	issues.map((issue) => [issue.url, issue]),
+);
+
+const hydrateIssue = (reference: IssueReference): Issue => {
+	const cached = issuesByUrl.get(reference.url);
+	if (cached) {
+		return cached;
+	}
+
+	const issue = runGhJson<Issue>([
+		'issue',
+		'view',
+		reference.url,
+		'--json',
+		'number,title,parent,state,url',
+	]);
+	issuesByUrl.set(issue.url, issue);
+	return issue;
+};
+
+const findParentChain = (issue: Issue): readonly IssueReference[] | null => {
+	const chain: IssueReference[] = [];
+	const seen = new Set<string>([issue.url]);
+	let parent = issue.parent;
+
+	while (parent !== null) {
+		if (seen.has(parent.url)) {
+			fail(`Parent cycle detected while inspecting ${issue.url}`);
+		}
+
+		seen.add(parent.url);
+		chain.push(parent);
+		if (isMasterplan(parent)) {
+			return null;
+		}
+
+		parent = hydrateIssue(parent).parent;
+	}
+
+	return chain;
+};
+
+const findings: Finding[] = [];
+
+for (const issue of issues) {
+	if (isMasterplan(issue) || isExempt(issue)) {
+		continue;
+	}
+
+	const parentChain = findParentChain(issue);
+	if (parentChain === null) {
+		continue;
+	}
+
+	findings.push({
+		number: issue.number,
+		parentChain,
+		reason: issue.parent === null ? 'no parent' : 'no masterplan ancestor',
+		title: issue.title,
+		url: issue.url,
+	});
+}
+
+findings.sort((left, right) => right.number - left.number);
+
+if (options.json) {
+	console.log(JSON.stringify(findings, null, 2));
+} else if (findings.length === 0) {
+	console.log('Every non-exempt open issue is connected to a masterplan.');
+} else {
+	console.log(
+		`Found ${findings.length} open issue(s) outside every masterplan:\n`,
+	);
+	for (const finding of findings) {
+		console.log(`#${finding.number}\t${finding.reason}\t${finding.title}`);
+		console.log(`  ${finding.url}`);
+		if (finding.parentChain.length > 0) {
+			const chain = finding.parentChain
+				.map((parent) => `#${parent.number} ${parent.title}`)
+				.join(' -> ');
+			console.log(`  parent chain: ${chain}`);
+		}
+	}
+}
+
+process.exit(options.check && findings.length > 0 ? 1 : 0);

--- a/.agents/skills/find-unplanned-issues/scripts/prune-closed-masterplan-issues.ts
+++ b/.agents/skills/find-unplanned-issues/scripts/prune-closed-masterplan-issues.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env bun
+
+export {};
+
+type IssueReference = {
+	readonly number: number;
+	readonly state: 'CLOSED' | 'OPEN';
+	readonly title: string;
+	readonly url: string;
+};
+
+type Issue = IssueReference & {
+	readonly parent: IssueReference | null;
+	readonly subIssues: {
+		readonly nodes: readonly IssueReference[];
+		readonly totalCount: number;
+	};
+};
+
+type TreeNode = {
+	readonly depth: number;
+	readonly issue: Issue;
+	readonly parent: IssueReference | null;
+};
+
+type Options = {
+	readonly apply: boolean;
+	readonly json: boolean;
+	readonly root: string;
+};
+
+const defaultRoot = 'https://github.com/remotion-dev/remotion/issues/9081';
+const concurrency = 8;
+
+const usage = `Recursively remove closed issues from a GitHub masterplan.
+
+Usage:
+  bun prune-closed-masterplan-issues.ts [options]
+
+Options:
+  --root ISSUE_URL  Root masterplan (default: ${defaultRoot})
+  --json            Print the dry-run report as JSON
+  --apply           Reparent open children and remove closed issues
+  --help            Show this help`;
+
+const fail = (message: string): never => {
+	console.error(message);
+	process.exit(2);
+};
+
+const readValue = (
+	args: readonly string[],
+	index: number,
+	flag: string,
+): string => {
+	const value = args[index + 1];
+	if (!value || value.startsWith('--')) {
+		fail(`${flag} requires a value`);
+	}
+
+	return value;
+};
+
+const parseOptions = (): Options => {
+	const args = Bun.argv.slice(2);
+	let apply = false;
+	let json = false;
+	let root = defaultRoot;
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (arg === '--apply') {
+			apply = true;
+			continue;
+		}
+
+		if (arg === '--json') {
+			json = true;
+			continue;
+		}
+
+		if (arg === '--help') {
+			console.log(usage);
+			process.exit(0);
+		}
+
+		if (arg === '--root') {
+			root = readValue(args, index, arg);
+			index++;
+			continue;
+		}
+
+		fail(`Unknown option: ${arg}\n\n${usage}`);
+	}
+
+	if (apply && json) {
+		fail('--json cannot be combined with --apply');
+	}
+
+	if (!/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/.test(root)) {
+		fail(`--root must be a full GitHub issue URL, received: ${root}`);
+	}
+
+	return {apply, json, root};
+};
+
+const runGh = async (args: readonly string[]): Promise<string> => {
+	const command = Bun.spawn(['gh', ...args], {
+		stderr: 'pipe',
+		stdout: 'pipe',
+	});
+	const [exitCode, stderr, stdout] = await Promise.all([
+		command.exited,
+		new Response(command.stderr).text(),
+		new Response(command.stdout).text(),
+	]);
+
+	if (exitCode !== 0) {
+		fail(stderr.trim() || `gh ${args.join(' ')} failed`);
+	}
+
+	return stdout;
+};
+
+const runGhJson = async <T>(args: readonly string[]): Promise<T> => {
+	const output = await runGh(args);
+	try {
+		return JSON.parse(output) as T;
+	} catch {
+		fail(`gh returned invalid JSON for: gh ${args.join(' ')}`);
+	}
+};
+
+const viewIssue = async (url: string): Promise<Issue> => {
+	const issue = await runGhJson<Issue>([
+		'issue',
+		'view',
+		url,
+		'--json',
+		'number,title,state,url,parent,subIssues',
+	]);
+
+	if (issue.subIssues.nodes.length !== issue.subIssues.totalCount) {
+		fail(
+			`GitHub returned only ${issue.subIssues.nodes.length} of ${issue.subIssues.totalCount} sub-issues for ${url}`,
+		);
+	}
+
+	return issue;
+};
+
+const mapWithConcurrency = async <Input, Output>(
+	items: readonly Input[],
+	mapper: (item: Input) => Promise<Output>,
+): Promise<Output[]> => {
+	const results: Output[] = new Array(items.length);
+	let nextIndex = 0;
+
+	const worker = async (): Promise<void> => {
+		while (nextIndex < items.length) {
+			const index = nextIndex;
+			nextIndex++;
+			results[index] = await mapper(items[index]);
+		}
+	};
+
+	await Promise.all(
+		Array.from({length: Math.min(concurrency, items.length)}, () => worker()),
+	);
+	return results;
+};
+
+const discoverTree = async (rootUrl: string): Promise<TreeNode[]> => {
+	const root = await viewIssue(rootUrl);
+	const nodes: TreeNode[] = [{depth: 0, issue: root, parent: null}];
+	const seen = new Set<string>([root.url]);
+	let frontier = root.subIssues.nodes.map((issue) => ({
+		depth: 1,
+		parent: root as IssueReference,
+		reference: issue,
+	}));
+
+	while (frontier.length > 0) {
+		for (const item of frontier) {
+			if (seen.has(item.reference.url)) {
+				fail(`Duplicate or cyclic sub-issue detected: ${item.reference.url}`);
+			}
+			seen.add(item.reference.url);
+		}
+
+		const current = await mapWithConcurrency(frontier, async (item) => ({
+			depth: item.depth,
+			issue: await viewIssue(item.reference.url),
+			parent: item.parent,
+		}));
+		nodes.push(...current);
+		frontier = current.flatMap((node) =>
+			node.issue.subIssues.nodes.map((issue) => ({
+				depth: node.depth + 1,
+				parent: node.issue as IssueReference,
+				reference: issue,
+			})),
+		);
+	}
+
+	return nodes;
+};
+
+const verifyParent = async (
+	issueUrl: string,
+	expectedParentUrl: string | null,
+): Promise<void> => {
+	const issue = await viewIssue(issueUrl);
+	const actualParentUrl = issue.parent?.url ?? null;
+	if (actualParentUrl !== expectedParentUrl) {
+		fail(
+			`Expected ${issueUrl} to have parent ${expectedParentUrl ?? 'none'}, found ${actualParentUrl ?? 'none'}`,
+		);
+	}
+};
+
+const applyRemoval = async (node: TreeNode): Promise<void> => {
+	if (node.parent === null) {
+		fail(`Refusing to remove the root issue: ${node.issue.url}`);
+	}
+
+	const current = await viewIssue(node.issue.url);
+	if (current.state !== 'CLOSED') {
+		fail(`Issue reopened during cleanup: ${current.url}`);
+	}
+
+	if (current.parent?.url !== node.parent.url) {
+		fail(
+			`Parent changed during cleanup for ${current.url}: expected ${node.parent.url}, found ${current.parent?.url ?? 'none'}`,
+		);
+	}
+
+	const closedChildren = current.subIssues.nodes.filter(
+		(child) => child.state === 'CLOSED',
+	);
+	if (closedChildren.length > 0) {
+		fail(
+			`Closed children still remain under ${current.url}: ${closedChildren.map((child) => child.url).join(', ')}`,
+		);
+	}
+
+	for (const child of current.subIssues.nodes) {
+		console.log(`Reparenting open #${child.number} to #${node.parent.number}`);
+		await runGh(['issue', 'edit', child.url, '--parent', node.parent.url]);
+		await verifyParent(child.url, node.parent.url);
+	}
+
+	console.log(`Removing closed #${current.number} from #${node.parent.number}`);
+	await runGh(['issue', 'edit', current.url, '--remove-parent']);
+	await verifyParent(current.url, null);
+};
+
+const options = parseOptions();
+const tree = await discoverTree(options.root);
+const closedIssues = tree
+	.filter((node) => node.depth > 0 && node.issue.state === 'CLOSED')
+	.sort((left, right) => right.depth - left.depth);
+
+if (options.json) {
+	console.log(
+		JSON.stringify(
+			closedIssues.map((node) => ({
+				depth: node.depth,
+				number: node.issue.number,
+				openChildren: node.issue.subIssues.nodes
+					.filter((child) => child.state === 'OPEN')
+					.map((child) => child.number),
+				parent: node.parent?.number ?? null,
+				title: node.issue.title,
+				url: node.issue.url,
+			})),
+			null,
+			2,
+		),
+	);
+} else if (closedIssues.length === 0) {
+	console.log(
+		options.apply
+			? 'Removed 0 closed issue(s) from the masterplan.'
+			: `No closed descendants found under ${options.root}.`,
+	);
+} else if (!options.apply) {
+	console.log(
+		`Found ${closedIssues.length} closed descendant(s) under ${options.root}:\n`,
+	);
+	for (const node of closedIssues) {
+		console.log(
+			`#${node.issue.number}\tdepth ${node.depth}\tparent #${node.parent?.number}\t${node.issue.title}`,
+		);
+		console.log(`  ${node.issue.url}`);
+		const openChildren = node.issue.subIssues.nodes.filter(
+			(child) => child.state === 'OPEN',
+		);
+		if (openChildren.length > 0) {
+			console.log(
+				`  would reparent open children: ${openChildren.map((child) => `#${child.number}`).join(', ')}`,
+			);
+		}
+	}
+	console.log('\nDry run only. Pass --apply to update GitHub.');
+} else {
+	for (const node of closedIssues) {
+		await applyRemoval(node);
+	}
+	console.log(
+		`Removed ${closedIssues.length} closed issue(s) from the masterplan.`,
+	);
+}


### PR DESCRIPTION
## Summary

- add an internal skill that finds open issues without a masterplan ancestor
- add a recursive cleanup script for closed descendants of the masterplan rooted at #9081
- support dry-run, JSON, and CI check modes while preserving open descendants during cleanup

## Testing

- `bun run build`
- `bun run stylecheck`
- live dry-run validation against the Remotion issue hierarchy
