### PR TITLE
`@remotion/studio-server`: Limit Studio Protocol request bodies

### DIFF
--- a/packages/studio-server/src/preview-server/handler.ts
+++ b/packages/studio-server/src/preview-server/handler.ts
@@ -39,7 +39,7 @@ export const handleRequest = async <Req, Res>({
 	response.writeHead(200);
 
 	try {
-		const body = (await parseRequestBody(request)) as Req;
+		const body = (await parseRequestBody(request, {maxBytes: null})) as Req;
 
 		const outputData = await handler({
 			entryPoint,

--- a/packages/studio-server/src/preview-server/parse-body.ts
+++ b/packages/studio-server/src/preview-server/parse-body.ts
@@ -1,16 +1,81 @@
 import type {IncomingMessage} from 'node:http';
 
+export class RequestBodyTooLargeError extends Error {
+	constructor(maxBytes: number) {
+		super(`Request body exceeds the limit of ${maxBytes} bytes`);
+		this.name = 'RequestBodyTooLargeError';
+	}
+}
+
 export const parseRequestBody = async (
 	req: IncomingMessage,
+	{
+		maxBytes,
+	}: {
+		readonly maxBytes: number | null;
+	},
 ): Promise<unknown> => {
-	const body = await new Promise<string>((_resolve) => {
+	const body = await new Promise<string>((resolve, reject) => {
+		const decoder = new TextDecoder();
+		const encoder = new TextEncoder();
 		let data = '';
-		req.on('data', (chunk) => {
-			data += chunk;
-		});
-		req.on('end', () => {
-			_resolve(data.toString());
-		});
+		let receivedBytes = 0;
+		let settled = false;
+
+		const cleanup = () => {
+			req.off('aborted', onAborted);
+			req.off('data', onData);
+			req.off('end', onEnd);
+			req.off('error', onError);
+		};
+
+		const rejectOnce = (error: Error) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			cleanup();
+			reject(error);
+		};
+
+		const onAborted = () => rejectOnce(new Error('Request body was aborted'));
+		const onData = (chunk: Uint8Array | string) => {
+			receivedBytes +=
+				typeof chunk === 'string'
+					? encoder.encode(chunk).byteLength
+					: chunk.byteLength;
+			if (maxBytes !== null && receivedBytes > maxBytes) {
+				rejectOnce(new RequestBodyTooLargeError(maxBytes));
+				// Discard the rest without buffering it. Keep request stream errors from
+				// becoming unhandled after the parser listeners have been removed.
+				req.on('error', () => undefined);
+				req.resume();
+				return;
+			}
+
+			data +=
+				typeof chunk === 'string'
+					? decoder.decode() + chunk
+					: decoder.decode(chunk, {stream: true});
+		};
+
+		const onEnd = () => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			cleanup();
+			resolve(data + decoder.decode());
+		};
+
+		const onError = (error: Error) => rejectOnce(error);
+
+		req.on('aborted', onAborted);
+		req.on('data', onData);
+		req.on('end', onEnd);
+		req.on('error', onError);
 	});
 
 	return JSON.parse(body);

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -5,7 +5,7 @@ import {z} from 'zod';
 import {consumeStudioProtocolTarget} from '../element-install-state';
 import type {getElementInstallTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
-import {parseRequestBody} from '../parse-body';
+import {parseRequestBody, RequestBodyTooLargeError} from '../parse-body';
 import {
 	isAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
@@ -20,6 +20,10 @@ const studioProtocolInstallRequestSchema = z.object({
 	targetId: z.string(),
 	payload: z.unknown(),
 });
+
+// A valid payload may contain 250,000 JSON characters. Allow room for its
+// UTF-8 representation and the protocol envelope while keeping memory bounded.
+const MAX_STUDIO_PROTOCOL_INSTALL_BODY_SIZE = 1_000_000;
 
 const deliverElementInstall = ({
 	element,
@@ -91,8 +95,20 @@ export const handleStudioProtocolInstall = async ({
 
 	let body: unknown;
 	try {
-		body = await parseRequestBody(request);
-	} catch {
+		body = await parseRequestBody(request, {
+			maxBytes: MAX_STUDIO_PROTOCOL_INSTALL_BODY_SIZE,
+		});
+	} catch (error) {
+		if (error instanceof RequestBodyTooLargeError) {
+			writeStudioProtocolError({
+				code: 'request-too-large',
+				message: 'The request body is too large.',
+				response,
+				status: 413,
+			});
+			return;
+		}
+
 		writeStudioProtocolError({
 			code: 'invalid-request',
 			message: 'The request body is not valid JSON.',

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test';
 import {createServer} from 'node:http';
+import {connect} from 'node:net';
 import {createElementPayload} from '@remotion/studio-protocol';
 import type {EventSourceEvent} from '@remotion/studio-shared';
 import {
@@ -19,6 +20,83 @@ const payload = createElementPayload({
 	slug: 'lower-third',
 	sourceCode: 'export const LowerThird = () => null;',
 });
+
+const sendUnfinishedOversizedInstallRequest = (
+	url: string,
+): Promise<{
+	readonly body: unknown;
+	readonly corsHeader: string | undefined;
+	readonly statusCode: number;
+}> => {
+	return new Promise((resolve, reject) => {
+		const parsedUrl = new URL(url);
+		let responseText = '';
+		let settled = false;
+		const socket = connect(Number(parsedUrl.port), parsedUrl.hostname, () => {
+			socket.write(
+				`POST ${parsedUrl.pathname} HTTP/1.1\r\nHost: ${parsedUrl.host}\r\nOrigin: http://localhost:4000\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n`,
+			);
+
+			const writeChunk = (chunk: string) => {
+				socket.write(`${chunk.length.toString(16)}\r\n${chunk}\r\n`);
+			};
+
+			writeChunk('{"padding":"');
+			for (let index = 0; index < 65; index++) {
+				writeChunk('x'.repeat(16_384));
+			}
+			// Deliberately omit the terminating zero-length chunk. The server must
+			// respond once the streaming limit is exceeded, before the body ends.
+		});
+		const rejectOnce = (error: Error) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			clearTimeout(timeout);
+			socket.destroy();
+			reject(error);
+		};
+
+		const timeout = setTimeout(
+			() => rejectOnce(new Error('Studio did not reject the unfinished body')),
+			5_000,
+		);
+		socket.on('data', (chunk: Buffer) => {
+			responseText += chunk.toString('utf8');
+		});
+		socket.on('error', rejectOnce);
+		socket.on('end', () => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			clearTimeout(timeout);
+			try {
+				const [headerText] = responseText.split('\r\n\r\n');
+				const headerLines = headerText!.split('\r\n');
+				const statusCode = Number(headerLines[0]!.split(' ')[1]);
+				const corsHeader = headerLines
+					.find((line) =>
+						line.toLowerCase().startsWith('access-control-allow-origin:'),
+					)
+					?.slice('access-control-allow-origin:'.length)
+					.trim();
+				const jsonStart = responseText.indexOf('{');
+				const jsonEnd = responseText.lastIndexOf('}');
+				resolve({
+					body: JSON.parse(responseText.slice(jsonStart, jsonEnd + 1)),
+					corsHeader,
+					statusCode,
+				});
+			} catch (error) {
+				reject(error);
+			}
+		});
+	});
+};
 
 test('discovers an exact Studio target and delivers one install request over HTTP', async () => {
 	clearElementInstallStateForTests();
@@ -157,6 +235,19 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		expect(await invalidPayloadResponse.json()).toMatchObject({
 			status: 'error',
 			error: {code: 'invalid-payload'},
+		});
+		expect(deliveredEvents).toHaveLength(0);
+
+		const oversizedResponse = await sendUnfinishedOversizedInstallRequest(
+			`${origin}/api/studio-protocol/install`,
+		);
+		expect(oversizedResponse.statusCode).toBe(413);
+		expect(oversizedResponse.corsHeader).toBe('http://localhost:4000');
+		expect(oversizedResponse.body).toMatchObject({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'error',
+			error: {code: 'request-too-large'},
 		});
 		expect(deliveredEvents).toHaveLength(0);
 


### PR DESCRIPTION
## Summary

- add a reusable streaming byte limit to Studio server request body parsing
- reject oversized Studio Protocol install requests with a structured `413` response while preserving CORS headers
- cover an unfinished chunked request at the HTTP route boundary and verify a normal install still succeeds afterward

Addresses the request-body buffering review finding from #9832.

## Validation

- `bun test packages/studio-server/src/test/studio-protocol-routes.test.ts packages/studio-server/src/test/handler.test.ts`
- `bunx turbo run test --filter='@remotion/studio-server'`
- `bun run build`
- `bun run stylecheck`
- red/green regression verification performed
