### PR TITLE
`remotion`: Avoid stack prop conflicts in interactive components

### DIFF
--- a/packages/brand/src/3DContext/Div3D.tsx
+++ b/packages/brand/src/3DContext/Div3D.tsx
@@ -40,7 +40,6 @@ type ExtrudeDivOptionalProps = Partial<{
 	readonly backFace: React.ReactNode;
 	readonly topFace: React.ReactNode;
 	readonly bottomFace: React.ReactNode;
-	readonly stack: string;
 }>;
 
 type ExtrudeDivTransformProps = Partial<{
@@ -418,7 +417,6 @@ const ExtrudeDivInner = React.forwardRef<
 			hidden,
 			name,
 			showInTimeline,
-			stack,
 			controls,
 		},
 		ref,
@@ -494,7 +492,6 @@ const ExtrudeDivInner = React.forwardRef<
 				name={name ?? '<ExtrudeDiv>'}
 				showInTimeline={showInTimeline ?? true}
 				controls={controls ?? undefined}
-				_remotionInternalStack={stack}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/studio/make-component-interactive"
 				outlineRef={outlineRef}
 			>

--- a/packages/brand/src/3DContext/transformation-context.tsx
+++ b/packages/brand/src/3DContext/transformation-context.tsx
@@ -97,9 +97,7 @@ export const NewTransform: React.FC<{
 
 type TransformBaseProps = InteractiveBaseProps & {
 	readonly children: React.ReactNode;
-} & Partial<{
-		readonly stack: string;
-	}>;
+};
 
 type TransformInnerProps<ValueKey extends string> = TransformBaseProps &
 	Readonly<Record<ValueKey, number>> & {
@@ -141,7 +139,6 @@ const make3DTransform = <ValueKey extends string>({
 				hidden,
 				name,
 				showInTimeline,
-				stack,
 				controls,
 			} = props;
 			const value = props[valueKey] ?? defaultValue;
@@ -158,7 +155,6 @@ const make3DTransform = <ValueKey extends string>({
 					name={name ?? componentName}
 					showInTimeline={showInTimeline ?? true}
 					controls={controls ?? undefined}
-					_remotionInternalStack={stack}
 					_remotionInternalDocumentationLink={transformDocumentationLink}
 				>
 					<NewTransform transform={transform}>{children}</NewTransform>

--- a/packages/brand/src/Compose/WhatIsRemotion.tsx
+++ b/packages/brand/src/Compose/WhatIsRemotion.tsx
@@ -32,10 +32,7 @@ import {LabelOpacityContext, useLabelOpacity} from './LabelOpacity';
 import {Rotations} from './Rotations';
 
 type LabelProps = InteractiveBaseProps &
-	InteractiveTransformProps &
-	Partial<{
-		readonly stack: string;
-	}> & {
+	InteractiveTransformProps & {
 		readonly children: string;
 	};
 
@@ -81,7 +78,6 @@ const LabelInner = React.forwardRef<
 			hidden,
 			name,
 			showInTimeline,
-			stack,
 			controls,
 			style,
 		},
@@ -108,7 +104,6 @@ const LabelInner = React.forwardRef<
 				name={name ?? '<Label>'}
 				showInTimeline={showInTimeline ?? true}
 				controls={controls ?? undefined}
-				_remotionInternalStack={stack}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/studio/make-component-interactive"
 				outlineRef={outlineRef}
 			>

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -5,6 +5,7 @@ import {Internals} from 'remotion';
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
 const sequenceComponent = Internals.getSequenceComponent();
+const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;
 
 const originalCreateElement = React.createElement;
 const originalJsx = JsxRuntime.jsx;
@@ -29,9 +30,12 @@ const enableProxy = <
 						? props?.children
 						: rest
 					: props?.children;
-				const newProps = props?.stack
+				const newProps = props?.[internalStackProp]
 					? {...props}
-					: {...(props ?? {}), stack: new Error().stack};
+					: {
+							...(props ?? {}),
+							[internalStackProp]: new Error().stack,
+						};
 				if (first === sequenceComponent) {
 					newProps._remotionInternalSingleChildComponent =
 						Internals.getSingleChildComponent(children);

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -1,0 +1,29 @@
+import {expect, test} from 'bun:test';
+import React from 'react';
+import {Internals} from 'remotion';
+
+test('injects a namespaced source stack without conflicting with application props', async () => {
+	const Component: React.FC<{readonly stack: string}> = () => null;
+	Internals.addSequenceStackTraces(Component);
+	await import('../setup-sequence-stack-traces');
+
+	const element = React.createElement(Component, {stack: 'application-stack'});
+	const props = element.props as typeof element.props & {
+		readonly _remotionInternalStack: string;
+	};
+
+	expect(props.stack).toBe('application-stack');
+	expect(props._remotionInternalStack).toContain('Error');
+
+	const existingStackElement = React.createElement(Component, {
+		stack: 'application-stack',
+		_remotionInternalStack: 'existing-source-stack',
+	} as React.ComponentProps<typeof Component> & {
+		readonly _remotionInternalStack: string;
+	});
+	const existingProps =
+		existingStackElement.props as typeof existingStackElement.props & {
+			readonly _remotionInternalStack: string;
+		};
+	expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
+});

--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -139,7 +139,9 @@ const InnerComposition = <
 	defaultProps,
 	schema,
 	...compProps
-}: CompositionProps<Schema, Props> & {readonly stack?: string}) => {
+}: CompositionProps<Schema, Props> & {
+	readonly _remotionInternalStack?: string;
+}) => {
 	const compManager = useContext(CompositionSetters);
 
 	const {registerComposition, unregisterComposition} = compManager;
@@ -179,7 +181,9 @@ const InnerComposition = <
 	}
 
 	const {folderName, parentName} = useContext(FolderContext);
-	const stack = (compProps as {stack?: string}).stack ?? null;
+	const stack =
+		(compProps as {readonly _remotionInternalStack?: string})
+			._remotionInternalStack ?? null;
 	const componentFromProps =
 		'component' in compProps ? compProps.component : null;
 

--- a/packages/core/src/Folder.tsx
+++ b/packages/core/src/Folder.tsx
@@ -35,7 +35,9 @@ export const Folder: FC<{
 	const parent = useContext(FolderContext);
 	const {registerFolder, unregisterFolder} = useContext(CompositionSetters);
 	const nonce = useNonce();
-	const stack = (props as {stack?: string}).stack ?? null;
+	const stack =
+		(props as {readonly _remotionInternalStack?: string})
+			._remotionInternalStack ?? null;
 
 	validateFolderName(name);
 

--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -66,10 +66,6 @@ export type ImgProps = NativeImgProps & {
 	readonly effects?: EffectsProp;
 	readonly showInTimeline?: boolean;
 	readonly name?: string;
-	/**
-	 * @deprecated For internal use only
-	 */
-	readonly stack?: string;
 } & InteractiveBaseProps &
 	InteractiveCropProps &
 	InteractivePremountProps;
@@ -83,7 +79,6 @@ type ImgContentProps = Omit<
 	ImgProps,
 	| 'hidden'
 	| 'name'
-	| 'stack'
 	| 'showInTimeline'
 	| 'from'
 	| 'trimBefore'
@@ -358,7 +353,6 @@ type NativeImgInnerProps = Omit<ImgProps, 'effects'> & {
 const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 	hidden,
 	name,
-	stack,
 	showInTimeline,
 	src,
 	from,
@@ -417,7 +411,6 @@ const NativeImgInner: React.FC<NativeImgInnerProps> = ({
 				trimBefore={trimBefore}
 				durationInFrames={durationInFrames ?? Infinity}
 				freeze={freeze}
-				_remotionInternalStack={stack}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/img"
 				_remotionInternalIsMedia={{type: 'image', src}}
 				_remotionInternalPremountDisplay={effectivePremountFor || null}
@@ -548,7 +541,6 @@ const ImgInner: React.FC<
 	ref,
 	hidden,
 	name,
-	stack,
 	showInTimeline,
 	src,
 	from,
@@ -585,7 +577,6 @@ const ImgInner: React.FC<
 				ref={ref}
 				hidden={hidden}
 				name={name}
-				stack={stack}
 				showInTimeline={showInTimeline}
 				src={src}
 				from={from}
@@ -660,7 +651,6 @@ const ImgInner: React.FC<
 			hidden={hidden}
 			name={name ?? '<Img>'}
 			showInTimeline={showInTimeline}
-			stack={stack}
 			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/img"
 			_remotionInternalCropComponentName="<Img />"
 			controls={controls}

--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -101,12 +101,7 @@ export type InteractivePremountProps = Pick<
 	| 'styleWhilePostmounted'
 >;
 
-type InteractiveSequenceProps = InteractiveBaseProps & {
-	/**
-	 * @deprecated For internal use only
-	 */
-	readonly stack?: string;
-};
+type InteractiveSequenceProps = InteractiveBaseProps;
 
 type InteractiveElementProps<Tag extends InteractiveTag> = Omit<
 	React.ComponentPropsWithoutRef<Tag>,
@@ -234,7 +229,6 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 			hidden,
 			name,
 			showInTimeline,
-			stack,
 			controls,
 			...props
 		} = propsWithControls as Props & {
@@ -260,7 +254,6 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 				name={name ?? displayName}
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
-				_remotionInternalStack={stack}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/interactive"
 				outlineRef={refForOutline}
 			>

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -11,6 +11,7 @@ import React, {
 import {AbsoluteFill} from './AbsoluteFill.js';
 import type {LoopDisplay, SequenceControls} from './CompositionManager.js';
 import type {EffectDefinition} from './effects/effect-types.js';
+import {getStackForControls} from './enable-sequence-stack-traces.js';
 import {Freeze} from './freeze.js';
 import {
 	sequenceSchema,
@@ -371,11 +372,12 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	const isInsideSeries = useContext(IsInsideSeriesContext);
 
-	const inheritedStack = (other as {readonly stack?: string})?.stack ?? null;
 	// Our assumption: Stack doesnt' change. After we symbolicate we assign it a nodePath
 	// and if it changes, it would lead to-remounting of the sequence.
 	const stackRef = useRef<string | null>(null);
-	stackRef.current = stack ?? inheritedStack;
+	stackRef.current = controls
+		? (getStackForControls(controls) ?? stack ?? null)
+		: (stack ?? null);
 	const registeredFrozenFrame = typeof freeze === 'number' ? freeze : null;
 	const registeredTrimBefore = trimBefore === 0 ? null : trimBefore;
 	const parentCumulatedNegativeFrom =

--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -35,7 +35,6 @@ type AudioForPreviewProps = RemotionAudioProps & {
 	readonly _remotionInternalNativeLoopPassed: boolean;
 	readonly _remotionInternalStack: string | null;
 	readonly showInTimeline: boolean;
-	readonly stack?: string | undefined;
 	readonly onNativeError: React.ReactEventHandler<HTMLAudioElement>;
 };
 
@@ -71,7 +70,6 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 		pauseWhenBuffering,
 		showInTimeline,
 		loopVolumeCurveBehavior,
-		stack,
 		crossOrigin,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,

--- a/packages/core/src/audio/html5-audio.tsx
+++ b/packages/core/src/audio/html5-audio.tsx
@@ -28,7 +28,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			/**
 			 * @deprecated For internal use only
 			 */
-			readonly stack?: string;
+			readonly _remotionInternalStack?: string;
 		}
 > = (props, ref) => {
 	const audioTagsContext = useContext(SharedAudioTagsContext);
@@ -39,7 +39,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 		trimBefore,
 		trimAfter,
 		name,
-		stack,
+		_remotionInternalStack,
 		pauseWhenBuffering,
 		showInTimeline,
 		onError: onRemotionError,
@@ -199,7 +199,7 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 			_remotionInternalNativeLoopPassed={
 				props._remotionInternalNativeLoopPassed ?? false
 			}
-			_remotionInternalStack={stack ?? null}
+			_remotionInternalStack={_remotionInternalStack ?? null}
 			shouldPreMountAudioTags={
 				audioTagsContext !== null && audioTagsContext.numberOfAudioTags > 0
 			}

--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -542,7 +542,6 @@ const CanvasImageInner = forwardRef<
 			cropRight,
 			cropTop,
 			cropBottom,
-			stack,
 			controls,
 			_remotionInternalDocumentationLink,
 			_remotionInternalCropComponentName,
@@ -605,7 +604,6 @@ const CanvasImageInner = forwardRef<
 					controls={controls}
 					_remotionInternalEffects={memoizedEffectDefinitions}
 					_remotionInternalIsMedia={{type: 'image', src}}
-					_remotionInternalStack={stack}
 					_remotionInternalPremountDisplay={effectivePremountFor || null}
 					_remotionInternalPostmountDisplay={effectivePostmountFor || null}
 					_remotionInternalIsPremounting={premountingActive}

--- a/packages/core/src/canvas-image/props.ts
+++ b/packages/core/src/canvas-image/props.ts
@@ -9,12 +9,7 @@ import type {
 
 type CanvasImageSequenceProps = InteractiveBaseProps &
 	InteractiveCropProps &
-	InteractivePremountProps & {
-		/**
-		 * @deprecated For internal use only.
-		 */
-		readonly stack?: string;
-	};
+	InteractivePremountProps;
 
 export type CanvasImageCanvasProps = Omit<
 	React.CanvasHTMLAttributes<HTMLCanvasElement>,

--- a/packages/core/src/effects/Solid.tsx
+++ b/packages/core/src/effects/Solid.tsx
@@ -312,7 +312,6 @@ const SolidOuter = forwardRef<
 				name={name ?? '<Solid>'}
 				outlineRef={actualRef}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/solid"
-				// 'stack' is in props
 				{...props}
 			>
 				<SolidInner

--- a/packages/core/src/enable-sequence-stack-traces.ts
+++ b/packages/core/src/enable-sequence-stack-traces.ts
@@ -1,7 +1,11 @@
 import React from 'react';
+import type {SequenceControls} from './CompositionManager.js';
 
 const componentsToAddStacksTo: unknown[] = [];
 let sequenceComponent: unknown = null;
+const stacksByControls = new WeakMap<SequenceControls, string>();
+
+export const REMOTION_INTERNAL_STACK_PROP = '_remotionInternalStack';
 
 export const getComponentsToAddStacksTo = () => componentsToAddStacksTo;
 
@@ -14,6 +18,24 @@ export const setSequenceComponent = (component: unknown) => {
 };
 
 export const getSequenceComponent = () => sequenceComponent;
+
+export const setStackForControls = (
+	controls: SequenceControls,
+	stack: string | undefined,
+) => {
+	if (stack === undefined) {
+		stacksByControls.delete(controls);
+		return;
+	}
+
+	stacksByControls.set(controls, stack);
+};
+
+export const getStackForControls = (
+	controls: SequenceControls,
+): string | null => {
+	return stacksByControls.get(controls) ?? null;
+};
 
 export const getSingleChildComponent = (children: React.ReactNode): unknown => {
 	const mountedChildren = React.Children.toArray(children);

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -70,6 +70,8 @@ import {
 	getComponentsToAddStacksTo,
 	getSequenceComponent,
 	getSingleChildComponent,
+	getStackForControls,
+	REMOTION_INTERNAL_STACK_PROP,
 } from './enable-sequence-stack-traces.js';
 import {findPropsToDelete} from './find-props-to-delete.js';
 import {
@@ -380,6 +382,8 @@ export const Internals = {
 	getComponentsToAddStacksTo,
 	getSequenceComponent,
 	getSingleChildComponent,
+	getStackForControls,
+	REMOTION_INTERNAL_STACK_PROP,
 	CurrentScaleContext,
 	PixelDensityContext,
 	PreviewSizeContext,

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -38,7 +38,6 @@ type SeriesSequenceProps = PropsWithChildren<
 
 type ResolvedSeriesSequenceProps = SeriesSequenceProps & {
 	readonly controls: SequenceControls | null | undefined;
-	readonly stack: string | null;
 };
 
 type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
@@ -65,19 +64,13 @@ const SeriesSequenceInner = forwardRef<
 	InternalSeriesSequenceProps
 >(
 	(
-		{
-			offset = 0,
-			className = '',
-			stack = null,
-			_remotionInternalRender = null,
-			...props
-		},
+		{offset = 0, className = '', _remotionInternalRender = null, ...props},
 		ref,
 	) => {
 		useRequireToBeInsideSeries();
 		if (_remotionInternalRender) {
 			return _remotionInternalRender(
-				{...props, offset, className: className || undefined, stack},
+				{...props, offset, className: className || undefined},
 				ref,
 			);
 		}
@@ -200,7 +193,6 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 						children: sequenceChildren,
 						offset: offsetProp,
 						controls,
-						stack,
 						from: _from,
 						name,
 						...passedProps
@@ -224,7 +216,6 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 								_remotionInternalDocumentationLink={
 									name ? undefined : 'https://www.remotion.dev/docs/series'
 								}
-								_remotionInternalStack={stack ?? undefined}
 								controls={controls ?? undefined}
 								from={currentStartFrame}
 								durationInFrames={durationInFramesProp}

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -5,7 +5,7 @@ import {
 	AnimatedImage,
 	animatedImageSchema,
 } from '../animated-image/AnimatedImage.js';
-import type {TSequence} from '../CompositionManager.js';
+import type {SequenceControls, TSequence} from '../CompositionManager.js';
 import type {
 	EffectDefinition,
 	EffectDescriptor,
@@ -327,13 +327,17 @@ test('Series.Sequence registers with its own visual controls', () => {
 				<Series.Sequence
 					durationInFrames={10}
 					premountFor={30}
-					{...({stack: firstStack} as {readonly stack: string})}
+					{...({
+						_remotionInternalStack: firstStack,
+					} as {readonly _remotionInternalStack: string})}
 				>
 					First
 				</Series.Sequence>
 				<Series.Sequence
 					durationInFrames={20}
-					{...({stack: secondStack} as {readonly stack: string})}
+					{...({
+						_remotionInternalStack: secondStack,
+					} as {readonly _remotionInternalStack: string})}
 				>
 					Second
 				</Series.Sequence>
@@ -363,6 +367,55 @@ test('Series.Sequence registers with its own visual controls', () => {
 		firstStack,
 		secondStack,
 	]);
+});
+
+test('Interactive.withSchema preserves source stacks through controls without consuming a public stack prop', () => {
+	const registeredSequences: TSequence[] = [];
+	const sourceStack = 'Error\n    at UserAuthoredComponent';
+	const received = {
+		stack: null as string | null,
+		internalStack: false,
+	};
+
+	type PublicProps = {readonly stack: string};
+	const Inner: React.FC<
+		PublicProps & {readonly controls: SequenceControls | undefined}
+	> = (props) => {
+		received.stack = props.stack;
+		received.internalStack = '_remotionInternalStack' in props;
+		return <Sequence controls={props.controls} name="<Component>" />;
+	};
+
+	const Component = Interactive.withSchema({
+		Component: Inner,
+		componentName: '<Component>',
+		componentIdentity: 'com.example.Component',
+		schema: {},
+		supportsEffects: false,
+	});
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Component
+				stack="application-stack"
+				{...({
+					_remotionInternalStack: sourceStack,
+				} as {readonly _remotionInternalStack: string})}
+			/>
+		</SequenceTestWrapper>,
+	);
+
+	expect(received.stack).toBe('application-stack');
+	expect(received.internalStack).toBe(false);
+	expect(registeredSequences).toHaveLength(1);
+	expect(registeredSequences[0]?.getStack()).toBe(sourceStack);
+	expect(registeredSequences[0]?.controls?.componentIdentity).toBe(
+		'com.example.Component',
+	);
 });
 
 test('read-only Studio registers visual controls without applying overrides', () => {

--- a/packages/core/src/test/still-stack.test.tsx
+++ b/packages/core/src/test/still-stack.test.tsx
@@ -45,7 +45,9 @@ test('Still forwards its stack to the registered composition', async () => {
 				component={AnyComp}
 				width={100}
 				height={100}
-				{...({stack: stillStack} as {readonly stack: string})}
+				{...({
+					_remotionInternalStack: stillStack,
+				} as {readonly _remotionInternalStack: string})}
 			/>
 		</CompositionSetters.Provider>,
 	);

--- a/packages/core/src/video/OffthreadVideo.tsx
+++ b/packages/core/src/video/OffthreadVideo.tsx
@@ -27,7 +27,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 		trimAfter,
 		name,
 		pauseWhenBuffering,
-		stack,
+		_remotionInternalStack,
 		showInTimeline,
 		...otherProps
 	} = props;
@@ -78,7 +78,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 					name={undefined}
 					showInTimeline={showInTimeline}
 					trimBefore={undefined}
-					stack={undefined}
+					_remotionInternalStack={undefined}
 					startFrom={undefined}
 					endAt={undefined}
 				/>
@@ -97,7 +97,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 				name={undefined}
 				showInTimeline={showInTimeline}
 				trimBefore={undefined}
-				stack={undefined}
+				_remotionInternalStack={undefined}
 				startFrom={undefined}
 				endAt={undefined}
 			/>
@@ -117,7 +117,7 @@ export const InnerOffthreadVideo: React.FC<AllOffthreadVideoProps> = (
 
 	return (
 		<VideoForPreview
-			_remotionInternalStack={stack ?? null}
+			_remotionInternalStack={_remotionInternalStack ?? null}
 			onDuration={onDuration}
 			onlyWarnForMediaSeekingError
 			pauseWhenBuffering={shouldPauseWhenBuffering}
@@ -164,7 +164,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 	volume,
 	_remotionInternalNativeLoopPassed,
 	endAt,
-	stack,
+	_remotionInternalStack,
 	startFrom,
 	imageFormat,
 	...props
@@ -195,7 +195,7 @@ export const OffthreadVideo: React.FC<RemotionOffthreadVideoProps> = ({
 			toneFrequency={toneFrequency ?? 1}
 			showInTimeline={showInTimeline ?? true}
 			src={src}
-			stack={stack}
+			_remotionInternalStack={_remotionInternalStack}
 			startFrom={startFrom}
 			_remotionInternalNativeLoopPassed={
 				_remotionInternalNativeLoopPassed ?? false

--- a/packages/core/src/video/html5-video.tsx
+++ b/packages/core/src/video/html5-video.tsx
@@ -26,7 +26,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			/**
 			 * @deprecated For internal use only
 			 */
-			readonly stack?: string;
+			readonly _remotionInternalStack?: string;
 		}
 > = (props, ref) => {
 	const {
@@ -36,7 +36,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 		trimAfter,
 		name,
 		pauseWhenBuffering,
-		stack,
+		_remotionInternalStack,
 		_remotionInternalNativeLoopPassed,
 		showInTimeline,
 		onAutoPlayError,
@@ -95,7 +95,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				<Html5Video
 					{...propsOtherThanLoop}
 					ref={ref}
-					stack={stack}
+					_remotionInternalStack={_remotionInternalStack}
 					_remotionInternalNativeLoopPassed
 				/>
 			);
@@ -118,7 +118,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 				<Html5Video
 					{...propsOtherThanLoop}
 					ref={ref}
-					stack={stack}
+					_remotionInternalStack={_remotionInternalStack}
 					_remotionInternalNativeLoopPassed
 				/>
 			</Loop>
@@ -146,7 +146,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 					onVideoFrame={onVideoFrame}
 					{...otherProps}
 					ref={ref}
-					stack={stack}
+					_remotionInternalStack={_remotionInternalStack}
 				/>
 			</Sequence>
 		);
@@ -180,7 +180,7 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 			onVideoFrame={onVideoFrame ?? null}
 			pauseWhenBuffering={shouldPauseWhenBuffering}
 			onDuration={onDuration}
-			_remotionInternalStack={stack ?? null}
+			_remotionInternalStack={_remotionInternalStack ?? null}
 			_remotionInternalNativeLoopPassed={
 				_remotionInternalNativeLoopPassed ?? false
 			}

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -92,7 +92,7 @@ type OptionalOffthreadVideoProps = {
 	/**
 	 * @deprecated For internal use only
 	 */
-	stack: string | undefined;
+	_remotionInternalStack: string | undefined;
 	showInTimeline: boolean;
 	onAutoPlayError: null | (() => void);
 	onVideoFrame: OnVideoFrame | undefined;

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -6,6 +6,10 @@ import type {
 import {deleteNestedKey} from './delete-nested-key.js';
 import {getPropStatusesCtx} from './effects/use-memoized-effects.js';
 import {
+	getStackForControls,
+	setStackForControls,
+} from './enable-sequence-stack-traces.js';
+import {
 	flattenActiveSchema,
 	getFlatSchemaWithAllKeys,
 } from './flatten-schema.js';
@@ -172,11 +176,16 @@ export const withInteractivitySchema = <
 	const flatKeys = Object.keys(flatSchema);
 
 	const Wrapped = forwardRef<unknown, Props>((props, ref) => {
+		const {
+			_remotionInternalStack: internalStack,
+			...propsWithoutInternalStack
+		} = props as Props & {readonly _remotionInternalStack?: string};
+		const cleanProps = propsWithoutInternalStack as Props;
 		const env = useRemotionEnvironment();
 
 		if (!env.isStudio || env.isRendering) {
 			return React.createElement(Component, {
-				...props,
+				...cleanProps,
 				controls: null,
 				ref,
 			} as Props & {
@@ -196,9 +205,15 @@ export const withInteractivitySchema = <
 
 		// If the parent has passed `controls`, we should not override it.
 		// @ts-expect-error
-		if (props.controls) {
+		if (cleanProps.controls) {
+			// @ts-expect-error `controls` is injected by another interactive wrapper.
+			const passedControls = cleanProps.controls as SequenceControls;
+			if (getStackForControls(passedControls) === null) {
+				setStackForControls(passedControls, internalStack);
+			}
+
 			return React.createElement(Component, {
-				...props,
+				...cleanProps,
 				ref,
 			} as unknown as Props & {
 				controls: SequenceControls | undefined;
@@ -208,18 +223,17 @@ export const withInteractivitySchema = <
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [overrideId] = useState(() => {
-			const {stack} = props as {stack?: string};
-			if (!stack) {
+			if (!internalStack) {
 				return String(Math.random());
 			}
 
-			const existingOverrideId = stackToOverrideMap[stack];
+			const existingOverrideId = stackToOverrideMap[internalStack];
 			if (existingOverrideId) {
 				return existingOverrideId;
 			}
 
 			const newOverrideId = String(Math.random());
-			stackToOverrideMap[stack] = newOverrideId;
+			stackToOverrideMap[internalStack] = newOverrideId;
 			return newOverrideId;
 		});
 		const nodePath = env.isReadOnlyStudio
@@ -234,14 +248,14 @@ export const withInteractivitySchema = <
 			getRuntimeValueForSchemaKey({
 				flatSchema,
 				key,
-				props: props as Record<string, unknown>,
+				props: cleanProps as Record<string, unknown>,
 			}),
 		);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const currentRuntimeValueDotNotation = useMemo(
 			() =>
 				readValuesFromProps(
-					props as Record<string, unknown>,
+					cleanProps as Record<string, unknown>,
 					flatKeys,
 					flatSchema,
 				),
@@ -260,6 +274,7 @@ export const withInteractivitySchema = <
 				componentName,
 			};
 		}, [currentRuntimeValueDotNotation, overrideId]);
+		setStackForControls(controls, internalStack);
 
 		// 3. Apply drag/code overrides on top of the runtime values.
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -291,7 +306,7 @@ export const withInteractivitySchema = <
 		// 5. Apply the active values back onto the props.
 		const mergedProps = mergeValues({
 			flatSchema,
-			props: props as Record<string, unknown>,
+			props: cleanProps as Record<string, unknown>,
 			valuesDotNotation,
 			schemaKeys: activeKeys,
 			propsToDelete,

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -154,6 +154,7 @@ In editable Studio sessions, it reads the current prop values, applies timeline 
 
 ## See also
 
+- [Make a component interactive](/docs/studio/make-component-interactive)
 - [`InteractivitySchema`](/docs/interactivity-schema)
 - [`Interactive`](/docs/interactive)
 - [Interactivity best practices](/docs/studio/interactivity-best-practices)

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -101,7 +101,7 @@ export const Circle = Interactive.withSchema({
 });
 ```
 
-The exported `Circle` component only accepts `CircleProps`. The `controls` prop is passed by `Interactive.withSchema()` to the inner component and should be forwarded to the [`<Sequence>`](/docs/sequence) that represents the component in the timeline.
+The exported `Circle` component only accepts `CircleProps`. The `controls` prop is passed by `Interactive.withSchema()` to the inner component and should be forwarded unchanged to the [`<Sequence>`](/docs/sequence) that represents the component in the timeline. It also preserves the outer component's source location for Studio edits.
 
 If you use `<Sequence layout="none">`, pass [`outlineRef`](/docs/sequence#outlineref) so the Studio can draw a canvas outline around the rendered element.
 

--- a/packages/docs/docs/sequence.mdx
+++ b/packages/docs/docs/sequence.mdx
@@ -251,6 +251,12 @@ Gives the sequence a specific `style={{width: width}}` style and overrides `widt
 
 You can give your sequence a name and it will be shown as the label of the sequence in the timeline of the Remotion Studio. This property is purely for helping you keep track of sequences in the timeline.
 
+### `controls?`<AvailableFrom v="4.0.501" />
+
+The control state created by [`Interactive.withSchema()`](/docs/interactive-with-schema).
+
+When [making a custom component interactive](/docs/studio/make-component-interactive), forward `controls` unchanged from the inner component to the `<Sequence>` that represents it in the timeline. Do not create this object manually.
+
 ### `layout?`
 
 Either `"absolute-fill"` _(default)_ or `"none"`. By default, your sequences will be absolutely positioned, so they will overlay each other. If you would like to opt out of it and handle layouting yourself, pass `layout="none"`. Available since v1.4.

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -71,11 +71,11 @@ const captionsSchema = {
 
 Studio can edit caption text when the prop is a direct JSX array literal, such as `captions={[...]}`. Variables, imports, computed expressions, and `satisfies` expressions are read-only.
 
-## Forward `controls` and `stack`
+## Forward `controls`
 
-The inner component receives `controls` and `stack` props from `Interactive.withSchema()`.
+The inner component receives a `controls` prop from `Interactive.withSchema()`.
 
-Forward them to the [`<Sequence>`](/docs/sequence) that represents your component in the timeline.
+Forward it unchanged to the [`<Sequence>`](/docs/sequence) that represents your component in the timeline. Forwarding it also allows the Studio to associate the timeline item with the outer component's source location.
 
 ```tsx twoslash title="Badge.tsx"
 import React, {forwardRef, useImperativeHandle, useRef} from 'react';
@@ -117,7 +117,6 @@ const BadgeInner = forwardRef<
   HTMLDivElement,
   BadgeProps & {
     readonly controls: SequenceControls | undefined;
-    readonly stack?: string;
   }
 >(
   (
@@ -128,7 +127,6 @@ const BadgeInner = forwardRef<
       style,
       name,
       controls,
-      stack,
       ...sequenceProps
     },
     ref,
@@ -143,7 +141,6 @@ const BadgeInner = forwardRef<
         {...sequenceProps}
         name={name ?? '<Badge>'}
         controls={controls}
-        _remotionInternalStack={stack}
         outlineRef={outlineRef}
       >
         <div
@@ -166,7 +163,7 @@ const BadgeInner = forwardRef<
 );
 ```
 
-The exported component should not expose `controls` or `stack` as public props.
+The exported component should not expose `controls` as a public prop.
 
 Pass [`outlineRef`](/docs/sequence#outlineref) when using `<Sequence layout="none">` so the Studio can draw an outline around the rendered element.
 
@@ -214,7 +211,6 @@ const BadgeInner = forwardRef<
   HTMLDivElement,
   BadgeProps & {
     readonly controls: SequenceControls | undefined;
-    readonly stack?: string;
   }
 >(
   (
@@ -225,7 +221,6 @@ const BadgeInner = forwardRef<
       style,
       name,
       controls,
-      stack,
       ...sequenceProps
     },
     ref,
@@ -240,7 +235,6 @@ const BadgeInner = forwardRef<
         {...sequenceProps}
         name={name ?? '<Badge>'}
         controls={controls}
-        _remotionInternalStack={stack}
         outlineRef={outlineRef}
       >
         <div

--- a/packages/docs/elements/text/timed-captions/timed-captions.tsx
+++ b/packages/docs/elements/text/timed-captions/timed-captions.tsx
@@ -15,6 +15,7 @@ import {
 	cancelRender,
 	Interactive,
 	interpolate,
+	Sequence,
 	spring,
 	type InteractiveBaseProps,
 	type InteractiveTransformProps,
@@ -35,10 +36,6 @@ export type TimedCaptionsProps = InteractiveBaseProps &
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
-type TimedCaptionsLayerProps = Omit<TimedCaptionsProps, 'captions'> & {
-	readonly captions: Caption[];
-};
-
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
@@ -51,6 +48,57 @@ const pillVerticalPadding = 12;
 const pillBorderRadius = 10;
 const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
+const defaultCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const timedCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -91,12 +139,6 @@ const timedCaptionsSchema = {
 	},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
-
-const InteractiveDivWithControls = Interactive.Div as React.ComponentType<
-	React.ComponentProps<typeof Interactive.Div> & {
-		readonly controls: SequenceControls | undefined;
-	}
->;
 
 const {fontFamily, waitUntilDone} = loadFont('normal', {
 	weights: [fontWeight],
@@ -465,7 +507,7 @@ const TimedCaptionsContent: React.FC<{
 
 const TimedCaptionsInner = forwardRef<
 	HTMLDivElement,
-	TimedCaptionsLayerProps & {
+	TimedCaptionsProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
@@ -485,6 +527,8 @@ const TimedCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
+		const usesDefaultCaptions = captions === undefined;
+		const captionAreaWidth = width ?? (usesDefaultCaptions ? 681 : null);
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -501,104 +545,39 @@ const TimedCaptionsInner = forwardRef<
 		}, []);
 
 		return (
-			<InteractiveDivWithControls
-				ref={outlineRef}
+			<Sequence
+				layout="none"
 				{...interactiveProps}
 				controls={controls}
 				name={name ?? '<TimedCaptions>'}
-				style={{
-					height: height ?? '100%',
-					width: width ?? '100%',
-					...style,
-				}}
+				outlineRef={outlineRef}
 			>
-				<TimedCaptionsContent
-					captionAreaWidth={width ?? null}
-					captions={captions}
-					combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
-					fontLoaded={fontLoaded}
-					mode={mode}
-				/>
-			</InteractiveDivWithControls>
+				<div
+					ref={outlineRef}
+					style={{
+						height: height ?? (usesDefaultCaptions ? 252 : '100%'),
+						width: width ?? (usesDefaultCaptions ? 681 : '100%'),
+						translate: usesDefaultCaptions ? '109.5px -36px' : undefined,
+						...style,
+					}}
+				>
+					<TimedCaptionsContent
+						captionAreaWidth={captionAreaWidth}
+						captions={captions ?? defaultCaptions}
+						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
+						fontLoaded={fontLoaded}
+						mode={mode}
+					/>
+				</div>
+			</Sequence>
 		);
 	},
 );
 
-const TimedCaptionsLayer = Interactive.withSchema({
+export const TimedCaptions = Interactive.withSchema({
 	Component: TimedCaptionsInner,
 	componentName: '<TimedCaptions>',
 	componentIdentity: null,
 	schema: timedCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<TimedCaptionsLayerProps>;
-
-export const TimedCaptions: React.FC<TimedCaptionsProps> = ({
-	captions,
-	...props
-}) => {
-	if (captions) {
-		return <TimedCaptionsLayer {...props} captions={captions} />;
-	}
-
-	return (
-		<TimedCaptionsLayer
-			{...props}
-			captions={[
-				{
-					text: 'Captions',
-					startMs: 0,
-					endMs: 800,
-					timestampMs: 400,
-					confidence: null,
-				},
-				{
-					text: ' can',
-					startMs: 800,
-					endMs: 1500,
-					timestampMs: 1150,
-					confidence: null,
-				},
-				{
-					text: ' move',
-					startMs: 1500,
-					endMs: 2300,
-					timestampMs: 1900,
-					confidence: null,
-				},
-				{
-					text: ' with',
-					startMs: 2300,
-					endMs: 3100,
-					timestampMs: 2700,
-					confidence: null,
-				},
-				{
-					text: ' every',
-					startMs: 3100,
-					endMs: 4000,
-					timestampMs: 3550,
-					confidence: null,
-				},
-				{
-					text: ' spoken',
-					startMs: 4000,
-					endMs: 5100,
-					timestampMs: 4550,
-					confidence: null,
-				},
-				{
-					text: ' word.',
-					startMs: 5100,
-					endMs: 6500,
-					timestampMs: 5800,
-					confidence: null,
-				},
-			]}
-			width={681}
-			height={252}
-			style={{
-				translate: '109.5px -36px',
-			}}
-		/>
-	);
-};
+}) as React.FC<TimedCaptionsProps>;

--- a/packages/docs/elements/text/timed-captions/timed-captions.tsx
+++ b/packages/docs/elements/text/timed-captions/timed-captions.tsx
@@ -36,6 +36,10 @@ export type TimedCaptionsProps = InteractiveBaseProps &
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
+type TimedCaptionsLayerProps = Omit<TimedCaptionsProps, 'captions'> & {
+	readonly captions: Caption[];
+};
+
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
@@ -48,57 +52,6 @@ const pillVerticalPadding = 12;
 const pillBorderRadius = 10;
 const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
-const defaultCaptions: Caption[] = [
-	{
-		text: 'Captions',
-		startMs: 0,
-		endMs: 800,
-		timestampMs: 400,
-		confidence: null,
-	},
-	{
-		text: ' can',
-		startMs: 800,
-		endMs: 1500,
-		timestampMs: 1150,
-		confidence: null,
-	},
-	{
-		text: ' move',
-		startMs: 1500,
-		endMs: 2300,
-		timestampMs: 1900,
-		confidence: null,
-	},
-	{
-		text: ' with',
-		startMs: 2300,
-		endMs: 3100,
-		timestampMs: 2700,
-		confidence: null,
-	},
-	{
-		text: ' every',
-		startMs: 3100,
-		endMs: 4000,
-		timestampMs: 3550,
-		confidence: null,
-	},
-	{
-		text: ' spoken',
-		startMs: 4000,
-		endMs: 5100,
-		timestampMs: 4550,
-		confidence: null,
-	},
-	{
-		text: ' word.',
-		startMs: 5100,
-		endMs: 6500,
-		timestampMs: 5800,
-		confidence: null,
-	},
-];
 
 const timedCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -507,7 +460,7 @@ const TimedCaptionsContent: React.FC<{
 
 const TimedCaptionsInner = forwardRef<
 	HTMLDivElement,
-	TimedCaptionsProps & {
+	TimedCaptionsLayerProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
@@ -527,8 +480,6 @@ const TimedCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
-		const usesDefaultCaptions = captions === undefined;
-		const captionAreaWidth = width ?? (usesDefaultCaptions ? 681 : null);
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -555,15 +506,14 @@ const TimedCaptionsInner = forwardRef<
 				<div
 					ref={outlineRef}
 					style={{
-						height: height ?? (usesDefaultCaptions ? 252 : '100%'),
-						width: width ?? (usesDefaultCaptions ? 681 : '100%'),
-						translate: usesDefaultCaptions ? '109.5px -36px' : undefined,
+						height: height ?? '100%',
+						width: width ?? '100%',
 						...style,
 					}}
 				>
 					<TimedCaptionsContent
-						captionAreaWidth={captionAreaWidth}
-						captions={captions ?? defaultCaptions}
+						captionAreaWidth={width ?? null}
+						captions={captions}
 						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
 						fontLoaded={fontLoaded}
 						mode={mode}
@@ -574,10 +524,81 @@ const TimedCaptionsInner = forwardRef<
 	},
 );
 
-export const TimedCaptions = Interactive.withSchema({
+const TimedCaptionsLayer = Interactive.withSchema({
 	Component: TimedCaptionsInner,
 	componentName: '<TimedCaptions>',
 	componentIdentity: null,
 	schema: timedCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<TimedCaptionsProps>;
+}) as React.FC<TimedCaptionsLayerProps>;
+
+export const TimedCaptions: React.FC<TimedCaptionsProps> = ({
+	captions,
+	...props
+}) => {
+	if (captions) {
+		return <TimedCaptionsLayer {...props} captions={captions} />;
+	}
+
+	return (
+		<TimedCaptionsLayer
+			{...props}
+			captions={[
+				{
+					text: 'Captions',
+					startMs: 0,
+					endMs: 800,
+					timestampMs: 400,
+					confidence: null,
+				},
+				{
+					text: ' can',
+					startMs: 800,
+					endMs: 1500,
+					timestampMs: 1150,
+					confidence: null,
+				},
+				{
+					text: ' move',
+					startMs: 1500,
+					endMs: 2300,
+					timestampMs: 1900,
+					confidence: null,
+				},
+				{
+					text: ' with',
+					startMs: 2300,
+					endMs: 3100,
+					timestampMs: 2700,
+					confidence: null,
+				},
+				{
+					text: ' every',
+					startMs: 3100,
+					endMs: 4000,
+					timestampMs: 3550,
+					confidence: null,
+				},
+				{
+					text: ' spoken',
+					startMs: 4000,
+					endMs: 5100,
+					timestampMs: 4550,
+					confidence: null,
+				},
+				{
+					text: ' word.',
+					startMs: 5100,
+					endMs: 6500,
+					timestampMs: 5800,
+					confidence: null,
+				},
+			]}
+			width={681}
+			height={252}
+			style={{
+				translate: '109.5px -36px',
+			}}
+		/>
+	);
+};

--- a/packages/docs/elements/text/timed-captions/timed-captions.tsx
+++ b/packages/docs/elements/text/timed-captions/timed-captions.tsx
@@ -467,7 +467,6 @@ const TimedCaptionsInner = forwardRef<
 	HTMLDivElement,
 	TimedCaptionsLayerProps & {
 		readonly controls: SequenceControls | undefined;
-		readonly stack?: string;
 	}
 >(
 	(
@@ -478,7 +477,6 @@ const TimedCaptionsInner = forwardRef<
 			height,
 			mode = 'background',
 			name,
-			stack,
 			style,
 			width,
 			...interactiveProps
@@ -508,7 +506,6 @@ const TimedCaptionsInner = forwardRef<
 				{...interactiveProps}
 				controls={controls}
 				name={name ?? '<TimedCaptions>'}
-				stack={stack}
 				style={{
 					height: height ?? '100%',
 					width: width ?? '100%',

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -143,14 +143,13 @@ describe('Elements must follow the colocated single-file format', () => {
 			const tsx = readFileSync(element.tsxPath, 'utf8');
 			const mdx = readFileSync(element.mdxPath, 'utf8');
 
-			test('source file is an Element, not a composition or wrapper Sequence', () => {
+			test('source file is an Element, not a composition', () => {
 				expect(tsx).not.toContain('export const durationInFrames');
 				expect(tsx).not.toContain('export const fps');
 				expect(tsx).not.toContain('export const width');
 				expect(tsx).not.toContain('export const height');
 				expect(tsx).not.toContain('export const RemotionRoot');
 				expect(tsx).not.toMatch(/<Composition(?:\s|\/?>)/);
-				expect(tsx).not.toMatch(/<Sequence(?:\s|\/?>)/);
 			});
 
 			test('MDX uses the ElementPage template', () => {

--- a/packages/example/src/SwitzerlandMap/MapOverlay.tsx
+++ b/packages/example/src/SwitzerlandMap/MapOverlay.tsx
@@ -21,7 +21,6 @@ type MapOverlayProps = InteractiveBaseProps &
 		readonly controls?: SequenceControls;
 		readonly latitude: number;
 		readonly longitude: number;
-		readonly stack?: string;
 	};
 
 const mapOverlaySchema = {
@@ -47,12 +46,7 @@ const mapOverlaySchema = {
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
-const MapOverlayInner = forwardRef<
-	HTMLDivElement,
-	MapOverlayProps & {
-		readonly stack?: undefined;
-	}
->(
+const MapOverlayInner = forwardRef<HTMLDivElement, MapOverlayProps>(
 	(
 		{
 			children,
@@ -67,7 +61,6 @@ const MapOverlayInner = forwardRef<
 			name,
 			showInTimeline,
 			controls,
-			stack,
 		},
 		ref,
 	) => {
@@ -89,7 +82,6 @@ const MapOverlayInner = forwardRef<
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
 				outlineRef={refForOutline}
-				_remotionInternalStack={stack}
 			>
 				<div
 					ref={refForOutline}

--- a/packages/example/src/SwitzerlandMap/MapRegion.tsx
+++ b/packages/example/src/SwitzerlandMap/MapRegion.tsx
@@ -34,7 +34,6 @@ type MapRegionProps = InteractiveBaseProps & {
 	readonly glow?: number;
 	readonly id: string;
 	readonly progress?: number;
-	readonly stack?: string;
 	readonly strokeColor?: string;
 	readonly strokeWidth?: number;
 };
@@ -322,12 +321,7 @@ const MapRegionBounds = ({
 	);
 };
 
-const MapRegionInner = forwardRef<
-	HTMLDivElement,
-	MapRegionProps & {
-		readonly stack?: undefined;
-	}
->(
+const MapRegionInner = forwardRef<HTMLDivElement, MapRegionProps>(
 	(
 		{
 			feature,
@@ -346,7 +340,6 @@ const MapRegionInner = forwardRef<
 			name,
 			showInTimeline,
 			controls,
-			stack,
 		},
 		ref,
 	) => {
@@ -366,7 +359,6 @@ const MapRegionInner = forwardRef<
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
 				outlineRef={refForOutline}
-				_remotionInternalStack={stack}
 			>
 				<MapRegionDrawing
 					feature={feature}

--- a/packages/example/src/SwitzerlandMap/MapRoute.tsx
+++ b/packages/example/src/SwitzerlandMap/MapRoute.tsx
@@ -32,7 +32,6 @@ type MapRouteProps = InteractiveBaseProps & {
 	readonly glow?: number;
 	readonly id: string;
 	readonly progress?: number;
-	readonly stack?: string;
 	readonly strokeColor?: string;
 	readonly strokeWidth?: number;
 };
@@ -257,12 +256,7 @@ const MapRouteBounds = ({
 	);
 };
 
-const MapRouteInner = forwardRef<
-	HTMLDivElement,
-	MapRouteProps & {
-		readonly stack?: undefined;
-	}
->(
+const MapRouteInner = forwardRef<HTMLDivElement, MapRouteProps>(
 	(
 		{
 			feature,
@@ -279,7 +273,6 @@ const MapRouteInner = forwardRef<
 			name,
 			showInTimeline,
 			controls,
-			stack,
 		},
 		ref,
 	) => {
@@ -299,7 +292,6 @@ const MapRouteInner = forwardRef<
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
 				outlineRef={refForOutline}
-				_remotionInternalStack={stack}
 			>
 				<MapRouteDrawing
 					feature={feature}

--- a/packages/example/src/SwitzerlandMap/MapViewport.tsx
+++ b/packages/example/src/SwitzerlandMap/MapViewport.tsx
@@ -30,7 +30,6 @@ type MapViewportProps = InteractiveBaseProps & {
 	readonly centerLongitude?: number;
 	readonly children?: ReactNode;
 	readonly controls?: SequenceControls;
-	readonly stack?: string;
 	readonly zoom?: number;
 };
 
@@ -107,12 +106,7 @@ const MissingApiKey = () => {
 	);
 };
 
-const MapViewportInner = forwardRef<
-	HTMLDivElement,
-	MapViewportProps & {
-		readonly stack?: undefined;
-	}
->(
+const MapViewportInner = forwardRef<HTMLDivElement, MapViewportProps>(
 	(
 		{
 			backgroundColor = '#dfe7e2',
@@ -129,7 +123,6 @@ const MapViewportInner = forwardRef<
 			showInTimeline,
 			zoom = 4,
 			controls,
-			stack,
 		},
 		ref,
 	) => {
@@ -267,7 +260,6 @@ const MapViewportInner = forwardRef<
 				name={name ?? '<MapViewport>'}
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
-				_remotionInternalStack={stack}
 			>
 				<div
 					ref={viewportRef}

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -40,7 +40,7 @@ type NewAudioForPreviewProps = {
 	readonly trimBefore: number | undefined;
 	readonly name: string | undefined;
 	readonly showInTimeline: boolean;
-	readonly stack: string | null;
+	readonly _remotionInternalStack: string | null;
 	readonly disallowFallbackToHtml5Audio: boolean;
 	readonly toneFrequency: number | undefined;
 	readonly audioStreamIndex: number | undefined;
@@ -63,7 +63,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	trimBefore,
 	name,
 	showInTimeline,
-	stack,
+	_remotionInternalStack,
 	disallowFallbackToHtml5Audio,
 	toneFrequency,
 	audioStreamIndex,
@@ -378,7 +378,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 				loop={loop}
 				showInTimeline={showInTimeline}
 				style={style ?? undefined}
-				stack={stack ?? undefined}
+				_remotionInternalStack={_remotionInternalStack ?? undefined}
 				toneFrequency={toneFrequency}
 				audioStreamIndex={audioStreamIndex}
 				pauseWhenBuffering={fallbackHtml5AudioProps?.pauseWhenBuffering}
@@ -411,7 +411,7 @@ type InnerAudioProps = {
 	readonly showInTimeline?: boolean;
 	readonly trimAfter?: number | undefined;
 	readonly trimBefore?: number | undefined;
-	readonly stack: string | null;
+	readonly _remotionInternalStack: string | null;
 	readonly disallowFallbackToHtml5Audio?: boolean;
 	readonly toneFrequency?: number;
 	readonly audioStreamIndex?: number;
@@ -434,7 +434,7 @@ export const AudioForPreview: React.FC<InnerAudioProps> = ({
 	trimAfter,
 	trimBefore,
 	showInTimeline,
-	stack,
+	_remotionInternalStack,
 	disallowFallbackToHtml5Audio,
 	toneFrequency,
 	audioStreamIndex,
@@ -498,7 +498,7 @@ export const AudioForPreview: React.FC<InnerAudioProps> = ({
 			trimBefore={trimBefore}
 			name={name}
 			showInTimeline={showInTimeline ?? true}
-			stack={stack}
+			_remotionInternalStack={_remotionInternalStack}
 			disallowFallbackToHtml5Audio={disallowFallbackToHtml5Audio ?? false}
 			toneFrequency={toneFrequency}
 			onError={onError}

--- a/packages/media/src/audio/audio.tsx
+++ b/packages/media/src/audio/audio.tsx
@@ -55,7 +55,6 @@ const AudioInner: React.FC<
 	// rest gets drilled down
 	const {
 		name,
-		stack,
 		showInTimeline,
 		controls,
 		from,
@@ -68,6 +67,7 @@ const AudioInner: React.FC<
 		...otherProps
 	} = props;
 	const environment = useRemotionEnvironment();
+	const sourceStack = controls ? Internals.getStackForControls(controls) : null;
 
 	const [mediaVolume] = Internals.useMediaVolumeState();
 	const mediaStartsAt = Internals.useMediaStartsAt();
@@ -168,7 +168,6 @@ const AudioInner: React.FC<
 				from={from ?? 0}
 				durationInFrames={basicInfo.duration}
 				freeze={freeze}
-				_remotionInternalStack={stack}
 				_remotionInternalIsMedia={isMedia}
 				_remotionInternalPremountDisplay={effectivePremountFor || null}
 				_remotionInternalPostmountDisplay={effectivePostmountFor || null}
@@ -195,7 +194,7 @@ const AudioInner: React.FC<
 						name={name}
 						{...otherProps}
 						style={premountingStyle}
-						stack={stack ?? null}
+						_remotionInternalStack={sourceStack}
 						setMediaDurationInSeconds={setMediaDurationInSeconds}
 					/>
 				)}

--- a/packages/media/src/audio/props.ts
+++ b/packages/media/src/audio/props.ts
@@ -26,10 +26,6 @@ export type AudioProps = {
 	playbackRate?: number;
 	muted?: boolean;
 	style?: React.CSSProperties;
-	/**
-	 * @deprecated For internal use only
-	 */
-	stack?: string;
 	logLevel?: LogLevel;
 	loop?: boolean;
 	audioStreamIndex?: number;

--- a/packages/media/src/video/props.ts
+++ b/packages/media/src/video/props.ts
@@ -55,10 +55,6 @@ type OptionalVideoProps = {
 	delayRenderRetries: number | null;
 	delayRenderTimeoutInMilliseconds: number | null;
 	style: React.CSSProperties;
-	/**
-	 * @deprecated For internal use only
-	 */
-	stack: string | undefined;
 	logLevel: LogLevel;
 	loop: boolean;
 	audioStreamIndex: number;
@@ -96,6 +92,7 @@ export type InnerVideoProps = MandatoryVideoProps &
 	Omit<OptionalVideoProps, 'effects'> &
 	NativeVideoProps & {
 		effects: EffectDefinitionAndStack<unknown>[];
+		_remotionInternalStack: string | undefined;
 	};
 
 export type VideoProps = MandatoryVideoProps &

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -63,7 +63,7 @@ type VideoForPreviewProps = NativeVideoProps & {
 	readonly loop: boolean;
 	readonly trimAfter: number | undefined;
 	readonly trimBefore: number | undefined;
-	readonly stack: string | null;
+	readonly _remotionInternalStack: string | null;
 	readonly disallowFallbackToOffthreadVideo: boolean;
 	readonly fallbackOffthreadVideoProps: FallbackOffthreadVideoProps;
 	readonly audioStreamIndex: number;
@@ -97,7 +97,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	loop,
 	trimAfter,
 	trimBefore,
-	stack,
+	_remotionInternalStack,
 	disallowFallbackToOffthreadVideo,
 	fallbackOffthreadVideoProps,
 	audioStreamIndex,
@@ -538,7 +538,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 				name={'<Html5Video> (fallback)'}
 				loop={loop}
 				showInTimeline={showInTimeline}
-				stack={stack ?? undefined}
+				_remotionInternalStack={_remotionInternalStack ?? undefined}
 				{...fallbackOffthreadVideoProps}
 			/>
 		);

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -52,7 +52,7 @@ type InnerVideoProps = NativeVideoProps & {
 	readonly fallbackOffthreadVideoProps: FallbackOffthreadVideoProps;
 	readonly audioStreamIndex: number;
 	readonly disallowFallbackToOffthreadVideo: boolean;
-	readonly stack: string | undefined;
+	readonly _remotionInternalStack: string | undefined;
 	readonly toneFrequency: number;
 	readonly trimBeforeValue: number | undefined;
 	readonly trimAfterValue: number | undefined;
@@ -84,7 +84,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 	fallbackOffthreadVideoProps,
 	audioStreamIndex,
 	disallowFallbackToOffthreadVideo,
-	stack,
+	_remotionInternalStack,
 	toneFrequency,
 	trimAfterValue,
 	trimBeforeValue,
@@ -494,7 +494,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 				preservePitch={fallbackOffthreadVideoProps?.preservePitch ?? true}
 				startFrom={undefined}
 				endAt={undefined}
-				stack={stack}
+				_remotionInternalStack={_remotionInternalStack}
 				_remotionInternalNativeLoopPassed={false}
 			/>
 		);

--- a/packages/media/src/video/video.tsx
+++ b/packages/media/src/video/video.tsx
@@ -82,7 +82,7 @@ const InnerVideo: React.FC<
 	trimAfter,
 	trimBefore,
 	volume,
-	stack,
+	_remotionInternalStack,
 	toneFrequency,
 	showInTimeline,
 	debugOverlay,
@@ -145,7 +145,7 @@ const InnerVideo: React.FC<
 				onVideoFrame={onVideoFrame}
 				playbackRate={playbackRate}
 				src={src}
-				stack={stack}
+				_remotionInternalStack={_remotionInternalStack}
 				style={style}
 				volume={volume}
 				toneFrequency={toneFrequency}
@@ -179,7 +179,7 @@ const InnerVideo: React.FC<
 			showInTimeline={showInTimeline}
 			trimAfter={trimAfterValue}
 			trimBefore={trimBeforeValue}
-			stack={stack ?? null}
+			_remotionInternalStack={_remotionInternalStack ?? null}
 			disallowFallbackToOffthreadVideo={disallowFallbackToOffthreadVideo}
 			fallbackOffthreadVideoProps={fallbackOffthreadVideoProps}
 			debugOverlay={debugOverlay ?? false}
@@ -222,7 +222,6 @@ const VideoInner: React.FC<
 	trimAfter,
 	trimBefore,
 	volume,
-	stack,
 	toneFrequency,
 	debugOverlay,
 	headless,
@@ -247,6 +246,9 @@ const VideoInner: React.FC<
 	cropBottom,
 	...props
 }) => {
+	const sourceStack = controls
+		? (Internals.getStackForControls(controls) ?? undefined)
+		: undefined;
 	const fallbackLogLevel = Internals.useLogLevel();
 	const [mediaVolume] = Internals.useMediaVolumeState();
 	const mediaStartsAt = Internals.useMediaStartsAt();
@@ -358,7 +360,6 @@ const VideoInner: React.FC<
 				from={from ?? 0}
 				durationInFrames={videoSequenceDuration}
 				freeze={freeze}
-				_remotionInternalStack={stack}
 				_remotionInternalIsMedia={isMedia}
 				_remotionInternalPremountDisplay={effectivePremountFor || null}
 				_remotionInternalPostmountDisplay={effectivePostmountFor || null}
@@ -402,7 +403,7 @@ const VideoInner: React.FC<
 					trimBefore={trimBefore}
 					volume={volume ?? 1}
 					toneFrequency={toneFrequency ?? 1}
-					stack={stack}
+					_remotionInternalStack={sourceStack}
 					debugOverlay={debugOverlay ?? false}
 					headless={headless ?? false}
 					onError={onError}

--- a/packages/rive/src/RemotionRiveCanvas.tsx
+++ b/packages/rive/src/RemotionRiveCanvas.tsx
@@ -484,7 +484,6 @@ const RemotionRiveCanvasInnerForwardRefFunction: React.ForwardRefRenderFunction<
 			controls={controls}
 			_remotionInternalEffects={memoizedEffectDefinitions}
 			outlineRef={canvasRef}
-			// 'stack' is in props
 			{...props}
 		>
 			<RemotionRiveCanvasContent

--- a/packages/rough-notation/src/Annotation.tsx
+++ b/packages/rough-notation/src/Annotation.tsx
@@ -351,7 +351,6 @@ const makeAnnotationComponent = ({
 	const AnnotationInner: React.FC<
 		InternalAnnotationProps & {
 			readonly controls: SequenceControls | undefined;
-			readonly stack?: string;
 		}
 	> = ({
 		children,
@@ -363,7 +362,6 @@ const makeAnnotationComponent = ({
 		name,
 		showInTimeline,
 		controls,
-		stack,
 		style,
 		progress,
 		seed,
@@ -412,7 +410,6 @@ const makeAnnotationComponent = ({
 				name={name ?? `<${componentName}>`}
 				showInTimeline={showInTimeline ?? true}
 				controls={controls}
-				_remotionInternalStack={stack}
 				_remotionInternalDocumentationLink={`https://www.remotion.dev/docs/rough-notation/${documentationSlug}`}
 				outlineRef={outlineRef}
 			>

--- a/packages/shapes/src/components/render-svg.tsx
+++ b/packages/shapes/src/components/render-svg.tsx
@@ -33,10 +33,6 @@ export type AllShapesProps = Omit<
 		readonly effects?: EffectsProp;
 		readonly pathStyle?: React.CSSProperties;
 		readonly pixelDensity?: HtmlInCanvasPixelDensity;
-		/**
-		 * @deprecated For internal use only
-		 */
-		readonly stack?: string;
 	};
 
 export const RenderSvg = ({
@@ -60,7 +56,6 @@ export const RenderSvg = ({
 	name,
 	showInTimeline,
 	controls,
-	stack,
 	...props
 }: {
 	readonly defaultName: string;
@@ -209,8 +204,6 @@ export const RenderSvg = ({
 			</HtmlInCanvasWithPrivateProps>
 		);
 
-	const stackProps = stack === undefined ? null : ({stack} as const);
-
 	if (!videoConfig) {
 		return svg;
 	}
@@ -231,7 +224,6 @@ export const RenderSvg = ({
 			_remotionInternalDocumentationLink={
 				name === undefined ? documentationLink : undefined
 			}
-			{...stackProps}
 		>
 			{content}
 		</Sequence>

--- a/packages/shapes/src/test/effects.test.tsx
+++ b/packages/shapes/src/test/effects.test.tsx
@@ -27,7 +27,6 @@ type SequenceCall = {
 	readonly _remotionInternalDocumentationLink: string | undefined;
 	readonly _remotionInternalEffects: unknown;
 	readonly outlineRef: React.RefObject<Element | null> | undefined;
-	readonly stack: string | undefined;
 };
 
 const htmlInCanvasCalls: HtmlInCanvasCall[] = [];
@@ -280,18 +279,6 @@ test('Should pass integer dimensions to HtmlInCanvas', async () => {
 
 	expect(htmlInCanvasCalls[0].width).toBe(11);
 	expect(htmlInCanvasCalls[0].height).toBe(21);
-});
-
-test('Should forward stack to the shape Sequence', async () => {
-	const {Circle} = await loadComponents();
-	hasVideoConfig = true;
-	htmlInCanvasCalls.length = 0;
-	sequenceCalls.length = 0;
-
-	render(<Circle radius={100} effects={[effect]} stack="shape-stack" />);
-
-	expect(htmlInCanvasCalls[0]).not.toBe(undefined);
-	expect(sequenceCalls[0].stack).toBe('shape-stack');
 });
 
 test('Should not add a documentation link if a custom name is passed', async () => {

--- a/packages/transitions/src/TransitionSeries.tsx
+++ b/packages/transitions/src/TransitionSeries.tsx
@@ -33,7 +33,6 @@ type ResolvedTransitionSeriesTransitionProps<
 	PresentationProps extends Record<string, unknown>,
 > = TransitionSeriesTransitionProps<PresentationProps> & {
 	readonly controls: SequenceControls | null | undefined;
-	readonly stack: string | null;
 };
 
 type InternalTransitionSeriesTransitionProps<
@@ -49,12 +48,11 @@ type InternalTransitionSeriesTransitionProps<
 const TransitionSeriesTransitionInner = <
 	PresentationProps extends Record<string, unknown>,
 >({
-	stack = null,
 	_remotionInternalRender = null,
 	...props
 }: InternalTransitionSeriesTransitionProps<PresentationProps>) => {
 	if (_remotionInternalRender) {
-		return _remotionInternalRender({...props, stack});
+		return _remotionInternalRender(props);
 	}
 
 	return null;
@@ -82,7 +80,6 @@ const TransitionSeriesTransition = Interactive.withSchema({
 
 type ResolvedTransitionSeriesOverlayProps = TransitionSeriesOverlayProps & {
 	readonly controls: SequenceControls | null | undefined;
-	readonly stack: string | null;
 };
 
 type InternalTransitionSeriesOverlayProps =
@@ -93,12 +90,11 @@ type InternalTransitionSeriesOverlayProps =
 	};
 
 const SeriesOverlayInner: FC<InternalTransitionSeriesOverlayProps> = ({
-	stack = null,
 	_remotionInternalRender = null,
 	...props
 }) => {
 	if (_remotionInternalRender) {
-		return _remotionInternalRender({...props, stack});
+		return _remotionInternalRender(props);
 	}
 
 	return null;
@@ -137,7 +133,6 @@ type SeriesSequenceProps = PropsWithChildren<
 
 type ResolvedSeriesSequenceProps = SeriesSequenceProps & {
 	readonly controls: SequenceControls | null | undefined;
-	readonly stack: string | null;
 };
 
 type InternalSeriesSequenceProps = ResolvedSeriesSequenceProps & {
@@ -159,7 +154,6 @@ const transitionSeriesSequenceSchema = {
 const SeriesSequenceInner: FC<InternalSeriesSequenceProps> = ({
 	offset = 0,
 	className = '',
-	stack = null,
 	_remotionInternalRender = null,
 	...props
 }) => {
@@ -168,7 +162,6 @@ const SeriesSequenceInner: FC<InternalSeriesSequenceProps> = ({
 			...props,
 			offset,
 			className: className || undefined,
-			stack,
 		});
 	}
 
@@ -310,7 +303,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 			readonly children: React.ReactNode;
 			readonly index: number;
 			readonly controls: SequenceControls | null | undefined;
-			readonly stack: string | null;
 		};
 
 		type RenderState = {
@@ -340,7 +332,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						durationInFrames={info.durationInFrames}
 						name="<TS.Overlay>"
 						_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
-						_remotionInternalStack={info.stack ?? undefined}
 						controls={info.controls ?? undefined}
 						layout="absolute-fill"
 					>
@@ -479,7 +470,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 							children: overlayProps.children,
 							index: i,
 							controls: overlayProps.controls,
-							stack: overlayProps.stack,
 						};
 
 						return renderNext({
@@ -527,7 +517,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 										durationInFrames={transitionDuration}
 										name="<TS.Transition>"
 										_remotionInternalDocumentationLink="https://www.remotion.dev/docs/transitions/transitionseries"
-										_remotionInternalStack={transitionProps.stack ?? undefined}
 										controls={transitionProps.controls ?? undefined}
 										layout="none"
 									/>
@@ -573,7 +562,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 						children: sequenceChildren,
 						offset: offsetProp,
 						controls,
-						stack,
 						from: _from,
 						...passedProps
 					} = resolvedProps as InternalSeriesSequenceProps & {from: never};
@@ -721,7 +709,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 										? undefined
 										: 'https://www.remotion.dev/docs/transitions/transitionseries'
 								}
-								_remotionInternalStack={stack ?? undefined}
 								controls={controls ?? undefined}
 							>
 								<UppercaseNextPresentation
@@ -798,7 +785,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 										? undefined
 										: 'https://www.remotion.dev/docs/transitions/transitionseries'
 								}
-								_remotionInternalStack={stack ?? undefined}
 								controls={controls ?? undefined}
 							>
 								<UppercasePrevPresentation
@@ -843,7 +829,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 										? undefined
 										: 'https://www.remotion.dev/docs/transitions/transitionseries'
 								}
-								_remotionInternalStack={stack ?? undefined}
 								controls={controls ?? undefined}
 							>
 								<UppercaseNextPresentation
@@ -883,7 +868,6 @@ const TransitionSeriesChildren: FC<{readonly children: React.ReactNode}> = ({
 									? undefined
 									: 'https://www.remotion.dev/docs/transitions/transitionseries'
 							}
-							_remotionInternalStack={stack ?? undefined}
 							controls={controls ?? undefined}
 						>
 							{sequenceChildren}
@@ -921,9 +905,6 @@ const TransitionSeriesInner: FC<SequencePropsWithoutDuration> = (props) => {
 	} = props as SequencePropsWithoutDuration & {
 		readonly controls: SequenceControls | null;
 	};
-	const {stack, ...propsForSequence} = otherProps as typeof otherProps & {
-		readonly stack: string | null;
-	};
 	const displayName = name ?? '<TransitionSeries>';
 	const layout = passedLayout ?? 'absolute-fill';
 	if (
@@ -944,8 +925,7 @@ const TransitionSeriesInner: FC<SequencePropsWithoutDuration> = (props) => {
 					? 'https://www.remotion.dev/docs/transitions/transitionseries'
 					: undefined
 			}
-			{...propsForSequence}
-			_remotionInternalStack={stack ?? undefined}
+			{...otherProps}
 			controls={controls ?? undefined}
 		>
 			<TransitionSeriesChildren>{children}</TransitionSeriesChildren>

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -150,12 +150,16 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 			dragOverrides={{}}
 		>
 			<TransitionSeries
-				{...({stack: transitionSeriesStack} as {readonly stack: string})}
+				{...({
+					_remotionInternalStack: transitionSeriesStack,
+				} as {readonly _remotionInternalStack: string})}
 			>
 				<TransitionSeries.Sequence
 					durationInFrames={10}
 					trimBefore={4}
-					{...({stack: childSequenceStack} as {readonly stack: string})}
+					{...({
+						_remotionInternalStack: childSequenceStack,
+					} as {readonly _remotionInternalStack: string})}
 				>
 					First
 				</TransitionSeries.Sequence>
@@ -230,7 +234,9 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 				</TransitionSeries.Sequence>
 				<TransitionSeries.Transition
 					timing={linearTiming({durationInFrames: 10})}
-					{...({stack: transitionStack} as {readonly stack: string})}
+					{...({
+						_remotionInternalStack: transitionStack,
+					} as {readonly _remotionInternalStack: string})}
 				/>
 				<TransitionSeries.Sequence durationInFrames={30}>
 					Second
@@ -238,7 +244,9 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 				<TransitionSeries.Overlay
 					durationInFrames={12}
 					offset={2}
-					{...({stack: overlayStack} as {readonly stack: string})}
+					{...({
+						_remotionInternalStack: overlayStack,
+					} as {readonly _remotionInternalStack: string})}
 				>
 					Overlay
 				</TransitionSeries.Overlay>
@@ -325,17 +333,23 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 					<TransitionSeries.Sequence
 						durationInFrames={10}
 						trimBefore={2}
-						{...({stack: firstStack} as {readonly stack: string})}
+						{...({
+							_remotionInternalStack: firstStack,
+						} as {readonly _remotionInternalStack: string})}
 					>
 						First
 					</TransitionSeries.Sequence>
 					<TransitionSeries.Transition
 						timing={linearTiming({durationInFrames: 5})}
-						{...({stack: transitionStack} as {readonly stack: string})}
+						{...({
+							_remotionInternalStack: transitionStack,
+						} as {readonly _remotionInternalStack: string})}
 					/>
 					<TransitionSeries.Sequence
 						durationInFrames={20}
-						{...({stack: secondStack} as {readonly stack: string})}
+						{...({
+							_remotionInternalStack: secondStack,
+						} as {readonly _remotionInternalStack: string})}
 					>
 						Second
 					</TransitionSeries.Sequence>


### PR DESCRIPTION
## Summary

- inject source locations through the namespaced `_remotionInternalStack` prop without overwriting application `stack` props
- associate source locations with `SequenceControls`, allowing interactive components to forward only `controls`
- update affected components, documentation, and regression coverage

## Testing

- `bun run build`
- `bun run stylecheck`
- focused core, bundler, transitions, and shapes tests
- `bunx turbo run make lint formatting --filter=docs`

Closes https://github.com/remotion-dev/remotion/issues/9595
Closes https://github.com/remotion-dev/remotion/issues/9848

## Preview

- [Sequence](https://remotion-git-codex-avoid-stack-prop-conflicts-remotion.vercel.app/docs/sequence)
- [Interactive.withSchema()](https://remotion-git-codex-avoid-stack-prop-conflicts-remotion.vercel.app/docs/interactive-with-schema)
- [Make a component interactive](https://remotion-git-codex-avoid-stack-prop-conflicts-remotion.vercel.app/docs/studio/make-component-interactive)
