### PR TITLE
`create-video`: Use bundler module resolution in templates

### DIFF
--- a/packages/browser-studio/src/templates/blank.ts
+++ b/packages/browser-studio/src/templates/blank.ts
@@ -74,7 +74,8 @@ export const MyComponent: React.FC<Props> = () => {
 	'/project/tsconfig.json': `{
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/it-tests/src/templates/validate-templates.test.ts
+++ b/packages/it-tests/src/templates/validate-templates.test.ts
@@ -261,6 +261,15 @@ describe('Templates should be valid', () => {
 			) {
 				expect(contents).not.toInclude('"incremental": true');
 			}
+
+			const tsconfig = JSON.parse(contents!);
+			const usesNodeModuleResolution = [
+				'template-still',
+				'template-skia',
+			].includes(template.templateInMonorepo);
+			if (!usesNodeModuleResolution) {
+				expect(tsconfig.compilerOptions.moduleResolution).toBe('Bundler');
+			}
 		});
 
 		it(`${template.shortName} should use correct prettier`, async () => {

--- a/packages/template-blank/tsconfig.json
+++ b/packages/template-blank/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-electron/tsconfig.json
+++ b/packages/template-electron/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "Preserve",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
     "lib": ["ES2023", "DOM"],
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/packages/template-helloworld/tsconfig.json
+++ b/packages/template-helloworld/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-next-app-tailwind/tsconfig.json
+++ b/packages/template-next-app-tailwind/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/template-next-app/tsconfig.json
+++ b/packages/template-next-app/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/template-next-pages/tsconfig.json
+++ b/packages/template-next-pages/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/template-overlay/tsconfig.json
+++ b/packages/template-overlay/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-prompt-to-motion-graphics/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/template-prompt-to-motion-graphics/src/components/CodeEditor/CodeEditor.tsx
@@ -54,7 +54,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     if (!isStreaming || !monacoRef.current) return;
 
     const clearAllMarkers = () => {
-      monacoRef.current?.editor.getModels().forEach((model) => {
+      const models = monacoRef.current?.editor.getModels() ?? [];
+      models.forEach((model: editor.ITextModel) => {
         monacoRef.current?.editor.setModelMarkers(model, "javascript", []);
         monacoRef.current?.editor.setModelMarkers(model, "typescript", []);
         monacoRef.current?.editor.setModelMarkers(model, "owner", []);
@@ -242,7 +243,11 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
     // Override marker setting to suppress during streaming
     const originalSetModelMarkers = monaco.editor.setModelMarkers;
-    monaco.editor.setModelMarkers = (mdl, owner, markers) => {
+    monaco.editor.setModelMarkers = (
+      mdl: editor.ITextModel,
+      owner: string,
+      markers: editor.IMarkerData[],
+    ) => {
       if (isStreamingRef.current) {
         return;
       }

--- a/packages/template-prompt-to-motion-graphics/tsconfig.json
+++ b/packages/template-prompt-to-motion-graphics/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/packages/template-prompt-to-video/tsconfig.json
+++ b/packages/template-prompt-to-video/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-recorder/tsconfig.json
+++ b/packages/template-recorder/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/packages/template-render-server/tsconfig.json
+++ b/packages/template-render-server/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-stargazer/tsconfig.json
+++ b/packages/template-stargazer/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-three/tsconfig.json
+++ b/packages/template-three/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-tiktok/tsconfig.json
+++ b/packages/template-tiktok/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "commonjs",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/template-vercel/tsconfig.json
+++ b/packages/template-vercel/tsconfig.json
@@ -9,7 +9,7 @@
 		"noEmit": true,
 		"esModuleInterop": true,
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "Bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- use TypeScript's bundler module resolution in newly created TypeScript templates
- use `module: "Preserve"` for bundled templates that previously declared CommonJS
- keep the emitted Still server and Skia's upstream source import on their existing Node resolution
- enforce the template default in integration tests and keep Browser Studio's Blank template in sync

## Verification

- `bun run build`
- `bun run stylecheck`
- all applicable template configs pass `tsc --noEmit`
- template validation: 263 tests pass
- Browser Studio Blank template tests: 2 tests pass
- red/green verified for the new module-resolution assertion

Closes #9493
