### PR TITLE
`@remotion/studio-protocol`: Fix malformed response classification

### DIFF
--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -179,39 +179,48 @@ const discoverStudios = async (
 	const studios = await Promise.all(
 		dependencies.ports.map(async (port): Promise<DiscoveredStudio | null> => {
 			const origin = `http://localhost:${port}`;
+			let response: Response;
 			try {
-				const response = await fetchWithTimeout({
+				response = await fetchWithTimeout({
 					fetchFn: dependencies.fetchFn,
 					options: {cache: 'no-store'},
 					url: `${origin}/api/studio-protocol`,
 				});
-				if (!response.ok) {
-					return null;
-				}
-
-				const value: unknown = await response.json();
-				if (
-					isRecord(value) &&
-					value.protocol === 'remotion-studio-protocol' &&
-					value.protocolVersion !== 1
-				) {
-					foundUnsupportedProtocol = true;
-					return null;
-				}
-
-				if (!isDescriptor(value)) {
-					foundInvalidResponse = true;
-					return null;
-				}
-
-				return {
-					descriptor: value,
-					discoveredAt: dependencies.now(),
-					origin,
-				};
 			} catch {
 				return null;
 			}
+
+			if (!response.ok) {
+				return null;
+			}
+
+			let value: unknown;
+			try {
+				value = await response.json();
+			} catch {
+				foundInvalidResponse = true;
+				return null;
+			}
+
+			if (
+				isRecord(value) &&
+				value.protocol === 'remotion-studio-protocol' &&
+				value.protocolVersion !== 1
+			) {
+				foundUnsupportedProtocol = true;
+				return null;
+			}
+
+			if (!isDescriptor(value)) {
+				foundInvalidResponse = true;
+				return null;
+			}
+
+			return {
+				descriptor: value,
+				discoveredAt: dependencies.now(),
+				origin,
+			};
 		}),
 	);
 
@@ -328,8 +337,9 @@ export const installInStudioWithDependencies = async (
 		);
 	}
 
+	let response: Response;
 	try {
-		const response = await fetchWithTimeout({
+		response = await fetchWithTimeout({
 			fetchFn: dependencies.fetchFn,
 			url: `${selected.origin}/api/studio-protocol/install`,
 			options: {
@@ -343,44 +353,6 @@ export const installInStudioWithDependencies = async (
 				}),
 			},
 		});
-		const result: unknown = await response.json();
-		if (
-			response.ok &&
-			isRecord(result) &&
-			result.protocol === 'remotion-studio-protocol' &&
-			result.protocolVersion === 1 &&
-			result.status === 'awaiting-confirmation'
-		) {
-			return {
-				success: true,
-				status: 'awaiting-confirmation',
-				target: {
-					projectName: selected.descriptor.projectName,
-					compositionId: selected.descriptor.installTarget.compositionId,
-					studioOrigin: selected.origin,
-					studioVersion: selected.descriptor.studioVersion,
-				},
-			};
-		}
-
-		if (
-			isRecord(result) &&
-			result.status === 'error' &&
-			isRecord(result.error) &&
-			typeof result.error.code === 'string' &&
-			typeof result.error.message === 'string'
-		) {
-			const {code} = result.error;
-			return failure(
-				code === 'target-expired' ? 'target-expired' : 'request-rejected',
-				result.error.message,
-			);
-		}
-
-		return failure(
-			'invalid-response',
-			'Remotion Studio returned an invalid installation response.',
-		);
 	} catch (error) {
 		return failure(
 			isAbortError(error) ? 'request-timed-out' : 'network-error',
@@ -389,6 +361,54 @@ export const installInStudioWithDependencies = async (
 				: 'Could not connect to Remotion Studio.',
 		);
 	}
+
+	let result: unknown;
+	try {
+		result = await response.json();
+	} catch {
+		return failure(
+			'invalid-response',
+			'Remotion Studio returned an invalid installation response.',
+		);
+	}
+
+	if (
+		response.ok &&
+		isRecord(result) &&
+		result.protocol === 'remotion-studio-protocol' &&
+		result.protocolVersion === 1 &&
+		result.status === 'awaiting-confirmation'
+	) {
+		return {
+			success: true,
+			status: 'awaiting-confirmation',
+			target: {
+				projectName: selected.descriptor.projectName,
+				compositionId: selected.descriptor.installTarget.compositionId,
+				studioOrigin: selected.origin,
+				studioVersion: selected.descriptor.studioVersion,
+			},
+		};
+	}
+
+	if (
+		isRecord(result) &&
+		result.status === 'error' &&
+		isRecord(result.error) &&
+		typeof result.error.code === 'string' &&
+		typeof result.error.message === 'string'
+	) {
+		const {code} = result.error;
+		return failure(
+			code === 'target-expired' ? 'target-expired' : 'request-rejected',
+			result.error.message,
+		);
+	}
+
+	return failure(
+		'invalid-response',
+		'Remotion Studio returned an invalid installation response.',
+	);
 };
 
 export const installInStudio = ({

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -165,6 +165,32 @@ test('returns an actionable result when no Studio is running', async () => {
 	});
 });
 
+test('reports malformed discovery JSON as an invalid response', async () => {
+	const fetchFn = (input: string | URL | Request) => {
+		if (String(input) === 'http://localhost:3000/api/studio-protocol') {
+			return Promise.resolve(
+				new Response('not JSON', {
+					headers: {'Content-Type': 'application/json'},
+				}),
+			);
+		}
+
+		return Promise.resolve(new Response(null, {status: 404}));
+	};
+
+	expect(
+		await installInStudioWithDependencies(elementPayload, {
+			...dependencies,
+			ports: [3000],
+			fetchFn,
+		}),
+	).toEqual({
+		success: false,
+		code: 'invalid-response',
+		message: 'Remotion Studio returned an invalid Studio Protocol response.',
+	});
+});
+
 test('reports a legacy Studio as requiring an upgrade without sending a payload', async () => {
 	const requests: string[] = [];
 	const fetchFn = (input: string | URL | Request) => {
@@ -234,6 +260,46 @@ test('returns a structured error when the selected target expired', async () => 
 		success: false,
 		code: 'target-expired',
 		message: 'Target expired',
+	});
+});
+
+test('reports a truncated install response as invalid', async () => {
+	const fetchFn = (input: string | URL | Request) => {
+		const url = String(input);
+		if (url === 'http://localhost:3000/api/studio-protocol') {
+			return Promise.resolve(
+				jsonResponse(
+					descriptor({
+						compositionId: 'Main',
+						lastFocusedAt: 950_000,
+						projectName: 'Project',
+						targetId: 'target',
+					}),
+				),
+			);
+		}
+
+		if (url === 'http://localhost:3000/api/studio-protocol/install') {
+			return Promise.resolve(
+				new Response('{"protocol":"remotion-studio-protocol"', {
+					headers: {'Content-Type': 'application/json'},
+				}),
+			);
+		}
+
+		return Promise.resolve(new Response(null, {status: 404}));
+	};
+
+	expect(
+		await installInStudioWithDependencies(elementPayload, {
+			...dependencies,
+			ports: [3000],
+			fetchFn,
+		}),
+	).toEqual({
+		success: false,
+		code: 'invalid-response',
+		message: 'Remotion Studio returned an invalid installation response.',
 	});
 });
 


### PR DESCRIPTION
## Summary

- classify malformed JSON from successful Studio discovery responses as `invalid-response`
- classify malformed or truncated install response JSON as `invalid-response` while keeping transport failures on their existing result codes
- preserve legacy Studio detection behavior and add focused regression tests

Addresses client error-classification review findings from #9832.

## Validation

- `bun test packages/studio-protocol/src/test/install-in-studio.test.ts`
- `bunx turbo run lint formatting make --filter='@remotion/studio-protocol' --no-update-notifier`
- `bun run build`
- `bun run stylecheck`
