### PR TITLE
Docs: TS aliases for Rspack

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -944,6 +944,7 @@
         "@remotion/transitions": "workspace:*",
         "@remotion/webcodecs": "workspace:*",
         "@remotion/zod-types": "workspace:*",
+        "@rspack/core": "1.7.11",
         "@types/node": "catalog:",
         "@types/sharp": "0.28.6",
         "create-video": "workspace:*",

--- a/packages/docs/docs/miscellaneous/ts-aliases.mdx
+++ b/packages/docs/docs/miscellaneous/ts-aliases.mdx
@@ -6,8 +6,7 @@ slug: /typescript-aliases
 crumb: 'How to'
 ---
 
-Typescript aliases are not supported by default, since the ESBuild Webpack loader we have does not support them.
-You can however patch the [Webpack config](/docs/bundlers) to make them resolve.
+TypeScript path aliases are not resolved by default. Add the matching aliases to the shared [bundler configuration](/docs/bundlers) to use them with Webpack or Rspack.
 
 Assuming you have a file:
 
@@ -32,13 +31,13 @@ and your tsconfig.json has the following `paths`:
 }
 ```
 
-you can add the aliases to Webpack, however you need to add each of them manually:
+you can add the aliases to both bundlers, however you need to add each of them manually:
 
-```ts twoslash
+```ts twoslash title="remotion.config.ts"
 import path from 'path';
 import {Config} from '@remotion/cli/config';
 
-Config.overrideWebpackConfig((config) => {
+Config.overrideBundlerConfig((config) => {
   return {
     ...config,
     resolve: {
@@ -52,13 +51,17 @@ Config.overrideWebpackConfig((config) => {
 });
 ```
 
-Remember that in Node.JS APIs, the config file does not apply, so you need to add the Webpack override also to the [`bundle()`](/docs/bundle) and [`deploySite()`](/docs/lambda/deploysite) functions.
+Remember that in Node.JS APIs, the config file does not apply, so you need to pass the shared override as `bundlerOverride` to the [`bundle()`](/docs/bundle) and [`deploySite()`](/docs/lambda/deploysite) functions.
 
 ## Automatically syncing Webpack and TypeScript aliases
 
 To not duplicate the aliases in your Webpack override and in your `tsconfig.json`, you can install `tsconfig-paths-webpack-plugin` and use it:
 
-```ts
+:::note Webpack only
+`tsconfig-paths-webpack-plugin` uses Webpack's resolver API and does not work with Rspack. When using Rspack, add the aliases manually with the shared override above.
+:::
+
+```ts title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 
@@ -81,4 +84,4 @@ We recommend that you don't use TypeScript aliases.
 
 ## See also
 
-- [Overriding webpack config](/docs/bundlers)
+- [Bundler configuration](/docs/bundlers)

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -63,7 +63,9 @@ Remotion provides three config file APIs:
 
 You can call each override API more than once. Overrides of the same type run in registration order.
 
