### PR TITLE
Skills: Format JSX examples

### DIFF
--- a/packages/skills/skills/remotion-captions/display-captions.md
+++ b/packages/skills/skills/remotion-captions/display-captions.md
@@ -54,7 +54,11 @@ export const MyComponent: React.FC = () => {
     return null;
   }
 
-  return <AbsoluteFill>{/* Render captions here */}</AbsoluteFill>;
+  return (
+    <AbsoluteFill>
+      {/* Render captions here */}
+    </AbsoluteFill>
+  );
 };
 ```
 

--- a/packages/skills/skills/remotion-captions/import-srt-captions.md
+++ b/packages/skills/skills/remotion-captions/import-srt-captions.md
@@ -58,7 +58,11 @@ export const MyComponent: React.FC = () => {
     return null;
   }
 
-  return <AbsoluteFill>{/* Use captions here */}</AbsoluteFill>;
+  return (
+    <AbsoluteFill>
+      {/* Use captions here */}
+    </AbsoluteFill>
+  );
 };
 ```
 

--- a/packages/skills/skills/remotion-interactivity/SKILL.md
+++ b/packages/skills/skills/remotion-interactivity/SKILL.md
@@ -19,7 +19,10 @@ If the markup is too complex for the Studio to make it interactive, then the val
 Every HTML and SVG element such as `<div>` can be turned interactive using `Interactive`:
 
 ```tsx title="Interactive elements"
-<Interactive.Div name="Greeting card" style={{fontSize: 80, padding: 24}}>
+<Interactive.Div
+  name="Greeting card"
+  style={{fontSize: 80, padding: 24}}
+>
   Hello
 </Interactive.Div>
 ```
@@ -116,12 +119,17 @@ const {fps, durationInFrames} = useVideoConfig();
       extrapolateLeft: 'clamp',
       extrapolateRight: 'clamp'
     }),
-    translate: interpolate(frame, [durationInFrames - 30, durationInFrames], ['0px 0px', '0px 120px'], {
-      easing: Easing.spring({damping: 200}),
-      output: 'perceptual-scale',
-      extrapolateLeft: 'clamp',
-      extrapolateRight: 'clamp'
-    }),
+    translate: interpolate(
+      frame,
+      [durationInFrames - 30, durationInFrames],
+      ['0px 0px', '0px 120px'],
+      {
+        easing: Easing.spring({damping: 200}),
+        output: 'perceptual-scale',
+        extrapolateLeft: 'clamp',
+        extrapolateRight: 'clamp'
+      }
+    ),
   }}
 />
 ```

--- a/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-geo-prep.md
+++ b/packages/skills/skills/remotion-maps/techniques/maptiler/references/map-geo-prep.md
@@ -17,7 +17,16 @@ for (const l of m.getStyle().layers as any[])
 - Logo/attribution: `maptilerLogo:false` + `attributionControl:false` aren't always enough — also hide
   via CSS in the component:
   ```tsx
