### PR TITLE
`remotion`: Truncate long blob URLs in delayRender labels

### DIFF
--- a/packages/core/src/test/truncate-src-for-label.test.ts
+++ b/packages/core/src/test/truncate-src-for-label.test.ts
@@ -26,3 +26,18 @@ test('truncates large data URLs', () => {
 	expect(result.startsWith('data:image/png;base64,')).toBe(true);
 	expect(result).toContain('[' + huge.length + ' chars total]');
 });
+
+test('truncates large blob URLs', () => {
+	const hugeBlob = 'blob:https://example.com/' + 'B'.repeat(500);
+	const result = truncateSrcForLabel(hugeBlob);
+
+	expect(result.length).toBeLessThan(200);
+	expect(result.startsWith('blob:https://example.com/')).toBe(true);
+	expect(result).toContain('[' + hugeBlob.length + ' chars total]');
+});
+
+test('handles non-string inputs safely', () => {
+	expect(truncateSrcForLabel(null as unknown as string)).toBe('');
+	expect(truncateSrcForLabel(undefined as unknown as string)).toBe('');
+	expect(truncateSrcForLabel(123 as unknown as string)).toBe('123');
+});

--- a/packages/core/src/test/truncate-src-for-label.test.ts
+++ b/packages/core/src/test/truncate-src-for-label.test.ts
@@ -36,8 +36,8 @@ test('truncates large blob URLs', () => {
 	expect(result).toContain('[' + hugeBlob.length + ' chars total]');
 });
 
-test('handles non-string inputs safely', () => {
-	expect(truncateSrcForLabel(null as unknown as string)).toBe('');
-	expect(truncateSrcForLabel(undefined as unknown as string)).toBe('');
+test('stringifies non-string inputs for diagnostic labels', () => {
+	expect(truncateSrcForLabel(null as unknown as string)).toBe('null');
+	expect(truncateSrcForLabel(undefined as unknown as string)).toBe('undefined');
 	expect(truncateSrcForLabel(123 as unknown as string)).toBe('123');
 });

--- a/packages/core/src/truncate-src-for-label.ts
+++ b/packages/core/src/truncate-src-for-label.ts
@@ -1,7 +1,10 @@
 // Data URLs like the ones from canvas.toDataURL() can be many megabytes, which makes the delayRender() label
 // unreadable and bloats log output
 export function truncateSrcForLabel(src: string): string {
-	if (src.startsWith('data:') && src.length > 100) {
+	if (typeof src !== 'string') {
+		return String(src ?? '');
+	}
+	if (src.length > 100 && (src.startsWith('data:') || src.startsWith('blob:'))) {
 		return src.slice(0, 60) + '...[' + src.length + ' chars total]';
 	}
 

--- a/packages/core/src/truncate-src-for-label.ts
+++ b/packages/core/src/truncate-src-for-label.ts
@@ -2,9 +2,13 @@
 // unreadable and bloats log output
 export function truncateSrcForLabel(src: string): string {
 	if (typeof src !== 'string') {
-		return String(src ?? '');
+		return String(src);
 	}
-	if (src.length > 100 && (src.startsWith('data:') || src.startsWith('blob:'))) {
+
+	if (
+		src.length > 100 &&
+		(src.startsWith('data:') || src.startsWith('blob:'))
+	) {
 		return src.slice(0, 60) + '...[' + src.length + ' chars total]';
 	}
 


### PR DESCRIPTION
## Description
This PR updates `truncateSrcForLabel` in `packages/core/src/truncate-src-for-label.ts`.

## Details
- Adds support for truncating long `blob:` URLs alongside `data:` URLs to keep delayRender labels compact.
- Adds a non-string type guard to prevent runtime errors if non-string values are passed.