### PR TITLE
`@remotion/cli`: Pin skills CLI to 1.5.20

### DIFF
--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -38,7 +38,7 @@ export const skillsCommand = (args: string[], logLevel: LogLevel) => {
 	const fullArgs = [
 		'-y',
 		'--loglevel=error',
-		'skills@1.2.0',
+		'skills@1.5.20',
 		subcommand,
 		'remotion-dev/skills',
 		...restArgs,

--- a/packages/create-video/src/install-skills.ts
+++ b/packages/create-video/src/install-skills.ts
@@ -7,7 +7,7 @@ export const installSkills = async (projectRoot: string) => {
 	try {
 		await execa(
 			command,
-			['-y', '--loglevel=error', 'skills@1.2.0', 'add', 'remotion-dev/skills'],
+			['-y', '--loglevel=error', 'skills@1.5.20', 'add', 'remotion-dev/skills'],
 			{
 				cwd: projectRoot,
 				stdio: 'inherit',


### PR DESCRIPTION
## Summary

- pin the Agent Skills CLI to `1.5.20` for `remotion skills add` and `remotion skills update`
- use the same pinned version when `create-video` installs Agent Skills

## Validation

- `bun run build`
- `bun run stylecheck`
