### PR TITLE
Docs: Fix SVGR and GLSL bundler snippets

### DIFF
--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -378,6 +378,11 @@ export const enableSvgr: WebpackOverrideFn = (currentConfiguration) => {
           resourceQuery: {not: [/url/]}, // Exclude react component if *.svg?url
           use: ['@svgr/webpack'],
         },
+        {
+          test: /\.svg$/i,
+          resourceQuery: /url/, // Load *.svg?url as an asset URL
+          type: 'asset/resource',
+        },
         ...(currentConfiguration.module?.rules ?? []).map((r) => {
           if (!r) {
             return r;
@@ -422,7 +427,7 @@ Config.overrideWebpackConfig(enableSvgr);
 
 1. Install the following dependencies:
 
-<Installation pkg="glsl-shader-loader glslify glslify-import-loader raw-loader" />
+<Installation pkg="glslify glslify-import-loader glslify-loader raw-loader" />
 
 2. Declare a webpack override:
 
@@ -439,7 +444,14 @@ export const enableGlsl: WebpackOverrideFn = (currentConfiguration) => {
         {
           test: /\.(glsl|vs|fs|vert|frag)$/,
           exclude: /node_modules/,
-          use: ['glslify-import-loader', 'raw-loader', 'glslify-loader'],
+          use: [
+            'glslify-import-loader',
+            {
+              loader: 'raw-loader',
+              options: {esModule: false},
+            },
+            'glslify-loader',
+          ],
         },
       ],
     },


### PR DESCRIPTION
## Summary

- preserve SVGR's documented `?url` behavior with an explicit asset rule
- install the GLSL loader referenced by the configuration snippet
- make `raw-loader` emit CommonJS so imported GLSL does not become `[object Module]`

## Testing

- `bunx oxfmt packages/docs/docs/overwriting-webpack-config.mdx --write`
- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/docs` (125 tests)
- `bun run build-docs` in `packages/docs` (1,487 Twoslash snippets, 0 errors)
- `bun run render-cards` in `packages/docs`

Part of #9541.

Closes #9794.
Closes #9795.

## Preview

- [Webpack and Rspack](https://remotion-git-codex-fix-svgr-glsl-snippets-remotion.vercel.app/docs/bundlers)
