### PR TITLE
`@remotion/studio`: Add composition quick action

### DIFF
--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -153,6 +153,7 @@ export const GlobalKeybindings: React.FC = () => {
 							: 'compositions',
 					invocationTimestamp: Date.now(),
 					assetSelection: null,
+					compositionSelection: null,
 				});
 			},
 			triggerIfInputFieldFocused: true,
@@ -205,6 +206,7 @@ export const GlobalKeybindings: React.FC = () => {
 					mode: 'docs',
 					invocationTimestamp: Date.now(),
 					assetSelection: null,
+					compositionSelection: null,
 				});
 			},
 			commandCtrlKey: false,

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -3,6 +3,7 @@ import type {_InternalTypes} from 'remotion';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {PicIcon} from '../../icons/frame';
 import {SolidIcon} from '../../icons/solid';
+import {FilmIcon} from '../../icons/video';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
 import {DefaultPropsEditor} from '../DefaultPropsEditor';
 import {useZodIfPossible} from '../get-zod-if-possible';
@@ -52,16 +53,19 @@ const CompositionActions: React.FC<{
 }> = ({readOnlyStudio}) => {
 	const {
 		canInsertAsset,
+		canInsertComposition,
 		canInsertSolid,
 		canShowInsertAsset,
+		canShowInsertComposition,
 		canShowInsertSolid,
 		insertAsset,
+		insertComposition,
 		insertSolid,
 	} = useCompositionActions();
 
 	if (
 		(readOnlyStudio && !canShowInsertSolid) ||
-		(!canShowInsertAsset && !canShowInsertSolid)
+		(!canShowInsertAsset && !canShowInsertComposition && !canShowInsertSolid)
 	) {
 		return null;
 	}
@@ -88,6 +92,17 @@ const CompositionActions: React.FC<{
 					)}
 				>
 					Add asset...
+				</InspectorInlineAction>
+			) : null}
+			{canShowInsertComposition ? (
+				<InspectorInlineAction
+					disabled={!canInsertComposition}
+					onClick={insertComposition}
+					renderIcon={(color) => (
+						<FilmIcon color={color} style={actionIconStyle} />
+					)}
+				>
+					Add composition...
 				</InspectorInlineAction>
 			) : null}
 		</InspectorActionSection>

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -1,13 +1,20 @@
+import {DragAndDropInternals} from '@remotion/drag-and-drop';
 import type {InsertJsxElementRequest} from '@remotion/studio-shared';
 import {useCallback, useContext, useMemo, useState} from 'react';
-import {Internals} from 'remotion';
+import {Internals, type _InternalTypes} from 'remotion';
 import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
+import {ModalsContext} from '../../state/modals';
 import {callApi} from '../call-api';