-  <style>{`.maplibregl-ctrl-bottom-left,.maplibregl-ctrl-bottom-right,.maplibregl-ctrl-attrib,.maptiler-logo{display:none!important}`}</style>
+  <style>
+    {`
+      .maplibregl-ctrl-bottom-left,
+      .maplibregl-ctrl-bottom-right,
+      .maplibregl-ctrl-attrib,
+      .maptiler-logo {
+        display: none !important;
+      }
+    `}
+  </style>
   ```
 
 ## `../scripts/prep-geo.mjs` → outputs

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -94,7 +94,10 @@ export const MyComposition = () => {
     <>
       <Video src={staticFile("video.mp4")} style={{ opacity: 0.5 }} />
       <Audio src={staticFile("audio.mp3")} />
-      <CanvasImage src={staticFile("logo.png")} style={{ width: 100, height: 100 }} />
+      <CanvasImage
+        src={staticFile("logo.png")}
+        style={{ width: 100, height: 100 }}
+      />
       <Video src="https://remotion.media/video.mp4" />
       <AnimatedImage src={staticFile('nyancat.gif')} />
     </>
@@ -121,7 +124,12 @@ export const Empty = () => {
   return (
     <AbsoluteFill
       name="Scene"
-      style={{display: 'flex', justifyContent: 'center', alignItems: 'center', backgroundColor: 'white'}}
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'white'
+      }}
     >
       <Interactive.Div
         name="Title"
@@ -183,8 +191,11 @@ For media, pass the natural duration of the media: `<Video durationInFrames={29.
 Useful for components whose internal clock should start later:
 
 ```tsx
-<Video trimBefore={2 * fps} {/* ... */} /> // Trim away first 2 seconds of footage
-<Sequence trimBefore={10 * fps} {/* ... */} /> // `useCurrenFrame()` for children starts at `10 * fps`
+// Trim away first 2 seconds of footage
+<Video trimBefore={2 * fps} {/* ... */} />
+
+// `useCurrenFrame()` for children starts at `10 * fps`
+<Sequence trimBefore={10 * fps} {/* ... */} />
 ```
 
 ### Fallback

--- a/packages/skills/skills/remotion-markup/audio.md
+++ b/packages/skills/skills/remotion-markup/audio.md
@@ -123,8 +123,10 @@ return (
 Use `playbackRate` to change the playback speed:
 
 ```tsx
-<Audio src={staticFile("audio.mp3")} playbackRate={2} /> {/* 2x speed */}
-<Audio src={staticFile("audio.mp3")} playbackRate={0.5} /> {/* Half speed */}
+// 2x speed
+<Audio src={staticFile("audio.mp3")} playbackRate={2} />
+// Half speed
+<Audio src={staticFile("audio.mp3")} playbackRate={0.5} />
 ```
 
 Reverse playback is not supported.

--- a/packages/skills/skills/remotion-markup/compositions.md
+++ b/packages/skills/skills/remotion-markup/compositions.md
@@ -23,7 +23,11 @@ type Props = {
   readonly title: string;
 };
 
-export const MyComposition = ({ title }: Props) => <h1>{title}</h1>;
+export const MyComposition = ({ title }: Props) => (
+  <h1>
+    {title}
+  </h1>
+);
 
 const defaultProps = { title: "Hello World" };
 
@@ -86,7 +90,12 @@ import { Thumbnail } from "./Thumbnail";
 
 export const RemotionRoot = () => {
   return (
-    <Still id="Thumbnail" component={Thumbnail} width={1280} height={720} />
+    <Still
+      id="Thumbnail"
+      component={Thumbnail}
+      width={1280}
+      height={720}
+    />
   );
 };
 ```

--- a/packages/skills/skills/remotion-markup/effects.md
+++ b/packages/skills/skills/remotion-markup/effects.md
@@ -24,7 +24,10 @@ Effects are functions passed to the `effects` prop of canvas-based components su
 import {Video} from '@remotion/media';
 import {blur} from '@remotion/effects/blur';
 
-<Video src="https://remotion.media/video.mp4" effects={[blur({radius: 8})]} />;
+<Video
+  src="https://remotion.media/video.mp4"
+  effects={[blur({radius: 8})]}
+/>;
 ```
 
 Use the effect docs for exact props and imports. Most `@remotion/effects` imports use `@remotion/effects/<effect-slug>`; `uvTranslate()` and `xyTranslate()` use `@remotion/effects/translate`.
@@ -46,7 +49,10 @@ Example:
 ```tsx
 import {brightness} from "@remotion/effects";
 
-<Video src="https://remotion.media/video.mp4" effects={[brightness({})]} />;
+<Video
+  src="https://remotion.media/video.mp4"
+  effects={[brightness({})]}
+/>;
 ```
 
 ## Custom effects

--- a/packages/skills/skills/remotion-markup/embedding-videos.md
+++ b/packages/skills/skills/remotion-markup/embedding-videos.md
@@ -125,8 +125,10 @@ Use `muted` to silence the video entirely:
 Use `playbackRate` to change the playback speed:
 
 ```tsx
-<Video src={staticFile("video.mp4")} playbackRate={2} /> {/* 2x speed */}
-<Video src={staticFile("video.mp4")} playbackRate={0.5} /> {/* Half speed */}
+// 2x speed
+<Video src={staticFile("video.mp4")} playbackRate={2} />
+// Half speed
+<Video src={staticFile("video.mp4")} playbackRate={0.5} />
 ```
 
 Reverse playback is not supported.

--- a/packages/skills/skills/remotion-markup/ffmpeg.md
+++ b/packages/skills/skills/remotion-markup/ffmpeg.md
@@ -23,7 +23,11 @@ You have 2 options for trimming videos:
 ```tsx
 import {Video} from '@remotion/media';
 
-<Video src={staticFile('video.mp4')} trimBefore={5 * fps} trimAfter={10 * fps} />;
+<Video
+  src={staticFile('video.mp4')}
+  trimBefore={5 * fps}
+  trimAfter={10 * fps}
+/>;
 ```
 
 2. Use the FFmpeg command line. You MUST re-encode the video to avoid frozen frames at the start of the video. Only use this if you need a standalone trimmed file (e.g. for upload or external use).

--- a/packages/skills/skills/remotion-markup/gifs.md
+++ b/packages/skills/skills/remotion-markup/gifs.md
@@ -16,7 +16,11 @@ import { AnimatedImage, staticFile } from "remotion";
 
 export const MyComposition = () => {
   return (
-    <AnimatedImage src={staticFile("animation.gif")} width={500} height={500} />
+    <AnimatedImage
+      src={staticFile("animation.gif")}
+      width={500}
+      height={500}
+    />
   );
 };
 ```
@@ -37,13 +41,28 @@ Control how the image fills its container with the `fit` prop:
 
 ```tsx
 // Stretch to fill (default)
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="fill" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={300}
+  fit="fill"
+/>
 
 // Maintain aspect ratio, fit inside container
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="contain" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={300}
+  fit="contain"
+/>
 
 // Fill container, crop if needed
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="cover" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={300}
+  fit="cover"
+/>
 ```
 
 ## Playback speed
@@ -51,8 +70,20 @@ Control how the image fills its container with the `fit` prop:
 Use `playbackRate` to control the animation speed:
 
 ```tsx
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={2} /> {/* 2x speed */}
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={0.5} /> {/* Half speed */}
+// 2x speed
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  playbackRate={2}
+/>
+// Half speed
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  playbackRate={0.5}
+/>
 ```
 
 ## Looping behavior
@@ -61,13 +92,28 @@ Control what happens when the animation finishes:
 
 ```tsx
 // Loop indefinitely (default)
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="loop" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  loopBehavior="loop"
+/>
 
 // Play once, show final frame
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="pause-after-finish" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  loopBehavior="pause-after-finish"
+/>
 
 // Play once, then clear canvas
-<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="clear-after-finish" />
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  loopBehavior="clear-after-finish"
+/>
 ```
 
 ## Styling

--- a/packages/skills/skills/remotion-markup/google-fonts.md
+++ b/packages/skills/skills/remotion-markup/google-fonts.md
@@ -29,7 +29,11 @@ import { loadFont } from "@remotion/google-fonts/Lobster";
 const { fontFamily } = loadFont();
 
 export const MyComposition = () => {
-  return <div style={{ fontFamily }}>Hello World</div>;
+  return (
+    <div style={{ fontFamily }}>
+      Hello World
+    </div>
+  );
 };
 ```
 

--- a/packages/skills/skills/remotion-markup/html-in-canvas.md
+++ b/packages/skills/skills/remotion-markup/html-in-canvas.md
@@ -38,7 +38,9 @@ import { HtmlInCanvas } from "remotion";
 export const MyComp = () => {
   return (
     <HtmlInCanvas width={1280} height={720}>
-      <div style={{ fontSize: 80 }}>Hello</div>
+      <div style={{ fontSize: 80 }}>
+        Hello
+      </div>
     </HtmlInCanvas>
   );
 };
@@ -79,8 +81,16 @@ export const Blur = () => {
 
   return (
     <HtmlInCanvas width={width} height={height} onPaint={onPaint}>
-      <AbsoluteFill style={{ justifyContent: "center", alignItems: "center", fontSize: 120 }}>
-        <h1>Hello</h1>
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          fontSize: 120,
+        }}
+      >
+        <h1>
+          Hello
+        </h1>
       </AbsoluteFill>
     </HtmlInCanvas>
   );

--- a/packages/skills/skills/remotion-markup/images.md
+++ b/packages/skills/skills/remotion-markup/images.md
@@ -32,7 +32,9 @@ const frame = useCurrentFrame();
 <Img src={staticFile(`avatars/${props.userId}.png`)} />
 
 // Conditional images
-<Img src={staticFile(`icons/${isActive ? "active" : "inactive"}.svg`)} />
+<Img
+  src={staticFile(`icons/${isActive ? "active" : "inactive"}.svg`)}
+/>
 ```
 
 This pattern is useful for:

--- a/packages/skills/skills/remotion-markup/local-fonts.md
+++ b/packages/skills/skills/remotion-markup/local-fonts.md
@@ -25,7 +25,11 @@ await loadFont({
 });
 
 export const MyComposition = () => {
-  return <div style={{ fontFamily: "MyFont" }}>Hello World</div>;
+  return (
+    <div style={{ fontFamily: "MyFont" }}>
+      Hello World
+    </div>
+  );
 };
 ```
 

--- a/packages/skills/skills/remotion-markup/lottie.md
+++ b/packages/skills/skills/remotion-markup/lottie.md
@@ -65,6 +65,9 @@ Lottie supports the `style` prop to allow styles and animations:
 
 ```tsx
 return (
-  <Lottie animationData={animationData} style={{ width: 400, height: 400 }} />
+  <Lottie
+    animationData={animationData}
+    style={{ width: 400, height: 400 }}
+  />
 );
 ```

--- a/packages/skills/skills/remotion-markup/measuring-dom-nodes.md
+++ b/packages/skills/skills/remotion-markup/measuring-dom-nodes.md
@@ -29,6 +29,10 @@ export const MyComponent = () => {
     });
   }, [scale]);
 
