### PR TITLE
Skills: Symlink Claude skills to agent skills

### DIFF
--- a/.claude/commands/add-bug.md
+++ b/.claude/commands/add-bug.md
@@ -1,1 +1,0 @@
-../../.agents/commands/add-bug.md

--- a/.claude/commands/checkout.md
+++ b/.claude/commands/checkout.md
@@ -1,1 +1,0 @@
-../../.agents/commands/checkout.md

--- a/.claude/commands/formatting.md
+++ b/.claude/commands/formatting.md
@@ -1,1 +1,0 @@
-../../.agents/commands/formatting.md

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,1 +1,0 @@
-../../.agents/commands/release.md

--- a/.claude/commands/update-chrome-binaries-test-region.md
+++ b/.claude/commands/update-chrome-binaries-test-region.md
@@ -1,1 +1,0 @@
-../../.agents/commands/update-chrome-binaries-test-region.md

--- a/.claude/commands/update-stars.md
+++ b/.claude/commands/update-stars.md
@@ -1,1 +1,0 @@
-../../.agents/commands/update-stars.md

--- a/.claude/commands/upgrade-caniuse.md
+++ b/.claude/commands/upgrade-caniuse.md
@@ -1,1 +1,0 @@
-../../.agents/commands/upgrade-caniuse.md

--- a/.claude/commands/upgrade-mediabunny.md
+++ b/.claude/commands/upgrade-mediabunny.md
@@ -1,1 +1,0 @@
-../../.agents/commands/upgrade-mediabunny.md

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.claude/skills/add-bug
+++ b/.claude/skills/add-bug
@@ -1,1 +1,0 @@
-../../.agents/skills/add-bug

--- a/.claude/skills/add-cli-option
+++ b/.claude/skills/add-cli-option
@@ -1,1 +1,0 @@
-../../.agents/skills/add-cli-option

--- a/.claude/skills/add-effect
+++ b/.claude/skills/add-effect
@@ -1,1 +1,0 @@
-../../.agents/skills/add-effect

--- a/.claude/skills/add-expert
+++ b/.claude/skills/add-expert
@@ -1,1 +1,0 @@
-../../.agents/skills/add-expert

--- a/.claude/skills/add-new-package
+++ b/.claude/skills/add-new-package
@@ -1,1 +1,0 @@
-../../.agents/skills/add-new-package

--- a/.claude/skills/add-sfx
+++ b/.claude/skills/add-sfx
@@ -1,1 +1,0 @@
-../../.agents/skills/add-sfx

--- a/.claude/skills/add-webcodecs-bug
+++ b/.claude/skills/add-webcodecs-bug
@@ -1,1 +1,0 @@
-../../.agents/skills/add-webcodecs-bug

--- a/.claude/skills/checkout
+++ b/.claude/skills/checkout
@@ -1,1 +1,0 @@
-../../.agents/skills/checkout

--- a/.claude/skills/docs-demo
+++ b/.claude/skills/docs-demo
@@ -1,1 +1,0 @@
-../../.agents/skills/docs-demo

--- a/.claude/skills/fix-dependabot
+++ b/.claude/skills/fix-dependabot
@@ -1,1 +1,0 @@
-../../.agents/skills/fix-dependabot

--- a/.claude/skills/flake
+++ b/.claude/skills/flake
@@ -1,1 +1,0 @@
-../../.agents/skills/flake

--- a/.claude/skills/formatting
+++ b/.claude/skills/formatting
@@ -1,1 +1,0 @@
-../../.agents/skills/formatting

--- a/.claude/skills/interactivity-best-practices
+++ b/.claude/skills/interactivity-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/interactivity-best-practices

--- a/.claude/skills/issue
+++ b/.claude/skills/issue
@@ -1,1 +1,0 @@
-../../.agents/skills/issue

--- a/.claude/skills/issue-management
+++ b/.claude/skills/issue-management
@@ -1,1 +1,0 @@
-../../.agents/skills/issue-management

--- a/.claude/skills/merge
+++ b/.claude/skills/merge
@@ -1,1 +1,0 @@
-../../.agents/skills/merge

--- a/.claude/skills/new-element
+++ b/.claude/skills/new-element
@@ -1,1 +1,0 @@
-../../.agents/skills/new-element

--- a/.claude/skills/nullable-new-params
+++ b/.claude/skills/nullable-new-params
@@ -1,1 +1,0 @@
-../../.agents/skills/nullable-new-params

--- a/.claude/skills/pr
+++ b/.claude/skills/pr
@@ -1,1 +1,0 @@
-../../.agents/skills/pr

--- a/.claude/skills/pr-name
+++ b/.claude/skills/pr-name
@@ -1,1 +1,0 @@
-../../.agents/skills/pr-name

--- a/.claude/skills/pr-ready
+++ b/.claude/skills/pr-ready
@@ -1,1 +1,0 @@
-../../.agents/skills/pr-ready

--- a/.claude/skills/publish-element
+++ b/.claude/skills/publish-element
@@ -1,1 +1,0 @@
-../../.agents/skills/publish-element

--- a/.claude/skills/release
+++ b/.claude/skills/release
@@ -1,1 +1,0 @@
-../../.agents/skills/release

--- a/.claude/skills/update-chrome-binaries-test-region
+++ b/.claude/skills/update-chrome-binaries-test-region
@@ -1,1 +1,0 @@
-../../.agents/skills/update-chrome-binaries-test-region

--- a/.claude/skills/update-stars
+++ b/.claude/skills/update-stars
@@ -1,1 +1,0 @@
-../../.agents/skills/update-stars

