### PR TITLE
`@remotion/studio`: Collapse default layout controls

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -73,5 +73,27 @@ test.describe('inspector section collapse', () => {
 			page.getByRole('button', {name: 'Collapse Crop', exact: true}),
 		).toBeVisible();
 		await expect(page.getByText('Crop left', {exact: true})).toBeVisible();
+
+		await page
+			.locator('[title="Default absolute-fill layout"]')
+			.first()
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Layout', exact: true}),
+		).toBeVisible();
+		await page
+			.getByRole('button', {name: 'Expand Layout', exact: true})
+			.click();
+		await expect(page.getByText('Premount For', {exact: true})).toBeVisible();
+
+		await page.locator('[title="Default none layout"]').first().click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Layout', exact: true}),
+		).toBeVisible();
+
+		await page.locator('[title="Default premount"]').first().click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Layout', exact: true}),
+		).toBeVisible();
 	});
 });

--- a/packages/example/src/Issue8216/Issue8216.tsx
+++ b/packages/example/src/Issue8216/Issue8216.tsx
@@ -1,8 +1,18 @@
-import {Solid} from 'remotion';
+import {Video} from '@remotion/media';
+import {Sequence, Series, Solid, staticFile} from 'remotion';
 
 export const Issue8216 = () => {
 	return (
 		<>
+			<Sequence name="Default absolute-fill layout">
+				<div />
+			</Sequence>
+			<Series name="Default none layout">
+				<Series.Sequence name="Series item" durationInFrames={90}>
+					<div />
+				</Series.Sequence>
+			</Series>
+			<Video name="Default premount" src={staticFile('vp8-vorbis.webm')} />
 			<Solid
 				name="Foreground"
 				width={200}

--- a/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
+++ b/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
@@ -1,9 +1,10 @@
 import type {SchemaFieldGroup} from '@remotion/studio-shared';
+import {Internals, type InteractivitySchema} from 'remotion';
 import {parseAnyColor} from '../../helpers/color-conversion';
 
 export type SmartCollapsibleInspectorGroup = Extract<
 	SchemaFieldGroup,
-	'background' | 'border' | 'border-radius' | 'crop'
+	'background' | 'border' | 'border-radius' | 'crop' | 'layout'
 >;
 
 export type InspectorSectionActivity = 'active' | 'inactive' | 'unknown';
@@ -27,6 +28,7 @@ const BORDER_RADIUS_LONGHAND_KEYS = [
 ] as const;
 
 const CROP_KEYS = ['cropLeft', 'cropRight', 'cropTop', 'cropBottom'] as const;
+const LAYOUT_KEYS = ['layout', 'premountFor'] as const;
 
 const BACKGROUND_COLOR_KEY = 'style.backgroundColor';
 
@@ -37,7 +39,8 @@ export const isSmartCollapsibleInspectorGroup = (
 		group === 'background' ||
 		group === 'border' ||
 		group === 'border-radius' ||
-		group === 'crop'
+		group === 'crop' ||
+		group === 'layout'
 	);
 };
 
@@ -143,15 +146,53 @@ const isBorderRadiusInactive = (
 	});
 };
 