-import {importAssets, pickFilesToImport} from '../import-assets';
+import {
+	importAssets,
+	insertComposition as insertCompositionFromDrop,
+	pickFilesToImport,
+} from '../import-assets';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {getOriginalLocationFromStack} from '../Timeline/TimelineStack/get-stack';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
 
 export const useCompositionActions = () => {
@@ -17,6 +24,8 @@ export const useCompositionActions = () => {
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const [isAddingSolid, setIsAddingSolid] = useState(false);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
+	const [isAddingComposition, setIsAddingComposition] = useState(false);
+	const {setSelectedModal} = useContext(ModalsContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const previewConnected = previewServerState.type === 'connected';
 	const previewInteractive = previewConnected && isStudioInteractivityEnabled();
@@ -66,6 +75,8 @@ export const useCompositionActions = () => {
 		currentCompositionId !== null &&
 		compositionFile !== null;
 	const canInsertAsset = canShowInsertAsset && !isAddingAsset;
+	const canShowInsertComposition = canShowInsertAsset;
+	const canInsertComposition = canShowInsertComposition && !isAddingComposition;
 
 	const insertSolid = useCallback(async () => {
 		if (
@@ -145,12 +156,85 @@ export const useCompositionActions = () => {
 		}
 	}, [canInsertAsset, compositionFile, currentCompositionId, videoConfig]);
 
+	const onCompositionSelected = useCallback(
+		async (composition: _InternalTypes['AnyComposition']) => {
+			if (
+				!canInsertComposition ||
+				currentCompositionId === null ||
+				compositionFile === null
+			) {
+				return;
+			}
+
+			setIsAddingComposition(true);
+			try {
+				const resolvedLocation = composition.stack
+					? await getOriginalLocationFromStack(composition.stack, 'sequence')
+					: null;
+				const selectedCompositionFile =
+					resolvedLocation?.source ??
+					browserStudioOperations?.getCompositionFile(composition.id) ??
+					null;
+				const compositionDragData = DragAndDropInternals.makeDragData({
+					type: 'composition',
+					compositionFile: selectedCompositionFile,
+					compositionId: composition.id,
+					width: composition.width ?? null,
+					height: composition.height ?? null,
+					durationInFrames: composition.durationInFrames ?? null,
+				}).data;
+
+				await insertCompositionFromDrop({
+					composition: compositionDragData,
+					compositionFile,
+					compositionId: currentCompositionId,
+					dropPosition: null,
+					from: null,
+				});
+			} catch (error) {
+				showNotification(
+					`Could not add composition: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					4000,
+				);
+			} finally {
+				setIsAddingComposition(false);
+			}
+		},
+		[
+			browserStudioOperations,
+			canInsertComposition,
+			compositionFile,
+			currentCompositionId,
+		],
+	);
+
+	const insertComposition = useCallback(() => {
+		if (!canInsertComposition) {
+			return;
+		}
+
+		setSelectedModal({
+			type: 'quick-switcher',
+			mode: 'compositions',
+			invocationTimestamp: Date.now(),
+			assetSelection: null,
+			compositionSelection: {
+				onSelected: onCompositionSelected,
+			},
+		});
+	}, [canInsertComposition, onCompositionSelected, setSelectedModal]);
+
 	return {
 		canInsertAsset,
+		canInsertComposition,
 		canInsertSolid,
 		canShowInsertAsset,
+		canShowInsertComposition,
 		canShowInsertSolid,
 		insertAsset,
+		insertComposition,
 		insertSolid,
 	};
 };

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -221,10 +221,16 @@ export const useCompositionActions = () => {
 			invocationTimestamp: Date.now(),
 			assetSelection: null,
 			compositionSelection: {
+				excludeCompositionId: currentCompositionId,
 				onSelected: onCompositionSelected,
 			},
 		});
-	}, [canInsertComposition, onCompositionSelected, setSelectedModal]);
+	}, [
+		canInsertComposition,
+		currentCompositionId,
+		onCompositionSelected,
+		setSelectedModal,
+	]);
 
 	return {
 		canInsertAsset,

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -181,6 +181,7 @@ export const Modals: React.FC<{
 					invocationTimestamp={modalContextType.invocationTimestamp}
 					initialMode={modalContextType.mode}
 					assetSelection={modalContextType.assetSelection}
+					compositionSelection={modalContextType.compositionSelection}
 				/>
 			)}
 			{modalContextType && modalContextType.type === 'add-effect' && (

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -43,6 +43,7 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 			mode,
 			invocationTimestamp: Date.now(),
 			assetSelection: null,
+			compositionSelection: null,
 		});
 	}, [mode, setSelectedModal]);
 

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -19,6 +19,7 @@ const QuickSwitcher: React.FC<{
 		readonly onSelected: (asset: StaticFile) => void;
 	} | null;
 	readonly compositionSelection: {
+		readonly excludeCompositionId: string;
 		readonly onSelected: (
 			composition: _InternalTypes['AnyComposition'],
 		) => void;

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type {_InternalTypes} from 'remotion';
 import type {StaticFile} from '../../api/get-static-files';
 import {DismissableModal} from '../NewComposition/DismissableModal';
 import type {QuickSwitcherMode} from './NoResults';
@@ -17,7 +18,18 @@ const QuickSwitcher: React.FC<{
 		readonly initialQuery: string;
 		readonly onSelected: (asset: StaticFile) => void;
 	} | null;
-}> = ({initialMode, invocationTimestamp, readOnlyStudio, assetSelection}) => {
+	readonly compositionSelection: {
+		readonly onSelected: (
+			composition: _InternalTypes['AnyComposition'],
+		) => void;
+	} | null;
+}> = ({
+	initialMode,
+	invocationTimestamp,
+	readOnlyStudio,
+	assetSelection,
+	compositionSelection,
+}) => {
 	return (
 		<DismissableModal panelStyle={panelStyle}>
 			<QuickSwitcherContent
@@ -25,6 +37,7 @@ const QuickSwitcher: React.FC<{
 				invocationTimestamp={invocationTimestamp}
 				initialMode={initialMode}
 				assetSelection={assetSelection}
+				compositionSelection={compositionSelection}
 			/>
 		</DismissableModal>
 	);

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -148,6 +148,7 @@ export const QuickSwitcherContent: React.FC<{
 		readonly onSelected: (asset: StaticFile) => void;
 	} | null;
 	readonly compositionSelection: {
+		readonly excludeCompositionId: string;
 		readonly onSelected: (
 			composition: _InternalTypes['AnyComposition'],
 		) => void;
@@ -258,33 +259,35 @@ export const QuickSwitcherContent: React.FC<{
 
 		return fuzzySearch(
 			actualQuery,
-			compositions.map((c) => {
-				return {
-					id: 'composition-' + c.id,
-					title: c.id,
-					type: 'composition',
-					onSelected: () => {
-						if (compositionSelection !== null) {
-							compositionSelection.onSelected(c);
+			compositions
+				.filter((c) => c.id !== compositionSelection?.excludeCompositionId)
+				.map((c) => {
+					return {
+						id: 'composition-' + c.id,
+						title: c.id,
+						type: 'composition',
+						onSelected: () => {
+							if (compositionSelection !== null) {
+								compositionSelection.onSelected(c);
+								setSelectedModal(null);
+								return;
+							}
+
+							selectComposition(c, true);
 							setSelectedModal(null);
-							return;
-						}
 
-						selectComposition(c, true);
-						setSelectedModal(null);
+							const selector = `.__remotion-composition[data-compname="${c.id}"]`;
 
-						const selector = `.__remotion-composition[data-compname="${c.id}"]`;
-
-						Internals.compositionSelectorRef.current?.expandComposition(c.id);
-						waitForElm(selector).then(() => {
-							document
-								.querySelector(selector)
-								?.scrollIntoView({block: 'center'});
-						});
-					},
-					compositionType: isCompositionStill(c) ? 'still' : 'composition',
-				};
-			}),
+							Internals.compositionSelectorRef.current?.expandComposition(c.id);
+							waitForElm(selector).then(() => {
+								document
+									.querySelector(selector)
+									?.scrollIntoView({block: 'center'});
+							});
+						},
+						compositionType: isCompositionStill(c) ? 'still' : 'composition',
+					};
+				}),
 		);
 	}, [
 		mode,

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -7,6 +7,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
+import type {_InternalTypes} from 'remotion';
 import type {StaticFile} from '../../api/get-static-files';
 import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {getPreviewFileType} from '../../helpers/get-preview-file-type';
@@ -146,14 +147,27 @@ export const QuickSwitcherContent: React.FC<{
 		readonly initialQuery: string;
 		readonly onSelected: (asset: StaticFile) => void;
 	} | null;
-}> = ({initialMode, invocationTimestamp, readOnlyStudio, assetSelection}) => {
+	readonly compositionSelection: {
+		readonly onSelected: (
+			composition: _InternalTypes['AnyComposition'],
+		) => void;
+	} | null;
+}> = ({
+	initialMode,
+	invocationTimestamp,
+	readOnlyStudio,
+	assetSelection,
+	compositionSelection,
+}) => {
 	const {compositions} = useContext(Internals.CompositionManager);
 	const staticFiles = useStaticFiles();
 	const [state, setState] = useState(() => {
 		return {
 			query:
 				assetSelection === null
-					? mapModeToQuery(initialMode)
+					? compositionSelection === null
+						? mapModeToQuery(initialMode)
+						: ''
 					: assetSelection.initialQuery,
 			selectedIndex: 0,
 		};
@@ -163,11 +177,13 @@ export const QuickSwitcherContent: React.FC<{
 		setState({
 			query:
 				assetSelection === null
-					? mapModeToQuery(initialMode)
+					? compositionSelection === null
+						? mapModeToQuery(initialMode)
+						: ''
 					: assetSelection.initialQuery,
 			selectedIndex: 0,
 		});
-	}, [assetSelection, initialMode, invocationTimestamp]);
+	}, [assetSelection, compositionSelection, initialMode, invocationTimestamp]);
 
 	const inputRef = useRef<HTMLInputElement>(null);
 	const selectComposition = useSelectComposition();
@@ -182,7 +198,11 @@ export const QuickSwitcherContent: React.FC<{
 	const keybindings = useKeybinding();
 
 	const mode: QuickSwitcherMode =
-		assetSelection !== null ? 'assets' : mapQueryToMode(state.query);
+		assetSelection !== null
+			? 'assets'
+			: compositionSelection !== null
+				? 'compositions'
+				: mapQueryToMode(state.query);
 
 	const actualQuery = useMemo(() => {
 		return stripQuery(state.query);
@@ -244,6 +264,12 @@ export const QuickSwitcherContent: React.FC<{
 					title: c.id,
 					type: 'composition',
 					onSelected: () => {
+						if (compositionSelection !== null) {
+							compositionSelection.onSelected(c);
+							setSelectedModal(null);
+							return;
+						}
+
 						selectComposition(c, true);
 						setSelectedModal(null);
 
@@ -268,6 +294,7 @@ export const QuickSwitcherContent: React.FC<{
 		docResults,
 		assetSearch,
 		assetSelection,
+		compositionSelection,
 		selectAsset,
 		selectComposition,
 		setSelectedModal,
@@ -439,7 +466,7 @@ export const QuickSwitcherContent: React.FC<{
 
 	return (
 		<div style={container}>
-			{assetSelection === null && (
+			{assetSelection === null && compositionSelection === null && (
 				<div style={modeSelector}>
 					<button
 						onClick={onCompositionsSelected}
@@ -475,7 +502,11 @@ export const QuickSwitcherContent: React.FC<{
 				</div>
 			)}
 			<div
-				style={assetSelection === null ? content : contentWithoutModeSelector}
+				style={
+					assetSelection === null && compositionSelection === null
+						? content
+						: contentWithoutModeSelector
+				}
 			>
 				<RemotionInput
 					ref={inputRef}

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -1664,9 +1664,7 @@ export const SelectedOutlineElement: React.FC<{
 							},
 						],
 					});
-					if (result.success) {
-						showNotification('Removed sequence from source file', 2000);
-					} else {
+					if (!result.success) {
 						showNotification(result.reason, 4000);
 					}
 				} catch (err) {

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -100,6 +100,7 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 				initialQuery,
 				onSelected: (asset) => onSelect(asset.name, asset.src),
 			},
+			compositionSelection: null,
 		});
 	}, [initialQuery, onSelect, setSelectedModal]);
 

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -438,9 +438,7 @@ const TimelineSequenceInner: React.FC<{
 					},
 				],
 			});
-			if (result.success) {
-				showNotification('Removed sequence from source file', 2000);
-			} else {
+			if (!result.success) {
 				showNotification(result.reason, 4000);
 			}
 		} catch (err) {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -396,9 +396,7 @@ export const TimelineSequenceItem: React.FC<{
 					},
 				],
 			});
-			if (result.success) {
-				showNotification('Removed sequence from source file', 2000);
-			} else {
+			if (!result.success) {
 				showNotification(result.reason, 4000);
 			}
 		} catch (err) {

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -69,14 +69,7 @@ export const deleteSequencesFromSource = async (
 		}),
 	})
 		.then((result) => {
-			if (result.success) {
-				showNotification(
-					nodePathInfos.length === 1
-						? 'Removed sequence from source file'
-						: 'Removed sequences from source files',
-					2000,
-				);
-			} else {
+			if (!result.success) {
 				showNotification(result.reason, 4000);
 			}
 

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -690,6 +690,7 @@ export const useMenuStructure = (
 								mode: 'compositions',
 								invocationTimestamp: Date.now(),
 								assetSelection: null,
+								compositionSelection: null,
 							});
 						},
 						type: 'item' as const,
@@ -874,6 +875,7 @@ export const useMenuStructure = (
 								mode: 'docs',
 								invocationTimestamp: Date.now(),
 								assetSelection: null,
+								compositionSelection: null,
 							});
 						},
 						keyHint: '?',

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -206,6 +206,9 @@ export type ModalState =
 				initialQuery: string;
 				onSelected: (asset: StaticFile) => void;
 			} | null;
+			compositionSelection: {
+				onSelected: (composition: _InternalTypes['AnyComposition']) => void;
+			} | null;
 	  }
 	| AddEffectModalState
 	| ConfirmationDialogState

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -207,6 +207,7 @@ export type ModalState =
 				onSelected: (asset: StaticFile) => void;
 			} | null;
 			compositionSelection: {
+				excludeCompositionId: string;
 				onSelected: (composition: _InternalTypes['AnyComposition']) => void;
 			} | null;
 	  }


### PR DESCRIPTION
## Summary

- add an "Add composition..." quick action to the composition inspector
- let the quick switcher return a selected composition without navigating away
- insert the selected composition through the existing canvas-drop insertion path

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio' --no-update-notifier` (534 tests)

Closes #9749