-  return <div ref={ref}>Content to measure</div>;
+  return (
+    <div ref={ref}>
+      Content to measure
+    </div>
+  );
 };
 ```

--- a/packages/skills/skills/remotion-markup/measuring-text.md
+++ b/packages/skills/skills/remotion-markup/measuring-text.md
@@ -130,11 +130,17 @@ const { width } = measureText({
   ...fontStyle,
 });
 
-return <div style={fontStyle}>Hello</div>;
+return (
+  <div style={fontStyle}>
+    Hello
+  </div>
+);
 ```
 
 **Avoid padding and border:** Use `outline` instead of `border` to prevent layout differences:
 
 ```tsx
-<div style={{ outline: "2px solid red" }}>Text</div>
+<div style={{ outline: "2px solid red" }}>
+  Text
+</div>
 ```

--- a/packages/skills/skills/remotion-markup/parameters.md
+++ b/packages/skills/skills/remotion-markup/parameters.md
@@ -47,7 +47,9 @@ export const MyCompositionSchema = z.object({
 const MyComponent: React.FC<z.infer<typeof MyCompositionSchema>> = () => {
   return (
     <div>
-      <h1>{props.title}</h1>
+      <h1>
+        {props.title}
+      </h1>
     </div>
   );
 };

--- a/packages/skills/skills/remotion-markup/sequencing.md
+++ b/packages/skills/skills/remotion-markup/sequencing.md
@@ -16,7 +16,12 @@ const Main = () => {
         <Sequence name="Title" from={30} durationInFrames={60} layout="none">
           <Title />
         </Sequence>
-        <Sequence name="Subtitle" from={60} durationInFrames={60} layout="none">
+        <Sequence
+          name="Subtitle"
+          from={60}
+          durationInFrames={60}
+          layout="none"
+        >
           <Subtitle />
         </Sequence>
       </AbsoluteFill>

--- a/packages/skills/skills/remotion-markup/video-editing.md
+++ b/packages/skills/skills/remotion-markup/video-editing.md
@@ -10,11 +10,35 @@ Keep every editable clip as its own authored JSX node. Do not generate editable 
 Place every `<Video>` directly in the composition and hardcode its timing props. `from={0}` may be omitted:
 
 ```tsx
-<Video src="https://remotion.media/video.mp4" trimBefore={0} durationInFrames={78} />
-<Video src="https://remotion.media/video.webm" trimBefore={12} from={78} durationInFrames={66} />
-<Video src="https://remotion.media/video.mp4" trimBefore={72} from={144} durationInFrames={90} />
-<Video src="https://remotion.media/video.webm" trimBefore={58} from={234} durationInFrames={72} />
-<Video src="https://remotion.media/video.mp4" trimBefore={180} from={306} durationInFrames={60} />
+<Video
+  src="https://remotion.media/video.mp4"
+  trimBefore={0}
+  durationInFrames={78}
+/>
+<Video
+  src="https://remotion.media/video.webm"
+  trimBefore={12}
+  from={78}
+  durationInFrames={66}
+/>
+<Video
+  src="https://remotion.media/video.mp4"
+  trimBefore={72}
+  from={144}
+  durationInFrames={90}
+/>
+<Video
+  src="https://remotion.media/video.webm"
+  trimBefore={58}
+  from={234}
+  durationInFrames={72}
+/>
+<Video
+  src="https://remotion.media/video.mp4"
+  trimBefore={180}
+  from={306}
+  durationInFrames={60}
+/>
 ```
 
 - `from` is the clip's absolute start frame in its parent timeline.


### PR DESCRIPTION
## Summary

- expand inline parent/child JSX in Remotion skill examples
- split long JSX props across lines
- keep the change limited to example layout

## Validation

- `bun run build`
- `bun run stylecheck`

Closes #9870
