### PR TITLE
Skills: Use Solid for light leaks

### DIFF
--- a/packages/skills/skills/remotion-markup/light-leaks.md
+++ b/packages/skills/skills/remotion-markup/light-leaks.md
@@ -1,36 +1,69 @@
 ---
 name: light-leaks
-description: Light leak overlay effects for Remotion using @remotion/light-leaks.
+description: Light leak overlay effects for Remotion using lightLeak() from @remotion/effects.
 metadata:
   tags: light-leaks, overlays, effects, transitions
 ---
 
 ## Light Leaks
 
-This only works from Remotion 4.0.415 and up. Use `npx remotion versions` to check your Remotion version and `npx remotion upgrade` to upgrade your Remotion version.
+This only works from Remotion 4.0.500 and up. Use `npx remotion versions` to check your Remotion version and `npx remotion upgrade` to upgrade your Remotion version.
 
-`<LightLeak>` from `@remotion/light-leaks` renders a WebGL-based light leak effect. It reveals during the first half of its duration and retracts during the second half.
+Apply `lightLeak()` from `@remotion/effects/light-leak` to a canvas-based component such as `<Solid>`. Animate `progress` from `0` to `1`; the light leak reveals during the first half and retracts during the second half.
 
-Typically used inside a `<TransitionSeries.Overlay>` to play over the cut point between two scenes. See the **transitions** rule for `<TransitionSeries>` and overlay usage.
+Typically use it inside a `<TransitionSeries.Overlay>` to play over the cut point between two scenes. See the **transitions** rule for `<TransitionSeries>` and overlay usage.
 
 ## Prerequisites
 
 ```bash
-npx remotion add @remotion/light-leaks
+npx remotion add @remotion/effects
+```
+
+## Light leak overlay component
+
+Keep the `progress` calculation inline so it is editable in Remotion Studio:
+
+```tsx
+import {lightLeak} from '@remotion/effects/light-leak';
+import {interpolate, Solid, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const LightLeakOverlay: React.FC<{
+  seed?: number;
+  hueShift?: number;
+}> = ({seed = 0, hueShift = 0}) => {
+  const frame = useCurrentFrame();
+  const {durationInFrames, height, width} = useVideoConfig();
+
+  return (
+    <Solid
+      width={width}
+      height={height}
+      effects={[
+        lightLeak({
+          seed,
+          hueShift,
+          progress: interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          }),
+        }),
+      ]}
+    />
+  );
+};
 ```
 
 ## Basic usage with TransitionSeries
 
 ```tsx
-import { TransitionSeries } from "@remotion/transitions";
-import { LightLeak } from "@remotion/light-leaks";
+import {TransitionSeries} from '@remotion/transitions';
 
 <TransitionSeries>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneA />
   </TransitionSeries.Sequence>
   <TransitionSeries.Overlay durationInFrames={30}>
-    <LightLeak />
+    <LightLeakOverlay />
   </TransitionSeries.Overlay>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneB />
@@ -38,36 +71,36 @@ import { LightLeak } from "@remotion/light-leaks";
 </TransitionSeries>;
 ```
 
-## Props
+## Options
 
-- `durationInFrames?` — defaults to the parent sequence/composition duration. The effect reveals during the first half and retracts during the second half.
+- `progress?` — controls the evolve/retract phase from `0` to `1`. Effects do not animate on their own, so drive it with `useCurrentFrame()` and `interpolate()`. Default: `0.5`.
 - `seed?` — determines the shape of the light leak pattern. Different seeds produce different patterns. Default: `0`.
 - `hueShift?` — rotates the hue in degrees (`0`–`360`). Default: `0` (yellow-to-orange). `120` = green, `240` = blue.
