### PR TITLE
Elements: Make preview metadata explicit

### DIFF
--- a/.agents/skills/publish-element/SKILL.md
+++ b/.agents/skills/publish-element/SKILL.md
@@ -26,7 +26,7 @@ bun run remotion
 
 ## 2. Perform the publication review
 
-Review the finished source, MDX page, and central definition against the Element Guidelines. Resolve placeholder content and finalize the description, display name, contributors, dimensions, duration, preview padding, and poster frame.
+Review the finished source, MDX page, and central definition against the Element Guidelines. Resolve placeholder content and finalize the description, display name, contributors, dimensions, duration, preview padding, poster frame, and `preview` object. Confirm that `posterUrl` and `videoUrl` use flat `https://remotion.media/elements/<category>-<slug>-preview.png` and `.mp4` paths. Preview assets are composited onto the standard background and use MP4 for broad browser, social-card, and embed compatibility, even when the Element itself supports transparency. These explicit URLs are the publishing source of truth.
 
 Re-check the technical implementation requirements from the [`scaffold-element` skill](../scaffold-element/SKILL.md): The reusable implementation must remain in one self-contained TSX file, fill its configured bounds without a wrapper `<Sequence>` or preview-only source padding, and leave outer placement to the surrounding project. Animated entrances must have exits with inline, hardcoded frame ranges on useful named `Interactive.*` elements. Inner control names must not repeat the Element display name.
 
@@ -79,7 +79,15 @@ bunx remotion render \
 cd ../..
 ```
 
-Do not run `render-element-previews`, because it renders every Element and clears the previous preview output.
+Do not run `render-element-previews` without an Element filter, because that renders every Element and clears the complete preview output. If uploading is explicitly requested later, use:
+
+```bash
+cd packages/docs
+bun run render-element-previews --element=<category>/<slug> --upload
+cd ../..
+```
+
+The filtered command clears and regenerates only that Element's nested local review output, then uses its explicit metadata URLs for the public locations and R2 keys.
 
 Inspect `packages/docs/.element-previews/<category>/<slug>/preview.png` and `preview.mp4`, then give both paths to the developer for visual review. Stop and wait for the developer to explicitly confirm that both previews look correct. Do not run the final repository checks or finish the publishing workflow until that approval is received.
 

--- a/.agents/skills/scaffold-element/SKILL.md
+++ b/.agents/skills/scaffold-element/SKILL.md
@@ -17,6 +17,11 @@ Choose an existing category and a kebab-case slug. Before creating files, determ
 - Fixed Element width and height, or `null` for both so it inherits the composition dimensions
 - Preview padding, which affects only the docs preview and not the Element bounds
 - A provisional poster frame
+- Explicit poster and video URLs using the flat asset convention:
+  - `https://remotion.media/elements/<category>-<slug>-preview.png`
+  - `https://remotion.media/elements/<category>-<slug>-preview.mp4`
+
+Preview videos are always opaque MP4 files for broad browser, social-card, and embed compatibility. Elements that are transparent in a composition are composited onto the standard preview background for these assets.
 
 Inspect `packages/docs/elements-template/` and at least one existing Element in the same category. Do not create a new category unless the task explicitly requires one.
 
@@ -39,7 +44,7 @@ Follow the Element Guidelines for the component itself. When using Studio-editab
 
 ## 3. Register the development composition
 
-Import and register the component in `packages/docs/src/components/Elements/element-definitions.ts` using the planned preview metadata.
+Import and register the component in `packages/docs/src/components/Elements/element-definitions.ts` using the planned preview metadata. Add the explicit `preview` object next to the render metadata, including `posterUrl` and `videoUrl`. The URLs in this object are the source of truth for publishing; do not add a helper that derives production URLs from the Element slug.
 
 Do not edit `packages/docs/src/remotion/Root.tsx`. It automatically creates a composition for every central definition using the same sizing and wrapper used by published Elements.
 

