### PR TITLE
`@remotion/browser-studio`: Add project download

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
         "@remotion/studio-codemods": "workspace:*",
         "@remotion/studio-shared": "workspace:*",
         "@rspack/browser": "2.1.1",
+        "fflate": "0.8.2",
       },
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",

--- a/packages/browser-studio/package.json
+++ b/packages/browser-studio/package.json
@@ -28,7 +28,8 @@
 	"dependencies": {
 		"@remotion/studio-codemods": "workspace:*",
 		"@remotion/studio-shared": "workspace:*",
-		"@rspack/browser": "2.1.1"
+		"@rspack/browser": "2.1.1",
+		"fflate": "0.8.2"
 	},
 	"exports": {
 		".": {

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -112,6 +112,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	const browserStudioOperations = useMemo(
 		() =>
 			createBrowserStudioOperations({
+				dependencyVersions: browserStudioDependencyVersions,
 				getProject: () => activeProjectRef.current,
 				onProjectChange: updateProject,
 			}),

--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -7,18 +7,32 @@ import type {
 	BrowserStudioOperations,
 	InsertJsxElementResponse,
 } from '@remotion/studio-shared';
+import {makeBrowserStudioProjectArchive} from './download-project';
 import type {VirtualProject} from './types';
 
 export {insertSolidIntoProject} from '@remotion/studio-codemods';
 
 export const createBrowserStudioOperations = ({
+	dependencyVersions,
 	getProject,
 	onProjectChange,
 }: {
+	dependencyVersions?: Record<string, string>;
 	getProject: () => VirtualProject;
 	onProjectChange: (project: VirtualProject) => void;
 }): BrowserStudioOperations => {
 	return {
+		...(dependencyVersions
+			? {
+					downloadProject: () =>
+						Promise.resolve(
+							makeBrowserStudioProjectArchive({
+								dependencyVersions,
+								project: getProject(),
+							}),
+						),
+				}
+			: {}),
 		getCompositionFile: (compositionId) =>
 			getCompositionFile({compositionId, project: getProject()}),
 		getCompositionComponentInfo: (request) =>

--- a/packages/browser-studio/src/download-project.ts
+++ b/packages/browser-studio/src/download-project.ts
@@ -1,0 +1,252 @@
+import {strToU8, zipSync} from 'fflate';
+import type {VirtualProject} from './types';
+
+type PackageJson = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	[key: string]: unknown;
+};
+
+const dependencyFields = [
+	'dependencies',
+	'devDependencies',
+	'optionalDependencies',
+	'peerDependencies',
+] as const;
+
+const validateRelativePath = (path: string) => {
+	if (path.includes('\0')) {
+		throw new Error('Project paths cannot contain null bytes');
+	}
+
+	if (path.includes('\\')) {
+		throw new Error(`Project paths must use forward slashes: ${path}`);
+	}
+
+	if (path.startsWith('/')) {
+		throw new Error(`Expected a relative project path, got: ${path}`);
+	}
+
+	const segments = path.split('/');
+	if (
+		segments.length === 0 ||
+		segments.some(
+			(segment) => segment === '' || segment === '.' || segment === '..',
+		)
+	) {
+		throw new Error(`Invalid project path: ${path}`);
+	}
+
+	return path;
+};
+
+const normalizeRootDir = (rootDir: string) => {
+	if (
+		!rootDir.startsWith('/') ||
+		rootDir.includes('\\') ||
+		rootDir.includes('\0')
+	) {
+		throw new Error(`Invalid Browser Studio root directory: ${rootDir}`);
+	}
+
+	const normalized = rootDir.replace(/\/+$/, '');
+	if (!normalized) {
+		throw new Error(
+			'The Browser Studio root directory cannot be the filesystem root',
+		);
+	}
+
+	validateRelativePath(normalized.slice(1));
+	return normalized;
+};
+
+const getProjectFileArchivePath = ({
+	path,
+	rootDir,
+}: {
+	path: string;
+	rootDir: string;
+}) => {
+	if (!path.startsWith('/')) {
+		return validateRelativePath(path);
+	}
+
+	const prefix = `${rootDir}/`;
+	if (!path.startsWith(prefix)) {
+		throw new Error(`Project file is outside the root directory: ${path}`);
+	}
+
+	return validateRelativePath(path.slice(prefix.length));
+};
+
+const getPublicFileArchivePath = (path: string) => {
+	const relativePath = path.startsWith('/') ? path.slice(1) : path;
+	return `public/${validateRelativePath(relativePath)}`;
+};
+
+const getPublishedVersion = ({
+	name,
+	dependencyVersions,
+}: {
+	name: string;
+	dependencyVersions: Record<string, string>;
+}) => {
+	const version =
+		dependencyVersions[name] ??
+		(name.startsWith('@remotion/') ? dependencyVersions.remotion : null);
+
+	if (!version) {
+		throw new Error(`No published version is known for ${name}`);
+	}
+
+	return version;
+};
+
+const resolvePortableDependencySpec = ({
+	dependencyVersions,
+	name,
+	spec,
+}: {
+	dependencyVersions: Record<string, string>;
+	name: string;
+	spec: string;
+}) => {
+	if (spec === 'catalog:') {
+		return getPublishedVersion({name, dependencyVersions});
+	}
+
+	if (!spec.startsWith('workspace:')) {
+		return spec;
+	}
+
+	const version = getPublishedVersion({name, dependencyVersions});
+	const workspaceRange = spec.slice('workspace:'.length);
+
+	if (workspaceRange === '*') {
+		return version;
+	}
+
+	if (workspaceRange === '^' || workspaceRange === '~') {
+		return `${workspaceRange}${version}`;
+	}
+
+	throw new Error(
+		`Unsupported workspace dependency range for ${name}: ${spec}`,
+	);
+};
+
+const makeDefaultPackageJson = (
+	dependencyVersions: Record<string, string>,
+): PackageJson => ({
+	name: 'remotion-project',
+	version: '1.0.0',
+	private: true,
+	scripts: {
+		dev: 'remotion studio',
+	},
+	dependencies: {
+		'@remotion/cli': getPublishedVersion({
+			name: '@remotion/cli',
+			dependencyVersions,
+		}),
+		react: getPublishedVersion({name: 'react', dependencyVersions}),
+		'react-dom': getPublishedVersion({
+			name: 'react-dom',
+			dependencyVersions,
+		}),
+		remotion: getPublishedVersion({name: 'remotion', dependencyVersions}),
+	},
+});
+
+const makePortablePackageJson = ({
+	contents,
+	dependencyVersions,
+}: {
+	contents: string | undefined;
+	dependencyVersions: Record<string, string>;
+}) => {
+	const packageJson = contents
+		? (JSON.parse(contents) as PackageJson)
+		: makeDefaultPackageJson(dependencyVersions);
+
+	for (const field of dependencyFields) {
+		const dependencies = packageJson[field];
+		if (!dependencies) {
+			continue;
+		}
+
+		packageJson[field] = Object.fromEntries(
+			Object.entries(dependencies).map(([name, spec]) => [
+				name,
+				resolvePortableDependencySpec({
+					dependencyVersions,
+					name,
+					spec,
+				}),
+			]),
+		);
+	}
+
+	return `${JSON.stringify(packageJson, null, 2)}\n`;
+};
+
+const addArchiveFile = ({
+	archiveFiles,
+	contents,
+	path,
+}: {
+	archiveFiles: Record<string, Uint8Array>;
+	contents: string | Uint8Array;
+	path: string;
+}) => {
+	if (archiveFiles[path]) {
+		throw new Error(`Multiple project files resolve to ${path}`);
+	}
+
+	archiveFiles[path] =
+		typeof contents === 'string' ? strToU8(contents) : contents;
+};
+
+export const makeBrowserStudioProjectArchive = ({
+	dependencyVersions,
+	project,
+}: {
+	dependencyVersions: Record<string, string>;
+	project: VirtualProject;
+}) => {
+	const rootDir = normalizeRootDir(project.rootDir);
+	const archiveFiles: Record<string, Uint8Array> = {};
+
+	for (const [path, contents] of Object.entries(project.files)) {
+		addArchiveFile({
+			archiveFiles,
+			contents,
+			path: getProjectFileArchivePath({path, rootDir}),
+		});
+	}
+
+	for (const [path, contents] of Object.entries(project.publicFiles ?? {})) {
+		addArchiveFile({
+			archiveFiles,
+			contents,
+			path: getPublicFileArchivePath(path),
+		});
+	}
+
+	const packageJsonContents = archiveFiles['package.json'];
+	archiveFiles['package.json'] = strToU8(
+		makePortablePackageJson({
+			contents: packageJsonContents
+				? new TextDecoder().decode(packageJsonContents)
+				: undefined,
+			dependencyVersions,
+		}),
+	);
+
+	return {
+		data: zipSync(archiveFiles, {level: 6}),
+		fileName: 'remotion-project.zip',
+	};
+};

--- a/packages/browser-studio/src/test/download-project.test.ts
+++ b/packages/browser-studio/src/test/download-project.test.ts
@@ -1,0 +1,127 @@
+import {expect, test} from 'bun:test';
+import {strFromU8, unzipSync} from 'fflate';
+import {createBrowserStudioOperations} from '../browser-studio-operations';
+import {makeBrowserStudioProjectArchive} from '../download-project';
+import {createBlankTemplateProject} from '../templates/blank';
+import type {VirtualProject} from '../types';
+
+const dependencyVersions = {
+	react: '19.2.3',
+	'react-dom': '19.2.3',
+	remotion: '4.0.500',
+};
+
+test('downloads the current Browser Studio project as a runnable archive', async () => {
+	let project: VirtualProject = {
+		...createBlankTemplateProject(),
+		publicFiles: {
+			'/logo.bin': new Uint8Array([0, 127, 128, 255]),
+		},
+	};
+	const operations = createBrowserStudioOperations({
+		dependencyVersions,
+		getProject: () => project,
+		onProjectChange: (nextProject) => {
+			project = nextProject;
+		},
+	});
+
+	const insertResult = await operations.insertSolid({
+		compositionFile: '/project/src/Composition.tsx',
+		compositionId: 'MyComp',
+		element: {
+			type: 'solid',
+			width: 1280,
+			height: 720,
+			position: null,
+		},
+		from: null,
+	});
+	expect(insertResult).toEqual({success: true});
+
+	const archive = await operations.downloadProject?.();
+	if (!archive) {
+		throw new Error('Expected Browser Studio to support project downloads');
+	}
+
+	const files = unzipSync(archive.data);
+	const packageJson = JSON.parse(strFromU8(files['package.json'])) as Record<
+		string,
+		unknown
+	>;
+
+	expect(archive.fileName).toBe('remotion-project.zip');
+	expect(strFromU8(files['src/Composition.tsx'])).toContain(
+		'<Solid width={1280}',
+	);
+	expect(strFromU8(files['tsconfig.json'])).toBe(
+		project.files['/project/tsconfig.json'],
+	);
+	expect(files['public/logo.bin']).toEqual(new Uint8Array([0, 127, 128, 255]));
+	expect(Object.keys(files).every((path) => !path.startsWith('/project'))).toBe(
+		true,
+	);
+	expect(packageJson).toMatchObject({
+		scripts: {
+			dev: 'remotion studio',
+		},
+		dependencies: {
+			'@remotion/cli': '4.0.500',
+			react: '19.2.3',
+			'react-dom': '19.2.3',
+			remotion: '4.0.500',
+		},
+		devDependencies: {
+			'@remotion/eslint-config-flat': '4.0.500',
+		},
+	});
+	expect(strFromU8(files['package.json'])).not.toMatch(
+		/(?:workspace|catalog):/,
+	);
+});
+
+test('adds a package.json if the virtual project has none', () => {
+	const {data} = makeBrowserStudioProjectArchive({
+		dependencyVersions,
+		project: {
+			rootDir: '/project',
+			entryPoint: '/project/src/index.ts',
+			files: {
+				'/project/src/index.ts': 'export {};',
+			},
+		},
+	});
+	const files = unzipSync(data);
+	const packageJson = JSON.parse(strFromU8(files['package.json'])) as {
+		scripts: Record<string, string>;
+	};
+
+	expect(packageJson.scripts.dev).toBe('remotion studio');
+});
+
+test('rejects unsafe paths and archive collisions', () => {
+	const invalidProjects: VirtualProject[] = [
+		{
+			rootDir: '/project',
+			entryPoint: '/project/src/index.ts',
+			files: {'/other/index.ts': 'export {};'},
+		},
+		{
+			rootDir: '/project',
+			entryPoint: '/project/src/index.ts',
+			files: {'../index.ts': 'export {};'},
+		},
+		{
+			rootDir: '/project',
+			entryPoint: '/project/src/index.ts',
+			files: {'/project/public/logo.svg': '<svg />'},
+			publicFiles: {'logo.svg': '<svg />'},
+		},
+	];
+
+	for (const project of invalidProjects) {
+		expect(() =>
+			makeBrowserStudioProjectArchive({dependencyVersions, project}),
+		).toThrow();
+	}
+});

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -6,6 +6,10 @@ import type {
 } from './api-requests';
 
 export type BrowserStudioOperations = {
+	downloadProject?: () => Promise<{
+		data: Uint8Array;
+		fileName: string;
+	}>;
 	getCompositionFile: (compositionId: string) => string | null;
 	getCompositionComponentInfo: (
 		request: CompositionComponentInfoRequest,

--- a/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
+++ b/packages/studio/src/components/RenderQueue/ClientRenderQueueProcessor.tsx
@@ -10,6 +10,7 @@ import {
 	registerClientRender,
 	saveOutputFile,
 } from '../../api/save-render-output';
+import {downloadBlob} from '../../helpers/download-blob';
 import type {
 	ClientRenderJob,
 	ClientRenderJobProgress,
@@ -23,18 +24,6 @@ type RenderResult = {
 	getBlob: GetBlobCallback;
 	width: number;
 	height: number;
-};
-
-export const downloadBlob = (blob: Blob, filename: string): void => {
-	const url = URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	const cleanFilename = filename.includes('/')
-		? filename.substring(filename.lastIndexOf('/') + 1)
-		: filename;
-	a.download = cleanFilename;
-	a.click();
-	URL.revokeObjectURL(url);
 };
 
 export const ClientRenderQueueProcessor: React.FC = () => {

--- a/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
@@ -1,10 +1,10 @@
 import React, {useCallback, useMemo} from 'react';
 import {CURRENT_COLOR} from '../../helpers/colors';
+import {downloadBlob} from '../../helpers/download-blob';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
 import type {ClientRenderJob} from './client-side-render-types';
-import {downloadBlob} from './ClientRenderQueueProcessor';
 
 export const RenderQueueDownloadItem: React.FC<{
 	readonly job: ClientRenderJob;

--- a/packages/studio/src/helpers/download-blob.ts
+++ b/packages/studio/src/helpers/download-blob.ts
@@ -1,0 +1,11 @@
+export const downloadBlob = (blob: Blob, filename: string): void => {
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	const cleanFilename = filename.includes('/')
+		? filename.substring(filename.lastIndexOf('/') + 1)
+		: filename;
+	a.download = cleanFilename;
+	a.click();
+	URL.revokeObjectURL(url);
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -28,9 +28,11 @@ import type {ModalState} from '../state/modals';
 import {ModalsContext} from '../state/modals';
 import type {SidebarCollapsedState} from '../state/sidebar';
 import {SidebarContext} from '../state/sidebar';
+import {getBrowserStudioOperations} from './browser-studio-operations';
 import {checkFullscreenSupport} from './check-fullscreen-support';
 import {StudioServerConnectionCtx} from './client-id';
 import {CURRENT_COLOR} from './colors';
+import {downloadBlob} from './download-blob';
 import {getFileManagerName} from './get-file-manager-name';
 import {getGitMenuItem} from './get-git-menu-item';
 import {useMobileLayout} from './mobile-layout';
@@ -71,6 +73,8 @@ const getFileMenu = ({
 	const fileManagerName = getFileManagerName(
 		window.remotion_fileSystemPlatform,
 	);
+	const browserStudioOperations = getBrowserStudioOperations();
+	const downloadProject = browserStudioOperations?.downloadProject;
 	const items: ComboboxValue[] = [
 		readOnlyStudio
 			? null
@@ -161,6 +165,40 @@ const getFileMenu = ({
 			subMenu: null,
 			quickSwitcherLabel: 'Render on web...',
 		},
+		downloadProject
+			? {
+					id: 'download-project',
+					value: 'download-project',
+					label: 'Download project',
+					onClick: async () => {
+						closeMenu();
+
+						try {
+							const {data, fileName} = await downloadProject();
+							const arrayBuffer = data.buffer.slice(
+								data.byteOffset,
+								data.byteOffset + data.byteLength,
+							) as ArrayBuffer;
+							downloadBlob(
+								new Blob([arrayBuffer], {type: 'application/zip'}),
+								fileName,
+							);
+						} catch (error) {
+							showNotification(
+								`Could not download project: ${
+									error instanceof Error ? error.message : String(error)
+								}`,
+								2000,
+							);
+						}
+					},
+					type: 'item' as const,
+					keyHint: null,
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: 'Download project',
+				}
+			: null,
 		!readOnlyStudio
 			? {
 					type: 'divider' as const,


### PR DESCRIPTION
## Summary

- add a typed Browser Studio capability for downloading the current virtual project
- create a safe ZIP containing project files, binary public assets, and a portable package manifest
- expose `File -> Download project` only when the browser capability is available
- reuse the Studio's browser download helper

## Test plan

- `bun run build`
- `bun run stylecheck`
- Browser Studio, Studio, and Studio Shared package tests
- red/green verification of the Browser Studio operation wiring
- manual Browser Studio download and ZIP manifest inspection

Closes #9806