+- `disabled?` — skips the effect when `true`. Default: `false`.
 
 ## Customizing the look
 
 ```tsx
-import { LightLeak } from "@remotion/light-leaks";
-
 // Blue-tinted light leak with a different pattern
-<LightLeak seed={5} hueShift={240} />;
+<LightLeakOverlay seed={5} hueShift={240} />;
 
 // Green-tinted light leak
-<LightLeak seed={2} hueShift={120} />;
+<LightLeakOverlay seed={2} hueShift={120} />;
 ```
 
 ## Standalone usage
 
-`<LightLeak>` can also be used outside of `<TransitionSeries>`, for example as a decorative overlay in any composition:
+The overlay component can also be used outside of `<TransitionSeries>` as a decorative layer in any composition:
 
 ```tsx
-import { AbsoluteFill } from "remotion";
-import { LightLeak } from "@remotion/light-leaks";
+import {AbsoluteFill} from 'remotion';
 
 const MyComp: React.FC = () => (
   <AbsoluteFill>
     <MyContent />
-    <LightLeak durationInFrames={60} seed={3} />
+    <LightLeakOverlay seed={3} />
   </AbsoluteFill>
 );
 ```
+
+`lightLeak()` uses WebGL2. Enable WebGL during rendering with `Config.setChromiumOpenGlRenderer("angle")`.

--- a/packages/skills/skills/remotion-markup/transitions.md
+++ b/packages/skills/skills/remotion-markup/transitions.md
@@ -45,15 +45,36 @@ import { fade } from "@remotion/transitions/fade";
 Any React component can be used as an overlay. For a ready-made effect, see the **light-leaks** rule.
 
 ```tsx
-import { TransitionSeries } from "@remotion/transitions";
-import { LightLeak } from "@remotion/light-leaks";
+import {lightLeak} from '@remotion/effects/light-leak';
+import {TransitionSeries} from '@remotion/transitions';
+import {interpolate, Solid, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const LightLeakOverlay: React.FC = () => {
+  const frame = useCurrentFrame();
+  const {durationInFrames, height, width} = useVideoConfig();
+
+  return (
+    <Solid
+      width={width}
+      height={height}
+      effects={[
+        lightLeak({
+          progress: interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          }),
+        }),
+      ]}
+    />
+  );
+};
 
 <TransitionSeries>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneA />
   </TransitionSeries.Sequence>
   <TransitionSeries.Overlay durationInFrames={20}>
-    <LightLeak />
+    <LightLeakOverlay />
   </TransitionSeries.Overlay>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneB />
@@ -66,16 +87,37 @@ import { LightLeak } from "@remotion/light-leaks";
 Transitions and overlays can coexist in the same `<TransitionSeries>`, but an overlay cannot be adjacent to a transition or another overlay.
 
 ```tsx
-import { TransitionSeries, linearTiming } from "@remotion/transitions";
-import { fade } from "@remotion/transitions/fade";
-import { LightLeak } from "@remotion/light-leaks";
+import {lightLeak} from '@remotion/effects/light-leak';
+import {TransitionSeries, linearTiming} from '@remotion/transitions';
+import {fade} from '@remotion/transitions/fade';
+import {interpolate, Solid, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const LightLeakOverlay: React.FC = () => {
+  const frame = useCurrentFrame();
+  const {durationInFrames, height, width} = useVideoConfig();
+
+  return (
+    <Solid
+      width={width}
+      height={height}
+      effects={[
+        lightLeak({
+          progress: interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          }),
+        }),
+      ]}
+    />
+  );
+};
 
 <TransitionSeries>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneA />
   </TransitionSeries.Sequence>
   <TransitionSeries.Overlay durationInFrames={30}>
-    <LightLeak />
+    <LightLeakOverlay />
   </TransitionSeries.Overlay>
   <TransitionSeries.Sequence durationInFrames={60}>
     <SceneB />


### PR DESCRIPTION
## Summary

- replace deprecated `@remotion/light-leaks` skill examples with `lightLeak()` from `@remotion/effects`
- apply the effect to `<Solid>` and animate its progress inline
- update light leak transition examples and installation guidance

## Checks

- `bun run build`
- `bun run stylecheck`

Closes #9839
