### PR TITLE
Docs: Document Video crop props

### DIFF
--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -67,6 +67,22 @@ The URL of the video to be rendered. Can be a remote URL or a local file referen
 
 Apply [effects](/docs/effects/api) to the video frame after it has been drawn to the canvas.
 
+### `cropLeft?`<AvailableFrom v="4.0.500" />
+
+Crops the video from the left by a ratio between `0` and `1`. See [`cropLeft`](/docs/sequence#cropleft).
+
+### `cropRight?`<AvailableFrom v="4.0.500" />
+
+Crops the video from the right by a ratio between `0` and `1`. See [`cropRight`](/docs/sequence#cropright).
+
+### `cropTop?`<AvailableFrom v="4.0.500" />
+
+Crops the video from the top by a ratio between `0` and `1`. See [`cropTop`](/docs/sequence#croptop).
+
+### `cropBottom?`<AvailableFrom v="4.0.500" />
+
+Crops the video from the bottom by a ratio between `0` and `1`. See [`cropBottom`](/docs/sequence#cropbottom).
+
 ### `from?`<AvailableFrom v="4.0.445" />
 
 At which frame this clip should start relative to the parent timeline. Default is `0`. Same meaning as [`from`](/docs/sequence#from) on [`<Sequence>`](/docs/sequence).


### PR DESCRIPTION
## Summary

- document `cropLeft`, `cropRight`, `cropTop`, and `cropBottom` on `@remotion/media`'s `<Video>` component
- mark the props as available from v4.0.500

## Testing

- `bun run build`
- `bun run stylecheck`

## Preview

- [`<Video>` documentation](https://remotion-git-codex-document-video-crop-props-remotion.vercel.app/docs/media/video)

Closes #9836
