### PR TITLE
`@remotion/browser-studio`: Support default props subscriptions

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -1,4 +1,5 @@
 import {
+	getCanUpdateDefaultPropsForProject,
 	getCompositionComponentInfo,
 	getCompositionFile,
 	insertSolidIntoProject,
@@ -32,11 +33,40 @@ export const createBrowserStudioOperations = ({
 	getProject: () => VirtualProject;
 	onProjectChange: (project: VirtualProject) => void;
 }): BrowserStudioOperationsController => {
+	const defaultPropsSubscriptions = new Map<string, Set<string>>();
+	const lastDefaultPropsResults = new Map<string, string>();
+	let refreshDefaultPropsSubscriptions = () => undefined;
 	const controller = createBrowserStudioProjectController({
 		getStaticFiles,
 		getProject,
-		onProjectChange,
+		onProjectChange: (project) => {
+			onProjectChange(project);
+			refreshDefaultPropsSubscriptions();
+		},
 	});
+
+	const getDefaultPropsStatus = (compositionId: string) =>
+		getCanUpdateDefaultPropsForProject({
+			compositionId,
+			project: getProject(),
+		});
+
+	refreshDefaultPropsSubscriptions = () => {
+		for (const compositionId of defaultPropsSubscriptions.keys()) {
+			const result = getDefaultPropsStatus(compositionId);
+			const serialized = JSON.stringify(result);
+			if (lastDefaultPropsResults.get(compositionId) === serialized) {
+				continue;
+			}
+
+			lastDefaultPropsResults.set(compositionId, serialized);
+			controller.emitEvent({
+				type: 'default-props-updatable-changed',
+				compositionId,
+				result,
+			});
+		}
+	};
 
 	return {
 		deleteStaticFile: controller.deleteStaticFile,
@@ -77,9 +107,31 @@ export const createBrowserStudioOperations = ({
 		},
 		redo: controller.redo,
 		renameStaticFile: controller.renameStaticFile,
-		resetHistory: controller.resetHistory,
+		resetHistory: () => {
+			controller.resetHistory();
+			refreshDefaultPropsSubscriptions();
+		},
+		subscribeToDefaultProps: ({clientId, compositionId}) => {
+			const clients =
+				defaultPropsSubscriptions.get(compositionId) ?? new Set<string>();
+			clients.add(clientId);
+			defaultPropsSubscriptions.set(compositionId, clients);
+			const result = getDefaultPropsStatus(compositionId);
+			lastDefaultPropsResults.set(compositionId, JSON.stringify(result));
+			return Promise.resolve(result);
+		},
 		subscribeToEvent: controller.subscribeToEvent,
 		undo: controller.undo,
+		unsubscribeFromDefaultProps: ({clientId, compositionId}) => {
+			const clients = defaultPropsSubscriptions.get(compositionId);
+			clients?.delete(clientId);
+			if (clients?.size === 0) {
+				defaultPropsSubscriptions.delete(compositionId);
+				lastDefaultPropsResults.delete(compositionId);
+			}
+
+			return Promise.resolve(undefined);
+		},
 		writeStaticFile: controller.writeStaticFile,
 	};
 };

--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from 'bun:test';
+import type {EventSourceEvent} from '@remotion/studio-shared';
 import {
 	createBrowserStudioOperations,
 	insertSolidIntoProject,
@@ -197,4 +198,78 @@ test('reports invalid timeline Solid input without changing the project', async 
 	}
 
 	expect(currentProject).toBe(project);
+});
+
+test('subscribes to default prop updates in the virtual project', async () => {
+	let currentProject: VirtualProject = {
+		rootDir: '/project',
+		entryPoint: '/project/src/index.tsx',
+		files: {
+			'/project/src/index.tsx': `import {Composition, registerRoot} from 'remotion';
+const Component = () => null;
+const Root = () => <Composition id="MyComp" component={Component} durationInFrames={60} fps={30} width={1280} height={720} defaultProps={{title: 'Before'}} />;
+registerRoot(Root);`,
+		},
+	};
+	const operations = createBrowserStudioOperations({
+		dependencyVersions: {},
+		getStaticFiles: null,
+		getProject: () => currentProject,
+		onProjectChange: (nextProject) => {
+			currentProject = nextProject;
+		},
+	});
+	const events: EventSourceEvent[] = [];
+	operations.subscribeToEvent((event) => events.push(event));
+
+	expect(
+		await operations.subscribeToDefaultProps({
+			clientId: 'browser-studio',
+			compositionId: 'MyComp',
+		}),
+	).toEqual({
+		canUpdate: true,
+		currentDefaultProps: {title: 'Before'},
+	});
+
+	currentProject = {
+		...currentProject,
+		files: {
+			...currentProject.files,
+			'/project/src/index.tsx': currentProject.files[
+				'/project/src/index.tsx'
+			].replace("title: 'Before'", "title: 'After'"),
+		},
+	};
+	operations.resetHistory();
+	expect(
+		events.filter((event) => event.type === 'default-props-updatable-changed'),
+	).toEqual([
+		{
+			type: 'default-props-updatable-changed',
+			compositionId: 'MyComp',
+			result: {
+				canUpdate: true,
+				currentDefaultProps: {title: 'After'},
+			},
+		},
+	]);
+
+	await operations.unsubscribeFromDefaultProps({
+		clientId: 'browser-studio',
+		compositionId: 'MyComp',
+	});
+	currentProject = {
+		...currentProject,
+		files: {
+			...currentProject.files,
+			'/project/src/index.tsx': currentProject.files[
+				'/project/src/index.tsx'
+			].replace("title: 'After'", "title: 'Ignored'"),
+		},
+	};
+	operations.resetHistory();
+	expect(
+		events.filter((event) => event.type === 'default-props-updatable-changed'),
+	).toHaveLength(1);
 });

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -1,5 +1,6 @@
 import {parse} from '@babel/parser';
 import type {
+	CanUpdateDefaultPropsResponse,
 	CompositionComponentInfoRequest,
 	InsertJsxElementRequest,
 } from '@remotion/studio-shared';
@@ -1223,4 +1224,227 @@ export const getCompositionFile = ({
 	}
 
 	return null;
+};
+
+const staticFileToken = 'remotion-file:';
+const dateToken = 'remotion-date:';
+
+type ExtractedStaticValue = {success: true; value: unknown} | {success: false};
+
+const extractSpecialDefaultPropValue = (
+	node: AstNode,
+): ExtractedStaticValue | null => {
+	if (node.type === 'CallExpression') {
+		const callee = getNode(node, 'callee');
+		const args = getNodes(node, 'arguments');
+		if (
+			callee?.type === 'Identifier' &&
+			getString(callee, 'name') === 'staticFile' &&
+			args.length === 1 &&
+			args[0].type === 'StringLiteral'
+		) {
+			const value = getString(args[0], 'value');
+			if (value !== null) {
+				return {
+					success: true,
+					value: `${staticFileToken}${value
+						.split('/')
+						.map(encodeURIComponent)
+						.join('/')}`,
+				};
+			}
+		}
+
+		return {success: false};
+	}
+
+	if (node.type === 'NewExpression') {
+		const callee = getNode(node, 'callee');
+		const args = getNodes(node, 'arguments');
+		if (
+			callee?.type === 'Identifier' &&
+			getString(callee, 'name') === 'Date' &&
+			args.length === 1 &&
+			args[0].type === 'StringLiteral'
+		) {
+			const value = getString(args[0], 'value');
+			if (value !== null) {
+				return {success: true, value: `${dateToken}${value}`};
+			}
+		}
+
+		return {success: false};
+	}
+
+	return null;
+};
+
+const extractStaticDefaultPropValue = (node: AstNode): ExtractedStaticValue => {
+	const special = extractSpecialDefaultPropValue(node);
+	if (special !== null) {
+		return special;
+	}
+
+	switch (node.type) {
+		case 'NumericLiteral':
+		case 'StringLiteral':
+		case 'BooleanLiteral':
+			return {success: true, value: node.value};
+		case 'NullLiteral':
+			return {success: true, value: null};
+		case 'UnaryExpression': {
+			const argument = getNode(node, 'argument');
+			const operator = getString(node, 'operator');
+			if (
+				argument?.type === 'NumericLiteral' &&
+				typeof argument.value === 'number' &&
+				(operator === '-' || operator === '+')
+			) {
+				return {
+					success: true,
+					value: operator === '-' ? -argument.value : argument.value,
+				};
+			}
+
+			return {success: false};
+		}
+
+		case 'TSAsExpression': {
+			const expression = getNode(node, 'expression');
+			return expression
+				? extractStaticDefaultPropValue(expression)
+				: {success: false};
+		}
+
+		case 'ArrayExpression': {
+			const {elements} = node;
+			if (!Array.isArray(elements)) {
+				return {success: false};
+			}
+
+			const values: unknown[] = [];
+			for (const element of elements) {
+				if (!isAstNode(element) || element.type === 'SpreadElement') {
+					return {success: false};
+				}
+
+				const extracted = extractStaticDefaultPropValue(element);
+				if (!extracted.success) {
+					return extracted;
+				}
+
+				values.push(extracted.value);
+			}
+
+			return {success: true, value: values};
+		}
+
+		case 'ObjectExpression': {
+			const result: Record<string, unknown> = {};
+			for (const property of getNodes(node, 'properties')) {
+				if (property.type !== 'ObjectProperty') {
+					return {success: false};
+				}
+
+				const value = getNode(property, 'value');
+				if (!value) {
+					return {success: false};
+				}
+
+				const extracted = extractStaticDefaultPropValue(value);
+				if (!extracted.success) {
+					return extracted;
+				}
+
+				const key = getNode(property, 'key');
+				const propertyName =
+					key?.type === 'Identifier'
+						? getString(key, 'name')
+						: key?.type === 'StringLiteral' || key?.type === 'NumericLiteral'
+							? String(key.value)
+							: null;
+				if (propertyName !== null) {
+					result[propertyName] = extracted.value;
+				}
+			}
+
+			return {success: true, value: result};
+		}
+
+		default:
+			return {success: false};
+	}
+};
+
+export const computeCanUpdateDefaultPropsFromContent = (
+	content: string,
+	compositionId: string,
+): CanUpdateDefaultPropsResponse => {
+	try {
+		const ast = parseSource(content);
+		const composition = findCompositionElement({ast, compositionId});
+		const defaultProps = composition
+			? getJsxAttribute(composition, 'defaultProps')
+			: null;
+		const value = defaultProps ? getNode(defaultProps, 'value') : null;
+		const expression =
+			value?.type === 'JSXExpressionContainer'
+				? getNode(value, 'expression')
+				: null;
+		const extracted = expression
+			? extractStaticDefaultPropValue(expression)
+			: {success: false as const};
+
+		if (
+			!extracted.success ||
+			extracted.value === null ||
+			typeof extracted.value !== 'object' ||
+			Array.isArray(extracted.value)
+		) {
+			throw new Error(
+				`Could not find or extract defaultProps for composition "${compositionId}"`,
+			);
+		}
+
+		return {
+			canUpdate: true,
+			currentDefaultProps: extracted.value as Record<string, unknown>,
+		};
+	} catch (error) {
+		return {
+			canUpdate: false,
+			reason: error instanceof Error ? error.message : String(error),
+		};
+	}
+};
+
+export const getCanUpdateDefaultPropsForProject = ({
+	compositionId,
+	project,
+}: {
+	compositionId: string;
+	project: CodemodProject;
+}): CanUpdateDefaultPropsResponse => {
+	const compositionFile = getCompositionFile({compositionId, project});
+	if (compositionFile === null) {
+		return {canUpdate: false, reason: 'Cannot find root file in project'};
+	}
+
+	if (
+		!compositionFile.endsWith('.tsx') &&
+		!compositionFile.endsWith('.ts') &&
+		!compositionFile.endsWith('.mtsx') &&
+		!compositionFile.endsWith('.mts')
+	) {
+		return {
+			canUpdate: false,
+			reason: 'Cannot update Root file if not using TypeScript',
+		};
+	}
+
+	const filePath = findProjectFile({filePath: compositionFile, project});
+	return computeCanUpdateDefaultPropsFromContent(
+		project.files[filePath],
+		compositionId,
+	);
 };

--- a/packages/studio-codemods/src/test/default-props.test.ts
+++ b/packages/studio-codemods/src/test/default-props.test.ts
@@ -1,0 +1,42 @@
+import {expect, test} from 'bun:test';
+import {computeCanUpdateDefaultPropsFromContent} from '..';
+
+test('extracts editable default props including special values', () => {
+	const source = `import {Composition, staticFile} from 'remotion';
+
+export const Root = () => <Composition
+  id="MyComp"
+  component={() => null}
+  durationInFrames={30}
+  fps={30}
+  width={1920}
+  height={1080}
+  defaultProps={{
+    title: 'Hello',
+    audio: staticFile('my folder/audio #1.wav'),
+    publishedAt: new Date('2026-07-29T00:00:00.000Z'),
+    options: [{mode: 'fast' as const}],
+  }}
+/>;`;
+
+	expect(computeCanUpdateDefaultPropsFromContent(source, 'MyComp')).toEqual({
+		canUpdate: true,
+		currentDefaultProps: {
+			title: 'Hello',
+			audio: 'remotion-file:my%20folder/audio%20%231.wav',
+			publishedAt: 'remotion-date:2026-07-29T00:00:00.000Z',
+			options: [{mode: 'fast'}],
+		},
+	});
+});
+
+test('rejects computed default props', () => {
+	const source = `import {Composition} from 'remotion';
+const defaults = {title: 'Hello'};
+export const Root = () => <Composition id="MyComp" component={() => null} durationInFrames={30} fps={30} width={1920} height={1080} defaultProps={defaults} />;`;
+
+	expect(computeCanUpdateDefaultPropsFromContent(source, 'MyComp')).toEqual({
+		canUpdate: false,
+		reason: 'Could not find or extract defaultProps for composition "MyComp"',
+	});
+});

--- a/packages/studio-server/src/preview-server/routes/can-update-default-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-default-props.ts
@@ -1,10 +1,9 @@
 import {readFileSync} from 'node:fs';
-import type {Expression} from '@babel/types';
+import {computeCanUpdateDefaultPropsFromContent} from '@remotion/studio-codemods';
 import type {CanUpdateDefaultPropsResponse} from '@remotion/studio-shared';
-import * as recast from 'recast';
-import {parseAst} from '../../codemods/parse-ast';
 import {getProjectInfo} from '../project-info';
-import {extractStaticValue, isStaticValue} from './can-update-sequence-props';
+
+export {computeCanUpdateDefaultPropsFromContent} from '@remotion/studio-codemods';
 
 export const checkIfTypeScriptFile = (file: string) => {
 	if (
@@ -14,138 +13,6 @@ export const checkIfTypeScriptFile = (file: string) => {
 		!file.endsWith('.mts')
 	) {
 		throw new Error('Cannot update Root file if not using TypeScript');
-	}
-};
-
-const extractDefaultPropsFromSource = (
-	input: string,
-	compositionId: string,
-): Record<string, unknown> | null => {
-	const ast = parseAst(input);
-	let result: Record<string, unknown> | null = null;
-
-	recast.types.visit(ast, {
-		visitJSXElement(path) {
-			const {openingElement} = path.node;
-			const openingName = openingElement.name;
-			if (
-				openingName.type !== 'JSXIdentifier' &&
-				openingName.type !== 'JSXNamespacedName'
-			) {
-				this.traverse(path);
-				return;
-			}
-
-			if (openingName.name !== 'Composition' && openingName.name !== 'Still') {
-				this.traverse(path);
-				return;
-			}
-
-			if (
-				!openingElement.attributes?.some((attr) => {
-					if (attr.type === 'JSXSpreadAttribute') {
-						return;
-					}
-
-					if (!attr.value) {
-						return;
-					}
-
-					if (attr.value.type === 'JSXElement') {
-						return;
-					}
-
-					if (attr.value.type === 'JSXExpressionContainer') {
-						return;
-					}
-
-					if (attr.value.type === 'JSXFragment') {
-						return;
-					}
-
-					return attr.name.name === 'id' && attr.value.value === compositionId;
-				})
-			) {
-				this.traverse(path);
-				return;
-			}
-
-			const defaultPropsAttr = openingElement.attributes.find((attr) => {
-				if (attr.type === 'JSXSpreadAttribute') {
-					return;
-				}
-
-				return attr.name.name === 'defaultProps';
-			});
-
-			if (!defaultPropsAttr || defaultPropsAttr.type === 'JSXSpreadAttribute') {
-				this.traverse(path);
-				return;
-			}
-
-			if (
-				!defaultPropsAttr.value ||
-				defaultPropsAttr.value.type !== 'JSXExpressionContainer'
-			) {
-				this.traverse(path);
-				return;
-			}
-
-			const {expression} = defaultPropsAttr.value;
-			if (expression.type === 'JSXEmptyExpression') {
-				this.traverse(path);
-				return;
-			}
-
-			if (
-				isStaticValue(expression as unknown as Expression, {
-					allowSpecialValues: true,
-				})
-			) {
-				const value = extractStaticValue(expression as unknown as Expression, {
-					allowSpecialValues: true,
-				});
-				if (
-					value !== null &&
-					typeof value === 'object' &&
-					!Array.isArray(value)
-				) {
-					result = value as Record<string, unknown>;
-				}
-			}
-
-			this.traverse(path);
-		},
-	});
-
-	return result;
-};
-
-export const computeCanUpdateDefaultPropsFromContent = (
-	content: string,
-	compositionId: string,
-): CanUpdateDefaultPropsResponse => {
-	try {
-		const currentDefaultProps = extractDefaultPropsFromSource(
-			content,
-			compositionId,
-		);
-
-		if (currentDefaultProps === null) {
-			throw new Error(
-				`Could not find or extract defaultProps for composition "${compositionId}"`,
-			);
-		}
-
-		return {
-			canUpdate: true,
-			currentDefaultProps,
-		};
-	} catch (err) {
-		return {
-			canUpdate: false,
-			reason: (err as Error).message,
-		};
 	}
 };
 

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -10,7 +10,10 @@ import type {
 	RedoResponse,
 	RenameStaticFileRequest,
 	RenameStaticFileResponse,
+	SubscribeToDefaultPropsRequest,
+	SubscribeToDefaultPropsResponse,
 	UndoResponse,
+	UnsubscribeFromDefaultPropsRequest,
 } from './api-requests';
 import type {EventSourceEvent} from './event-source-event';
 
@@ -40,8 +43,14 @@ export type BrowserStudioOperations = {
 	renameStaticFile: (
 		request: RenameStaticFileRequest,
 	) => Promise<RenameStaticFileResponse>;
+	subscribeToDefaultProps: (
+		request: SubscribeToDefaultPropsRequest,
+	) => Promise<SubscribeToDefaultPropsResponse>;
 	subscribeToEvent: (listener: (event: EventSourceEvent) => void) => () => void;
 	undo: () => Promise<UndoResponse>;
+	unsubscribeFromDefaultProps: (
+		request: UnsubscribeFromDefaultPropsRequest,
+	) => Promise<undefined>;
 	writeStaticFile: (request: WriteStaticFileRequest) => Promise<void>;
 };
 

--- a/packages/studio/src/components/ObserveDefaultPropsContext.tsx
+++ b/packages/studio/src/components/ObserveDefaultPropsContext.tsx
@@ -7,8 +7,12 @@ import React, {
 } from 'react';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {callApi} from './call-api';
+import {
+	subscribeToDefaultProps,
+	unsubscribeFromDefaultProps,
+} from './default-props-api';
 import type {TypeCanSaveState} from './RenderModal/get-render-modal-warnings';
 
 type AllCompStates = {
@@ -85,11 +89,15 @@ export const ObserveDefaultProps: React.FC<{
 	);
 
 	useEffect(() => {
-		if (readOnlyStudio || !clientId || compositionId === null) {
+		if (
+			(readOnlyStudio && !getBrowserStudioOperations()) ||
+			!clientId ||
+			compositionId === null
+		) {
 			return;
 		}
 
-		callApi('/api/subscribe-to-default-props', {compositionId, clientId})
+		subscribeToDefaultProps({compositionId, clientId})
 			.then((can) => {
 				applyResult(compositionId, can);
 			})
@@ -101,7 +109,7 @@ export const ObserveDefaultProps: React.FC<{
 			});
 
 		return () => {
-			callApi('/api/unsubscribe-from-default-props', {
+			unsubscribeFromDefaultProps({
 				compositionId,
 				clientId,
 			}).catch(() => {

--- a/packages/studio/src/components/default-props-api.ts
+++ b/packages/studio/src/components/default-props-api.ts
@@ -1,0 +1,25 @@
+import type {
+	SubscribeToDefaultPropsRequest,
+	SubscribeToDefaultPropsResponse,
+	UnsubscribeFromDefaultPropsRequest,
+} from '@remotion/studio-shared';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
+import {callApi} from './call-api';
+
+export const subscribeToDefaultProps = (
+	request: SubscribeToDefaultPropsRequest,
+): Promise<SubscribeToDefaultPropsResponse> => {
+	const browserStudioOperations = getBrowserStudioOperations();
+	return browserStudioOperations
+		? browserStudioOperations.subscribeToDefaultProps(request)
+		: callApi('/api/subscribe-to-default-props', request);
+};
+
+export const unsubscribeFromDefaultProps = (
+	request: UnsubscribeFromDefaultPropsRequest,
+): Promise<undefined> => {
+	const browserStudioOperations = getBrowserStudioOperations();
+	return browserStudioOperations
+		? browserStudioOperations.unsubscribeFromDefaultProps(request)
+		: callApi('/api/unsubscribe-from-default-props', request);
+};

--- a/packages/studio/src/test/browser-studio-default-props.test.ts
+++ b/packages/studio/src/test/browser-studio-default-props.test.ts
@@ -1,0 +1,57 @@
+import {afterEach, expect, test} from 'bun:test';
+import {
+	subscribeToDefaultProps,
+	unsubscribeFromDefaultProps,
+} from '../components/default-props-api';
+import {makeBrowserStudioOperations} from './make-browser-studio-operations';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+		return;
+	}
+
+	Reflect.deleteProperty(globalThis, 'window');
+});
+
+test('routes default prop subscriptions through Browser Studio operations', async () => {
+	const calls: string[] = [];
+	const operations = makeBrowserStudioOperations({
+		subscribeToDefaultProps: ({clientId, compositionId}) => {
+			calls.push(`subscribe:${clientId}:${compositionId}`);
+			return Promise.resolve({
+				canUpdate: true,
+				currentDefaultProps: {title: 'Hello'},
+			});
+		},
+		unsubscribeFromDefaultProps: ({clientId, compositionId}) => {
+			calls.push(`unsubscribe:${clientId}:${compositionId}`);
+			return Promise.resolve(undefined);
+		},
+	});
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {remotion_browserStudio: operations},
+	});
+
+	expect(
+		await subscribeToDefaultProps({
+			clientId: 'browser-studio',
+			compositionId: 'MyComp',
+		}),
+	).toEqual({canUpdate: true, currentDefaultProps: {title: 'Hello'}});
+	await unsubscribeFromDefaultProps({
+		clientId: 'browser-studio',
+		compositionId: 'MyComp',
+	});
+	expect(calls).toEqual([
+		'subscribe:browser-studio:MyComp',
+		'unsubscribe:browser-studio:MyComp',
+	]);
+});

--- a/packages/studio/src/test/make-browser-studio-operations.ts
+++ b/packages/studio/src/test/make-browser-studio-operations.ts
@@ -18,8 +18,11 @@ export const makeBrowserStudioOperations = (
 		insertSolid: () => unusedOperation('insertSolid'),
 		redo: () => unusedOperation('redo'),
 		renameStaticFile: () => unusedOperation('renameStaticFile'),
+		subscribeToDefaultProps: () => unusedOperation('subscribeToDefaultProps'),
 		subscribeToEvent: () => unusedOperation('subscribeToEvent'),
 		undo: () => unusedOperation('undo'),
+		unsubscribeFromDefaultProps: () =>
+			unusedOperation('unsubscribeFromDefaultProps'),
 		writeStaticFile: () => unusedOperation('writeStaticFile'),
 		...overrides,
 	};


### PR DESCRIPTION
## Summary

- share default-props editability analysis through `@remotion/studio-codemods`
- add typed Browser Studio subscribe and unsubscribe operations with change events
- route the Studio default-props observer through Browser Studio and cover the integration

## Testing

- `bun run build`
- `bun run stylecheck`
- Browser Studio, Studio codemod, Studio server, and Studio routing tests

Part of #9807.