--- a/.claude/skills/update-version
+++ b/.claude/skills/update-version
@@ -1,1 +1,0 @@
-../../.agents/skills/update-version

--- a/.claude/skills/upgrade-caniuse
+++ b/.claude/skills/upgrade-caniuse
@@ -1,1 +1,0 @@
-../../.agents/skills/upgrade-caniuse

--- a/.claude/skills/upgrade-mediabunny
+++ b/.claude/skills/upgrade-mediabunny
@@ -1,1 +1,0 @@
-../../.agents/skills/upgrade-mediabunny

--- a/.claude/skills/upload-r2
+++ b/.claude/skills/upload-r2
@@ -1,1 +1,0 @@
-../../.agents/skills/upload-r2

--- a/.claude/skills/version
+++ b/.claude/skills/version
@@ -1,1 +1,0 @@
-../../.agents/skills/version

--- a/.claude/skills/video-report
+++ b/.claude/skills/video-report
@@ -1,1 +1,0 @@
-../../.agents/skills/video-report

--- a/.claude/skills/visual-mode
+++ b/.claude/skills/visual-mode
@@ -1,1 +1,0 @@
-../../.agents/skills/visual-mode

--- a/.claude/skills/web-renderer-test
+++ b/.claude/skills/web-renderer-test
@@ -1,1 +1,0 @@
-../../.agents/skills/web-renderer-test

--- a/.claude/skills/writing-docs
+++ b/.claude/skills/writing-docs
@@ -1,1 +1,0 @@
-../../.agents/skills/writing-docs

--- a/packages/docs/docs/cli/skills.mdx
+++ b/packages/docs/docs/cli/skills.mdx
@@ -33,7 +33,7 @@ npx remotion skills update
 
 Agent Skills are instructions that define best practices for working in Remotion projects. These skills are useful for AI agents like Claude Code, Codex, or Cursor.
 
-Skills are installed to the `.agents/skills` directory in your project. Claude Code compatibility is provided via per-skill symlinks in `.claude/skills`.
+Skills are installed to the `.agents/skills` directory in your project. Claude Code compatibility is provided by symlinking `.claude/skills` to `.agents/skills`.
 
 ## See also
 

--- a/packages/skills/scripts/sync-agent-skills.ts
+++ b/packages/skills/scripts/sync-agent-skills.ts
@@ -1,4 +1,10 @@
-import {lstatSync, readdirSync, readlinkSync, symlinkSync} from 'node:fs';
+import {
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readlinkSync,
+	symlinkSync,
+} from 'node:fs';
 import path from 'node:path';
 
 const repoRoot = process.env.SKILLS_REPO_ROOT
@@ -6,6 +12,7 @@ const repoRoot = process.env.SKILLS_REPO_ROOT
 	: path.resolve(__dirname, '..', '..', '..');
 const skillsRoot = path.join(repoRoot, 'packages', 'skills', 'skills');
 const agentsSkillsRoot = path.join(repoRoot, '.agents', 'skills');
+const claudeSkillsRoot = path.join(repoRoot, '.claude', 'skills');
 const checkOnly = process.argv.includes('--check');
 const issues: string[] = [];
 
@@ -47,12 +54,39 @@ for (const skillFolder of skillFolders) {
 	}
 }
 
+const expectedClaudeTarget = '../.agents/skills';
+const claudeSkillsStats = lstatSync(claudeSkillsRoot, {throwIfNoEntry: false});
+
+if (!claudeSkillsStats) {
+	const message = `Missing ${path.relative(repoRoot, claudeSkillsRoot)} -> ${expectedClaudeTarget}`;
+	if (checkOnly) {
+		issues.push(message);
+	} else {
+		mkdirSync(path.dirname(claudeSkillsRoot), {recursive: true});
+		symlinkSync(expectedClaudeTarget, claudeSkillsRoot, 'dir');
+		console.log(
+			`Created ${path.relative(repoRoot, claudeSkillsRoot)} -> ${expectedClaudeTarget}`,
+		);
+	}
+} else if (!claudeSkillsStats.isSymbolicLink()) {
+	issues.push(
+		`${path.relative(repoRoot, claudeSkillsRoot)} exists but is not a symlink`,
+	);
+} else {
+	const actualTarget = readlinkSync(claudeSkillsRoot);
+	if (actualTarget !== expectedClaudeTarget) {
+		issues.push(
+			`${path.relative(repoRoot, claudeSkillsRoot)} points to ${actualTarget}, expected ${expectedClaudeTarget}`,
+		);
+	}
+}
+
 if (issues.length > 0) {
-	console.error('Public skills are not linked into .agents/skills:');
+	console.error('Skill links are out of sync:');
 	for (const issue of issues) {
 		console.error(`- ${issue}`);
 	}
 	process.exit(1);
 }
 
-console.log('All public skills are linked into .agents/skills.');
+console.log('All skill links are in sync.');


### PR DESCRIPTION
## Summary

- remove obsolete `.claude/commands` links
- replace the partial per-skill Claude links with `.claude/skills` pointing to `.agents/skills`
- make skill synchronization validate the Claude compatibility link and update the CLI documentation

## Verification

- `bunx oxfmt packages/skills/scripts/sync-agent-skills.ts packages/docs/docs/cli/skills.mdx --write`
- `bun run build`
- `bun run stylecheck`
- `bun render-cards.ts` in `packages/docs`

## Preview

- [CLI skills documentation](https://remotion-git-codex-symlink-claude-skills-remotion.vercel.app/docs/cli/skills)
