### PR TITLE
Docs: Clarify automation license eligibility

### DIFF
--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -95,7 +95,7 @@ Previews in the [Remotion Studio](/docs/studio) or [Remotion Player](/docs/playe
 
 ### When do I need to purchase Renders?
 
-If you are setting up an automation to render videos programmatically, you need to purchase Renders.
+If you don't qualify for the Free License and are setting up an automation to render videos programmatically, you need to purchase Renders.
 
 Low-volume video production, such as rendering locally or one-off renders on a server, fall under the Remotion for Creators option and do not require purchasing Renders.
 


### PR DESCRIPTION
## Summary

- clarify that purchasing renders for automation applies only to users who do not qualify for the Free License

## Testing

- `bun run build`
- `bun run stylecheck`

## Preview

- [License FAQ](https://remotion-git-codex-clarify-free-license-automation-remotion.vercel.app/docs/license/faq)