--- a/packages/docs/elements-template/index.mdx
+++ b/packages/docs/elements-template/index.mdx
@@ -18,6 +18,10 @@ export const elementDefinition = {
   fps: 30,
   height: 1080,
   posterFrame: 60,
+  preview: {
+    posterUrl: 'https://remotion.media/elements/category-element-title-preview.png',
+    videoUrl: 'https://remotion.media/elements/category-element-title-preview.mp4',
+  },
   previewPadding: 0,
   slug: 'category/element-title',
   width: 1920,

--- a/packages/docs/render-element-previews.ts
+++ b/packages/docs/render-element-previews.ts
@@ -4,10 +4,7 @@ import {bundle} from '@remotion/bundler';
 import {getCompositions, renderMedia, renderStill} from '@remotion/renderer';
 import {S3Client} from 'bun';
 import {elementDefinitions} from './src/components/Elements/element-definitions';
-import {
-	getElementCompositionId,
-	getElementPreviewUrls,
-} from './src/components/Elements/element-utils';
+import {getElementCompositionId} from './src/components/Elements/element-utils';
 
 const r2Endpoint =
 	'https://2fe488b3b0f4deee223aef7464784c46.r2.cloudflarestorage.com';
@@ -19,6 +16,45 @@ const outputDirectoryArgument = process.argv.find((argument) =>
 const outputDirectory = outputDirectoryArgument
 	? path.resolve(outputDirectoryArgument.slice('--output-dir='.length))
 	: path.join(process.cwd(), '.element-previews');
+const elementArguments = process.argv.filter((argument) =>
+	argument.startsWith('--element='),
+);
+if (process.argv.includes('--element')) {
+	throw new Error('Use --element=<category>/<slug>');
+}
+
+if (elementArguments.length > 1) {
+	throw new Error('Only one --element argument may be specified');
+}
+
+const selectedElementSlug = elementArguments[0]
+	? elementArguments[0].slice('--element='.length)
+	: null;
+const allElementDefinitions = Object.values(elementDefinitions);
+const selectedElementDefinition = selectedElementSlug
+	? allElementDefinitions.find(
+			(definition) => definition.slug === selectedElementSlug,
+		)
+	: null;
+if (selectedElementSlug !== null && !selectedElementDefinition) {
+	throw new Error(`Unknown Element: ${selectedElementSlug}`);
+}
+
+const definitionsToRender = selectedElementDefinition
+	? [selectedElementDefinition]
+	: allElementDefinitions;
+
+const getUploadKey = (publicUrl: string) => {
+	const url = new URL(publicUrl);
+	if (
+		url.origin !== 'https://remotion.media' ||
+		!url.pathname.startsWith('/elements/')
+	) {
+		throw new Error(`Unexpected Element preview URL: ${publicUrl}`);
+	}
+
+	return url.pathname.slice(1);
+};
 
 const ensureUploadCredentials = () => {
 	if (!Bun.env.AWS_ACCESS_KEY_ID || !Bun.env.AWS_SECRET_ACCESS_KEY) {
@@ -82,7 +118,15 @@ const client = credentials
 		})
 	: null;
 
-rmSync(outputDirectory, {force: true, recursive: true});
+if (selectedElementSlug === null) {
+	rmSync(outputDirectory, {force: true, recursive: true});
+} else {
+	rmSync(path.join(outputDirectory, ...selectedElementSlug.split('/')), {
+		force: true,
+		recursive: true,
+	});
+}
+
 mkdirSync(outputDirectory, {recursive: true});
 
 const serveUrl = await bundle({
@@ -118,7 +162,8 @@ for (const actualId of actualCompositionIds) {
 	}
 }
 
-for (const definition of Object.values(elementDefinitions)) {
+for (const definition of definitionsToRender) {
+	const {posterUrl, videoUrl} = definition.preview;
 	const compositionId = getElementCompositionId(definition.slug);
 	const composition = elementCompositions.find(
 		(candidate) => candidate.id === compositionId,
@@ -133,11 +178,7 @@ for (const definition of Object.values(elementDefinitions)) {
 	);
 	mkdirSync(elementOutputDirectory, {recursive: true});
 	const pngPath = path.join(elementOutputDirectory, 'preview.png');
-	const videoExtension = definition.transparentPreview ? 'webm' : 'mp4';
-	const videoPath = path.join(
-		elementOutputDirectory,
-		`preview.${videoExtension}`,
-	);
+	const videoPath = path.join(elementOutputDirectory, 'preview.mp4');
 
 	console.log(`Rendering ${definition.displayName} poster`);
 	await renderStill({
@@ -151,13 +192,13 @@ for (const definition of Object.values(elementDefinitions)) {
 	console.log(`Rendering ${definition.displayName} video`);
 	await renderMedia({
 		chromiumOptions: {gl: 'angle'},
-		codec: definition.transparentPreview ? 'vp8' : 'h264',
+		codec: 'h264',
 		composition,
 		crf: 23,
 		imageFormat: 'png',
 		muted: true,
 		outputLocation: videoPath,
-		pixelFormat: definition.transparentPreview ? 'yuva420p' : 'yuv420p',
+		pixelFormat: 'yuv420p',
 		serveUrl,
 	});
 
@@ -165,27 +206,28 @@ for (const definition of Object.values(elementDefinitions)) {
 	console.log(`Rendered ${videoPath}`);
 
 	if (client) {
-		const urls = getElementPreviewUrls(definition);
-		const baseKey = `elements/${definition.slug}`;
 		await uploadAsset({
 			client,
 			contentType: 'image/png',
 			filePath: pngPath,
-			key: `${baseKey}/preview.png`,
-			publicUrl: urls.png,
+			key: getUploadKey(posterUrl),
+			publicUrl: posterUrl,
 		});
 		await uploadAsset({
 			client,
-			contentType: definition.transparentPreview ? 'video/webm' : 'video/mp4',
+			contentType: 'video/mp4',
 			filePath: videoPath,
-			key: `${baseKey}/preview.${videoExtension}`,
-			publicUrl: urls.video,
+			key: getUploadKey(videoUrl),
+			publicUrl: videoUrl,
 		});
 	}
 }
 
+const renderedScope = selectedElementSlug
+	? `Element ${selectedElementSlug}`
+	: 'all Element previews';
 console.log(
 	upload
-		? 'Rendered and uploaded all Element previews.'
-		: `Rendered all Element previews to ${outputDirectory}.`,
+		? `Rendered and uploaded ${renderedScope}.`
+		: `Rendered ${renderedScope} to ${outputDirectory}.`,
 );

--- a/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
+++ b/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
@@ -72,13 +72,7 @@ export const ElementAssetComposition: React.FC<{
 	const definition = getElementDefinition(slug);
 
 	return (
-		<AbsoluteFill
-			style={{
-				backgroundColor: definition.transparentPreview
-					? 'transparent'
-					: ELEMENT_PREVIEW_BACKGROUND,
-			}}
-		>
+		<AbsoluteFill style={{backgroundColor: ELEMENT_PREVIEW_BACKGROUND}}>
 			<ElementPreviewComposition definition={definition} />
 		</AbsoluteFill>
 	);

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -16,6 +16,11 @@ import {TextMarker} from '../../../elements/text/text-marker/text-marker';
 import {TimedCaptions} from '../../../elements/text/timed-captions/timed-captions';
 import type {Contributor} from '../Credits';
 
+export type ElementPreviewMetadata = {
+	readonly posterUrl: `https://remotion.media/elements/${string}-preview.png`;
+	readonly videoUrl: `https://remotion.media/elements/${string}-preview.mp4`;
+};
+
 export type ElementDefinition = {
 	readonly category: string;
 	readonly component: ComponentType<Record<string, never>>;
@@ -28,9 +33,9 @@ export type ElementDefinition = {
 	readonly fps: number;
 	readonly height: number;
 	readonly posterFrame: number;
+	readonly preview: ElementPreviewMetadata;
 	readonly previewPadding: number;
 	readonly slug: string;
-	readonly transparentPreview: boolean;
 	readonly width: number;
 };
 
@@ -48,9 +53,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 120,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-liquid-contours-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-liquid-contours-preview.mp4',
+		},
 		previewPadding: 0,
 		slug: 'backgrounds/liquid-contours',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'backgrounds/notebook-paper': {
@@ -65,9 +75,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 0,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-notebook-paper-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-notebook-paper-preview.mp4',
+		},
 		previewPadding: 0,
 		slug: 'backgrounds/notebook-paper',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'backgrounds/paper-texture': {
@@ -83,9 +98,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-paper-texture-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-paper-texture-preview.mp4',
+		},
 		previewPadding: 0,
 		slug: 'backgrounds/paper-texture',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'backgrounds/rotating-starburst': {
@@ -100,9 +120,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 120,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.mp4',
+		},
 		previewPadding: 0,
 		slug: 'backgrounds/rotating-starburst',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'overlays/location-lower-third': {
@@ -117,9 +142,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/overlays-location-lower-third-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/overlays-location-lower-third-preview.mp4',
+		},
 		previewPadding: 300,
 		slug: 'overlays/location-lower-third',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'overlays/lower-third': {
@@ -135,9 +165,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/overlays-lower-third-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/overlays-lower-third-preview.mp4',
+		},
 		previewPadding: 300,
 		slug: 'overlays/lower-third',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'data/horizontal-bar-chart': {
@@ -153,9 +188,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 48,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/data-horizontal-bar-chart-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/data-horizontal-bar-chart-preview.mp4',
+		},
 		previewPadding: 56,
 		slug: 'data/horizontal-bar-chart',
-		transparentPreview: true,
 		width: 1920,
 	},
 	'data/number-counter': {
@@ -176,9 +216,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/data-number-counter-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/data-number-counter-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'data/number-counter',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'data/product-offer': {
@@ -194,9 +239,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 75,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/data-product-offer-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/data-product-offer-preview.mp4',
+		},
 		previewPadding: 90,
 		slug: 'data/product-offer',
-		transparentPreview: true,
 		width: 1080,
 	},
 	'text/circle-marker': {
@@ -212,9 +262,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/text-circle-marker-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/text-circle-marker-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'text/circle-marker',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'text/crossed-off': {
@@ -230,9 +285,12 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl: 'https://remotion.media/elements/text-crossed-off-preview.png',
+			videoUrl: 'https://remotion.media/elements/text-crossed-off-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'text/crossed-off',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'text/news-article-headline-highlight': {
@@ -248,9 +306,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 100,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/text-news-article-headline-highlight-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/text-news-article-headline-highlight-preview.mp4',
+		},
 		previewPadding: 0,
 		slug: 'text/news-article-headline-highlight',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'text/strike-through': {
@@ -266,9 +329,14 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/text-strike-through-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/text-strike-through-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'text/strike-through',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'text/text-marker': {
@@ -284,9 +352,12 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 60,
+		preview: {
+			posterUrl: 'https://remotion.media/elements/text-text-marker-preview.png',
+			videoUrl: 'https://remotion.media/elements/text-text-marker-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'text/text-marker',
-		transparentPreview: false,
 		width: 1920,
 	},
 	'text/timed-captions': {
@@ -302,6 +373,12 @@ export const elementDefinitions = {
 		fps: 30,
 		height: 1080,
 		posterFrame: 75,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/text-timed-captions-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/text-timed-captions-preview.mp4',
+		},
 		previewPadding: 120,
 		slug: 'text/timed-captions',
 		width: 1920,

--- a/packages/docs/src/components/Elements/element-utils.ts
+++ b/packages/docs/src/components/Elements/element-utils.ts
@@ -15,15 +15,6 @@ export const getElementCompositionId = (slug: string) => {
 	return `element-${slug.replaceAll('/', '-')}`;
 };
 
-export const getElementPreviewUrls = (definition: ElementDefinition) => {
-	const base = `https://remotion.media/elements/${definition.slug}`;
-
-	return {
-		png: `${base}/preview.png`,
-		video: `${base}/preview.${definition.transparentPreview ? 'webm' : 'mp4'}`,
-	};
-};
-
 export const getElementDefinition = (slug: string) => {
 	const definition =
 		elementDefinitions[slug as keyof typeof elementDefinitions];

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -301,10 +301,12 @@ describe('Element preview definitions', () => {
 
 	test('the Element template includes explicit flat preview URLs', () => {
 		const template = readFileSync(path.join(templateRoot, 'index.mdx'), 'utf8');
-		expect(template).toContain(`preview: {
-    posterUrl: 'https://remotion.media/elements/category-element-title-preview.png',
-    videoUrl: 'https://remotion.media/elements/category-element-title-preview.mp4',
-  },`);
+		expect(template).toContain(
+			"posterUrl: 'https://remotion.media/elements/category-element-title-preview.png'",
+		);
+		expect(template).toContain(
+			"videoUrl: 'https://remotion.media/elements/category-element-title-preview.mp4'",
+		);
 	});
 
 	test('registers Element compositions in a Folder', () => {

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -10,7 +10,6 @@ import {elementDefinitions} from '../components/Elements/element-definitions';
 import {
 	getElementCompositionId,
 	getElementDimensionsLabel,
-	getElementPreviewUrls,
 } from '../components/Elements/element-utils';
 import {getElementPreviewDimensions} from '../components/Elements/ElementPreviewComposition';
 
@@ -283,29 +282,29 @@ describe('Element preview definitions', () => {
 		}
 	});
 
-	test('derives stable composition IDs and preview URLs', () => {
+	test('uses stable composition IDs and explicit flat MP4 preview URLs', () => {
 		const compositionIds = elementDefinitionList.map((definition) =>
 			getElementCompositionId(definition.slug),
 		);
 		expect(new Set(compositionIds).size).toBe(compositionIds.length);
 
 		for (const definition of elementDefinitionList) {
-			expect(getElementPreviewUrls(definition)).toEqual({
-				png: `https://remotion.media/elements/${definition.slug}/preview.png`,
-				video: `https://remotion.media/elements/${definition.slug}/preview.${definition.transparentPreview ? 'webm' : 'mp4'}`,
-			});
+			const assetSlug = definition.slug.replaceAll('/', '-');
+			expect(String(definition.preview.posterUrl)).toBe(
+				`https://remotion.media/elements/${assetSlug}-preview.png`,
+			);
+			expect(String(definition.preview.videoUrl)).toBe(
+				`https://remotion.media/elements/${assetSlug}-preview.mp4`,
+			);
 		}
 	});
 
-	test('supports transparent preview assets', () => {
-		expect(elementDefinitions['data/product-offer'].transparentPreview).toBe(
-			true,
-		);
-		expect(
-			elementDefinitionList
-				.filter((definition) => definition.transparentPreview)
-				.map((definition) => definition.slug),
-		).toEqual(['data/horizontal-bar-chart', 'data/product-offer']);
+	test('the Element template includes explicit flat preview URLs', () => {
+		const template = readFileSync(path.join(templateRoot, 'index.mdx'), 'utf8');
+		expect(template).toContain(`preview: {
+    posterUrl: 'https://remotion.media/elements/category-element-title-preview.png',
+    videoUrl: 'https://remotion.media/elements/category-element-title-preview.mp4',
+  },`);
 	});
 
 	test('registers Element compositions in a Folder', () => {


### PR DESCRIPTION
## Summary

- define explicit flat poster and video URLs alongside each Element's preview metadata
- render broadly compatible opaque MP4 previews and derive R2 upload keys from the metadata URLs
- support rendering and uploading a single Element while preserving unrelated local preview output
- update the Element template, publishing skills, and metadata tests

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- `bun run render-element-previews --element=data/horizontal-bar-chart --upload`
- `bun run render-element-previews --element=data/product-offer --upload`
- verified the generated videos are H.264/yuv420p and the posters are opaque
