### PR TITLE
`@remotion/bundler`: Update docs+overrides for Rspack

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -908,6 +908,8 @@
       "name": "@remotion/it-tests",
       "version": "4.0.500",
       "devDependencies": {
+        "@mdx-js/loader": "2.3.0",
+        "@remotion/babel-loader": "workspace:*",
         "@remotion/bundler": "workspace:*",
         "@remotion/captions": "workspace:*",
         "@remotion/cli": "workspace:*",
@@ -916,6 +918,7 @@
         "@remotion/compositor-darwin-x64": "workspace:*",
         "@remotion/compositor-linux-x64-gnu": "workspace:*",
         "@remotion/compositor-win32-x64-msvc": "workspace:*",
+        "@remotion/enable-scss": "workspace:*",
         "@remotion/example-videos": "workspace:*",
         "@remotion/google-fonts": "workspace:*",
         "@remotion/install-whisper-cpp": "workspace:*",
@@ -935,6 +938,7 @@
         "@remotion/shapes": "workspace:*",
         "@remotion/studio-server": "workspace:*",
         "@remotion/studio-shared": "workspace:*",
+        "@remotion/tailwind": "workspace:*",
         "@remotion/transitions": "workspace:*",
         "@remotion/webcodecs": "workspace:*",
         "@remotion/zod-types": "workspace:*",
@@ -942,7 +946,11 @@
         "@types/sharp": "0.28.6",
         "create-video": "workspace:*",
         "execa": "5.1.1",
+        "postcss": "8.5.18",
+        "postcss-loader": "7.3.4",
+        "postcss-size": "5.0.0",
         "remotion": "workspace:*",
+        "sass": "1.77.2",
         "sharp": "catalog:",
       },
     },
@@ -7319,6 +7327,8 @@
     "postcss-selector-not": ["postcss-selector-not@7.0.1", "", { "dependencies": { "postcss-selector-parser": "6.1.1" }, "peerDependencies": { "postcss": "8.4.47" } }, "sha512-1zT5C27b/zeJhchN7fP0kBr16Cc61mu7Si9uWWLoA3Px/D9tIJPKchJCkUH3tPO5D0pCFmGeApAv8XpXBQJ8SQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.1", "", { "dependencies": { "cssesc": "3.0.0", "util-deprecate": "1.0.2" } }, "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg=="],