+const isLayoutInactive = ({
+	propStatuses,
+	schema,
+}: {
+	readonly propStatuses:
+		| Readonly<Record<string, InspectorSectionPropStatus>>
+		| undefined;
+	readonly schema: InteractivitySchema | undefined;
+}): boolean => {
+	if (!schema) {
+		return false;
+	}
+
+	const flatSchema = Internals.getFlatSchemaWithAllKeys(schema);
+	const layoutKeys = LAYOUT_KEYS.filter((key) => flatSchema[key] !== undefined);
+	if (layoutKeys.length === 0) {
+		return false;
+	}
+
+	return layoutKeys.every((key) => {
+		const result = getStaticValue({key, propStatuses});
+		const field = flatSchema[key];
+		if (!result.found || !field || field.type === 'hidden') {
+			return false;
+		}
+
+		const effectiveValue =
+			result.value === undefined ? field.default : result.value;
+		return Object.is(effectiveValue, field.default);
+	});
+};
+
 export const isInspectorSectionEffectivelyInactive = ({
 	group,
 	propStatuses,
+	schema,
 }: {
 	readonly group: SmartCollapsibleInspectorGroup;
 	readonly propStatuses:
 		| Readonly<Record<string, InspectorSectionPropStatus>>
 		| undefined;
+	readonly schema?: InteractivitySchema;
 }): boolean => {
+	if (group === 'layout') {
+		return isLayoutInactive({propStatuses, schema});
+	}
+
 	if (group === 'border') {
 		return isBorderInactive(propStatuses);
 	}
@@ -203,11 +244,13 @@ const hasEveryStatus = ({
 export const getInspectorSectionActivity = ({
 	group,
 	propStatuses,
+	schema,
 }: {
 	readonly group: SmartCollapsibleInspectorGroup;
 	readonly propStatuses:
 		| Readonly<Record<string, InspectorSectionPropStatus>>
 		| undefined;
+	readonly schema?: InteractivitySchema;
 }): InspectorSectionActivity => {
 	let resolved = false;
 	if (group === 'border') {
@@ -221,6 +264,15 @@ export const getInspectorSectionActivity = ({
 			hasEveryStatus({keys: BORDER_RADIUS_LONGHAND_KEYS, propStatuses});
 	} else if (group === 'crop') {
 		resolved = hasEveryStatus({keys: CROP_KEYS, propStatuses});
+	} else if (group === 'layout') {
+		const flatSchema = schema
+			? Internals.getFlatSchemaWithAllKeys(schema)
+			: undefined;
+		const layoutKeys = LAYOUT_KEYS.filter(
+			(key) => flatSchema?.[key] !== undefined,
+		);
+		resolved =
+			layoutKeys.length > 0 && hasEveryStatus({keys: layoutKeys, propStatuses});
 	} else {
 		resolved = hasOwnStatus({key: BACKGROUND_COLOR_KEY, propStatuses});
 	}
@@ -229,7 +281,7 @@ export const getInspectorSectionActivity = ({
 		return 'unknown';
 	}
 
-	return isInspectorSectionEffectivelyInactive({group, propStatuses})
+	return isInspectorSectionEffectivelyInactive({group, propStatuses, schema})
 		? 'inactive'
 		: 'active';
 };

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -510,6 +510,7 @@ export const InspectorSequenceSection: React.FC<{
 		propStatuses,
 		nodePathInfo.sequenceSubscriptionKey,
 	);
+	const {schema} = sequence.controls;
 	const getControlGroupActivity = useCallback(
 		(group: InspectorControlGroup) => {
 			if (!isSmartCollapsibleInspectorGroup(group.id)) {
@@ -519,9 +520,10 @@ export const InspectorSequenceSection: React.FC<{
 			return getInspectorSectionActivity({
 				group: group.id,
 				propStatuses: sequencePropStatuses,
+				schema,
 			});
 		},
-		[sequencePropStatuses],
+		[schema, sequencePropStatuses],
 	);
 	useEffect(() => {
 		setAutomaticSectionExpansion((previous) => {
@@ -609,7 +611,6 @@ export const InspectorSequenceSection: React.FC<{
 		[visibleControlRows],
 	);
 
-	const {schema} = sequence.controls;
 	const borderRadiusGroup = controlGroups.find(
 		(group) => group.id === 'border-radius',
 	);
@@ -831,8 +832,10 @@ export const InspectorSequenceSection: React.FC<{
 				) : null}
 				{layoutGroup ? (
 					<TimelineSelectionOrderProvider items={controlSelectableItems}>
-						<InspectorSection header={layoutGroup.label}>
-							{layoutGroup.rows.map(renderRow)}
+						<InspectorSection header={renderControlGroupHeader(layoutGroup)}>
+							{isControlGroupExpanded(layoutGroup)
+								? layoutGroup.rows.map(renderRow)
+								: null}
 						</InspectorSection>
 					</TimelineSelectionOrderProvider>
 				) : null}

--- a/packages/studio/src/test/inspector-section-collapse.test.ts
+++ b/packages/studio/src/test/inspector-section-collapse.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from 'bun:test';
+import type {InteractivitySchema} from 'remotion';
 import {
 	getInspectorSectionActivity,
 	isInspectorSectionEffectivelyInactive,
@@ -193,4 +194,103 @@ test('treats a static border as inactive only when it cannot be seen', () => {
 			},
 		}),
 	).toBe(false);
+});
+
+test('uses the component schema defaults to determine layout activity', () => {
+	const schema = ({
+		layout,
+		premountFor,
+	}: {
+		readonly layout: string;
+		readonly premountFor: number;
+	}): InteractivitySchema => ({
+		layout: {
+			type: 'enum',
+			default: layout,
+			variants: {
+				'absolute-fill': {
+					premountFor: {
+						type: 'number',
+						default: premountFor,
+						hiddenFromList: false,
+					},
+				},
+				none: {},
+			},
+		},
+	});
+
+	for (const defaults of [
+		{layout: 'absolute-fill', premountFor: 0},
+		{layout: 'none', premountFor: 30},
+	]) {
+		const componentSchema = schema(defaults);
+		const defaultStatuses = staticStatuses({
+			layout: undefined,
+			premountFor: undefined,
+		});
+
+		expect(
+			getInspectorSectionActivity({
+				group: 'layout',
+				propStatuses: defaultStatuses,
+				schema: componentSchema,
+			}),
+		).toBe('inactive');
+		expect(
+			getInspectorSectionActivity({
+				group: 'layout',
+				propStatuses: staticStatuses(defaults),
+				schema: componentSchema,
+			}),
+		).toBe('inactive');
+		expect(
+			getInspectorSectionActivity({
+				group: 'layout',
+				propStatuses: {
+					...defaultStatuses,
+					layout: {
+						status: 'static',
+						codeValue: defaults.layout === 'none' ? 'absolute-fill' : 'none',
+					},
+				},
+				schema: componentSchema,
+			}),
+		).toBe('active');
+		expect(
+			getInspectorSectionActivity({
+				group: 'layout',
+				propStatuses: {
+					...defaultStatuses,
+					premountFor: {
+						status: 'static',
+						codeValue: defaults.premountFor + 1,
+					},
+				},
+				schema: componentSchema,
+			}),
+		).toBe('active');
+	}
+
+	const premountOnlySchema = {
+		premountFor: {
+			type: 'number',
+			default: 0,
+			hiddenFromList: false,
+		},
+	} as const satisfies InteractivitySchema;
+	expect(
+		getInspectorSectionActivity({
+			group: 'layout',
+			propStatuses: staticStatuses({premountFor: undefined}),
+			schema: premountOnlySchema,
+		}),
+	).toBe('inactive');
+	expect(
+		getInspectorSectionActivity({
+			group: 'layout',
+			propStatuses: staticStatuses({premountFor: 1}),
+			schema: premountOnlySchema,
+		}),
+	).toBe('active');
 });


### PR DESCRIPTION
## Summary

- collapse the Studio Inspector Layout section when supported controls match their schema defaults
- handle premount-only component schemas such as `<Video>`
- add unit and Studio end-to-end coverage for Sequence, Series, and Video defaults

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/inspector-section-collapse.test.ts`
- `bunx playwright test e2e/inspector-section-collapse.test.mts`