-Only use [`Config.overrideBundlerConfig()`](/docs/config#overridebundlerconfig) for changes that are compatible with both bundlers. Webpack and Rspack plugins are not interchangeable.
+Only use [`Config.overrideBundlerConfig()`](/docs/config#overridebundlerconfig) for changes that are compatible with both bundlers. Many loaders implement an API that works with both bundlers, but you should verify each loader individually.
+
+Webpack and Rspack plugins are not interchangeable. Use the plugin implementation from the selected bundler in its bundler-specific override.
 
 Remotion ships with its own [Webpack configuration](https://github.com/remotion-dev/remotion/blob/main/packages/bundler/src/webpack-config.ts) and [Rspack configuration](https://github.com/remotion-dev/remotion/blob/main/packages/bundler/src/rspack-config.ts). Each override receives the previous configuration and returns the next one.
 
@@ -221,6 +223,50 @@ Config.overrideBundlerConfig(enableTailwind);
 ```
 
 ## Snippets
+
+### Add a plugin
+
+Use Webpack plugins with `Config.overrideWebpackConfig()`:
+
+```ts twoslash title="remotion.config.ts"
+import {webpack} from '@remotion/bundler';
+import {Config} from '@remotion/cli/config';
+
+Config.overrideWebpackConfig((config) => {
+  return {
+    ...config,
+    plugins: [
+      ...(config.plugins ?? []),
+      new webpack.DefinePlugin({
+        MY_CONSTANT: JSON.stringify('value'),
+      }),
+    ],
+  };
+});
+```
+
+Use the equivalent Rspack plugin with `Config.overrideRspackConfig()`:
+
+<Installation pkg="@rspack/core" />
+
+```ts title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+import {DefinePlugin} from '@rspack/core';
+
+Config.overrideRspackConfig((config) => {
+  return {
+    ...config,
+    plugins: [
+      ...(config.plugins ?? []),
+      new DefinePlugin({
+        MY_CONSTANT: JSON.stringify('value'),
+      }),
+    ],
+  };
+});
+```
+
+Do not pass a plugin created by `webpack` to Rspack or a plugin created by `@rspack/core` to Webpack.
 
 ### Enabling MDX support
 
@@ -540,7 +586,9 @@ Add the asynchronous override as `bundlerOverride` to your [Node.JS API calls if
 
 ### Change the `@jsxImportSource`
 
-```tsx twoslash
+Webpack uses Remotion's esbuild loader for TypeScript and JSX. Change its `jsxImportSource` option in a Webpack-specific override:
+
+```tsx twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 
 Config.overrideWebpackConfig((config) => {
@@ -567,6 +615,62 @@ Config.overrideWebpackConfig((config) => {
               options: {
                 ...use.options,
                 jsxImportSource: 'react',
+              },
+            };
+          }),
+        };
+      }),
+    },
+  };
+});
+```
+
+Rspack uses its built-in SWC loader instead. Change `jsc.transform.react.importSource` in a Rspack-specific override:
+
+```tsx twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+
+Config.overrideRspackConfig((config) => {
+  return {
+    ...config,
+    module: {
+      ...config.module,
+      rules: config.module?.rules?.map((rule) => {
+        if (!rule || rule === '...' || !Array.isArray(rule.use)) {
+          return rule;
+        }
+
+        return {
+          ...rule,
+          use: rule.use.map((use) => {
+            if (
+              typeof use === 'string' ||
+              use.loader !== 'builtin:swc-loader'
+            ) {
+              return use;
+            }
+
+            const options = use.options as
+              | {
+                  jsc?: {
+                    transform?: {react?: Record<string, unknown>};
+                  };
+                }
+              | undefined;
+            return {
+              ...use,
+              options: {
+                ...options,
+                jsc: {
+                  ...options?.jsc,
+                  transform: {
+                    ...options?.jsc?.transform,
+                    react: {
+                      ...options?.jsc?.transform?.react,
+                      importSource: 'react',
+                    },
+                  },
+                },
               },
             };
           }),

--- a/packages/it-tests/package.json
+++ b/packages/it-tests/package.json
@@ -51,6 +51,7 @@
 		"@remotion/tailwind": "workspace:*",
 		"@remotion/transitions": "workspace:*",
 		"@remotion/webcodecs": "workspace:*",
+		"@rspack/core": "1.7.11",
 		"@types/sharp": "0.28.6",
 		"create-video": "workspace:*",
 		"execa": "5.1.1",

--- a/packages/it-tests/src/bundle/fixtures/rspack-specific-overrides/entry.tsx
+++ b/packages/it-tests/src/bundle/fixtures/rspack-specific-overrides/entry.tsx
@@ -1,0 +1,9 @@
+declare const BUNDLER_PLUGIN_SENTINEL: string;
+
+console.log(
+	<div>
+		{typeof BUNDLER_PLUGIN_SENTINEL === 'undefined'
+			? 'PLUGIN_NOT_DEFINED'
+			: BUNDLER_PLUGIN_SENTINEL}
+	</div>,
+);

--- a/packages/it-tests/src/bundle/fixtures/rspack-specific-overrides/jsx-runtime.ts
+++ b/packages/it-tests/src/bundle/fixtures/rspack-specific-overrides/jsx-runtime.ts
@@ -1,0 +1,5 @@
+export const jsx = () => 'CUSTOM_JSX_RUNTIME_SENTINEL';
+
+export const jsxs = jsx;
+
+export const Fragment = Symbol.for('custom-jsx-runtime.fragment');

--- a/packages/it-tests/src/bundle/rspack-portable-overrides.test.ts
+++ b/packages/it-tests/src/bundle/rspack-portable-overrides.test.ts
@@ -2,9 +2,16 @@ import {afterAll, expect, test} from 'bun:test';
 import {readdirSync, readFileSync, rmSync} from 'node:fs';
 import path from 'node:path';
 import {replaceLoadersWithBabel} from '@remotion/babel-loader';
-import {bundle, type BundlerOverrideFn} from '@remotion/bundler';
+import {
+	bundle,
+	type BundlerOverrideFn,
+	type RspackOverrideFn,
+	type WebpackOverrideFn,
+	webpack,
+} from '@remotion/bundler';
 import {enableScss} from '@remotion/enable-scss';
 import {enableTailwind} from '@remotion/tailwind';
+import {DefinePlugin as RspackDefinePlugin} from '@rspack/core';
 
 const outputDirectories: string[] = [];
 
@@ -26,9 +33,15 @@ const readJavaScriptFiles = (directory: string): string => {
 const bundleFixture = async ({
 	entryPoint,
 	bundlerOverride,
+	rspack,
+	rspackOverride,
+	webpackOverride,
 }: {
 	entryPoint: string;
-	bundlerOverride: BundlerOverrideFn;
+	bundlerOverride?: BundlerOverrideFn;
+	rspack: boolean;
+	rspackOverride?: RspackOverrideFn;
+	webpackOverride?: WebpackOverrideFn;
 }) => {
 	const outputDirectory = await bundle({
 		entryPoint,
@@ -36,7 +49,9 @@ const bundleFixture = async ({
 		enableCaching: false,
 		ignoreRegisterRootWarning: true,
 		rootDir: path.dirname(entryPoint),
-		rspack: true,
+		rspack,
+		rspackOverride,
+		webpackOverride,
 	});
 	outputDirectories.push(outputDirectory);
 	return readJavaScriptFiles(outputDirectory);
@@ -102,6 +117,7 @@ test(
 		const result = await bundleFixture({
 			entryPoint: path.join(fixtureDirectory, 'entry.ts'),
 			bundlerOverride,
+			rspack: true,
 		});
 
 		expect(result).toContain('MDX portable override sentinel');
@@ -157,6 +173,7 @@ test(
 		const result = await bundleFixture({
 			entryPoint: path.join(fixtureDirectory, 'entry.tsx'),
 			bundlerOverride,
+			rspack: true,
 		});
 
 		expect(scriptLoaders[0]).toContain('babel-loader');
@@ -167,6 +184,129 @@ test(
 		expect(result).toContain('moduleClass');
 		expect(result).toContain('#654321');
 		expect(result).toContain('.text-red-500');
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'Rspack supports a custom JSX import source through the SWC loader',
+	async () => {
+		const fixtureDirectory = path.join(
+			import.meta.dir,
+			'fixtures',
+			'rspack-specific-overrides',
+		);
+		const rspackOverride: RspackOverrideFn = (configuration) => ({
+			...configuration,
+			resolve: {
+				...configuration.resolve,
+				alias: {
+					...configuration.resolve?.alias,
+					'custom-jsx-runtime/jsx-runtime': path.join(
+						fixtureDirectory,
+						'jsx-runtime.ts',
+					),
+				},
+			},
+			module: {
+				...configuration.module,
+				rules: (configuration.module?.rules ?? []).map((rule) => {
+					if (!rule || rule === '...' || !Array.isArray(rule.use)) {
+						return rule;
+					}
+
+					return {
+						...rule,
+						use: rule.use.map((use) => {
+							if (
+								typeof use === 'string' ||
+								use.loader !== 'builtin:swc-loader'
+							) {
+								return use;
+							}
+
+							const options = use.options as
+								| {
+										jsc?: {
+											transform?: {react?: Record<string, unknown>};
+										};
+								  }
+								| undefined;
+							return {
+								...use,
+								options: {
+									...options,
+									jsc: {
+										...options?.jsc,
+										transform: {
+											...options?.jsc?.transform,
+											react: {
+												...options?.jsc?.transform?.react,
+												importSource: 'custom-jsx-runtime',
+											},
+										},
+									},
+								},
+							};
+						}),
+					};
+				}),
+			},
+		});
+
+		const result = await bundleFixture({
+			entryPoint: path.join(fixtureDirectory, 'entry.tsx'),
+			rspack: true,
+			rspackOverride,
+		});
+
+		expect(result).toContain('CUSTOM_JSX_RUNTIME_SENTINEL');
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'Webpack and Rspack use their own DefinePlugin implementations',
+	async () => {
+		const entryPoint = path.join(
+			import.meta.dir,
+			'fixtures',
+			'rspack-specific-overrides',
+			'entry.tsx',
+		);
+		const webpackResult = await bundleFixture({
+			entryPoint,
+			rspack: false,
+			webpackOverride: (configuration) => ({
+				...configuration,
+				plugins: [
+					...(configuration.plugins ?? []),
+					new webpack.DefinePlugin({
+						BUNDLER_PLUGIN_SENTINEL: JSON.stringify(
+							'WEBPACK_DEFINE_PLUGIN_SENTINEL',
+						),
+					}),
+				],
+			}),
+		});
+		const rspackResult = await bundleFixture({
+			entryPoint,
+			rspack: true,
+			rspackOverride: (configuration) => ({
+				...configuration,
+				plugins: [
+					...(configuration.plugins ?? []),
+					new RspackDefinePlugin({
+						BUNDLER_PLUGIN_SENTINEL: JSON.stringify(
+							'RSPACK_DEFINE_PLUGIN_SENTINEL',
+						),
+					}),
+				],
+			}),
+		});
+
+		expect(webpackResult).toContain('WEBPACK_DEFINE_PLUGIN_SENTINEL');
+		expect(rspackResult).toContain('RSPACK_DEFINE_PLUGIN_SENTINEL');
 	},
 	{timeout: 60_000},
 );


### PR DESCRIPTION
## Summary

- document bundler-native `DefinePlugin` usage for Webpack and Rspack
- add separate esbuild and SWC examples for changing `jsxImportSource`
- move manual aliases to the shared bundler override and mark `tsconfig-paths-webpack-plugin` as Webpack-only
- cover the SWC JSX runtime and both plugin implementations with real bundle integration tests

## Testing

- `bun test packages/it-tests/src/bundle/rspack-portable-overrides.test.ts --timeout 60000`
- `bun prewarm-twoslash.ts` in `packages/docs`
- `bun run build`
- `bun run stylecheck`

Closes #9797

## Preview

- [Webpack and Rspack](https://remotion-git-codex-rspack-configuration-docs-remotion.vercel.app/docs/bundlers)
- [TypeScript aliases](https://remotion-git-codex-rspack-configuration-docs-remotion.vercel.app/docs/typescript-aliases)