+
+    "postcss-size": ["postcss-size@5.0.0", "", { "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-FCDVT8YrdtzJFqzfpDM2gy/uUk3F2UkOtatIjrDeTJgadmOtL/X9jN6iD6YIepK4eK4NoJtAPZ/ZPXIDNdabfQ=="],
 
     "postcss-sort-media-queries": ["postcss-sort-media-queries@5.2.0", "", { "dependencies": { "sort-css-media-queries": "2.2.0" }, "peerDependencies": { "postcss": "8.5.5" } }, "sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA=="],
 

--- a/packages/babel-loader/src/index.ts
+++ b/packages/babel-loader/src/index.ts
@@ -1,5 +1,4 @@
-import type {WebpackConfiguration} from '@remotion/bundler';
-import type {RuleSetUseItem} from 'webpack';
+import type {BundlerConfiguration} from '@remotion/bundler';
 
 const envPreset = [
 	require.resolve('@babel/preset-env'),
@@ -15,9 +14,11 @@ function truthy<T>(value: T): value is Truthy<T> {
 	return Boolean(value);
 }
 
-export const replaceLoadersWithBabel = (
-	conf: WebpackConfiguration,
-): WebpackConfiguration => {
+export const replaceLoadersWithBabel = <
+	Configuration extends BundlerConfiguration,
+>(
+	conf: Configuration,
+): Configuration => {
 	return {
 		...conf,
 		module: {
@@ -29,6 +30,7 @@ export const replaceLoadersWithBabel = (
 
 				// All modules that use require.resolve need to be added to cli/src/load-config -> external array
 				if (rule && rule.test?.toString().includes('.tsx')) {
+					const existingUse = Array.isArray(rule.use) ? rule.use : [];
 					return {
 						test: /\.tsx?$/,
 						use: [
@@ -59,7 +61,7 @@ export const replaceLoadersWithBabel = (
 									].filter(truthy),
 								},
 							},
-							(rule.use as RuleSetUseItem[])[1],
+							existingUse[1],
 						].filter(truthy),
 					};
 				}

--- a/packages/docs/components/TableOfContents/api.tsx
+++ b/packages/docs/components/TableOfContents/api.tsx
@@ -85,7 +85,7 @@ export const TableOfContents: React.FC = () => {
 			<p>Work with transcriptions from ElevenLabs</p>
 			<ElevenLabsTableOfContents />
 			<h2>@remotion/enable-scss</h2>
-			<p>Webpack override for enabling SASS/SCSS</p>
+			<p>Bundler override for enabling SASS/SCSS</p>
 			<EnableScssTableOfContents />
 			<h2>@remotion/fonts</h2>
 			<p>Load font files onto a page.</p>
@@ -169,10 +169,10 @@ export const TableOfContents: React.FC = () => {
 			<p>APIs for controlling theRemotion Studio</p>
 			<StudioTableOfContents />
 			<h2>@remotion/tailwind</h2>
-			<p>Webpack override for using TailwindCSS v3</p>
+			<p>Bundler override for using TailwindCSS v3</p>
 			<TailwindTableOfContents />
 			<h2>@remotion/tailwind-v4</h2>
-			<p>Webpack override for using TailwindCSS v4</p>
+			<p>Bundler override for using TailwindCSS v4</p>
 			<TailwindV4TableOfContents />
 			<h2>@remotion/three</h2>
 			<p>Create 3D videos using React Three Fiber</p>

--- a/packages/docs/docs/enable-scss/TableOfContents.tsx
+++ b/packages/docs/docs/enable-scss/TableOfContents.tsx
@@ -8,7 +8,7 @@ export const TableOfContents: React.FC = () => {
 			<Grid>
 				<TOCItem link="/docs/enable-scss/enable-scss">
 					<strong>{'enableScss()'}</strong>
-					<div>Override the Webpack config to enable SCSS</div>
+					<div>Override the bundler config to enable SCSS</div>
 				</TOCItem>
 			</Grid>
 		</div>

--- a/packages/docs/docs/enable-scss/enable-scss.mdx
+++ b/packages/docs/docs/enable-scss/enable-scss.mdx
@@ -7,13 +7,13 @@ crumb: "@remotion/enable-scss"
 
 _available from v4.0.162_
 
-A function that modifies the default Webpack configuration to make the necessary changes to support SASS/SCSS.
+A function that modifies the default bundler configuration to make the necessary changes to support SASS/SCSS.
 
 ```ts twoslash title="remotion.config.ts"
 import { Config } from "@remotion/cli/config";
 import { enableScss } from "@remotion/enable-scss";
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableScss(currentConfiguration);
 });
 ```
@@ -24,7 +24,7 @@ If you want to make other configuration changes, you can do so by doing them red
 import { Config } from "@remotion/cli/config";
 import { enableScss } from "@remotion/enable-scss";
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableScss({
     ...currentConfiguration,
     // Make other changes

--- a/packages/docs/docs/enable-scss/overview.mdx
+++ b/packages/docs/docs/enable-scss/overview.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import {ExperimentalBadge} from '../../components/Experimental';
 import {TableOfContents} from './TableOfContents';
 
-This package provides a Webpack override for enabling [SCSS/SASS](https://sass-lang.com/) with Remotion.
+This package provides a bundler override for enabling [SCSS/SASS](https://sass-lang.com/) with Remotion.
 
 ## Installation
 
@@ -32,7 +32,7 @@ Newer versions may not work.
 import {Config} from '@remotion/cli/config';
 import {enableScss} from '@remotion/enable-scss';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableScss(currentConfiguration);
 });
 ```

--- a/packages/docs/docs/legacy-babel-loader.mdx
+++ b/packages/docs/docs/legacy-babel-loader.mdx
@@ -8,13 +8,13 @@ crumb: "How To"
 import Tabs from "@theme/Tabs";
 import TabItem from '@theme/TabItem';
 
-In Remotion 2.0, the traditional transpilation of Javascript and Typescript using the `babel-loader` has been replaced by the faster `esbuild-loader` by default.
+Remotion uses faster transpilation by default: `esbuild-loader` with Webpack and SWC with Rspack.
 
-If you for some reason need to go back to the previous behavior, you may [override the Webpack configuration](/docs/bundlers). Remember that overriding the Webpack configuration works reducer-style, where you get the default configuration in a function argument and you return the modified version of your config.
+To use Babel instead, [override the bundler configuration](/docs/bundlers). Overrides work reducer-style: You receive the default configuration and return the modified configuration.
 
-We provide a compatibility package `@remotion/babel-loader` that you can install into your Remotion project and use the function `replaceLoadersWithBabel()` to swap out the ESBuild loader with the old Babel one that was in Remotion 1.0
+The `@remotion/babel-loader` compatibility package provides `replaceLoadersWithBabel()` to replace the default JavaScript and TypeScript loaders with Babel.
 
-This should not be necessary in general, it is encouraged to [report issues](https://github.com/remotion-dev/remotion/issues/new) regarding the new ESBuild loader.
+This should not be necessary in general. We encourage you to [report issues](https://github.com/remotion-dev/remotion/issues/new) with the default transpiler.
 
 ## Example
 
@@ -55,19 +55,19 @@ import { Config } from "@remotion/cli/config";
 // ---cut---
 import { replaceLoadersWithBabel } from "@remotion/babel-loader";
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return replaceLoadersWithBabel(currentConfiguration);
 });
 ```
 
 ## When using `bundle` or `deploySite`
 
-When using the Node.JS APIs - [`bundle()`](/docs/bundle) for SSR or [`deploySite()`](/docs/lambda/deploysite) for Lambda, you also need to provide the Webpack override, since the Node.JS APIs do not read from the config file.
+When using the Node.JS APIs - [`bundle()`](/docs/bundle) for SSR or [`deploySite()`](/docs/lambda/deploysite) for Lambda, also provide the bundler override because these APIs do not read the config file.
 
 ```ts twoslash title="my-script.js"
-// @filename: ./src/webpack-override.ts
-import { WebpackOverrideFn } from "@remotion/bundler";
-export const webpackOverride: WebpackOverrideFn = (c) => c;
+// @filename: ./src/bundler-override.ts
+import { BundlerOverrideFn } from "@remotion/bundler";
+export const bundlerOverride: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // @target: esnext
 // ---cut---
@@ -76,10 +76,10 @@ import { replaceLoadersWithBabel } from "@remotion/babel-loader";
 
 await bundle({
   entryPoint: require.resolve("./src/index.ts"),
-  webpackOverride: (config) => replaceLoadersWithBabel(config),
+  bundlerOverride: (config) => replaceLoadersWithBabel(config),
 });
 ```
 
 ## See also
 
-- [Custom Webpack config](/docs/bundlers)
+- [Custom bundler config](/docs/bundlers)

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -129,12 +129,12 @@ Config.overrideRspackConfig((currentConfiguration) => {
 
 Node.js APIs do not read `remotion.config.ts`. Pass the overrides directly to [`bundle()`](/docs/bundle) or [`deploySite()`](/docs/lambda/deploysite). Put an override in a separate file to import it from both `remotion.config.ts` and your Node.js script.
 
-For Rspack, pass `rspackOverride`. Pass portable changes as `bundlerOverride`.
+Pass portable changes as `bundlerOverride`.
 
-```ts twoslash title="src/webpack-override.ts"
-import {WebpackOverrideFn} from '@remotion/bundler';
+```ts twoslash title="src/bundler-override.ts"
+import {BundlerOverrideFn} from '@remotion/bundler';
 
-export const webpackOverride: WebpackOverrideFn = (currentConfiguration) => {
+export const bundlerOverride: BundlerOverrideFn = (currentConfiguration) => {
   return {
     ...currentConfiguration,
     // Your override here
@@ -143,57 +143,59 @@ export const webpackOverride: WebpackOverrideFn = (currentConfiguration) => {
 ```
 
 ```ts twoslash title="remotion.config.ts"
-// @filename: ./src/webpack-override.ts
-import {WebpackOverrideFn} from '@remotion/bundler';
-export const webpackOverride: WebpackOverrideFn = (c) => c;
+// @filename: ./src/bundler-override.ts
+import {BundlerOverrideFn} from '@remotion/bundler';
+export const bundlerOverride: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // ---cut---
 import {Config} from '@remotion/cli/config';
-import {webpackOverride} from './src/webpack-override';
+import {bundlerOverride} from './src/bundler-override';
 
-Config.overrideWebpackConfig(webpackOverride);
+Config.overrideBundlerConfig(bundlerOverride);
 ```
 
 With `bundle`:
 
 ```ts twoslash title="my-script.js"
-// @filename: ./src/webpack-override.ts
-import {WebpackOverrideFn} from '@remotion/bundler';
-export const webpackOverride: WebpackOverrideFn = (c) => c;
+// @filename: ./src/bundler-override.ts
+import {BundlerOverrideFn} from '@remotion/bundler';
+export const bundlerOverride: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // @target: esnext
 // ---cut---
 import {bundle} from '@remotion/bundler';
-import {webpackOverride} from './src/webpack-override';
+import {bundlerOverride} from './src/bundler-override';
 
 await bundle({
   entryPoint: require.resolve('./src/index.ts'),
-  webpackOverride,
+  bundlerOverride,
 });
 ```
 
 Or while using with `deploySite`:
 
 ```ts twoslash title="my-script.js"
-// @filename: ./src/webpack-override.ts
-import {WebpackOverrideFn} from '@remotion/bundler';
-export const webpackOverride: WebpackOverrideFn = (c) => c;
+// @filename: ./src/bundler-override.ts
+import {BundlerOverrideFn} from '@remotion/bundler';
+export const bundlerOverride: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // @target: esnext
 // ---cut---
 import {deploySite} from '@remotion/lambda';
-import {webpackOverride} from './src/webpack-override';
+import {bundlerOverride} from './src/bundler-override';
 
 await deploySite({
   entryPoint: require.resolve('./src/index.ts'),
   region: 'us-east-1',
   bucketName: 'remotionlambda-c7fsl3d',
   options: {
-    webpackOverride,
+    bundlerOverride,
   },
   // ...other parameters
 });
 ```
+
+For bundler-specific changes, pass `webpackOverride` or `rspackOverride` instead.
 
 ## Multiple overrides
 
@@ -204,18 +206,18 @@ import {Config} from '@remotion/cli/config';
 import {enableScss} from '@remotion/enable-scss';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig((c) => enableScss(enableTailwind(c)));
+Config.overrideBundlerConfig((c) => enableScss(enableTailwind(c)));
 ```
 
-From Remotion v4.0.229, you can also use `Config.overrideWebpackConfig` multiple times, but this only works in the config file:
+You can also call `Config.overrideBundlerConfig()` multiple times in the config file:
 
 ```tsx twoslash
 import {Config} from '@remotion/cli/config';
 import {enableScss} from '@remotion/enable-scss';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig(enableScss);
-Config.overrideWebpackConfig(enableTailwind);
+Config.overrideBundlerConfig(enableScss);
+Config.overrideBundlerConfig(enableTailwind);
 ```
 
 ## Snippets
@@ -226,12 +228,12 @@ Config.overrideWebpackConfig(enableTailwind);
 
 <Installation pkg="@mdx-js/loader @mdx-js/react" />
 
-2. Create a file with the Webpack override:
+2. Create a file with the bundler override:
 
 ```ts twoslash title="enable-mdx.ts"
-import {WebpackOverrideFn} from '@remotion/bundler';
+import {BundlerOverrideFn} from '@remotion/bundler';
 // ---cut---
-export const enableMdx: WebpackOverrideFn = (currentConfiguration) => {
+export const enableMdx: BundlerOverrideFn = (currentConfiguration) => {
   return {
     ...currentConfiguration,
     module: {
@@ -257,14 +259,14 @@ export const enableMdx: WebpackOverrideFn = (currentConfiguration) => {
 
 ```ts twoslash title="remotion.config.ts"
 // @filename: ./src/enable-mdx.ts
-import {WebpackOverrideFn} from '@remotion/bundler';
-export const enableMdx: WebpackOverrideFn = (c) => c;
+import {BundlerOverrideFn} from '@remotion/bundler';
+export const enableMdx: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // ---cut---
 import {Config} from '@remotion/cli/config';
 import {enableMdx} from './src/enable-mdx';
 
-Config.overrideWebpackConfig(enableMdx);
+Config.overrideBundlerConfig(enableMdx);
 ```
 
 4. Add it to your [Node.JS API calls as well if necessary](#when-using-bundle-and-deploysite).
@@ -285,12 +287,12 @@ For TailwindCSS, use the [TailwindCSS docs](/docs/tailwind) instead.
 
 <Installation pkg="postcss postcss-loader postcss-size" />
 
-2. Create a file with the Webpack override:
+2. Create a file with the bundler override:
 
 ```ts twoslash title="src/enable-postcss.ts"
-import {WebpackOverrideFn} from '@remotion/bundler';
+import {BundlerOverrideFn} from '@remotion/bundler';
 // ---cut---
-export const enablePostCSS: WebpackOverrideFn = (currentConfiguration) => {
+export const enablePostCSS: BundlerOverrideFn = (currentConfiguration) => {
   return {
     ...currentConfiguration,
     module: {
@@ -334,14 +336,14 @@ export const enablePostCSS: WebpackOverrideFn = (currentConfiguration) => {
 
 ```ts twoslash title="remotion.config.ts"
 // @filename: ./src/enable-postcss.ts
-import {WebpackOverrideFn} from '@remotion/bundler';
-export const enablePostCSS: WebpackOverrideFn = (c) => c;
+import {BundlerOverrideFn} from '@remotion/bundler';
+export const enablePostCSS: BundlerOverrideFn = (c) => c;
 // @filename: remotion.config.ts
 // ---cut---
 import {Config} from '@remotion/cli/config';
 import {enablePostCSS} from './src/enable-postcss';
 
-Config.overrideWebpackConfig(enablePostCSS);
+Config.overrideBundlerConfig(enablePostCSS);
 ```
 
 4. Add it to your [Node.JS API calls as well if necessary](#when-using-bundle-and-deploysite).

--- a/packages/docs/docs/tailwind-2.mdx
+++ b/packages/docs/docs/tailwind-2.mdx
@@ -51,7 +51,7 @@ yarn add postcss-loader postcss postcss-preset-env tailwindcss@2 autoprefixer
 ```ts twoslash
 import { Config } from "@remotion/cli/config";
 // ---cut---
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return {
     ...currentConfiguration,
     module: {

--- a/packages/docs/docs/tailwind-v4/TableOfContents.tsx
+++ b/packages/docs/docs/tailwind-v4/TableOfContents.tsx
@@ -8,7 +8,7 @@ export const TableOfContents: React.FC = () => {
 			<Grid>
 				<TOCItem link="/docs/tailwind-v4/enable-tailwind">
 					<strong>{'enableTailwind()'}</strong>
-					<div>Override the Webpack config to enable TailwindCSS</div>
+					<div>Override the bundler config to enable TailwindCSS</div>
 				</TOCItem>
 			</Grid>
 		</div>

--- a/packages/docs/docs/tailwind-v4/enable-tailwind.mdx
+++ b/packages/docs/docs/tailwind-v4/enable-tailwind.mdx
@@ -6,19 +6,19 @@ crumb: '@remotion/tailwind-v4'
 
 _available from v4.0.256_
 
-A function that modifies the default Webpack configuration to make the necessary changes to support TailwindCSS.
+A function that modifies the default bundler configuration to make the necessary changes to support TailwindCSS.
 See the [setup](/docs/tailwind) to see full instructions on how to setup TailwindCSS in Remotion.
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```
 
-## Multiple Webpack changes
+## Multiple bundler changes
 
 If you want to make other configuration changes, you can do so by doing them reducer-style:
 
@@ -26,7 +26,7 @@ If you want to make other configuration changes, you can do so by doing them red
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind({
     ...currentConfiguration,
 

--- a/packages/docs/docs/tailwind-v4/overview.mdx
+++ b/packages/docs/docs/tailwind-v4/overview.mdx
@@ -26,7 +26,7 @@ Install `@remotion/tailwind-v4` as well as TailwindCSS dependencies.
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```

--- a/packages/docs/docs/tailwind.mdx
+++ b/packages/docs/docs/tailwind.mdx
@@ -101,18 +101,18 @@ bun i -D @remotion/tailwind-v4 tailwindcss
   </TabItem>
 </Tabs>
 
-2. Add the Webpack override from `@remotion/tailwind-v4` to your config file:
+2. Add the bundler override from `@remotion/tailwind-v4` to your config file:
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind-v4';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```
 
-3. If you use the [`bundle()` or `deploySite()` Node.JS API, add the Webpack override to it as well](/docs/bundlers#when-using-bundle-and-deploysite).
+3. If you use the [`bundle()` or `deploySite()` Node.JS API, add the bundler override to it as well](/docs/bundlers#when-using-bundle-and-deploysite).
 
 4. Create a file `src/index.css` with the following content:
 
@@ -184,13 +184,13 @@ bun i -D @remotion/tailwind
   </TabItem>
 </Tabs>
 
-2. Add the Webpack override from `@remotion/tailwind` to your config file:
+2. Add the bundler override from `@remotion/tailwind` to your config file:
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```
@@ -199,7 +199,7 @@ Config.overrideWebpackConfig((currentConfiguration) => {
 Prior to `v3.3.39`, the option was called `Config.Bundling.overrideWebpackConfig()`.
 :::
 
-3. If you use the [`bundle()` or `deploySite()` Node.JS API, add the Webpack override to it as well](/docs/bundlers#when-using-bundle-and-deploysite).
+3. If you use the [`bundle()` or `deploySite()` Node.JS API, add the bundler override to it as well](/docs/bundlers#when-using-bundle-and-deploysite).
 
 4. Create a file `src/style.css` with the following content:
 

--- a/packages/docs/docs/tailwind/TableOfContents.tsx
+++ b/packages/docs/docs/tailwind/TableOfContents.tsx
@@ -8,7 +8,7 @@ export const TableOfContents: React.FC = () => {
 			<Grid>
 				<TOCItem link="/docs/tailwind/enable-tailwind">
 					<strong>{'enableTailwind()'}</strong>
-					<div>Override the Webpack config to enable TailwindCSS</div>
+					<div>Override the bundler config to enable TailwindCSS</div>
 				</TOCItem>
 			</Grid>
 		</div>

--- a/packages/docs/docs/tailwind/enable-tailwind.mdx
+++ b/packages/docs/docs/tailwind/enable-tailwind.mdx
@@ -11,19 +11,19 @@ This is documentation for enabling Tailwind v3.
 For the Tailwind v4 version of this site, see the [Tailwind v4 documentation](/docs/tailwind-v4/enable-tailwind).
 :::
 
-A function that modifies the default Webpack configuration to make the necessary changes to support TailwindCSS.
+A function that modifies the default bundler configuration to make the necessary changes to support TailwindCSS.
 See the [setup](/docs/tailwind) to see full instructions on how to setup TailwindCSS in Remotion.
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```
 
-## Multiple Webpack changes
+## Multiple bundler changes
 
 If you want to make other configuration changes, you can do so by doing them reducer-style:
 
@@ -31,7 +31,7 @@ If you want to make other configuration changes, you can do so by doing them red
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind({
     ...currentConfiguration,
 
@@ -53,7 +53,7 @@ import path from 'node:path';
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration, {
     configLocation: path.join(__dirname, 'tailwind.config.js'),
   });

--- a/packages/docs/docs/tailwind/overview.mdx
+++ b/packages/docs/docs/tailwind/overview.mdx
@@ -31,7 +31,7 @@ Install `@remotion/tailwind` as well as TailwindCSS dependencies.
 import {Config} from '@remotion/cli/config';
 import {enableTailwind} from '@remotion/tailwind';
 
-Config.overrideWebpackConfig((currentConfiguration) => {
+Config.overrideBundlerConfig((currentConfiguration) => {
   return enableTailwind(currentConfiguration);
 });
 ```

--- a/packages/enable-scss/src/enable-scss.ts
+++ b/packages/enable-scss/src/enable-scss.ts
@@ -1,6 +1,8 @@
-import type {WebpackOverrideFn} from '@remotion/bundler';
+import type {BundlerConfiguration} from '@remotion/bundler';
 
-export const enableScss: WebpackOverrideFn = (currentConfiguration) => {
+export const enableScss = <Configuration extends BundlerConfiguration>(
+	currentConfiguration: Configuration,
+): Configuration => {
 	return {
 		...currentConfiguration,
 		module: {

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -1,12 +1,11 @@
 import {Config} from '@remotion/cli/config';
-import {webpackOverride} from './src/webpack-override.mjs';
+import {bundlerOverride} from './src/webpack-override.mjs';
 
 Config.setOverwriteOutput(true);
 Config.setExperimentalRspackEnabled(true);
-Config.overrideWebpackConfig(async (config) => {
+Config.overrideBundlerConfig(async (config) => {
 	await new Promise((resolve) => {
 		setTimeout(resolve, 10);
 	});
-	return webpackOverride(config);
+	return bundlerOverride(config);
 });
-Config.overrideRspackConfig(webpackOverride);

--- a/packages/example/src/webpack-override.mjs
+++ b/packages/example/src/webpack-override.mjs
@@ -84,10 +84,8 @@ const aliases = {
 	),
 };
 
-/**
- * @typedef {import('@remotion/bundler').WebpackOverrideFn} WebpackOverrideFn
- */
-export const webpackOverride = (currentConfiguration) => {
+/** @type {import('@remotion/bundler').BundlerOverrideFn} */
+export const bundlerOverride = (currentConfiguration) => {
 	const replaced = (() => {
 		if (WEBPACK_OR_ESBUILD === 'webpack') {
 			const {replaceLoadersWithBabel} = require(

--- a/packages/it-tests/package.json
+++ b/packages/it-tests/package.json
@@ -16,6 +16,8 @@
 	},
 	"private": true,
 	"devDependencies": {
+		"@mdx-js/loader": "2.3.0",
+		"@remotion/babel-loader": "workspace:*",
 		"@types/node": "catalog:",
 		"@remotion/bundler": "workspace:*",
 		"@remotion/cli": "workspace:*",
@@ -26,6 +28,7 @@
 		"@remotion/compositor-win32-x64-msvc": "workspace:*",
 		"@remotion/compositor-linux-x64-gnu": "workspace:*",
 		"@remotion/cloudrun": "workspace:*",
+		"@remotion/enable-scss": "workspace:*",
 		"@remotion/player": "workspace:*",
 		"@remotion/preload": "workspace:*",
 		"@remotion/renderer": "workspace:*",
@@ -45,12 +48,17 @@
 		"@remotion/serverless-client": "workspace:*",
 		"@remotion/studio-server": "workspace:*",
 		"@remotion/studio-shared": "workspace:*",
+		"@remotion/tailwind": "workspace:*",
 		"@remotion/transitions": "workspace:*",
 		"@remotion/webcodecs": "workspace:*",
 		"@types/sharp": "0.28.6",
 		"create-video": "workspace:*",
 		"execa": "5.1.1",
+		"postcss": "8.5.18",
+		"postcss-loader": "7.3.4",
+		"postcss-size": "5.0.0",
 		"remotion": "workspace:*",
+		"sass": "1.77.2",
 		"sharp": "catalog:"
 	}
 }

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/entry.tsx
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/entry.tsx
@@ -1,0 +1,15 @@
+import styles from './module.module.scss';
+import './global.scss';
+import './tailwind.css';
+
+class BabelExperiment {
+	field = 'BABEL_LOADER_SENTINEL';
+}
+
+(
+	globalThis as typeof globalThis & {__portableHelpers: unknown}
+).__portableHelpers = (
+	<div className={`text-red-500 ${styles.moduleClass}`}>
+		{new BabelExperiment().field}
+	</div>
+);

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/global.scss
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/global.scss
@@ -1,0 +1,5 @@
+$global-color: #123456;
+
+.scss-global-sentinel {
+	color: $global-color;
+}

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/module.module.scss
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/module.module.scss
@@ -1,0 +1,5 @@
+$module-color: #654321;
+
+.moduleClass {
+	background-color: $module-color;
+}

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/tailwind.config.cjs
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/tailwind.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	content: [__dirname + '/entry.tsx'],
+	corePlugins: {
+		preflight: false,
+	},
+};

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/tailwind.css
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/tailwind.css
@@ -1,0 +1,1 @@
+@tailwind utilities;

--- a/packages/it-tests/src/bundle/fixtures/portable-helpers/types.d.ts
+++ b/packages/it-tests/src/bundle/fixtures/portable-helpers/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.scss' {
+	const classNames: Record<string, string>;
+	export default classNames;
+}

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/content.mdx
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/content.mdx
@@ -1,0 +1,3 @@
+# MDX portable override sentinel
+
+The answer is {40 + 2}.

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/custom-loader.cjs
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/custom-loader.cjs
@@ -1,0 +1,3 @@
+module.exports = function customLoader(source) {
+	return `export default ${JSON.stringify(`CUSTOM_LOADER:${source.trim()}`)};`;
+};

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/entry.ts
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/entry.ts
@@ -1,0 +1,10 @@
+import Content from './content.mdx';
+import message from './message.custom';
+import './style.css';
+
+(
+	globalThis as typeof globalThis & {__portableOverrides: unknown}
+).__portableOverrides = {
+	Content,
+	message,
+};

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/message.custom
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/message.custom
@@ -1,0 +1,1 @@
+custom loader input

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/style.css
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/style.css
@@ -1,0 +1,3 @@
+.postcss-size-sentinel {
+	size: 321px 181px;
+}

--- a/packages/it-tests/src/bundle/fixtures/portable-overrides/types.d.ts
+++ b/packages/it-tests/src/bundle/fixtures/portable-overrides/types.d.ts
@@ -1,0 +1,11 @@
+declare module '*.mdx' {
+	import type {ComponentType} from 'react';
+
+	const Content: ComponentType;
+	export default Content;
+}
+
+declare module '*.custom' {
+	const content: string;
+	export default content;
+}

--- a/packages/it-tests/src/bundle/rspack-portable-overrides.test.ts
+++ b/packages/it-tests/src/bundle/rspack-portable-overrides.test.ts
@@ -1,0 +1,172 @@
+import {afterAll, expect, test} from 'bun:test';
+import {readdirSync, readFileSync, rmSync} from 'node:fs';
+import path from 'node:path';
+import {replaceLoadersWithBabel} from '@remotion/babel-loader';
+import {bundle, type BundlerOverrideFn} from '@remotion/bundler';
+import {enableScss} from '@remotion/enable-scss';
+import {enableTailwind} from '@remotion/tailwind';
+
+const outputDirectories: string[] = [];
+
+const readJavaScriptFiles = (directory: string): string => {
+	return readdirSync(directory, {withFileTypes: true})
+		.flatMap((entry) => {
+			const absolutePath = path.join(directory, entry.name);
+			if (entry.isDirectory()) {
+				return readJavaScriptFiles(absolutePath);
+			}
+
+			return entry.name.endsWith('.js')
+				? [readFileSync(absolutePath, 'utf8')]
+				: [];
+		})
+		.join('\n');
+};
+
+const bundleFixture = async ({
+	entryPoint,
+	bundlerOverride,
+}: {
+	entryPoint: string;
+	bundlerOverride: BundlerOverrideFn;
+}) => {
+	const outputDirectory = await bundle({
+		entryPoint,
+		bundlerOverride,
+		enableCaching: false,
+		ignoreRegisterRootWarning: true,
+		rootDir: path.dirname(entryPoint),
+		rspack: true,
+	});
+	outputDirectories.push(outputDirectory);
+	return readJavaScriptFiles(outputDirectory);
+};
+
+afterAll(() => {
+	for (const outputDirectory of outputDirectories) {
+		rmSync(outputDirectory, {recursive: true, force: true});
+	}
+});
+
+test(
+	'MDX, PostCSS, and custom loaders work through a shared Rspack override',
+	async () => {
+		const fixtureDirectory = path.join(
+			import.meta.dir,
+			'fixtures',
+			'portable-overrides',
+		);
+		const customLoader = path.join(fixtureDirectory, 'custom-loader.cjs');
+		const bundlerOverride: BundlerOverrideFn = (configuration) => ({
+			...configuration,
+			module: {
+				...configuration.module,
+				rules: [
+					...(configuration.module?.rules ?? []).map((rule) => {
+						if (
+							!rule ||
+							rule === '...' ||
+							!rule.test?.toString().includes('.css')
+						) {
+							return rule;
+						}
+
+						const use = Array.isArray(rule.use)
+							? rule.use
+							: rule.use
+								? [rule.use]
+								: [];
+
+						return {
+							...rule,
+							use: [
+								...use,
+								{
+									loader: 'postcss-loader',
+									options: {
+										postcssOptions: {plugins: ['postcss-size']},
+									},
+								},
+							],
+						};
+					}),
+					{
+						test: /\.mdx?$/,
+						use: [{loader: '@mdx-js/loader', options: {}}],
+					},
+					{test: /\.custom$/, use: [customLoader]},
+				],
+			},
+		});
+
+		const result = await bundleFixture({
+			entryPoint: path.join(fixtureDirectory, 'entry.ts'),
+			bundlerOverride,
+		});
+
+		expect(result).toContain('MDX portable override sentinel');
+		expect(result).toContain('width: 321px');
+		expect(result).toContain('height: 181px');
+		expect(result).toContain('CUSTOM_LOADER:custom loader input');
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'SCSS, Tailwind v3, and Babel helpers work through a shared Rspack override',
+	async () => {
+		const fixtureDirectory = path.join(
+			import.meta.dir,
+			'fixtures',
+			'portable-helpers',
+		);
+		let scriptLoaders: string[] = [];
+		const bundlerOverride: BundlerOverrideFn = (configuration) => {
+			const withHelpers = replaceLoadersWithBabel(
+				enableScss(
+					enableTailwind(configuration, {
+						configLocation: path.join(fixtureDirectory, 'tailwind.config.cjs'),
+					}),
+				),
+			);
+
+			const scriptRule = (withHelpers.module?.rules ?? []).find(
+				(rule) =>
+					rule && rule !== '...' && rule.test?.toString().includes('.tsx'),
+			);
+			if (scriptRule && scriptRule !== '...') {
+				const use = Array.isArray(scriptRule.use)
+					? scriptRule.use
+					: [scriptRule.use];
+				scriptLoaders = use.flatMap((item) => {
+					if (typeof item === 'string') {
+						return item;
+					}
+
+					return item &&
+						typeof item === 'object' &&
+						'loader' in item &&
+						typeof item.loader === 'string'
+						? [item.loader]
+						: [];
+				});
+			}
+			return withHelpers;
+		};
+
+		const result = await bundleFixture({
+			entryPoint: path.join(fixtureDirectory, 'entry.tsx'),
+			bundlerOverride,
+		});
+
+		expect(scriptLoaders[0]).toContain('babel-loader');
+		expect(scriptLoaders).not.toContain('builtin:swc-loader');
+		expect(result).toContain('BABEL_LOADER_SENTINEL');
+		expect(result).toContain('scss-global-sentinel');
+		expect(result).toContain('#123456');
+		expect(result).toContain('moduleClass');
+		expect(result).toContain('#654321');
+		expect(result).toContain('.text-red-500');
+	},
+	{timeout: 60_000},
+);

--- a/packages/it-tests/tsconfig.json
+++ b/packages/it-tests/tsconfig.json
@@ -8,6 +8,9 @@
 	},
 	"references": [
 		{
+			"path": "../babel-loader"
+		},
+		{
 			"path": "../bundler"
 		},
 		{
@@ -15,6 +18,9 @@
 		},
 		{
 			"path": "../create-video"
+		},
+		{
+			"path": "../enable-scss"
 		},
 		{
 			"path": "../lambda"
@@ -30,6 +36,9 @@
 		},
 		{
 			"path": "../studio-shared"
+		},
+		{
+			"path": "../tailwind"
 		},
 		{
 			"path": "../cli"

--- a/packages/tailwind/src/enable.ts
+++ b/packages/tailwind/src/enable.ts
@@ -1,15 +1,15 @@
-import type {WebpackConfiguration} from '@remotion/bundler';
+import type {BundlerConfiguration} from '@remotion/bundler';
 
 /**
- * @description A function that modifies the default Webpack configuration to make the necessary changes to support Tailwind.
+ * @description A function that modifies the default bundler configuration to make the necessary changes to support Tailwind.
  * @see [Documentation](https://www.remotion.dev/docs/tailwind/enable-tailwind)
  */
-export const enableTailwind: (
-	currentConfiguration: WebpackConfiguration,
+export const enableTailwind = <Configuration extends BundlerConfiguration>(
+	currentConfiguration: Configuration,
 	options?: {
 		configLocation?: string;
 	},
-) => WebpackConfiguration = (currentConfiguration, options) => {
+): Configuration => {
 	return {
 		...currentConfiguration,
 		module: {


### PR DESCRIPTION
## Summary

- generalize the SCSS, Tailwind v3, and Babel override helpers so they preserve either supported bundler configuration type
- migrate portable MDX, PostCSS, SCSS, Tailwind, and Babel documentation to shared bundler overrides
- add real Rspack bundle coverage for MDX, PostCSS, a custom loader, SCSS, Tailwind v3, and Babel

Part of #9541.

Closes #9792.
Closes #9793.

## Testing

- `bun test packages/it-tests/src/bundle/rspack-portable-overrides.test.ts`
- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/docs`
- `bun run build-docs` in `packages/docs`
- `bun run render-cards` in `packages/docs`

## Docs previews

- [Webpack and Rspack](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/bundlers)
- [SCSS overview](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/enable-scss/overview)
- [enableScss()](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/enable-scss/enable-scss)
- [Legacy Babel transpilation](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/legacy-babel)
- [TailwindCSS setup](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind)
- [TailwindCSS v2](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind-legacy)
- [Tailwind v3 overview](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind/tailwind)
- [Tailwind v3 enableTailwind()](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind/enable-tailwind)
- [Tailwind v4 overview](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind-v4/overview)
- [Tailwind v4 enableTailwind()](https://remotion-git-codex-rspack-portable-overrides-remotion.vercel.app/docs/tailwind-v4/enable-tailwind)
