### PR TITLE
Skills: Standardize API deprecations

### DIFF
--- a/.agents/skills/deprecate-api/SKILL.md
+++ b/.agents/skills/deprecate-api/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: deprecate-api
+description: Deprecate a public Remotion API consistently in its TypeScript source and documentation. Use when marking a function, component, hook, type, prop, option, or other public API as deprecated while keeping it available.
+---
+
+# Deprecate a Remotion API
+
+Apply all three changes below when deprecating a public API that remains available.
+
+## TypeScript API
+
+Add a JSDoc `@deprecated` annotation to the public symbol. State the replacement when one exists and link to its documentation when useful.
+
+```ts
+/**
+ * @deprecated Use `newApi()` instead: https://www.remotion.dev/docs/new-api
+ */
+export const oldApi = () => {};
+```
+
+Place the annotation where consumers receive it. For a re-export or compatibility alias, annotate the exported symbol rather than the non-deprecated implementation.
+
+## Documentation heading
+
+Strikethrough the deprecated API name in its heading with double tildes. Keep `<AvailableFrom>` outside the strikethrough.
+
+```mdx
+# ~~oldApi()~~<AvailableFrom v="4.0.0" />
+```
+
+For a prop or option:
+
+```mdx
+### ~~`oldOption?`~~
+```
+
+Keep the frontmatter `title` unchanged. Add an explicit heading if the page currently relies only on its frontmatter title.
+
+## Documentation admonition
+
+Place an info admonition directly after the deprecated heading. Name it `Deprecated` and point to the replacement when one exists.
+
+```mdx
+:::info Deprecated
+Use [`newApi()`](/docs/new-api) instead.
+:::
+```
+
+## Scope
+
+Do not infer or standardize runtime warnings, sidebar badges, release notes, removal versions, or removal behavior. Change those only when the task explicitly requires them.
+
+Do not apply this skill to an API that has already been removed. Removed APIs may remain documented for migration purposes, but they no longer have a public symbol to annotate.

--- a/.agents/skills/deprecate-api/SKILL.md
+++ b/.agents/skills/deprecate-api/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: deprecate-api
-description: Deprecate a public Remotion API consistently in its TypeScript source and documentation. Use when marking a function, component, hook, type, prop, option, or other public API as deprecated while keeping it available.
+description: Reference for how deprecation of public Remotion APIs is represented in TypeScript source and documentation. Use when adding, reviewing, or discussing a deprecation of a function, component, hook, type, prop, option, or other public API that remains available.
 ---
 
-# Deprecate a Remotion API
+# API deprecations in Remotion
 
-Apply all three changes below when deprecating a public API that remains available.
+Deprecation of a public API that remains available is represented in three places:
 
-## TypeScript API
+1. A JSDoc `@deprecated` annotation on the public TypeScript API.
+2. Strikethrough formatting on the API's documentation heading.
+3. An `info` admonition named `Deprecated` directly after that heading.
 
-Add a JSDoc `@deprecated` annotation to the public symbol. State the replacement when one exists and link to its documentation when useful.
+These conventions apply to functions, components, hooks, types, props, options, and other public APIs.
+
+## TypeScript representation
+
+The public symbol carries a JSDoc `@deprecated` annotation. The annotation states the replacement when one exists and may link to its documentation.
 
 ```ts
 /**
@@ -18,11 +24,11 @@ Add a JSDoc `@deprecated` annotation to the public symbol. State the replacement
 export const oldApi = () => {};
 ```
 
-Place the annotation where consumers receive it. For a re-export or compatibility alias, annotate the exported symbol rather than the non-deprecated implementation.
+The annotation belongs where consumers receive it. For a re-export or compatibility alias, this is the exported symbol rather than the non-deprecated implementation.
 
-## Documentation heading
+## Documentation representation
 
-Strikethrough the deprecated API name in its heading with double tildes. Keep `<AvailableFrom>` outside the strikethrough.
+The deprecated API name in its heading uses double-tilde strikethrough. `<AvailableFrom>` remains outside the strikethrough.
 
 ```mdx
 # ~~oldApi()~~<AvailableFrom v="4.0.0" />
@@ -34,11 +40,9 @@ For a prop or option:
 ### ~~`oldOption?`~~
 ```
 
