### PR TITLE
`@remotion/media`: Stabilize effect-heavy video playback

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -437,6 +437,7 @@ export class MediaPlayer {
 					'[MediaPlayer] Failed to start audio and video iterators',
 					error,
 				);
+				throw error;
 			}
 
 			return {type: 'success', durationInSeconds};
@@ -502,6 +503,7 @@ export class MediaPlayer {
 					nonce,
 					fps: this.fps,
 					playbackRate: this.playbackRate,
+					globalPlaybackRate: this.globalPlaybackRate,
 					isPlaying: this.playing,
 				}),
 				this.audioIteratorManager?.seek({

--- a/packages/media/src/test/video-iterator-manager.test.ts
+++ b/packages/media/src/test/video-iterator-manager.test.ts
@@ -13,7 +13,9 @@ test('detects one timeline frame as a sequential media time advance', () => {
 			newTime: 1 / 30,
 			fps: 30,
 			playbackRate: 1,
+			globalPlaybackRate: 1,
 			isPlaying: true,
+			elapsedTimeInSeconds: 0,
 		}),
 	).toBe(true);
 
@@ -23,7 +25,9 @@ test('detects one timeline frame as a sequential media time advance', () => {
 			newTime: 2 / 30,
 			fps: 30,
 			playbackRate: 1,
+			globalPlaybackRate: 1,
 			isPlaying: true,
+			elapsedTimeInSeconds: 0,
 		}),
 	).toBe(false);
 });
@@ -35,7 +39,9 @@ test('accounts for playback rate when detecting sequential advances', () => {
 			newTime: 1 + 2 / 30,
 			fps: 30,
 			playbackRate: 2,
+			globalPlaybackRate: 1,
 			isPlaying: true,
+			elapsedTimeInSeconds: 0,
 		}),
 	).toBe(true);
 
@@ -45,7 +51,9 @@ test('accounts for playback rate when detecting sequential advances', () => {
 			newTime: 0.9,
 			fps: 30,
 			playbackRate: 2,
+			globalPlaybackRate: 1,
 			isPlaying: true,
+			elapsedTimeInSeconds: 0,
 		}),
 	).toBe(false);
 });
@@ -57,7 +65,49 @@ test('does not treat a paused forward scrub as sequential playback', () => {
 			newTime: 1.1,
 			fps: 30,
 			playbackRate: 4,
+			globalPlaybackRate: 1,
 			isPlaying: false,
+			elapsedTimeInSeconds: 0.1,
+		}),
+	).toBe(false);
+});
+
+test('allows playback to skip frames after expensive frame processing', () => {
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 0,
+			newTime: 4 / 30,
+			fps: 30,
+			playbackRate: 1,
+			globalPlaybackRate: 1,
+			isPlaying: true,
+			elapsedTimeInSeconds: 0.1,
+		}),
+	).toBe(true);
+});
+
+test('still detects user seeks while playback is active', () => {
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 0,
+			newTime: 4 / 30,
+			fps: 30,
+			playbackRate: 1,
+			globalPlaybackRate: 1,
+			isPlaying: true,
+			elapsedTimeInSeconds: 0,
+		}),
+	).toBe(false);
+
+	expect(
+		isSequentialMediaTimeAdvance({
+			previousTime: 0,
+			newTime: 2,
+			fps: 30,
+			playbackRate: 1,
+			globalPlaybackRate: 1,
+			isPlaying: true,
+			elapsedTimeInSeconds: 2,
 		}),
 	).toBe(false);
 });
@@ -114,6 +164,7 @@ test('plays at a high playback rate without restarting the iterator', async () =
 				nonce: nonceManager.createAsyncOperation(),
 				fps: 30,
 				playbackRate: 3.75,
+				globalPlaybackRate: 1,
 				isPlaying: true,
 			});
 		}
@@ -151,6 +202,7 @@ test('paused forward scrubs do not wait for pending frames', async () => {
 			nonce: nonceManager.createAsyncOperation(),
 			fps: 30,
 			playbackRate: 4,
+			globalPlaybackRate: 1,
 			isPlaying: false,
 		});
 
