### PR TITLE
Docs: Add FAQ item for remotion.pro sign-up options

### DIFF
--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -166,7 +166,7 @@ You can sign up for an account on [remotion.pro](https://www.remotion.pro/) usin
 - **Google**: Sign up with your Google account for a quicker login experience.
 - **GitHub**: Sign up with your GitHub account for a quicker login experience.
 
-If you signed up using email, you can link your Remotion account to Google or GitHub in your [accountsettings](https://www.remotion.pro/settings) for a smoother login experience.
+If you signed up using email, you can link your Remotion account to Google or GitHub in your [account settings](https://www.remotion.pro/settings) for a smoother login experience.
 
 ### Where is my Remotion project hosted?
 

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -158,6 +158,16 @@ To create an account:
 
 Holding a Company License also comes with perks such as **priority support** and access to **Remotion templates**, which are available through the licensing platform within your created project.
 
+### How can I sign up for an account on remotion.pro?
+
+You can sign up for an account on [remotion.pro](https://www.remotion.pro/) using one of the following methods:
+
+- **Email**: Enter your email address and we will send you a magic link to confirm your address. Password-based authentication is not supported.
+- **Google**: Sign up with your Google account for a quicker login experience.
+- **GitHub**: Sign up with your GitHub account for a quicker login experience.
+
+If you signed up using email, you can link your Remotion account to Google or GitHub in your [accountsettings](https://www.remotion.pro/settings) for a smoother login experience.
+
 ### Where is my Remotion project hosted?
 
 You have to set up your own infrastructure by either using cloud services (e.g., AWS, Google Cloud, or Azure), setting up your own on-premise infrastructure or using client-side rendering.


### PR DESCRIPTION
## Summary
- Add a new FAQ entry in `packages/docs/docs/license/faq.mdx` explaining the sign-up options on remotion.pro (email via magic link, Google, GitHub).
- Note that password-based authentication is not supported, and that users who signed up with email can link their Google or GitHub account in their account settings for a smoother login experience.

## Test plan
- [ ] Verify the new FAQ item renders correctly on the docs site.
- [ ] Verify the links to remotion.pro and the settings page work.

Made with [Cursor](https://cursor.com)