### PR TITLE
Docs: Remove self-link from Video page

### DIFF
--- a/packages/docs/docs/media/video.mdx
+++ b/packages/docs/docs/media/video.mdx
@@ -4,7 +4,7 @@ title: '<Video>'
 crumb: 'API - @remotion/media'
 ---
 
-[`<Video>` from `@remotion/media`](/docs/media/video) is the recommended component for embedding videos in Remotion.
+`<Video>` from `@remotion/media` is the recommended component for embedding videos in Remotion.
 
 During rendering, it extracts the exact frame from the video using [Mediabunny](/docs/mediabunny) and displays it in a `<canvas>` tag. This keeps the video in sync with Remotion's timeline.
 


### PR DESCRIPTION
## Summary

Remove the self-referential link at the beginning of the `<Video>` documentation page.

## Testing

- `bunx oxfmt packages/docs/docs/media/video.mdx --write`
- `bun run build`
- `bun run stylecheck`

## Preview

- [`/docs/media/video`](https://remotion-git-codex-docs-remove-video-self-link-remotion.vercel.app/docs/media/video)