-Keep the frontmatter `title` unchanged. Add an explicit heading if the page currently relies only on its frontmatter title.
+The frontmatter `title` remains unchanged. A page that otherwise relies only on its frontmatter title has an explicit struck-through heading.
 
-## Documentation admonition
-
-Place an info admonition directly after the deprecated heading. Name it `Deprecated` and point to the replacement when one exists.
+An info admonition named `Deprecated` appears directly after the heading and points to the replacement when one exists.
 
 ```mdx
 :::info Deprecated
@@ -48,6 +52,6 @@ Use [`newApi()`](/docs/new-api) instead.
 
 ## Scope
 
-Do not infer or standardize runtime warnings, sidebar badges, release notes, removal versions, or removal behavior. Change those only when the task explicitly requires them.
+Runtime warnings, sidebar badges, release notes, removal versions, and removal behavior are not currently standardized as part of API deprecation.
 
-Do not apply this skill to an API that has already been removed. Removed APIs may remain documented for migration purposes, but they no longer have a public symbol to annotate.
+Removed APIs are outside this convention. They may remain documented for migration purposes, but they no longer have a public symbol to annotate.

--- a/.agents/skills/deprecate-api/agents/openai.yaml
+++ b/.agents/skills/deprecate-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Deprecate API'
+  short_description: 'Standardize public Remotion API deprecations'
+  default_prompt: 'Use $deprecate-api to deprecate a public Remotion API consistently.'

--- a/.agents/skills/deprecate-api/agents/openai.yaml
+++ b/.agents/skills/deprecate-api/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: 'Deprecate API'
-  short_description: 'Standardize public Remotion API deprecations'
-  default_prompt: 'Use $deprecate-api to deprecate a public Remotion API consistently.'

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -229,7 +229,9 @@ The [command line flag](/docs/cli/studio#--disable-interactivity) `--disable-int
 
 ## ~~`setAllowHtmlInCanvasEnabled()`~~<AvailableFrom v="4.0.447" />
 
+:::info Deprecated
 From Remotion v4.0.491, this method is a no-op and can be removed from your config file. [`@remotion/web-renderer`](/docs/web-renderer) automatically uses HTML-in-canvas when the browser supports nested captures.
+:::
 
 ## `setExperimentalRspackEnabled()`<AvailableFrom v="4.0.426" />
 
