### PR TITLE
`@remotion/studio`: Collapse inactive inspector sections

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -1,0 +1,77 @@
+import {expect, test} from '@playwright/test';
+import {EXPANDED_SIDEBAR_STATE, STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test.describe('inspector section collapse', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('collapses inactive static sections and lets the user expand them', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/issue-8216`);
+		await expect(page).toHaveURL(/issue-8216/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await page.locator('[title="Foreground"]').first().click();
+
+		await expect(
+			page.getByRole('button', {name: 'Expand Background', exact: true}),
+		).toBeVisible({timeout: 15_000});
+		await expect(
+			page.getByRole('button', {name: 'Expand Border', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Expand Border radius', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByTitle('Use individual corner radii', {exact: true}),
+		).toHaveCount(0);
+		await expect(
+			page.getByRole('button', {name: 'Expand Crop', exact: true}),
+		).toBeVisible();
+
+		await page
+			.getByRole('button', {name: 'Expand Border radius', exact: true})
+			.click();
+		await expect(
+			page.getByTitle('Use individual corner radii', {exact: true}),
+		).toBeVisible();
+		const expandedBorderRadiusButton = page.getByRole('button', {
+			name: 'Collapse Border radius',
+			exact: true,
+		});
+		await expect(expandedBorderRadiusButton).toBeFocused();
+		expect(
+			await expandedBorderRadiusButton.evaluate((element) => {
+				const style = getComputedStyle(element);
+				return {boxShadow: style.boxShadow, outlineStyle: style.outlineStyle};
+			}),
+		).toEqual({boxShadow: 'none', outlineStyle: 'none'});
+
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Shift+Tab');
+		await expect(expandedBorderRadiusButton).toBeFocused();
+		expect(
+			await expandedBorderRadiusButton.evaluate(
+				(element) => getComputedStyle(element).boxShadow,
+			),
+		).not.toBe('none');
+
+		await page.getByRole('button', {name: 'Expand Crop', exact: true}).click();
+		await expect(
+			page.getByRole('button', {name: 'Collapse Crop', exact: true}),
+		).toBeVisible();
+		await expect(page.getByText('Crop left', {exact: true})).toBeVisible();
+	});
+});

--- a/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
+++ b/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
@@ -1,0 +1,235 @@
+import type {SchemaFieldGroup} from '@remotion/studio-shared';
+import {parseAnyColor} from '../../helpers/color-conversion';
+
+export type SmartCollapsibleInspectorGroup = Extract<
+	SchemaFieldGroup,
+	'background' | 'border' | 'border-radius' | 'crop'
+>;
+
+export type InspectorSectionActivity = 'active' | 'inactive' | 'unknown';
+
+type InspectorSectionPropStatus =
+	| {readonly status: 'static'; readonly codeValue: unknown}
+	| {readonly status: 'computed' | 'keyframed'};
+
+const BORDER_KEYS = [
+	'style.borderWidth',
+	'style.borderStyle',
+	'style.borderColor',
+] as const;
+
+const BORDER_RADIUS_SHORTHAND_KEY = 'style.borderRadius';
+const BORDER_RADIUS_LONGHAND_KEYS = [
+	'style.borderTopLeftRadius',
+	'style.borderTopRightRadius',
+	'style.borderBottomRightRadius',
+	'style.borderBottomLeftRadius',
+] as const;
+
+const CROP_KEYS = ['cropLeft', 'cropRight', 'cropTop', 'cropBottom'] as const;
+
+const BACKGROUND_COLOR_KEY = 'style.backgroundColor';
+
+export const isSmartCollapsibleInspectorGroup = (
+	group: SchemaFieldGroup,
+): group is SmartCollapsibleInspectorGroup => {
+	return (
+		group === 'background' ||
+		group === 'border' ||
+		group === 'border-radius' ||
+		group === 'crop'
+	);
+};
+
+const getStaticValue = ({
+	key,
+	propStatuses,
+}: {
+	readonly key: string;
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}):
+	| {readonly found: true; readonly value: unknown}
+	| {readonly found: false} => {
+	const status = propStatuses?.[key];
+	if (status?.status !== 'static') {
+		return {found: false};
+	}
+
+	return {found: true, value: status.codeValue};
+};
+
+const isZeroOrUndefined = (value: unknown): boolean => {
+	return value === undefined || value === 0;
+};
+
+const isTransparentOrUndefined = (value: unknown): boolean => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== 'string') {
+		return false;
+	}
+
+	return parseAnyColor(value).a === 0;
+};
+
+const hasOnlyStaticZeroValues = ({
+	keys,
+	propStatuses,
+}: {
+	readonly keys: readonly string[];
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}): boolean => {
+	for (const key of keys) {
+		const result = getStaticValue({key, propStatuses});
+		if (!result.found || !isZeroOrUndefined(result.value)) {
+			return false;
+		}
+	}
+
+	return true;
+};
+
+const isBorderInactive = (
+	propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined,
+): boolean => {
+	const [width, style, color] = BORDER_KEYS.map((key) =>
+		getStaticValue({key, propStatuses}),
+	);
+
+	if (!width.found || !style.found || !color.found) {
+		return false;
+	}
+
+	if (
+		style.value === undefined ||
+		style.value === 'none' ||
+		style.value === 'hidden'
+	) {
+		return true;
+	}
+
+	if (width.value === 0) {
+		return true;
+	}
+
+	return isTransparentOrUndefined(color.value) && color.value !== undefined;
+};
+
+const isBorderRadiusInactive = (
+	propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined,
+): boolean => {
+	const shorthandStatus = propStatuses?.[BORDER_RADIUS_SHORTHAND_KEY];
+	if (shorthandStatus && shorthandStatus.status !== 'static') {
+		return false;
+	}
+
+	if (shorthandStatus?.codeValue !== undefined) {
+		return shorthandStatus.codeValue === 0;
+	}
+
+	return hasOnlyStaticZeroValues({
+		keys: BORDER_RADIUS_LONGHAND_KEYS,
+		propStatuses,
+	});
+};
+
+export const isInspectorSectionEffectivelyInactive = ({
+	group,
+	propStatuses,
+}: {
+	readonly group: SmartCollapsibleInspectorGroup;
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}): boolean => {
+	if (group === 'border') {
+		return isBorderInactive(propStatuses);
+	}
+
+	if (group === 'border-radius') {
+		return isBorderRadiusInactive(propStatuses);
+	}
+
+	if (group === 'crop') {
+		return hasOnlyStaticZeroValues({keys: CROP_KEYS, propStatuses});
+	}
+
+	const backgroundColor = getStaticValue({
+		key: BACKGROUND_COLOR_KEY,
+		propStatuses,
+	});
+	return (
+		backgroundColor.found && isTransparentOrUndefined(backgroundColor.value)
+	);
+};
+
+const hasOwnStatus = ({
+	key,
+	propStatuses,
+}: {
+	readonly key: string;
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}): boolean => {
+	return (
+		propStatuses !== undefined &&
+		Object.prototype.hasOwnProperty.call(propStatuses, key)
+	);
+};
+
+const hasEveryStatus = ({
+	keys,
+	propStatuses,
+}: {
+	readonly keys: readonly string[];
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}): boolean => {
+	return keys.every((key) => hasOwnStatus({key, propStatuses}));
+};
+
+export const getInspectorSectionActivity = ({
+	group,
+	propStatuses,
+}: {
+	readonly group: SmartCollapsibleInspectorGroup;
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+}): InspectorSectionActivity => {
+	let resolved = false;
+	if (group === 'border') {
+		resolved = hasEveryStatus({keys: BORDER_KEYS, propStatuses});
+	} else if (group === 'border-radius') {
+		const shorthandStatus = propStatuses?.[BORDER_RADIUS_SHORTHAND_KEY];
+		resolved =
+			(shorthandStatus !== undefined &&
+				(shorthandStatus.status !== 'static' ||
+					shorthandStatus.codeValue !== undefined)) ||
+			hasEveryStatus({keys: BORDER_RADIUS_LONGHAND_KEYS, propStatuses});
+	} else if (group === 'crop') {
+		resolved = hasEveryStatus({keys: CROP_KEYS, propStatuses});
+	} else {
+		resolved = hasOwnStatus({key: BACKGROUND_COLOR_KEY, propStatuses});
+	}
+
+	if (!resolved) {
+		return 'unknown';
+	}
+
+	return isInspectorSectionEffectivelyInactive({group, propStatuses})
+		? 'inactive'
+		: 'active';
+};

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -51,9 +51,11 @@ export const sequenceHeaderDivider: React.CSSProperties = {
 
 export const sectionHeader: React.CSSProperties = {
 	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
 	fontSize: 12,
 	fontWeight: 'bold',
-	padding: `8px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
+	lineHeight: '24px',
+	padding: `4px ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
 	userSelect: 'none',
 };
 
@@ -92,11 +94,15 @@ export const sectionHeaderRow: React.CSSProperties = {
 };
 
 export const sectionHeaderTitle: React.CSSProperties = {
+	alignItems: 'center',
 	color: LIGHT_TEXT,
+	display: 'flex',
 	flexShrink: 0,
+	fontFamily: 'sans-serif',
 	fontSize: 12,
 	fontWeight: 'bold',
 	lineHeight: '16px',
+	minHeight: 24,
 	minWidth: 0,
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -1,5 +1,11 @@
 import type {Caption} from '@remotion/captions';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import {Internals, type TSequence} from 'remotion';
 import type {CodePosition} from '../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
@@ -22,6 +28,10 @@ import {AssetFileIcon} from './AssetFileIcon';
 import {InlineAction} from './InlineAction';
 import {InlineCaptionInspector} from './InlineCaptionInspector';
 import {InspectorSection} from './InspectorPanel/common';
+import {
+	getInspectorSectionActivity,
+	isSmartCollapsibleInspectorGroup,
+} from './InspectorPanel/inspector-section-collapse';
 import {sectionHeaderRow, sectionHeaderTitle} from './InspectorPanel/styles';
 import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
@@ -85,6 +95,61 @@ const borderRadiusToggleIcon: React.CSSProperties = {
 	width: 15,
 };
 
+const collapsibleSectionHeaderButton: React.CSSProperties = {
+	appearance: 'none',
+	backgroundColor: 'transparent',
+	border: 'none',
+	borderRadius: 3,
+	cursor: 'default',
+	display: 'block',
+	flex: 1,
+	fontFamily: 'Arial, Helvetica, sans-serif',
+	fontSize: 12,
+	fontWeight: 'bold',
+	lineHeight: '16px',
+	margin: 0,
+	minWidth: 0,
+	overflow: 'hidden',
+	padding: '4px 0',
+	textAlign: 'left',
+	textOverflow: 'ellipsis',
+	userSelect: 'none',
+	whiteSpace: 'nowrap',
+};
+
+const CollapsibleInspectorSectionHeader: React.FC<{
+	readonly action: React.ReactNode;
+	readonly expanded: boolean;
+	readonly label: string;
+	readonly onToggle: () => void;
+}> = ({action, expanded, label, onToggle}) => {
+	const [hovered, setHovered] = useState(false);
+	const style = useMemo<React.CSSProperties>(() => {
+		return {
+			...collapsibleSectionHeaderButton,
+			color: hovered ? WHITE : LIGHT_TEXT,
+		};
+	}, [hovered]);
+
+	return (
+		<div style={sectionHeaderRow}>
+			<button
+				type="button"
+				aria-expanded={expanded}
+				aria-label={`${expanded ? 'Collapse' : 'Expand'} ${label}`}
+				className="__remotion-inspector-section-title"
+				onClick={onToggle}
+				onPointerEnter={() => setHovered(true)}
+				onPointerLeave={() => setHovered(false)}
+				style={style}
+			>
+				{label}
+			</button>
+			{action}
+		</div>
+	);
+};
+
 const assetSelectorIcon: React.CSSProperties = {
 	flexShrink: 0,
 	height: 18,
@@ -138,6 +203,8 @@ const isEffectsRoot = (
 
 const INSPECTOR_COLLAPSED_ROWS_SESSION_STORAGE_KEY =
 	'remotion.editor.inspectorCollapsedRows';
+const INSPECTOR_SECTION_EXPANSION_OVERRIDES_SESSION_STORAGE_KEY =
+	'remotion.editor.inspectorSectionExpansionOverrides';
 
 const getInspectorExpansionKey = (nodePathInfo: SequenceNodePathInfo) => {
 	return JSON.stringify(nodePathInfo);
@@ -180,6 +247,73 @@ const persistInspectorCollapsedKeys = (keys: ReadonlySet<string>): void => {
 	} catch {
 		// Ignore quota errors or disabled storage.
 	}
+};
+
+type InspectorSectionExpansionOverrides = Readonly<Record<string, boolean>>;
+
+const loadInspectorSectionExpansionOverrides =
+	(): InspectorSectionExpansionOverrides => {
+		if (typeof window === 'undefined') {
+			return {};
+		}
+
+		try {
+			const raw = window.sessionStorage.getItem(
+				INSPECTOR_SECTION_EXPANSION_OVERRIDES_SESSION_STORAGE_KEY,
+			);
+			if (raw === null) {
+				return {};
+			}
+
+			const parsed: unknown = JSON.parse(raw);
+			if (
+				parsed === null ||
+				typeof parsed !== 'object' ||
+				Array.isArray(parsed)
+			) {
+				return {};
+			}
+
+			return Object.fromEntries(
+				Object.entries(parsed).filter((entry): entry is [string, boolean] => {
+					return typeof entry[1] === 'boolean';
+				}),
+			);
+		} catch {
+			return {};
+		}
+	};
+
+const persistInspectorSectionExpansionOverrides = (
+	overrides: InspectorSectionExpansionOverrides,
+): void => {
+	if (typeof window === 'undefined') {
+		return;
+	}
+
+	try {
+		window.sessionStorage.setItem(
+			INSPECTOR_SECTION_EXPANSION_OVERRIDES_SESSION_STORAGE_KEY,
+			JSON.stringify(overrides),
+		);
+	} catch {
+		// Ignore quota errors or disabled storage.
+	}
+};
+
+const getInspectorSectionExpansionKey = ({
+	nodePathInfo,
+	groupId,
+}: {
+	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly groupId: SchemaFieldGroupInfo['id'];
+}) => {
+	return JSON.stringify([
+		nodePathInfo.sequenceSubscriptionKey.absolutePath,
+		nodePathInfo.sequenceSubscriptionKey.nodePath,
+		nodePathInfo.index,
+		groupId,
+	]);
 };
 
 type SequenceWithControls = TSequence & {
@@ -240,6 +374,12 @@ export const InspectorSequenceSection: React.FC<{
 	const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(
 		loadInspectorCollapsedKeys,
 	);
+	const [sectionExpansionOverrides, setSectionExpansionOverrides] = useState(
+		loadInspectorSectionExpansionOverrides,
+	);
+	const [automaticSectionExpansion, setAutomaticSectionExpansion] = useState<
+		Readonly<Record<string, boolean>>
+	>({});
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
@@ -354,15 +494,6 @@ export const InspectorSequenceSection: React.FC<{
 		};
 	}, [getIsExpanded, tree]);
 
-	const controlSelectableItems = useMemo(
-		() =>
-			getInspectorSelectableItems(
-				controlRows.filter(
-					({node}) => node.kind !== 'field' || node.field?.key !== 'src',
-				),
-			),
-		[controlRows],
-	);
 	const effectSelectableItems = useMemo(
 		() => getInspectorSelectableItems(effectRows),
 		[effectRows],
@@ -375,6 +506,108 @@ export const InspectorSequenceSection: React.FC<{
 	const controlGroupsWithoutLayout = controlGroups.filter(
 		(group) => group.id !== 'layout',
 	);
+	const sequencePropStatuses = Internals.getPropStatusesCtx(
+		propStatuses,
+		nodePathInfo.sequenceSubscriptionKey,
+	);
+	const getControlGroupActivity = useCallback(
+		(group: InspectorControlGroup) => {
+			if (!isSmartCollapsibleInspectorGroup(group.id)) {
+				return 'active' as const;
+			}
+
+			return getInspectorSectionActivity({
+				group: group.id,
+				propStatuses: sequencePropStatuses,
+			});
+		},
+		[sequencePropStatuses],
+	);
+	useEffect(() => {
+		setAutomaticSectionExpansion((previous) => {
+			let changed = false;
+			const next = {...previous};
+			for (const group of controlGroups) {
+				if (!isSmartCollapsibleInspectorGroup(group.id)) {
+					continue;
+				}
+
+				const expansionKey = getInspectorSectionExpansionKey({
+					nodePathInfo,
+					groupId: group.id,
+				});
+				const activity = getControlGroupActivity(group);
+				if (activity === 'active' && next[expansionKey] !== true) {
+					next[expansionKey] = true;
+					changed = true;
+				} else if (
+					activity === 'inactive' &&
+					next[expansionKey] === undefined
+				) {
+					next[expansionKey] = false;
+					changed = true;
+				}
+			}
+
+			return changed ? next : previous;
+		});
+	}, [controlGroups, getControlGroupActivity, nodePathInfo]);
+	const isControlGroupExpanded = useCallback(
+		(group: InspectorControlGroup): boolean => {
+			if (!isSmartCollapsibleInspectorGroup(group.id)) {
+				return true;
+			}
+
+			const expansionKey = getInspectorSectionExpansionKey({
+				nodePathInfo,
+				groupId: group.id,
+			});
+			const override = sectionExpansionOverrides[expansionKey];
+			if (override !== undefined) {
+				return override;
+			}
+
+			const automaticExpansion = automaticSectionExpansion[expansionKey];
+			if (automaticExpansion !== undefined) {
+				return automaticExpansion;
+			}
+
+			return getControlGroupActivity(group) !== 'inactive';
+		},
+		[
+			automaticSectionExpansion,
+			getControlGroupActivity,
+			nodePathInfo,
+			sectionExpansionOverrides,
+		],
+	);
+	const toggleControlGroup = useCallback(
+		(group: InspectorControlGroup) => {
+			const expansionKey = getInspectorSectionExpansionKey({
+				nodePathInfo,
+				groupId: group.id,
+			});
+			const nextExpanded = !isControlGroupExpanded(group);
+			setSectionExpansionOverrides((previous) => {
+				const next = {...previous, [expansionKey]: nextExpanded};
+				persistInspectorSectionExpansionOverrides(next);
+				return next;
+			});
+		},
+		[isControlGroupExpanded, nodePathInfo],
+	);
+	const visibleControlRows = controlGroups.flatMap((group) => {
+		return isControlGroupExpanded(group) ? group.rows : [];
+	});
+	const controlSelectableItems = useMemo(
+		() =>
+			getInspectorSelectableItems(
+				visibleControlRows.filter(
+					({node}) => node.kind !== 'field' || node.field?.key !== 'src',
+				),
+			),
+		[visibleControlRows],
+	);
 
 	const {schema} = sequence.controls;
 	const borderRadiusGroup = controlGroups.find(
@@ -385,10 +618,7 @@ export const InspectorSequenceSection: React.FC<{
 			node.kind === 'field' && node.field?.key === BORDER_RADIUS_SHORTHAND_KEY,
 	);
 	const borderRadiusConversion = getBorderRadiusConversion(
-		Internals.getPropStatusesCtx(
-			propStatuses,
-			nodePathInfo.sequenceSubscriptionKey,
-		),
+		sequencePropStatuses,
 		getDragOverrides(nodePathInfo.sequenceSubscriptionKey),
 	);
 	const inlineCaptionValue =
@@ -461,33 +691,30 @@ export const InspectorSequenceSection: React.FC<{
 		validatedLocation.source,
 	]);
 
-	const borderRadiusHeader = borderRadiusGroup ? (
-		<div style={sectionHeaderRow}>
-			<div style={effectsHeaderTitle}>Border radius</div>
-			<InlineAction
-				disabled={
-					borderRadiusConversion === null ||
-					previewServerState.type !== 'connected'
-				}
-				onClick={onConvertBorderRadius}
-				title={
-					borderRadiusConversion === null
-						? borderRadiusUsesShorthand
-							? 'A static border radius is required to use individual corners'
-							: 'All four corners must have the same static value'
-						: borderRadiusUsesShorthand
-							? 'Use individual corner radii'
-							: 'Use one border radius value'
-				}
-				renderAction={(color) =>
-					borderRadiusUsesShorthand ? (
-						<FullscreenIcon color={color} style={borderRadiusToggleIcon} />
-					) : (
-						<BorderRadiusIcon color={color} style={borderRadiusToggleIcon} />
-					)
-				}
-			/>
-		</div>
+	const borderRadiusAction = borderRadiusGroup ? (
+		<InlineAction
+			disabled={
+				borderRadiusConversion === null ||
+				previewServerState.type !== 'connected'
+			}
+			onClick={onConvertBorderRadius}
+			title={
+				borderRadiusConversion === null
+					? borderRadiusUsesShorthand
+						? 'A static border radius is required to use individual corners'
+						: 'All four corners must have the same static value'
+					: borderRadiusUsesShorthand
+						? 'Use individual corner radii'
+						: 'Use one border radius value'
+			}
+			renderAction={(color) =>
+				borderRadiusUsesShorthand ? (
+					<FullscreenIcon color={color} style={borderRadiusToggleIcon} />
+				) : (
+					<BorderRadiusIcon color={color} style={borderRadiusToggleIcon} />
+				)
+			}
+		/>
 	) : null;
 
 	const effectsHeader = (
@@ -525,6 +752,29 @@ export const InspectorSequenceSection: React.FC<{
 		);
 	};
 
+	const renderControlGroupHeader = (group: InspectorControlGroup) => {
+		const collapsible = isSmartCollapsibleInspectorGroup(group.id);
+		const expanded = isControlGroupExpanded(group);
+		if (collapsible) {
+			return (
+				<CollapsibleInspectorSectionHeader
+					action={
+						group.id === 'border-radius' && expanded ? borderRadiusAction : null
+					}
+					expanded={expanded}
+					label={group.label}
+					onToggle={() => toggleControlGroup(group)}
+				/>
+			);
+		}
+
+		return (
+			<div style={sectionHeaderRow}>
+				<div style={effectsHeaderTitle}>{group.label}</div>
+			</div>
+		);
+	};
+
 	if (
 		controlRows.length === 0 &&
 		!showEffectsSection &&
@@ -547,14 +797,16 @@ export const InspectorSequenceSection: React.FC<{
 						{controlGroupsWithoutLayout.map((group) => (
 							<InspectorSection
 								key={group.id}
-								header={
-									group.id === 'border-radius'
-										? borderRadiusHeader
-										: group.label
-								}
+								header={renderControlGroupHeader(group)}
 							>
-								{group.id === 'transforms' ? renderTransformControls() : null}
-								{group.rows.map(renderRow)}
+								{isControlGroupExpanded(group) ? (
+									<>
+										{group.id === 'transforms'
+											? renderTransformControls()
+											: null}
+										{group.rows.map(renderRow)}
+									</>
+								) : null}
 							</InspectorSection>
 						))}
 					</TimelineSelectionOrderProvider>

--- a/packages/studio/src/helpers/inject-css.ts
+++ b/packages/studio/src/helpers/inject-css.ts
@@ -91,20 +91,22 @@ const makeDefaultGlobalCSS = () => {
 
   input:focus,
   textarea:focus,
-  button:focus:not(.__remotion_input_dragger):not(.__remotion_color_swatch),
+  button:focus:not(.__remotion_input_dragger):not(.__remotion_color_swatch):not(.__remotion-inspector-section-title),
   a:focus {
 	    outline: none;
 	    box-shadow: ${FOCUS_BOX_SHADOW};
 	  }
 
   .__remotion-composition-selector-item:focus,
-  .__remotion-inspector-inline-action:focus {
+  .__remotion-inspector-inline-action:focus,
+  .__remotion-inspector-section-title:focus {
     outline: none;
     box-shadow: none;
   }
 
   .__remotion-composition-selector-item:focus-visible,
-  .__remotion-inspector-inline-action:focus-visible {
+  .__remotion-inspector-inline-action:focus-visible,
+  .__remotion-inspector-section-title:focus-visible {
     box-shadow: ${FOCUS_BOX_SHADOW};
   }
 

--- a/packages/studio/src/test/inspector-section-collapse.test.ts
+++ b/packages/studio/src/test/inspector-section-collapse.test.ts
@@ -1,0 +1,196 @@
+import {expect, test} from 'bun:test';
+import {
+	getInspectorSectionActivity,
+	isInspectorSectionEffectivelyInactive,
+} from '../components/InspectorPanel/inspector-section-collapse';
+
+const staticStatuses = (values: Record<string, unknown>) => {
+	return Object.fromEntries(
+		Object.entries(values).map(([key, codeValue]) => [
+			key,
+			{status: 'static' as const, codeValue},
+		]),
+	);
+};
+
+test('only treats confidently inactive static background values as inactive', () => {
+	expect(
+		getInspectorSectionActivity({
+			group: 'background',
+			propStatuses: undefined,
+		}),
+	).toBe('unknown');
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'background',
+			propStatuses: staticStatuses({
+				'style.backgroundColor': 'rgba(12, 34, 56, 0)',
+			}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'background',
+			propStatuses: staticStatuses({'style.backgroundColor': '#ff0000'}),
+		}),
+	).toBe(false);
+	expect(
+		getInspectorSectionActivity({
+			group: 'background',
+			propStatuses: {'style.backgroundColor': {status: 'computed'}},
+		}),
+	).toBe('active');
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'background',
+			propStatuses: {'style.backgroundColor': {status: 'keyframed'}},
+		}),
+	).toBe(false);
+});
+
+test('treats only static zero border radius and crop values as inactive', () => {
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: staticStatuses({'style.borderRadius': 0}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: staticStatuses({
+				'style.borderRadius': undefined,
+				'style.borderTopLeftRadius': 0,
+				'style.borderTopRightRadius': 0,
+				'style.borderBottomRightRadius': 0,
+				'style.borderBottomLeftRadius': 0,
+			}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: staticStatuses({'style.borderRadius': 12}),
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: staticStatuses({
+				'style.borderRadius': undefined,
+				'style.borderTopLeftRadius': 0,
+				'style.borderTopRightRadius': 16,
+				'style.borderBottomRightRadius': 0,
+				'style.borderBottomLeftRadius': 0,
+			}),
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: {'style.borderRadius': {status: 'keyframed'}},
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border-radius',
+			propStatuses: {
+				'style.borderRadius': {status: 'computed'},
+				...staticStatuses({
+					'style.borderTopLeftRadius': 0,
+					'style.borderTopRightRadius': 0,
+					'style.borderBottomRightRadius': 0,
+					'style.borderBottomLeftRadius': 0,
+				}),
+			},
+		}),
+	).toBe(false);
+
+	const emptyCrop = staticStatuses({
+		cropLeft: 0,
+		cropRight: undefined,
+		cropTop: 0,
+		cropBottom: 0,
+	});
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'crop',
+			propStatuses: emptyCrop,
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'crop',
+			propStatuses: {...emptyCrop, cropLeft: {status: 'computed'}},
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'crop',
+			propStatuses: staticStatuses({cropLeft: 0}),
+		}),
+	).toBe(false);
+});
+
+test('treats a static border as inactive only when it cannot be seen', () => {
+	const border = (values: {
+		readonly width: unknown;
+		readonly style: unknown;
+		readonly color: unknown;
+	}) =>
+		staticStatuses({
+			'style.borderWidth': values.width,
+			'style.borderStyle': values.style,
+			'style.borderColor': values.color,
+		});
+
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({
+				width: undefined,
+				style: undefined,
+				color: undefined,
+			}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({width: 4, style: 'none', color: 'red'}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({width: 0, style: 'solid', color: 'red'}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({width: 4, style: 'solid', color: 'transparent'}),
+		}),
+	).toBe(true);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({width: 4, style: 'solid', color: undefined}),
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: border({width: undefined, style: 'solid', color: 'red'}),
+		}),
+	).toBe(false);
+	expect(
+		isInspectorSectionEffectivelyInactive({
+			group: 'border',
+			propStatuses: {
+				...border({width: 4, style: 'solid', color: 'red'}),
+				'style.borderWidth': {status: 'computed'},
+			},
+		}),
+	).toBe(false);
+});


### PR DESCRIPTION
## Summary

- collapse inspector sections only when their static values are effectively inactive
- keep computed and keyframed sections expanded, and persist manual expansion choices per sequence
- use aligned, compact clickable headers with expanded-only actions and keyboard-only focus rings

## Testing

- `bun test ./packages/studio/src/test/inspector-section-collapse.test.ts`
- `bunx playwright test e2e/inspector-section-collapse.test.mts`
- `bun run build`
- `bun run stylecheck`

Closes #9683