@@ -208,6 +260,7 @@ test('seek should not cause overlapping block/unblock cycles', async () => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 	await manager.seek({
@@ -215,6 +268,7 @@ test('seek should not cause overlapping block/unblock cycles', async () => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 	await manager.seek({
@@ -222,6 +276,7 @@ test('seek should not cause overlapping block/unblock cycles', async () => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 
@@ -281,6 +336,7 @@ test('rapid sequential seeks should not cause overlapping blocks', async () => {
 			nonce: nonceManager.createAsyncOperation(),
 			fps: 30,
 			playbackRate: 1,
+			globalPlaybackRate: 1,
 			isPlaying: false,
 		});
 	}

--- a/packages/media/src/test/video-onerror-stable.test.tsx
+++ b/packages/media/src/test/video-onerror-stable.test.tsx
@@ -1,6 +1,7 @@
 import {Player} from '@remotion/player';
 import React, {useEffect, useState} from 'react';
 import {createRoot} from 'react-dom/client';
+import {createEffect} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {MediaPlayer} from '../media-player';
 import {Video} from '../video/video';
@@ -79,5 +80,65 @@ test('does not reinitialize MediaPlayer when onError identity changes', async ()
 		root.unmount();
 		container.remove();
 		initSpy.mockRestore();
+	}
+});
+
+test('effect setup errors are passed to onError and trigger the fallback', async () => {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+
+	const setupError = new Error('Effect setup failed');
+	const effect = createEffect<Record<string, never>, null>({
+		type: 'dev.remotion.test.setup-error',
+		label: 'Setup error',
+		documentationLink: null,
+		backend: '2d',
+		calculateKey: () => 'setup-error',
+		setup: () => {
+			throw setupError;
+		},
+		apply: () => undefined,
+		cleanup: () => undefined,
+		schema: {},
+		validateParams: () => undefined,
+	});
+	let receivedError: Error | null = null;
+	const root = createRoot(container);
+	const VideoComposition: React.FC = () => {
+		return (
+			<Video
+				src="/bigbuckbunny.mp4"
+				effects={[effect({})]}
+				onError={(error) => {
+					receivedError = error;
+					return 'fallback';
+				}}
+			/>
+		);
+	};
+
+	root.render(
+		<Player
+			acknowledgeRemotionLicense
+			component={VideoComposition}
+			compositionHeight={720}
+			compositionWidth={1280}
+			durationInFrames={100}
+			fps={30}
+			initiallyMuted
+			inputProps={{}}
+		/>,
+	);
+
+	try {
+		await waitFor(
+			() =>
+				receivedError === setupError &&
+				container.querySelector('video') !== null,
+		);
+		expect(receivedError).toBe(setupError);
+	} finally {
+		root.unmount();
+		container.remove();
 	}
 });

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -52,6 +52,7 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 	await manager.seek({
@@ -59,6 +60,7 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 	await manager.seek({
@@ -66,6 +68,7 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 
@@ -77,6 +80,7 @@ test('in preview, should properly buffer and draw frames', async (t) => {
 		nonce: nonceManager.createAsyncOperation(),
 		fps: 30,
 		playbackRate: 1,
+		globalPlaybackRate: 1,
 		isPlaying: false,
 	});
 

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -17,24 +17,34 @@ import {
 
 const {runEffectChain} = Internals;
 
+const MAXIMUM_DROPPED_FRAME_RECOVERY_IN_SECONDS = 1;
+
 export const isSequentialMediaTimeAdvance = ({
 	previousTime,
 	newTime,
 	fps,
 	playbackRate,
+	globalPlaybackRate,
 	isPlaying,
+	elapsedTimeInSeconds,
 }: {
 	previousTime: number;
 	newTime: number;
 	fps: number;
 	playbackRate: number;
+	globalPlaybackRate: number;
 	isPlaying: boolean;
+	elapsedTimeInSeconds: number;
 }) => {
 	if (!isPlaying || newTime < previousTime) {
 		return false;
 	}
 
-	const maximumSequentialAdvance = Math.abs(playbackRate) / fps;
+	const oneFrameInMediaTime = Math.abs(playbackRate) / fps;
+	const elapsedPlaybackTime =
+		Math.min(elapsedTimeInSeconds, MAXIMUM_DROPPED_FRAME_RECOVERY_IN_SECONDS) *
+		Math.abs(playbackRate * globalPlaybackRate);
+	const maximumSequentialAdvance = oneFrameInMediaTime + elapsedPlaybackTime;
 	return (
 		roundTo4Digits(newTime - previousTime) <=
 		roundTo4Digits(maximumSequentialAdvance)
@@ -77,6 +87,7 @@ export const videoIteratorManager = async ({
 	let currentDelayHandle: {unblock: () => void} | null = null;
 	let lastDrawnFrame: WrappedCanvas | null = null;
 	let currentSeek: number | null = null;
+	let currentSeekStartedAt: number | null = null;
 
 	const clearLastDrawnFrame = () => {
 		lastDrawnFrame = null;
@@ -167,12 +178,14 @@ export const videoIteratorManager = async ({
 	const startVideoIterator = async (
 		timeToSeek: number,
 		nonce: Nonce,
+		seekStartedAt = performance.now(),
 	): Promise<void> => {
 		clearLastDrawnFrame();
 		videoFrameIterator?.destroy();
 		using delayHandle = delayPlaybackHandleIfNotPremounting();
 		currentDelayHandle = delayHandle;
 		currentSeek = timeToSeek;
+		currentSeekStartedAt = seekStartedAt;
 
 		const iterator = await createVideoIterator(
 			timeToSeek,
@@ -206,12 +219,14 @@ export const videoIteratorManager = async ({
 		nonce,
 		fps,
 		playbackRate,
+		globalPlaybackRate,
 		isPlaying,
 	}: {
 		newTime: number;
 		nonce: Nonce;
 		fps: number;
 		playbackRate: number;
+		globalPlaybackRate: number;
 		isPlaying: boolean;
 	}) => {
 		if (!videoFrameIterator) {
@@ -225,8 +240,11 @@ export const videoIteratorManager = async ({
 			return;
 		}
 
+		const seekStartedAt = performance.now();
 		const previousTime = currentSeek;
+		const previousSeekStartedAt = currentSeekStartedAt;
 		currentSeek = newTime;
+		currentSeekStartedAt = seekStartedAt;
 
 		if (getIsLooping()) {
 			// If less than 1 second from the end away, we pre-warm a new iterator
@@ -244,7 +262,12 @@ export const videoIteratorManager = async ({
 				newTime,
 				fps,
 				playbackRate,
+				globalPlaybackRate,
 				isPlaying,
+				elapsedTimeInSeconds:
+					previousSeekStartedAt === null
+						? 0
+						: (seekStartedAt - previousSeekStartedAt) / 1000,
 			})
 				? 'wait'
 				: 'restart-iterator';
@@ -268,7 +291,7 @@ export const videoIteratorManager = async ({
 			return;
 		}
 
-		await startVideoIterator(newTime, nonce);
+		await startVideoIterator(newTime, nonce, seekStartedAt);
 	};
 
 	return {

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -375,6 +375,11 @@ const VideoForPreviewAssertedShowing: React.FC<
 					}
 				})
 				.catch((error) => {
+					if (mediaPlayerRef.current === player) {
+						player.dispose();
+						mediaPlayerRef.current = null;
+					}
+
 					// ProRes without a registered decoder is unrecoverable and must not
 					// fall back to a native <video> (which cannot decode it either).
 					// Notify onError once for observability, then rethrow.


### PR DESCRIPTION
## Summary

- Treat multi-frame timeline advances as dropped playback frames when they match elapsed wall-clock time, avoiding unnecessary video iterator restarts during expensive effect processing.
- Preserve iterator restarts for paused scrubbing, backwards seeks, rapid user seeks, and jumps larger than the one-second recovery window.
- Propagate effect and iterator startup errors through the existing `onError` and fallback path, and dispose partially initialized media players before falling back.

## Testing

- `bun run test` in `packages/media` (98 tests)
- `bun run build`
- `bun run stylecheck`

Closes #9747