@@ -1130,8 +1132,9 @@ The [command line flag](/docs/cli/render#--ffprobe-executable-) `--ffprobe-execu
 
 ## ~~`setPort()`~~
 
-_deprecated in v4.0.61 - use [`setStudioPort()`](/docs/config#setstudioport)_
-and [`setRendererPort()`](/docs/config#setrendererport) instead.
+:::info Deprecated
+Use [`setStudioPort()`](/docs/config#setstudioport) and [`setRendererPort()`](/docs/config#setrendererport) instead.
+:::
 
 Define on which port Remotion should start it's HTTP servers.  
 By default, Remotion will try to find a free port.  

--- a/packages/docs/docs/get-audio-duration-in-seconds.mdx
+++ b/packages/docs/docs/get-audio-duration-in-seconds.mdx
@@ -5,7 +5,9 @@ id: get-audio-duration-in-seconds
 crumb: '@remotion/media-utils'
 ---
 
-:::warning Deprecated
+# ~~getAudioDurationInSeconds()~~
+
+:::info Deprecated
 This function has been deprecated. Use [`getMediaMetadata()`](/docs/mediabunny/metadata) instead, which is faster and supports more formats.
 :::
 

--- a/packages/docs/docs/get-video-metadata.mdx
+++ b/packages/docs/docs/get-video-metadata.mdx
@@ -5,12 +5,14 @@ id: get-video-metadata
 crumb: '@remotion/media-utils'
 ---
 
-_Part of the `@remotion/media-utils` package of helper functions._
+# ~~getVideoMetadata()~~
 
-:::note
-Deprecated: Does not support H.265 videos on Linux and also fails on some other formats.  
+:::info Deprecated
+This function does not support H.265 videos on Linux and also fails on some other formats.
 Better solution: [Get metadata using Mediabunny](/docs/mediabunny/metadata)
 :::
+
+_Part of the `@remotion/media-utils` package of helper functions._
 
 :::note
 Only works in the browser.

--- a/packages/docs/docs/html5-audio.mdx
+++ b/packages/docs/docs/html5-audio.mdx
@@ -97,7 +97,7 @@ export const MyVideo = () => {
 
 ### ~~`startFrom?` / `endAt?`~~
 
-:::note Deprecated
+:::info Deprecated
 These props have been renamed to [`trimBefore`](#trimbefore--trimafter) and [`trimAfter`](#trimbefore--trimafter) in 4.0.319. They will continue to work but you cannot use them together with the new props.
 :::
 
@@ -237,12 +237,15 @@ Handle an error playing the audio.
 Corresponds to the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#attr-crossorigin) attribute of the `<audio>` element.
 One of `"anonymous"`, `"use-credentials"` or `undefined`.
 
-### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
+### ~~`allowAmplificationDuringRender?`~~<AvailableFrom v="3.3.17" />
 
+:::info Deprecated
 Deprecated since v4.0.279: This prop intended to opt into setting the volume to a value higher than one, even though it would only apply during render.
 
-The option does not make sense anymore, because it is now possible to set the volume higher than `1`.  
 To prevent synthetic amplification, set a volume not higher than 1.
+:::
+
+The option does not make sense anymore, because it is now possible to set the volume higher than `1`.
 
 ## Compatibility
 

--- a/packages/docs/docs/html5-video.mdx
+++ b/packages/docs/docs/html5-video.mdx
@@ -87,13 +87,13 @@ Removes a portion of the video at the end (right side). See [`trimBefore`](#trim
 
 ### ~~`startFrom?`~~
 
-:::note Deprecated
+:::info Deprecated
 This prop has been renamed to [`trimBefore`](#trimbefore) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
 ### ~~`endAt?`~~
 
-:::note Deprecated
+:::info Deprecated
 This prop has been renamed to [`trimAfter`](#trimafter) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
@@ -311,12 +311,15 @@ Default: `"anonymous"` if `onVideoFrame` is specified, `undefined`, otherwise.
 
 Enables the Web Audio API for the video tag, allowing volume values above `1` and volume control on iOS Safari. Set `crossOrigin="anonymous"` and ensure the video source supports CORS. On Safari, this cannot be combined with [`playbackRate`](#playbackrate); otherwise, volume changes are ignored.
 
-### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
+### ~~`allowAmplificationDuringRender?`~~<AvailableFrom v="3.3.17" />
 
+:::info Deprecated
 Deprecated since v4.0.279: This prop intended to opt into setting the volume to a value higher than one, even though it would only apply during render.
 
-The option does not make sense anymore, because it is now possible to set the volume higher than `1`.  
 To prevent synthetic amplification, set a volume not higher than 1.
+:::
+
+The option does not make sense anymore, because it is now possible to set the volume higher than `1`.
 
 ## Speed up renders for video with silent audio
 

--- a/packages/docs/docs/install-whisper-cpp/convert-to-captions.mdx
+++ b/packages/docs/docs/install-whisper-cpp/convert-to-captions.mdx
@@ -4,11 +4,13 @@ title: convertToCaptions()
 crumb: '@remotion/install-whisper-cpp'
 ---
 
-# ~convertToCaptions()~<AvailableFrom v="4.0.131 "/>
+# ~~convertToCaptions()~~<AvailableFrom v="4.0.131 "/>
 
+:::info Deprecated
 This API was deprecated as of Remotion 4.0.216.
 
 It is recommended to use the [`toCaptions()`](/docs/install-whisper-cpp/to-captions) function from `@remotion/install-whisper-cpp` instead, and then process the captions using [`createTikTokStyleCaptions()`](/docs/captions/create-tiktok-style-captions) from [`@remotion/captions`](/docs/captions/api).
+:::
 
 [Click here](https://github.com/remotion-dev/remotion/blob/v4.0.215/packages/docs/docs/install-whisper-cpp/convert-to-captions.mdx) to see documentation for this function that was previously on this page.
 

--- a/packages/docs/docs/lambda/deploysite.mdx
+++ b/packages/docs/docs/lambda/deploysite.mdx
@@ -6,7 +6,9 @@ slug: /lambda/deploysite
 crumb: 'Lambda API'
 ---
 
-:::warning Deprecated
+# ~~deploySite()~~
+
+:::info Deprecated
 Prefer building with [`bundle()`](/docs/bundle) and uploading its output with [`deploySiteFromBundle()`](/docs/lambda/deploysitefrombundle). Separating these steps avoids rebuilding an unchanged bundle during deployment.
 :::
 

--- a/packages/docs/docs/lambda/getcompositionsonlambda.mdx
+++ b/packages/docs/docs/lambda/getcompositionsonlambda.mdx
@@ -117,7 +117,9 @@ Logs can be read through the CloudWatch URL that this function returns.
 
 ### ~~`dumpBrowserLogs?`~~
 
-Deprecated in v4.0 in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ## Return value
 

--- a/packages/docs/docs/lambda/rendermediaonlambda.mdx
+++ b/packages/docs/docs/lambda/rendermediaonlambda.mdx
@@ -377,13 +377,17 @@ _default `true`_
 
 ### ~~`apiKey?`<AvailableFrom v="4.0.253"/>~~
 
-_deprecated in v4.0.409_
+:::info Deprecated
+Use [`licenseKey`](#licensekey) instead.
+:::
 
 <Options id="api-key" />
 
 ### ~~`dumpBrowserLogs?`~~
 
-Deprecated in v4.0 in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ## Return value
 

--- a/packages/docs/docs/lambda/renderstillonlambda.mdx
+++ b/packages/docs/docs/lambda/renderstillonlambda.mdx
@@ -261,7 +261,9 @@ _default `true`_
 
 ### ~~`dumpBrowserLogs?`~~
 
-Deprecated in v4.0 in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ## Return value
 

--- a/packages/docs/docs/licensing/get-usage.mdx
+++ b/packages/docs/docs/licensing/get-usage.mdx
@@ -56,7 +56,9 @@ The lowest timestamp you can use is 90 days ago (`Date.now() - 90 * 24 * 60 * 60
 
 ### ~~`apiKey`~~
 
-_deprecated in v4.0.409_
+:::info Deprecated
+Use `licenseKey` instead.
+:::
 
 Type: `string`
 
@@ -76,7 +78,9 @@ An object with the following properties:
 
 ### ~~`webcodecConversions`~~
 
-_deprecated - use `webRenders` instead_
+:::info Deprecated
+Use `webRenders` instead.
+:::
 
 Same as `webRenders`.
 

--- a/packages/docs/docs/light-leaks/index.mdx
+++ b/packages/docs/docs/light-leaks/index.mdx
@@ -5,9 +5,9 @@ slug: /light-leaks/api
 title: '@remotion/light-leaks'
 ---
 
-# @remotion/light-leaks<AvailableFrom v="4.0.415" />
+# ~~@remotion/light-leaks~~<AvailableFrom v="4.0.415" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`lightLeak()`](/docs/effects/light-leak) from `@remotion/effects/light-leak`. The `<LightLeak>` component will not be moved to `@remotion/effects`.
 :::
 

--- a/packages/docs/docs/light-leaks/light-leak-effect.mdx
+++ b/packages/docs/docs/light-leaks/light-leak-effect.mdx
@@ -6,9 +6,9 @@ sidebar_label: lightLeak()
 crumb: '@remotion/light-leaks'
 ---
 
-# lightLeak()<AvailableFrom v="4.0.468" />
+# ~~lightLeak()~~<AvailableFrom v="4.0.468" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`lightLeak()`](/docs/effects/light-leak) from `@remotion/effects/light-leak`.
 :::
 

--- a/packages/docs/docs/light-leaks/light-leak.mdx
+++ b/packages/docs/docs/light-leaks/light-leak.mdx
@@ -4,9 +4,9 @@ title: '<LightLeak>'
 crumb: '@remotion/light-leaks'
 ---
 
-# &lt;LightLeak&gt;<AvailableFrom v="4.0.415" />
+# ~~&lt;LightLeak&gt;~~<AvailableFrom v="4.0.415" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/light-leaks` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`lightLeak()`](/docs/effects/light-leak) from `@remotion/effects/light-leak`. The `<LightLeak>` component will not be moved to `@remotion/effects`.
 :::
 

--- a/packages/docs/docs/media-parser/parse-media.mdx
+++ b/packages/docs/docs/media-parser/parse-media.mdx
@@ -8,7 +8,7 @@ crumb: '@remotion/media-parser'
 
 # ~~parseMedia()~~
 
-:::warning
+:::info Deprecated
 Deprecated in favor of [getting metadata using Mediabunny](/docs/mediabunny/metadata).
 :::
 

--- a/packages/docs/docs/media/audio.mdx
+++ b/packages/docs/docs/media/audio.mdx
@@ -259,7 +259,7 @@ export const MyComposition = () => {
 
 ### ~~`credentials?`<AvailableFrom v="4.0.437" />~~
 
-:::note Deprecated
+:::info Deprecated
 Use [`requestInit`](#requestinit) instead.
 :::
 

--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -378,7 +378,7 @@ export const MyComposition = () => {
 
 ### ~~`credentials?`<AvailableFrom v="4.0.437" />~~
 
-:::note Deprecated
+:::info Deprecated
 Use [`requestInit`](#requestinit) instead.
 :::
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -83,13 +83,13 @@ Removes a portion of the video at the end (right side). See [`trimBefore`](/docs
 
 ### ~~`startFrom?`~~
 
-:::note Deprecated
+:::info Deprecated
 This prop has been renamed to [`trimBefore`](#trimbefore) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
 ### ~~`endAt?`~~
 
-:::note Deprecated
+:::info Deprecated
 This prop has been renamed to [`trimAfter`](#trimafter) in 4.0.319. It will continue to work but you cannot use it together with the new prop.
 :::
 
@@ -315,12 +315,15 @@ _removed in v4.0.0_
 Either `jpeg` or `png`. Default `jpeg`.  
 With `png`, transparent videos (VP8, VP9, ProRes) can be displayed, however it is around 40% slower, with VP8 videos being [much slower](/docs/slow-method-to-extract-frame).
 
-### ~`allowAmplificationDuringRender?`<AvailableFrom v="3.3.17" />~
+### ~~`allowAmplificationDuringRender?`~~<AvailableFrom v="3.3.17" />
 
+:::info Deprecated
 Deprecated since v4.0.279: This prop intended to opt into setting the volume to a value higher than one, even though it would only apply during render.
 
-The option does not make sense anymore, because it is now possible to set the volume higher than `1`.  
 To prevent synthetic amplification, set a volume not higher than 1.
+:::
+
+The option does not make sense anymore, because it is now possible to set the volume higher than `1`.
 
 ### Other props
 

--- a/packages/docs/docs/renderer/get-video-metadata.mdx
+++ b/packages/docs/docs/renderer/get-video-metadata.mdx
@@ -7,7 +7,7 @@ crumb: '@remotion/renderer'
 
 # ~~getVideoMetadata()~~<AvailableFrom v="4.0.6" />
 
-:::note
+:::info Deprecated
 Deprecated in favor of [getting metadata using Mediabunny](/docs/mediabunny/metadata).
 :::
 

--- a/packages/docs/docs/renderer/open-browser.mdx
+++ b/packages/docs/docs/renderer/open-browser.mdx
@@ -30,12 +30,13 @@ Currently the only valid option is `"chrome"`. This field is reserved for future
 
 An object containing one or more of the following options:
 
-#### ~`shouldDumpIo?`~
+#### ~~`shouldDumpIo?`~~
 
-Deprecated since v4.0.189, scheduled for removal in v5.0.
+:::info Deprecated
+Deprecated since v4.0.189, scheduled for removal in v5.0. Use `logLevel` instead.
+:::
 
-If set to `true`, logs and other browser diagnostics are being printed to standard output. This setting is useful for debugging.  
-**Will be removed in 5.0:** Use `logLevel` instead.
+If set to `true`, logs and other browser diagnostics are being printed to standard output. This setting is useful for debugging.
 
 #### `logLevel?`<AvailableFrom v="4.0.189"/>
 

--- a/packages/docs/docs/renderer/render-frames.mdx
+++ b/packages/docs/docs/renderer/render-frames.mdx
@@ -300,7 +300,9 @@ Renamed to `jpegQuality` in `v4.0.0`.
 
 ### ~~`dumpBrowserLogs?`~~
 
-Deprecated in v4.0 in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ### ~~`parallelism?`~~
 

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -505,7 +505,9 @@ _default `true`_
 
 ### ~~`apiKey?`<AvailableFrom v="4.0.375"/>~~
 
-_deprecated in v4.0.409_
+:::info Deprecated
+Use [`licenseKey`](#licensekey) instead.
+:::
 
 <Options id="api-key" />
 
@@ -520,15 +522,17 @@ Renamed to `jpegQuality` in `v4.0.0`.
 
 ### ~~`dumpBrowserLogs?`~~
 
-_default `false`, deprecated in v4.0_
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
-Deprecated in favor of [`logLevel`](#loglevel).
+_default `false`_
 
 ### ~~`verbose?`~~
 
-_deprecated in v4.0_
-
-Deprecated in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ### ~~`onSlowestFrames?`~~
 

--- a/packages/docs/docs/renderer/render-still.mdx
+++ b/packages/docs/docs/renderer/render-still.mdx
@@ -230,13 +230,17 @@ _default `true`_
 
 ### ~~`apiKey?`<AvailableFrom v="4.0.375"/>~~
 
-_deprecated in v4.0.409_
+:::info Deprecated
+Use [`licenseKey`](#licensekey) instead.
+:::
 
 <Options id="api-key" />
 
 ### ~~`dumpBrowserLogs?`~~
 
-Deprecated in v4.0 in favor of [`logLevel`](#loglevel).
+:::info Deprecated
+Use [`logLevel`](#loglevel) instead.
+:::
 
 ### ~~`quality?`~~
 

--- a/packages/docs/docs/starburst/index.mdx
+++ b/packages/docs/docs/starburst/index.mdx
@@ -6,9 +6,9 @@ title: '@remotion/starburst'
 crumb: API
 ---
 
-# @remotion/starburst<AvailableFrom v="4.0.435" />
+# ~~@remotion/starburst~~<AvailableFrom v="4.0.435" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/starburst` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`starburst()`](/docs/effects/starburst) from `@remotion/effects/starburst`. The `<Starburst>` component will not be moved to `@remotion/effects`.
 :::
 

--- a/packages/docs/docs/starburst/starburst-effect.mdx
+++ b/packages/docs/docs/starburst/starburst-effect.mdx
@@ -6,9 +6,9 @@ sidebar_label: starburst()
 crumb: '@remotion/starburst'
 ---
 
-# starburst()<AvailableFrom v="4.0.468" />
+# ~~starburst()~~<AvailableFrom v="4.0.468" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/starburst` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`starburst()`](/docs/effects/starburst) from `@remotion/effects/starburst`.
 :::
 

--- a/packages/docs/docs/starburst/starburst.mdx
+++ b/packages/docs/docs/starburst/starburst.mdx
@@ -6,9 +6,9 @@ title: '<Starburst>'
 crumb: '@remotion/starburst'
 ---
 
-# &lt;Starburst><AvailableFrom v="4.0.435" />
+# ~~&lt;Starburst&gt;~~<AvailableFrom v="4.0.435" />
 
-:::warning Deprecated
+:::info Deprecated
 `@remotion/starburst` is deprecated and will no longer be published starting with Remotion 5.0. Migrate to [`starburst()`](/docs/effects/starburst) from `@remotion/effects/starburst`. The `<Starburst>` component will not be moved to `@remotion/effects`.
 :::
 

--- a/packages/docs/docs/studio/update-default-props.mdx
+++ b/packages/docs/docs/studio/update-default-props.mdx
@@ -4,10 +4,10 @@ title: updateDefaultProps()
 crumb: "@remotion/studio"
 ---
 
-# ~updateDefaultProps()~<AvailableFrom v="4.0.154"/>
+# ~~updateDefaultProps()~~<AvailableFrom v="4.0.154"/>
 
-:::info
-**Deprecated**: This function is an alias for [`saveDefaultProps()`](/docs/studio/save-default-props). Use `saveDefaultProps()` instead.
+:::info Deprecated
+This function is an alias for [`saveDefaultProps()`](/docs/studio/save-default-props). Use `saveDefaultProps()` instead.
 
 Before v4.0.437, this function only updated the props in the Props Editor without saving them to the root file.
 Starting from v4.0.437, all prop changes are immediately saved, making this function identical to `saveDefaultProps()`.

--- a/packages/docs/docs/use-offthread-video-texture.mdx
+++ b/packages/docs/docs/use-offthread-video-texture.mdx
@@ -5,10 +5,10 @@ crumb: '@remotion/three'
 sidebar_label: useOffthreadVideoTexture()
 ---
 
-# ~useOffthreadVideoTexture()~<AvailableFrom v="4.0.83"/>
+# ~~useOffthreadVideoTexture()~~<AvailableFrom v="4.0.83"/>
 
-:::warning
-Deprecated - we recommend using [`@remotion/media`](/docs/videos/as-threejs-texture) instead.
+:::info Deprecated
+We recommend using [`@remotion/media`](/docs/videos/as-threejs-texture) instead.
 :::
 
 Allows you to use a video in React Three Fiber that is synchronized with Remotion's `useCurrentFrame()`, similar to [`useVideoTexture()`](/docs/use-video-texture), but uses [`<OffthreadVideo>`](/docs/offthreadvideo) instead.

--- a/packages/docs/docs/use-video-texture.mdx
+++ b/packages/docs/docs/use-video-texture.mdx
@@ -5,10 +5,10 @@ sidebar_label: useVideoTexture()
 crumb: '@remotion/three'
 ---
 
-# ~useVideoTexture()~
+# ~~useVideoTexture()~~
 
-:::warning
-Deprecated - we recommend using [`@remotion/media`](/docs/videos/as-threejs-texture) instead.
+:::info Deprecated
+We recommend using [`@remotion/media`](/docs/videos/as-threejs-texture) instead.
 :::
 
 Allows you to use a video in React Three Fiber that is synchronized with Remotion's `useCurrentFrame()`.

--- a/packages/docs/docs/web-renderer/types.mdx
+++ b/packages/docs/docs/web-renderer/types.mdx
@@ -105,10 +105,13 @@ import type {RenderMediaOnWebProgress} from '@remotion/web-renderer';
 //                ^?
 ```
 
-### `renderedFrames`
+### ~~`renderedFrames`~~
 
-Deprecated and kept for backward compatibility. The number of frames that have been rendered.
-Prefer `progress` for overall status updates.
+:::info Deprecated
+Kept for backward compatibility. Prefer `progress` for overall status updates.
+:::
+
+The number of frames that have been rendered.
 
 ### `encodedFrames`
 

--- a/packages/light-leaks/src/LightLeak.tsx
+++ b/packages/light-leaks/src/LightLeak.tsx
@@ -304,6 +304,9 @@ const LightLeakInner: React.FC<
 	);
 };
 
+/**
+ * @deprecated Use `lightLeak()` from `@remotion/effects/light-leak` instead: https://www.remotion.dev/docs/effects/light-leak
+ */
 export const LightLeak = Interactive.withSchema({
 	Component: LightLeakInner,
 	componentName: '<LightLeak>',

--- a/packages/light-leaks/src/light-leak-internals.ts
+++ b/packages/light-leaks/src/light-leak-internals.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Import `lightLeak()` from `@remotion/effects/light-leak` instead: https://www.remotion.dev/docs/effects/light-leak
+ */
 export {
 	lightLeak,
 	lightLeakEffectSchema,

--- a/packages/renderer/src/open-browser.ts
+++ b/packages/renderer/src/open-browser.ts
@@ -116,7 +116,13 @@ type LogOptions =
 		? {
 				logLevel?: LogLevel;
 			}
-		: {shouldDumpIo?: boolean; logLevel?: LogLevel};
+		: {
+				/**
+				 * @deprecated Use `logLevel` instead.
+				 */
+				shouldDumpIo?: boolean;
+				logLevel?: LogLevel;
+			};
 
 export type OpenBrowserOptions = {
 	browserExecutable?: string | null;

--- a/packages/starburst/src/Starburst.tsx
+++ b/packages/starburst/src/Starburst.tsx
@@ -438,6 +438,9 @@ const StarburstInner: React.FC<
 	);
 };
 
+/**
+ * @deprecated Use `starburst()` from `@remotion/effects/starburst` instead: https://www.remotion.dev/docs/effects/starburst
+ */
 export const Starburst = Interactive.withSchema({
 	Component: StarburstInner,
 	componentName: '<Starburst>',

--- a/packages/starburst/src/starburst-effect.ts
+++ b/packages/starburst/src/starburst-effect.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Import `starburst()` from `@remotion/effects/starburst` instead: https://www.remotion.dev/docs/effects/starburst
+ */
 export {
 	starburst,
 	starburstEffectSchema,


### PR DESCRIPTION
## Summary

- standardize deprecated API docs with struck headings and info admonitions
- add missing `@deprecated` annotations to public compatibility APIs
- document the convention in a new internal `deprecate-api` skill

## Validation

- `bun run build`
- `bun run stylecheck`
- Docusaurus production build
- preview-card generation

## Previews

- [Configuration file](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/config)
- [getAudioDurationInSeconds()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/get-audio-duration-in-seconds)
- [getVideoMetadata() from `@remotion/media-utils`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/get-video-metadata)
- [`<Html5Audio>`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/html5-audio)
- [`<Html5Video>`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/html5-video)
- [convertToCaptions()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/install-whisper-cpp/convert-to-captions)
- [deploySite()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/lambda/deploysite)
- [getCompositionsOnLambda()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/lambda/getcompositionsonlambda)
- [renderMediaOnLambda()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/lambda/rendermediaonlambda)
- [renderStillOnLambda()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/lambda/renderstillonlambda)
- [getUsage()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/licensing/get-usage)
- [`@remotion/light-leaks`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/light-leaks/api)
- [lightLeak()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/light-leaks/light-leak-effect)
- [`<LightLeak>`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/light-leaks/light-leak)
- [parseMedia()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/media-parser/parse-media)
- [`<Audio>` from `@remotion/media`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/media/audio)
- [`<Video>` from `@remotion/media`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/media/video)
- [`<OffthreadVideo>`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/offthreadvideo)
- [getVideoMetadata() from `@remotion/renderer`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/renderer/get-video-metadata)
- [openBrowser()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/renderer/open-browser)
- [renderFrames()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/renderer/render-frames)
- [renderMedia()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/renderer/render-media)
- [renderStill()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/renderer/render-still)
- [`@remotion/starburst`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/starburst/api)
- [starburst()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/starburst/starburst-effect)
- [`<Starburst>`](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/starburst/starburst)
- [updateDefaultProps()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/studio/update-default-props)
- [useOffthreadVideoTexture()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/use-offthread-video-texture)
- [useVideoTexture()](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/use-video-texture)
- [Web Renderer TypeScript types](https://remotion-git-codex-standardize-api-deprecations-remotion.vercel.app/docs/web-renderer/types)

Closes #9842
