### PR TITLE
`@remotion/transitions`: Support connected compositions in TransitionSeries

### DIFF
--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -577,6 +577,11 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						from: _from,
 						...passedProps
 					} = resolvedProps as InternalSeriesSequenceProps & {from: never};
+					const propsForSequence = {
+						...passedProps,
+						_remotionInternalSingleChildComponent:
+							Internals.getSingleChildComponent(sequenceChildren),
+					};
 					validateDurationInFrames(durationInFramesProp, {
 						component: `of a <TransitionSeries.Sequence /> component`,
 						allowFloats: true,
@@ -714,7 +719,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								key={i}
 								from={actualStartFrame}
 								durationInFrames={durationInFramesProp}
-								{...passedProps}
+								{...propsForSequence}
 								name={passedProps.name || '<TS.Sequence>'}
 								_remotionInternalDocumentationLink={
 									passedProps.name
@@ -791,7 +796,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								key={i}
 								from={actualStartFrame}
 								durationInFrames={durationInFramesProp}
-								{...passedProps}
+								{...propsForSequence}
 								name={passedProps.name || '<TS.Sequence>'}
 								_remotionInternalDocumentationLink={
 									passedProps.name
@@ -836,7 +841,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 								key={i}
 								from={actualStartFrame}
 								durationInFrames={durationInFramesProp}
-								{...passedProps}
+								{...propsForSequence}
 								name={passedProps.name || '<TS.Sequence>'}
 								_remotionInternalDocumentationLink={
 									passedProps.name
@@ -876,7 +881,7 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 							key={i}
 							from={actualStartFrame}
 							durationInFrames={durationInFramesProp}
-							{...passedProps}
+							{...propsForSequence}
 							name={passedProps.name || '<TS.Sequence>'}
 							_remotionInternalDocumentationLink={
 								passedProps.name

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -26,6 +26,7 @@ type RegisteredSequence = {
 	readonly duration: number;
 	readonly from: number;
 	readonly trimBefore: number | null;
+	readonly singleChildComponent?: unknown;
 };
 
 const remotionEnvironment = {
@@ -139,6 +140,7 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 	const transitionSeriesStack = 'Error\n    at UserAuthoredTransitionSeries';
 	const childSequenceStack =
 		'Error\n    at UserAuthoredTransitionSeriesSequence';
+	const ConnectedComposition: React.FC = () => null;
 
 	root.render(
 		<SequenceTestWrapper
@@ -157,7 +159,7 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 					trimBefore={4}
 					{...({stack: childSequenceStack} as {readonly stack: string})}
 				>
-					First
+					<ConnectedComposition />
 				</TransitionSeries.Sequence>
 			</TransitionSeries>
 		</SequenceTestWrapper>,
@@ -195,6 +197,13 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 					10 &&
 				sequence.controls.currentRuntimeValueDotNotation.trimBefore === 4 &&
 				sequence.trimBefore === 4,
+		),
+	).toBe(true);
+	expect(
+		registeredSequences.some(
+			(sequence) =>
+				sequence.displayName === '<TS.Sequence>' &&
+				sequence.singleChildComponent === ConnectedComposition,
 		),
 	).toBe(true);
 });


### PR DESCRIPTION
## Summary

- preserve the single child component identity when `TransitionSeries.Sequence` creates its internal Sequence
- let Studio recognize registered scene components as connected compositions in `MultiSceneSample`
- cover the Sequence registration path with an integration test

## Testing

- `bunx turbo run make lint test --filter='@remotion/transitions'`
- `bun run build`
- `bun run stylecheck`
- red/green regression verification for the focused transition-series test

Closes #9840
