### PR TITLE
fix(@remotion/web-renderer): treat compositions without audio as muted

### DIFF
--- a/packages/core/src/RenderAssetManager.tsx
+++ b/packages/core/src/RenderAssetManager.tsx
@@ -25,6 +25,7 @@ export const RenderAssetManager = createContext<RenderAssetManagerContext>({
 
 export type CollectAssetsRef = {
 	collectAssets: () => TRenderAsset[];
+	peekAssets: () => TRenderAsset[];
 };
 
 export const RenderAssetManagerProvider: React.FC<{
@@ -49,6 +50,9 @@ export const RenderAssetManagerProvider: React.FC<{
 					renderAssetsRef.current = [];
 					setRenderAssets([]);
 					return assets;
+				},
+				peekAssets: () => {
+					return renderAssetsRef.current;
 				},
 			};
 		}, []);

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -166,6 +166,7 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	timeUpdater: React.RefObject<TimeUpdaterRef | null>;
 	collectAssets: React.RefObject<{
 		collectAssets: () => TRenderAsset[];
+		peekAssets: () => TRenderAsset[];
 	} | null>;
 	errorHolder: ErrorHolder;
 	htmlInCanvasContext: HtmlInCanvasContext | null;
@@ -251,6 +252,7 @@ export function createScaffold<Props extends Record<string, unknown>>({
 
 	const collectAssets = createRef<{
 		collectAssets: () => TRenderAsset[];
+		peekAssets: () => TRenderAsset[];
 	}>();
 
 	flushSync(() => {

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -408,6 +408,36 @@ const internalRenderMediaOnWeb = async <
 			throw new Error('renderMediaOnWeb() was cancelled');
 		}
 
+		// A composition without any audio should not get an audio track:
+		// An all-silence AAC track would be longer than the video track due to
+		// encoder priming, inflating the container duration (#7099).
+		// Scan the frame range for audio and treat the render as muted if there
+		// is none. Audio-only containers keep their track.
+		let compositionHasAudio = false;
+		if (!muted && finalAudioCodec !== null && videoEnabled) {
+			for (let frame = realFrameRange[0]; frame <= realFrameRange[1]; frame++) {
+				if (signal?.aborted) {
+					throw new Error('renderMediaOnWeb() was cancelled');
+				}
+
+				timeUpdater.current?.update(frame);
+				await waitForRenderReady();
+
+				const assets = collectAssets.current!.peekAssets();
+				if (assets.some((asset) => asset.type === 'inline-audio')) {
+					compositionHasAudio = true;
+					break;
+				}
+
+				await waitForPageResponsiveness();
+			}
+
+			timeUpdater.current?.update(realFrameRange[0]);
+			await waitForRenderReady();
+		} else {
+			compositionHasAudio = !muted;
+		}
+
 		using videoSampleSource =
 			videoEnabled && codec
 				? makeVideoSampleSourceCleanup({
@@ -443,7 +473,7 @@ const internalRenderMediaOnWeb = async <
 		}
 
 		using audioSampleSource = createAudioSampleSource({
-			muted,
+			muted: muted || !compositionHasAudio,
 			codec: finalAudioCodec
 				? audioCodecToMediabunnyAudioCodec(finalAudioCodec)
 				: null,
@@ -588,9 +618,9 @@ const internalRenderMediaOnWeb = async <
 
 			await waitForPageResponsiveness();
 
-			const audio = muted
-				? null
-				: onlyInlineAudio({assets, fps: resolved.fps, timestamp, sampleRate});
+			const audio = audioSampleSource
+				? onlyInlineAudio({assets, fps: resolved.fps, timestamp, sampleRate})
+				: null;
 			internalState.addAudioMixingTime(performance.now() - audioCombineStart);
 
 			await waitForPageResponsiveness();

--- a/packages/web-renderer/src/test/audio.test.tsx
+++ b/packages/web-renderer/src/test/audio.test.tsx
@@ -1,6 +1,6 @@
 import {Audio, Video} from '@remotion/media';
 import {ALL_FORMATS, BlobSource, Input, type InputAudioTrack} from 'mediabunny';
-import {staticFile} from 'remotion';
+import {Sequence, staticFile} from 'remotion';
 import {expect, test} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import '../symbol-dispose';
@@ -264,6 +264,78 @@ test('should render audio at 44100 Hz when sampleRate is set', async (t) => {
 	const blob = await result.getBlob();
 	const track = await getAudioTrackFromBlob(blob);
 	expect(track.sampleRate).toBe(44100);
+});
+
+test('silent composition should not get an audio track that inflates the container duration', async () => {
+	const Component: React.FC = () => {
+		return null;
+	};
+
+	const durationInFrames = 10;
+	const fps = 30;
+
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: Component,
+			id: 'silent-no-audio-track-test',
+			width: 100,
+			height: 100,
+			fps,
+			durationInFrames,
+			calculateMetadata: null,
+		},
+		container: 'mp4',
+		outputTarget: 'arraybuffer',
+	});
+
+	const blob = await result.getBlob();
+	using input = new Input({
+		formats: ALL_FORMATS,
+		source: new BlobSource(blob),
+	});
+
+	const tracks = await input.getTracks();
+	expect(tracks.some((track) => track.isAudioTrack())).toBe(false);
+
+	const duration = await input.computeDuration();
+	expect(duration).toBeLessThanOrEqual(durationInFrames / fps);
+});
+
+test('audio starting after a silent lead-in should stay in sync', async () => {
+	const from = 5;
+
+	const Component: React.FC = () => {
+		return (
+			<Sequence from={from}>
+				<Audio src={staticFile('dialogue.wav')} />
+			</Sequence>
+		);
+	};
+
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: Component,
+			id: 'silent-lead-in-test',
+			width: 100,
+			height: 100,
+			fps: 30,
+			durationInFrames: 10,
+			calculateMetadata: null,
+		},
+		container: 'mp4',
+		outputTarget: 'arraybuffer',
+	});
+
+	const blob = await result.getBlob();
+	const track = await getAudioTrackFromBlob(blob);
+
+	const firstTimestamp = await track.getFirstTimestamp();
+	expect(firstTimestamp).toBe(0);
+
+	const duration = await track.computeDuration();
+	expect(duration).toBeGreaterThanOrEqual(10 / 30);
 });
 
 test('should render audio at default 48000 Hz when sampleRate is not set', async (t) => {


### PR DESCRIPTION

Follow-up to #9622 implementing the suggested approach from https://github.com/remotion-dev/remotion/pull/9622#issuecomment-5091262300: determine that a composition has no audio sources and behave as if `muted: true` was passed.

Fixes #7099

## Summary

`renderMediaOnWeb()` registers an audio track whenever rendering is not muted and an audio codec is available, and every frame feeds an all-zero sample to the AAC encoder even when the composition contains no audio. Encoder priming then makes the silent audio track longer than the video track, so the MP4 container duration exceeds `durationInFrames / fps` (repro on `main`, 10 frames @ 30fps: `0.3627s` vs `0.3333s` expected).

Unlike #9622, this does not change how audio samples are timed or emitted — compositions that contain audio anywhere in the range render exactly as before (silence-padded from frame 0, no disjointed tracks).

## Implementation

- Before creating the muxer tracks, scan the frame range (`timeUpdater.update(frame)` → `waitForRenderReady()` → check assets for `inline-audio`, breaking at the first hit) and reset back to the first frame. If no audio is found, `muted: true` is effectively passed to `createAudioSampleSource()`, so no audio track is registered at all.
- The scan is skipped for `muted` renders, containers without an audio codec, and audio-only containers (which keep their track so the output is not empty).
- Added `peekAssets()` alongside `collectAssets()` on the scaffold's asset ref: `collectAssets()` clears the registered assets, and assets only re-register when the frame value changes, so a consuming pre-scan would have swallowed the first frame's assets from the render loop (caught by the existing `toneFrequency` test).

## Tradeoffs

- Compositions with an audio codec pay an extra React render pass per frame (no screenshots/encoding) up to the first frame containing audio. Compositions with audio from frame 0 only pay a single extra frame render.

## Tests

- New test: a silent composition produces no audio track and the container duration does not exceed `durationInFrames / fps` (fails on `main`, passes with this change).
- New test: audio starting after a silent lead-in (`<Sequence from={5}>`) still starts at timestamp 0 and covers the full composition duration.
- Verified with ffprobe/ffmpeg out-of-band: silent renders (full and frame-range) have zero excess container duration; renders with audio keep an audible, full-length AAC track; mid-start audio keeps a silent lead-in and correctly timed content.

Co-Authored-By: Aiden <aiden@weco.ai>