### PR TITLE
Elements: Confirm before overwriting Element files

### DIFF
--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -117,7 +117,14 @@ export const insertElementHandler: ApiHandler<
 	InsertElementRequest,
 	InsertElementResponse
 > = ({
-	input: {compositionFile, compositionId, element, from, position},
+	input: {
+		compositionFile,
+		compositionId,
+		element,
+		from,
+		position,
+		overwriteExisting,
+	},
 	remotionRoot,
 	logLevel,
 }) =>
@@ -175,17 +182,30 @@ export const insertElementHandler: ApiHandler<
 			}
 
 			const elementFileExists = existsSync(elementFileName);
-			if (elementFileExists) {
-				const existingSource = readFileSync(elementFileName, 'utf-8');
-				if (
-					normalizeSourceForComparison(existingSource) !==
-					normalizeSourceForComparison(element.sourceCode)
-				) {
-					throw new Error(
-						`Element file already exists with different contents: ${derivedElementFileName}`,
-					);
-				}
+			const existingElementSource = elementFileExists
+				? readFileSync(elementFileName, 'utf-8')
+				: null;
+			const elementSourcesDiffer =
+				existingElementSource !== null &&
+				normalizeSourceForComparison(existingElementSource) !==
+					normalizeSourceForComparison(element.sourceCode);
+
+			if (elementSourcesDiffer && !overwriteExisting) {
+				return {
+					success: false,
+					type: 'file-conflict',
+					conflict: {
+						filePath: path
+							.relative(remotionRoot, elementFileName)
+							.split(path.sep)
+							.join('/'),
+						existingSource: existingElementSource,
+						incomingSource: element.sourceCode,
+					},
+				};
 			}
+
+			const shouldWriteElementFile = !elementFileExists || elementSourcesDiffer;
 
 			const importPath = makeRelativeImportPath({
 				fromFile: location.fileName,
@@ -216,16 +236,16 @@ export const insertElementHandler: ApiHandler<
 
 			pushTransactionToUndoStack({
 				snapshots: [
-					...(elementFileExists
-						? []
-						: [
+					...(shouldWriteElementFile
+						? [
 								{
 									filePath: elementFileName,
-									oldContents: null,
+									oldContents: existingElementSource,
 									newContents: element.sourceCode,
 									logLine: 1,
 								},
-							]),
+							]
+						: []),
 					{
 						filePath: inserted.fileName,
 						oldContents: inserted.oldContents,
@@ -242,13 +262,13 @@ export const insertElementHandler: ApiHandler<
 				entryType: 'insert-jsx-element',
 				suppressHmrOnFileRestore: false,
 			});
-			if (!elementFileExists) {
+			if (shouldWriteElementFile) {
 				suppressUndoStackInvalidation(elementFileName);
 			}
 
 			suppressUndoStackInvalidation(inserted.fileName);
 
-			if (!elementFileExists) {
+			if (shouldWriteElementFile) {
 				writeFileAndNotifyFileWatchers(
 					elementFileName,
 					element.sourceCode,
@@ -272,9 +292,14 @@ export const insertElementHandler: ApiHandler<
 				absolutePath: elementFileName,
 				line: 1,
 			});
+			const elementFileAction = elementSourcesDiffer
+				? 'Overwrote existing Element source'
+				: elementFileExists
+					? 'Reused existing Element source'
+					: 'Created Element source';
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(elementLocationLabel)} ${elementFileExists ? 'Reused existing Element source' : 'Created Element source'}`,
+				`${RenderInternals.chalk.blueBright(elementLocationLabel)} ${elementFileAction}`,
 			);
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
@@ -292,6 +317,7 @@ export const insertElementHandler: ApiHandler<
 		} catch (err) {
 			return {
 				success: false,
+				type: 'error',
 				reason: (err as Error).message,
 				stack: (err as Error).stack as string,
 			};

--- a/packages/studio-server/src/test/insert-element.test.ts
+++ b/packages/studio-server/src/test/insert-element.test.ts
@@ -1,0 +1,198 @@
+import {expect, test} from 'bun:test';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import type {InsertElementRequest} from '@remotion/studio-shared';
+import {
+	createFileWatcherRegistry,
+	setFileWatcherRegistry,
+} from '../file-watcher';
+import {setLiveEventsListener} from '../preview-server/live-events';
+import {insertElementHandler} from '../preview-server/routes/insert-element';
+import {
+	clearUndoStackForTests,
+	getUndoStack,
+	popUndo,
+} from '../preview-server/undo-stack';
+
+const compositionSource = `import React from 'react';
+import {Composition} from 'remotion';
+
+const Target = () => <div>Hello</div>;
+
+export const RemotionRoot = () => (
+	<Composition
+		id="target"
+		component={Target}
+		durationInFrames={100}
+		fps={30}
+		width={1920}
+		height={1080}
+	/>
+);
+`;
+
+const incomingElementSource =
+	'export const LowerThird = () => <div>Incoming</div>;\n';
+const existingElementSource =
+	'export const LowerThird = () => <div>Locally changed</div>;\n';
+
+const element = {
+	dependencies: [],
+	dimensions: {width: 900, height: 260},
+	displayName: 'Lower Third',
+	slug: 'overlays/lower-third',
+	sourceCode: incomingElementSource,
+};
+
+const makeFixture = () => {
+	const remotionRoot = mkdtempSync(path.join(tmpdir(), 'remotion-element-'));
+	const compositionFile = path.join(remotionRoot, 'Root.tsx');
+	const elementFile = path.join(remotionRoot, 'lower-third.element.tsx');
+	writeFileSync(compositionFile, compositionSource);
+
+	clearUndoStackForTests();
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	const cleanupLiveEvents = setLiveEventsListener({
+		sendEventToClient: () => undefined,
+		sendEventToClientId: () => true,
+		router: () => Promise.resolve(),
+		closeConnections: () => Promise.resolve(),
+		addNewClientListener: () => () => undefined,
+	});
+
+	const callHandler = (overwriteExisting: boolean) => {
+		const input: InsertElementRequest = {
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element,
+			from: null,
+			overwriteExisting,
+			position: null,
+		};
+
+		return insertElementHandler({
+			binariesDirectory: null,
+			configFile: null,
+			entryPoint: compositionFile,
+			input,
+			logLevel: 'error',
+			methods: {
+				addJob: () => undefined,
+				cancelJob: () => undefined,
+				removeJob: () => undefined,
+			},
+			publicDir: remotionRoot,
+			remotionRoot,
+			request: {} as never,
+			response: {} as never,
+		});
+	};
+
+	const cleanup = () => {
+		clearUndoStackForTests();
+		cleanupLiveEvents();
+		cleanupFileWatcher();
+		rmSync(remotionRoot, {force: true, recursive: true});
+	};
+
+	return {callHandler, cleanup, compositionFile, elementFile};
+};
+
+test('creates a new Element file without an overwrite conflict', async () => {
+	const fixture = makeFixture();
+	try {
+		const response = await fixture.callHandler(false);
+
+		expect(response).toEqual({success: true});
+		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
+			incomingElementSource,
+		);
+		expect(readFileSync(fixture.compositionFile, 'utf-8')).toContain(
+			'<LowerThird',
+		);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('reuses an identical Element file without an overwrite conflict', async () => {
+	const fixture = makeFixture();
+	try {
+		writeFileSync(fixture.elementFile, incomingElementSource);
+		const response = await fixture.callHandler(false);
+
+		expect(response).toEqual({success: true});
+		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
+			incomingElementSource,
+		);
+		expect(readFileSync(fixture.compositionFile, 'utf-8')).toContain(
+			'<LowerThird',
+		);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('returns a structured conflict without changing the project', async () => {
+	const fixture = makeFixture();
+	try {
+		writeFileSync(fixture.elementFile, existingElementSource);
+		const response = await fixture.callHandler(false);
+
+		expect(response).toEqual({
+			success: false,
+			type: 'file-conflict',
+			conflict: {
+				filePath: 'lower-third.element.tsx',
+				existingSource: existingElementSource,
+				incomingSource: incomingElementSource,
+			},
+		});
+		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
+			existingElementSource,
+		);
+		expect(readFileSync(fixture.compositionFile, 'utf-8')).toBe(
+			compositionSource,
+		);
+		expect(getUndoStack()).toHaveLength(0);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('overwrites conflicting source and undo restores both files', async () => {
+	const fixture = makeFixture();
+	try {
+		writeFileSync(fixture.elementFile, existingElementSource);
+		const response = await fixture.callHandler(true);
+
+		expect(response).toEqual({success: true});
+		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
+			incomingElementSource,
+		);
+		expect(readFileSync(fixture.compositionFile, 'utf-8')).toContain(
+			'<LowerThird',
+		);
+		expect(getUndoStack()).toHaveLength(1);
+
+		expect(popUndo()).toEqual({success: true});
+		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
+			existingElementSource,
+		);
+		expect(readFileSync(fixture.compositionFile, 'utf-8')).toBe(
+			compositionSource,
+		);
+		expect(existsSync(fixture.elementFile)).toBe(true);
+	} finally {
+		fixture.cleanup();
+	}
+});

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -856,6 +856,13 @@ export type InsertElementRequest = {
 	element: ElementDragData['element'];
 	from: number | null;
 	position: InsertableCompositionElementPosition | null;
+	overwriteExisting: boolean;
+};
+
+export type InsertElementFileConflict = {
+	filePath: string;
+	existingSource: string;
+	incomingSource: string;
 };
 
 export type InsertElementResponse =
@@ -864,6 +871,12 @@ export type InsertElementResponse =
 	  }
 	| {
 			success: false;
+			type: 'file-conflict';
+			conflict: InsertElementFileConflict;
+	  }
+	| {
+			success: false;
+			type: 'error';
 			reason: string;
 			stack: string;
 	  };

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -51,6 +51,7 @@ export {
 	FindInFileRequest,
 	FindInFileResponse,
 	GoogleFontSourceEdit,
+	InsertElementFileConflict,
 	InsertElementRequest,
 	InsertElementResponse,
 	InsertJsxElementRequest,

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -74,6 +74,7 @@ import {ResetZoomButton} from './ResetZoomButton';
 import {useSvgImportDialog} from './SvgImportDialog';
 import {getCurrentFrame} from './Timeline/imperative-state';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
+import {useElementOverwriteConfirmation} from './use-element-overwrite-confirmation';
 
 const elementInstallCompositionIdStyle: React.CSSProperties = {
 	fontFamily: 'monospace',
@@ -251,6 +252,7 @@ export const Canvas: React.FC<{
 	} | null>(null);
 	const keybindings = useKeybinding();
 	const confirm = useConfirmationDialog();
+	const confirmElementOverwrite = useElementOverwriteConfirmation();
 	const chooseSvgImportMode = useSvgImportDialog();
 	const config = Internals.useUnsafeVideoConfig();
 	const areRulersVisible = useIsRulerVisible();
@@ -934,6 +936,7 @@ export const Canvas: React.FC<{
 					element: activeElementInstallRequest.element,
 					compositionFile: activeElementInstallRequest.compositionFile,
 					compositionId: activeElementInstallRequest.compositionId,
+					confirmOverwrite: confirmElementOverwrite,
 					dropPosition: null,
 					from: null,
 				});
@@ -958,7 +961,7 @@ export const Canvas: React.FC<{
 		return () => {
 			canceled = true;
 		};
-	}, [activeElementInstallRequest, confirm]);
+	}, [activeElementInstallRequest, confirm, confirmElementOverwrite]);
 
 	const onDragOver = useCallback(
 		(event: DragEvent) => {
@@ -1167,6 +1170,7 @@ export const Canvas: React.FC<{
 				await handleDrop({
 					chooseSvgImportMode,
 					compositionFile,
+					confirmElementOverwrite,
 					compositionId: currentCompositionId,
 					destinationDimensions:
 						contentDimensions === 'none' ? null : contentDimensions,
@@ -1185,6 +1189,7 @@ export const Canvas: React.FC<{
 			cannotAddSequence,
 			chooseSvgImportMode,
 			compositionFile,
+			confirmElementOverwrite,
 			config,
 			contentDimensions,
 			currentCompositionId,

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -8,6 +8,7 @@ import {getEffectDragData} from '../effect-drag-and-drop';
 import {handleDrop} from '../handle-drop';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSvgImportDialog} from '../SvgImportDialog';
+import {useElementOverwriteConfirmation} from '../use-element-overwrite-confirmation';
 import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
 import {useResolvedStack} from './use-resolved-stack';
@@ -33,6 +34,7 @@ export const useTimelineAssetDrop = () => {
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const chooseSvgImportMode = useSvgImportDialog();
+	const confirmElementOverwrite = useElementOverwriteConfirmation();
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const [assetDropFrame, setAssetDropFrame] = useState<number | null>(null);
@@ -160,6 +162,7 @@ export const useTimelineAssetDrop = () => {
 				await handleDrop({
 					chooseSvgImportMode,
 					compositionFile,
+					confirmElementOverwrite,
 					compositionId: currentCompositionId,
 					destinationDimensions: {
 						height: videoConfig.height,
@@ -182,6 +185,7 @@ export const useTimelineAssetDrop = () => {
 			chooseSvgImportMode,
 			compositionComponentInfo?.canAddSequence,
 			compositionFile,
+			confirmElementOverwrite,
 			currentCompositionId,
 			getDropFrame,
 			videoConfig,

--- a/packages/studio/src/components/handle-drop.ts
+++ b/packages/studio/src/components/handle-drop.ts
@@ -20,6 +20,7 @@ import {
 	insertElement,
 	insertExistingAssets,
 	insertRemoteAudio,
+	type ConfirmElementOverwrite,
 	type InsertElementDropPosition,
 } from './import-assets';
 import type {SvgImportMode} from './SvgImportDialog';
@@ -27,6 +28,7 @@ import type {SvgImportMode} from './SvgImportDialog';
 export const handleDrop = async ({
 	chooseSvgImportMode,
 	compositionFile,
+	confirmElementOverwrite,
 	compositionId,
 	destinationDimensions,
 	dropPosition,
@@ -36,6 +38,7 @@ export const handleDrop = async ({
 }: {
 	chooseSvgImportMode: () => Promise<SvgImportMode | null>;
 	compositionFile: string;
+	confirmElementOverwrite: ConfirmElementOverwrite;
 	compositionId: string;
 	destinationDimensions: Dimensions | null;
 	dropPosition: InsertElementDropPosition | null;
@@ -124,6 +127,7 @@ export const handleDrop = async ({
 		await insertElement({
 			compositionFile,
 			compositionId,
+			confirmOverwrite: confirmElementOverwrite,
 			dropPosition,
 			element: element.element,
 			from,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -10,6 +10,7 @@ import {
 	isUrl,
 	type DownloadRemoteAssetResponse,
 	type FileType,
+	type InsertElementFileConflict,
 	type InsertableCompositionElement,
 	type InsertableCompositionElementPosition,
 } from '@remotion/studio-shared';
@@ -28,6 +29,10 @@ export type InsertElementDropPosition = {
 	readonly centerX: number;
 	readonly centerY: number;
 };
+
+export type ConfirmElementOverwrite = (
+	conflict: InsertElementFileConflict,
+) => Promise<boolean>;
 
 type InsertableAssetElement = Extract<
 	InsertableCompositionElement,
@@ -1310,12 +1315,14 @@ export const insertComposition = async ({
 export const insertElement = async ({
 	compositionFile,
 	compositionId,
+	confirmOverwrite,
 	dropPosition,
 	element,
 	from,
 }: {
 	compositionFile: string;
 	compositionId: string;
+	confirmOverwrite: ConfirmElementOverwrite;
 	dropPosition: InsertElementDropPosition | null;
 	element: ElementDragData['element'];
 	from: number | null;
@@ -1323,19 +1330,36 @@ export const insertElement = async ({
 	try {
 		await installRequiredPackages(element.dependencies);
 
-		const response = await callApi('/api/insert-element', {
-			compositionFile,
-			compositionId,
-			element,
-			from,
-			position: getElementPositionForDrop({
-				dimensions: element.dimensions,
-				dropPosition,
-			}),
+		const position = getElementPositionForDrop({
+			dimensions: element.dimensions,
+			dropPosition,
 		});
+		const callInsertElementApi = (overwriteExisting: boolean) =>
+			callApi('/api/insert-element', {
+				compositionFile,
+				compositionId,
+				element,
+				from,
+				overwriteExisting,
+				position,
+			});
+
+		let response = await callInsertElementApi(false);
+		if (!response.success && response.type === 'file-conflict') {
+			const shouldOverwrite = await confirmOverwrite(response.conflict);
+			if (!shouldOverwrite) {
+				return;
+			}
+
+			response = await callInsertElementApi(true);
+		}
 
 		if (!response.success) {
-			showNotification(`Could not add Element: ${response.reason}`, 4000);
+			const reason =
+				response.type === 'error'
+					? response.reason
+					: `Element file still conflicts: ${response.conflict.filePath}`;
+			showNotification(`Could not add Element: ${reason}`, 4000);
 			return;
 		}
 

--- a/packages/studio/src/components/use-element-overwrite-confirmation.tsx
+++ b/packages/studio/src/components/use-element-overwrite-confirmation.tsx
@@ -1,0 +1,95 @@
+import type {InsertElementFileConflict} from '@remotion/studio-shared';
+import React, {useCallback} from 'react';
+import {useConfirmationDialog} from './ConfirmationDialog';
+
+const filePathStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'monospace',
+	fontSize: 13,
+	lineHeight: 1.4,
+};
+
+const warningStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: 1.4,
+	marginTop: 12,
+};
+
+const sourceDetailsStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: 1.4,
+	marginTop: 12,
+};
+
+const sourceSummaryStyle: React.CSSProperties = {
+	color: 'inherit',
+	cursor: 'pointer',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const sourceCodeBlockStyle: React.CSSProperties = {
+	backgroundColor: 'rgba(255, 255, 255, 0.06)',
+	borderRadius: 6,
+	color: 'inherit',
+	fontFamily: 'monospace',
+	fontSize: 12,
+	lineHeight: 1.5,
+	marginBottom: 0,
+	marginTop: 8,
+	maxHeight: 200,
+	overflow: 'auto',
+	padding: 12,
+	whiteSpace: 'pre',
+};
+
+const sourceCodeStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'monospace',
+	fontSize: 12,
+	lineHeight: 1.5,
+};
+
+export const useElementOverwriteConfirmation = () => {
+	const confirm = useConfirmationDialog();
+
+	return useCallback(
+		(conflict: InsertElementFileConflict) => {
+			return confirm({
+				title: 'Overwrite Element file?',
+				message: (
+					<>
+						The Element file{' '}
+						<code style={filePathStyle}>{conflict.filePath}</code> already
+						exists with different contents.
+						<div style={warningStyle}>
+							Overwriting will replace local changes in this file. The
+							composition will only be updated if you choose Overwrite.
+						</div>
+						<details style={sourceDetailsStyle} open>
+							<summary style={sourceSummaryStyle}>Existing source</summary>
+							<pre style={sourceCodeBlockStyle}>
+								<code style={sourceCodeStyle}>{conflict.existingSource}</code>
+							</pre>
+						</details>
+						<details style={sourceDetailsStyle}>
+							<summary style={sourceSummaryStyle}>Incoming source</summary>
+							<pre style={sourceCodeBlockStyle}>
+								<code style={sourceCodeStyle}>{conflict.incomingSource}</code>
+							</pre>
+						</details>
+					</>
+				),
+				confirmLabel: 'Overwrite',
+				cancelLabel: 'Cancel',
+			});
+		},
+		[confirm],
+	);
+};


### PR DESCRIPTION
## Summary

- return structured Element source conflicts from the Studio server
- prompt before replacing local `.element.tsx` changes, with existing and incoming source previews
- apply overwrite confirmation across Element installation entry points and restore overwritten source through undo
- cover creation, reuse, conflict cancellation, overwrite, and undo behavior with server tests

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio-server/src/test/insert-element.test.ts`
- manually verified install, cancel, overwrite, source inspection, and undo through the live docs and Studio using Playwriter

Closes #9785
