### PR TITLE
`@remotion/browser-studio`: Align Bun and esm.sh externals

### DIFF
--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -1,6 +1,7 @@
 import {getStudioEntryPoints} from '@remotion/studio-shared/studio-entry-points';
 import type * as RspackBrowser from '@rspack/browser';
 import {browserStudioDependencyVersions} from './dependency-versions';
+import {studioRenderEntryExternal} from './dev/studio-render-entry-external';
 import type {
 	BrowserStudioDependencyResolution,
 	BrowserStudioError,
@@ -152,7 +153,7 @@ const getPackageName = (request: string) => {
 
 const externalizeSharedDependencies = (url: URL) => {
 	url.searchParams.set('dev', '');
-	url.searchParams.set('external', 'mediabunny,react,react-dom');
+	url.searchParams.set('external', studioRenderEntryExternal.join(','));
 };
 
 const compileProject = async ({

--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -150,9 +150,9 @@ const getPackageName = (request: string) => {
 	return request.split('/')[0];
 };
 
-const externalizeSharedReactDependencies = (url: URL) => {
+const externalizeSharedDependencies = (url: URL) => {
 	url.searchParams.set('dev', '');
-	url.searchParams.set('external', 'react,react-dom');
+	url.searchParams.set('external', 'mediabunny,react,react-dom');
 };
 
 const compileProject = async ({
@@ -283,13 +283,13 @@ const compileProject = async ({
 							getVersionedPackageRequest(request, version),
 							'https://esm.sh/',
 						);
-						externalizeSharedReactDependencies(url);
+						externalizeSharedDependencies(url);
 						return url.href;
 					},
 					dependencyVersions: resolvedVersions,
 					domain: 'https://esm.sh',
 					postprocess: ({url}) => {
-						externalizeSharedReactDependencies(url);
+						externalizeSharedDependencies(url);
 					},
 				}),
 				new rspack.optimize.LimitChunkCountPlugin({maxChunks: 1}),


### PR DESCRIPTION
## Summary

- use the same external dependency list for the Bun render entry and esm.sh package builds
- route direct and transitive Remotion, Mediabunny, React, and Zod imports through Browser Studio's pinned resolver
- prevent different CDN module identities from creating duplicate shared runtimes

## Verification

- `bun test packages/browser-studio/src/test`
- `bun run build`
- `bun run stylecheck`
- verified the local Browser Studio bundle contains one Remotion implementation, one Mediabunny implementation at `1.50.8`, and no unversioned shared-package requests

Closes #9817
