### PR TITLE
`@remotion/studio-server`: Implement Studio Protocol installation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1737,6 +1737,7 @@
         "recast": "0.23.11",
         "remotion": "workspace:*",
         "semver": "7.5.3",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@remotion/eslint-config-internal": "workspace:*",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -30,6 +30,7 @@
 		"@svgr/plugin-jsx": "8.1.0",
 		"kiwi-schema": "0.5.0",
 		"semver": "7.5.3",
+		"zod": "catalog:",
 		"prettier": "catalog:",
 		"remotion": "workspace:*",
 		"recast": "0.23.11",

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -1,4 +1,7 @@
+import {randomUUID} from 'node:crypto';
+
 export const ELEMENT_INSTALL_TARGET_MAX_AGE = 5000;
+export const STUDIO_PROTOCOL_TARGET_MAX_AGE = 4000;
 
 export type ElementInstallTarget = {
 	requestId: string | null;
@@ -13,6 +16,14 @@ export type ElementInstallTarget = {
 };
 
 const targetsByClientId = new Map<string, ElementInstallTarget>();
+
+type StudioProtocolTarget = {
+	readonly id: string;
+	readonly target: ElementInstallTarget;
+	readonly expiresAt: number;
+};
+
+const studioProtocolTargets = new Map<string, StudioProtocolTarget>();
 
 const compareTargets = (a: ElementInstallTarget, b: ElementInstallTarget) => {
 	const aFocusedAt = a.lastFocusedAt ?? 0;
@@ -32,6 +43,10 @@ export const updateElementInstallTarget = (
 		...newTarget,
 		updatedAt: Date.now(),
 	});
+};
+
+export const getElementInstallTargetByClientId = (clientId: string) => {
+	return targetsByClientId.get(clientId) ?? null;
 };
 
 export const getElementInstallTarget = (requestId: string | null) => {
@@ -56,6 +71,57 @@ export const getElementInstallTarget = (requestId: string | null) => {
 	return bestTarget;
 };
 
+export const issueStudioProtocolTarget = ({
+	now,
+	target,
+}: {
+	readonly now: number;
+	readonly target: ElementInstallTarget;
+}) => {
+	for (const [id, existing] of studioProtocolTargets) {
+		if (existing.expiresAt <= now) {
+			studioProtocolTargets.delete(id);
+		}
+	}
+
+	const issued: StudioProtocolTarget = {
+		id: randomUUID(),
+		target: {...target},
+		expiresAt: now + STUDIO_PROTOCOL_TARGET_MAX_AGE,
+	};
+	studioProtocolTargets.set(issued.id, issued);
+	return issued;
+};
+
+export const consumeStudioProtocolTarget = ({
+	now,
+	targetId,
+}: {
+	readonly now: number;
+	readonly targetId: string;
+}): ElementInstallTarget | null => {
+	const issued = studioProtocolTargets.get(targetId);
+	studioProtocolTargets.delete(targetId);
+	if (issued === undefined || issued.expiresAt <= now) {
+		return null;
+	}
+
+	const current = getElementInstallTargetByClientId(issued.target.clientId);
+	if (
+		current === null ||
+		now - current.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE ||
+		!current.canInstall ||
+		current.readOnly ||
+		current.compositionFile !== issued.target.compositionFile ||
+		current.compositionId !== issued.target.compositionId
+	) {
+		return null;
+	}
+
+	return issued.target;
+};
+
 export const clearElementInstallStateForTests = () => {
 	targetsByClientId.clear();
+	studioProtocolTargets.clear();
 };

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -1,0 +1,139 @@
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import path from 'node:path';
+import type {GitSource} from '@remotion/studio-shared';
+import {getProjectName} from '@remotion/studio-shared';
+import {VERSION} from 'remotion/version';
+import {
+	ELEMENT_INSTALL_TARGET_MAX_AGE,
+	getElementInstallTarget,
+	issueStudioProtocolTarget,
+} from '../element-install-state';
+import type {LiveEventsServer} from '../live-events';
+import {
+	isAllowedStudioProtocolOrigin,
+	setStudioProtocolCorsHeaders,
+} from './origin-policy';
+import {writeStudioProtocolError} from './protocol-response';
+
+const ELEMENT_INSTALL_FOCUS_MAX_AGE = 5 * 60 * 1000;
+export const ELEMENT_INSTALL_TARGET_RESPONSE_WAIT = 250;
+
+const requestInstallTarget = ({
+	liveEventsServer,
+}: {
+	readonly liveEventsServer: LiveEventsServer;
+}) => {
+	const requestId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	liveEventsServer.sendEventToClient({
+		type: 'request-element-install-target',
+		requestId,
+	});
+	return requestId;
+};
+
+const getLiveInstallableTarget = (requestId: string) => {
+	const target = getElementInstallTarget(requestId);
+	const now = Date.now();
+	if (
+		target === null ||
+		now - target.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE ||
+		target.lastFocusedAt === null ||
+		now - target.lastFocusedAt >= ELEMENT_INSTALL_FOCUS_MAX_AGE ||
+		!target.canInstall ||
+		target.readOnly ||
+		target.compositionFile === null ||
+		target.compositionId === null
+	) {
+		return null;
+	}
+
+	return target;
+};
+
+const getProject = ({
+	gitSource,
+	remotionRoot,
+}: {
+	readonly gitSource: GitSource | null;
+	readonly remotionRoot: string;
+}) =>
+	getProjectName({
+		basename: path.basename,
+		gitSource,
+		resolvedRemotionRoot: remotionRoot,
+	});
+
+export const handleStudioProtocolDiscovery = ({
+	gitSource,
+	liveEventsServer,
+	remotionRoot,
+	request,
+	response,
+}: {
+	readonly gitSource: GitSource | null;
+	readonly liveEventsServer: LiveEventsServer;
+	readonly remotionRoot: string;
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+}): Promise<void> => {
+	setStudioProtocolCorsHeaders({request, response});
+	if (!isAllowedStudioProtocolOrigin(request.headers.origin)) {
+		writeStudioProtocolError({
+			code: 'unsupported-origin',
+			message: 'Origin not allowed',
+			response,
+			status: 403,
+		});
+		return Promise.resolve();
+	}
+
+	if (request.method !== 'GET') {
+		writeStudioProtocolError({
+			code: 'method-not-allowed',
+			message: 'Use GET for Studio Protocol discovery.',
+			response,
+			status: 405,
+		});
+		return Promise.resolve();
+	}
+
+	const requestId = requestInstallTarget({liveEventsServer});
+	return new Promise<void>((resolve) => {
+		setTimeout(() => {
+			const now = Date.now();
+			const target = getLiveInstallableTarget(requestId);
+			const issued =
+				target === null ? null : issueStudioProtocolTarget({now, target});
+			response.writeHead(200, {
+				'Cache-Control': 'no-store',
+				'Content-Type': 'application/json',
+			});
+			response.end(
+				JSON.stringify({
+					protocol: 'remotion-studio-protocol',
+					protocolVersion: 1,
+					studioVersion: VERSION,
+					capabilities: {
+						install: [
+							{
+								payloadType: 'remotion-element',
+								payloadVersions: [1],
+							},
+						],
+					},
+					projectName: getProject({gitSource, remotionRoot}),
+					installTarget:
+						issued === null || target === null
+							? null
+							: {
+									id: issued.id,
+									expiresAt: issued.expiresAt,
+									compositionId: target.compositionId,
+									lastFocusedAt: target.lastFocusedAt,
+								},
+				}),
+			);
+			resolve();
+		}, ELEMENT_INSTALL_TARGET_RESPONSE_WAIT);
+	});
+};

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -1,0 +1,170 @@
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {StudioProtocolInternals} from '@remotion/studio-protocol';
+import type {ElementInstallRequest} from '@remotion/studio-shared';
+import {consumeStudioProtocolTarget} from '../element-install-state';
+import type {getElementInstallTarget} from '../element-install-state';
+import type {LiveEventsServer} from '../live-events';
+import {parseRequestBody} from '../parse-body';
+import {
+	isAllowedStudioProtocolOrigin,
+	setStudioProtocolCorsHeaders,
+} from './origin-policy';
+import {writeStudioProtocolError} from './protocol-response';
+
+type FocusStudioTab = (studioUrl: string) => void;
+
+const deliverElementInstall = ({
+	element,
+	focusStudioTab,
+	liveEventsServer,
+	target,
+}: {
+	readonly element: ElementInstallRequest['element'];
+	readonly focusStudioTab: FocusStudioTab;
+	readonly liveEventsServer: LiveEventsServer;
+	readonly target: NonNullable<ReturnType<typeof getElementInstallTarget>>;
+}): boolean => {
+	if (target.compositionFile === null || target.compositionId === null) {
+		return false;
+	}
+
+	const installRequest: ElementInstallRequest = {
+		id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		clientId: target.clientId,
+		createdAt: Date.now(),
+		compositionFile: target.compositionFile,
+		compositionId: target.compositionId,
+		element,
+		position: null,
+	};
+
+	const delivered = liveEventsServer.sendEventToClientId(target.clientId, {
+		type: 'element-install-request',
+		request: installRequest,
+	});
+	if (delivered) {
+		focusStudioTab(target.studioUrl);
+	}
+
+	return delivered;
+};
+
+export const handleStudioProtocolInstall = async ({
+	focusStudioTab,
+	liveEventsServer,
+	request,
+	response,
+}: {
+	readonly focusStudioTab: FocusStudioTab;
+	readonly liveEventsServer: LiveEventsServer;
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+}): Promise<void> => {
+	setStudioProtocolCorsHeaders({request, response});
+	if (!isAllowedStudioProtocolOrigin(request.headers.origin)) {
+		writeStudioProtocolError({
+			code: 'unsupported-origin',
+			message: 'Origin not allowed',
+			response,
+			status: 403,
+		});
+		return;
+	}
+
+	if (request.method !== 'POST') {
+		writeStudioProtocolError({
+			code: 'method-not-allowed',
+			message: 'Use POST to request an Element installation.',
+			response,
+			status: 405,
+		});
+		return;
+	}
+
+	let body: unknown;
+	try {
+		body = await parseRequestBody(request);
+	} catch {
+		writeStudioProtocolError({
+			code: 'invalid-request',
+			message: 'The request body is not valid JSON.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	if (
+		typeof body !== 'object' ||
+		body === null ||
+		Array.isArray(body) ||
+		!('protocol' in body) ||
+		body.protocol !== 'remotion-studio-protocol' ||
+		!('protocolVersion' in body) ||
+		body.protocolVersion !== 1 ||
+		!('targetId' in body) ||
+		typeof body.targetId !== 'string' ||
+		!('payload' in body)
+	) {
+		writeStudioProtocolError({
+			code: 'unsupported-protocol',
+			message: 'Invalid Remotion Studio Protocol request.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	const payload = StudioProtocolInternals.parseStudioElementPayload(
+		body.payload,
+	);
+	if (payload === null) {
+		writeStudioProtocolError({
+			code: 'invalid-payload',
+			message: 'Invalid Element payload.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	const target = consumeStudioProtocolTarget({
+		now: Date.now(),
+		targetId: body.targetId,
+	});
+	if (target === null) {
+		writeStudioProtocolError({
+			code: 'target-expired',
+			message: 'The selected Studio target is no longer available.',
+			response,
+			status: 409,
+		});
+		return;
+	}
+
+	if (
+		!deliverElementInstall({
+			element: payload.element,
+			focusStudioTab,
+			liveEventsServer,
+			target,
+		})
+	) {
+		writeStudioProtocolError({
+			code: 'target-expired',
+			message: 'The selected Remotion Studio tab is no longer connected.',
+			response,
+			status: 409,
+		});
+		return;
+	}
+
+	response.writeHead(200, {'Content-Type': 'application/json'});
+	response.end(
+		JSON.stringify({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'awaiting-confirmation',
+		}),
+	);
+};

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -1,6 +1,7 @@
 import type {IncomingMessage, ServerResponse} from 'node:http';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import type {ElementInstallRequest} from '@remotion/studio-shared';
+import {z} from 'zod';
 import {consumeStudioProtocolTarget} from '../element-install-state';
 import type {getElementInstallTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
@@ -12,6 +13,13 @@ import {
 import {writeStudioProtocolError} from './protocol-response';
 
 type FocusStudioTab = (studioUrl: string) => void;
+
+const studioProtocolInstallRequestSchema = z.object({
+	protocol: z.literal('remotion-studio-protocol'),
+	protocolVersion: z.literal(1),
+	targetId: z.string(),
+	payload: z.unknown(),
+});
 
 const deliverElementInstall = ({
 	element,
@@ -94,18 +102,8 @@ export const handleStudioProtocolInstall = async ({
 		return;
 	}
 
-	if (
-		typeof body !== 'object' ||
-		body === null ||
-		Array.isArray(body) ||
-		!('protocol' in body) ||
-		body.protocol !== 'remotion-studio-protocol' ||
-		!('protocolVersion' in body) ||
-		body.protocolVersion !== 1 ||
-		!('targetId' in body) ||
-		typeof body.targetId !== 'string' ||
-		!('payload' in body)
-	) {
+	const parsedRequest = studioProtocolInstallRequestSchema.safeParse(body);
+	if (!parsedRequest.success) {
 		writeStudioProtocolError({
 			code: 'unsupported-protocol',
 			message: 'Invalid Remotion Studio Protocol request.',
@@ -116,7 +114,7 @@ export const handleStudioProtocolInstall = async ({
 	}
 
 	const payload = StudioProtocolInternals.parseStudioElementPayload(
-		body.payload,
+		parsedRequest.data.payload,
 	);
 	if (payload === null) {
 		writeStudioProtocolError({
@@ -130,7 +128,7 @@ export const handleStudioProtocolInstall = async ({
 
 	const target = consumeStudioProtocolTarget({
 		now: Date.now(),
-		targetId: body.targetId,
+		targetId: parsedRequest.data.targetId,
 	});
 	if (target === null) {
 		writeStudioProtocolError({

--- a/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
@@ -1,0 +1,57 @@
+import type {IncomingMessage, ServerResponse} from 'node:http';
+
+export const isAllowedStudioProtocolOrigin = (
+	origin: string | undefined,
+): boolean => {
+	if (!origin) {
+		return false;
+	}
+
+	try {
+		const url = new URL(origin);
+		return (
+			(url.protocol === 'https:' &&
+				(url.hostname === 'remotion.dev' ||
+					url.hostname === 'www.remotion.dev')) ||
+			(url.protocol === 'http:' &&
+				(url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
+		);
+	} catch {
+		return false;
+	}
+};
+
+export const setStudioProtocolCorsHeaders = ({
+	request,
+	response,
+}: {
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+}): void => {
+	const {origin} = request.headers;
+	if (typeof origin !== 'string' || !isAllowedStudioProtocolOrigin(origin)) {
+		return;
+	}
+
+	response.setHeader('Access-Control-Allow-Origin', origin);
+	response.setHeader('Vary', 'Origin');
+	response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+	response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+	response.setHeader('Access-Control-Max-Age', '600');
+	response.setHeader('Access-Control-Allow-Private-Network', 'true');
+};
+
+export const handleStudioProtocolOptions = ({
+	request,
+	response,
+}: {
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+}): Promise<void> => {
+	setStudioProtocolCorsHeaders({request, response});
+	response.writeHead(
+		isAllowedStudioProtocolOrigin(request.headers.origin) ? 204 : 403,
+	);
+	response.end();
+	return Promise.resolve();
+};

--- a/packages/studio-server/src/preview-server/studio-protocol/protocol-response.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/protocol-response.ts
@@ -1,0 +1,23 @@
+import type {ServerResponse} from 'node:http';
+
+export const writeStudioProtocolError = ({
+	code,
+	message,
+	response,
+	status,
+}: {
+	readonly code: string;
+	readonly message: string;
+	readonly response: ServerResponse;
+	readonly status: number;
+}): void => {
+	response.writeHead(status, {'Content-Type': 'application/json'});
+	response.end(
+		JSON.stringify({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'error',
+			error: {code, message},
+		}),
+	);
+};

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -6,10 +6,8 @@ import {URLSearchParams} from 'node:url';
 import {BundlerInternals} from '@remotion/bundler';
 import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
-import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import type {
 	ApiRoutes,
-	ElementInstallRequest,
 	GitSource,
 	RenderDefaults,
 	RenderJob,
@@ -23,24 +21,20 @@ import {getInstalledInstallablePackages} from './helpers/get-installed-installab
 import {resolveOutputPath} from './helpers/resolve-output-path';
 import {allApiRoutes} from './preview-server/api-routes';
 import type {ApiHandler, QueueMethods} from './preview-server/api-types';
-import {
-	ELEMENT_INSTALL_TARGET_MAX_AGE,
-	getElementInstallTarget,
-} from './preview-server/element-install-state';
 import {getPackageManager} from './preview-server/get-package-manager';
 import {getStaticFileFallbackHint} from './preview-server/get-static-file-fallback-hint';
 import {handleRequest} from './preview-server/handler';
 import type {LiveEventsServer} from './preview-server/live-events';
-import {parseRequestBody} from './preview-server/parse-body';
 import {fetchFolder, getFiles} from './preview-server/public-folder';
 import {getEditorName} from './preview-server/routes/open-in-editor';
 import {serveStatic} from './preview-server/serve-static';
+import {handleStudioProtocolDiscovery} from './preview-server/studio-protocol/handle-discovery';
+import {handleStudioProtocolInstall} from './preview-server/studio-protocol/handle-install';
+import {handleStudioProtocolOptions} from './preview-server/studio-protocol/origin-policy';
 import {validateSameOrigin} from './preview-server/validate-same-origin';
 import {reloadPreviouslySuppressedFiles} from './preview-server/watch-ignore-next-change';
 import type {RemotionConfigResponse} from './remotion-config-response';
 const loggedStaticFileHints = new Set<string>();
-const ELEMENT_INSTALL_FOCUS_MAX_AGE = 5 * 60 * 1000;
-const ELEMENT_INSTALL_TARGET_RESPONSE_WAIT = 250;
 
 const static404 = (response: ServerResponse): Promise<void> => {
 	response.writeHead(404);
@@ -72,221 +66,6 @@ const handleRemotionConfig = (
 	};
 	response.end(JSON.stringify(body));
 	return Promise.resolve();
-};
-
-const isAllowedElementInstallOrigin = (origin: string | undefined) => {
-	if (!origin) {
-		return false;
-	}
-
-	try {
-		const url = new URL(origin);
-		return (
-			(url.protocol === 'https:' &&
-				(url.hostname === 'remotion.dev' ||
-					url.hostname === 'www.remotion.dev')) ||
-			(url.protocol === 'http:' &&
-				(url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
-		);
-	} catch {
-		return false;
-	}
-};
-
-const setElementInstallCorsHeaders = ({
-	request,
-	response,
-}: {
-	request: IncomingMessage;
-	response: ServerResponse;
-}) => {
-	const {origin} = request.headers;
-	if (isAllowedElementInstallOrigin(origin)) {
-		response.setHeader('Access-Control-Allow-Origin', origin as string);
-		response.setHeader('Vary', 'Origin');
-		response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-		response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-		response.setHeader('Access-Control-Max-Age', '600');
-		response.setHeader('Access-Control-Allow-Private-Network', 'true');
-	}
-};
-
-const handleElementInstallOptions = ({
-	request,
-	response,
-}: {
-	request: IncomingMessage;
-	response: ServerResponse;
-}) => {
-	setElementInstallCorsHeaders({request, response});
-	response.writeHead(
-		isAllowedElementInstallOrigin(request.headers.origin) ? 204 : 403,
-	);
-	response.end();
-	return Promise.resolve();
-};
-
-const handleElementInstallTarget = ({
-	liveEventsServer,
-	request,
-	response,
-	remotionRoot,
-	gitSource,
-}: {
-	liveEventsServer: LiveEventsServer;
-	request: IncomingMessage;
-	response: ServerResponse;
-	remotionRoot: string;
-	gitSource: GitSource | null;
-}) => {
-	if (!isAllowedElementInstallOrigin(request.headers.origin)) {
-		response.writeHead(403);
-		response.end(
-			JSON.stringify({success: false, reason: 'Origin not allowed'}),
-		);
-		return Promise.resolve();
-	}
-
-	const requestId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-
-	liveEventsServer.sendEventToClient({
-		type: 'request-element-install-target',
-		requestId,
-	});
-
-	return new Promise<void>((resolve) => {
-		setTimeout(() => {
-			const target = getElementInstallTarget(requestId);
-			const now = Date.now();
-			const targetIsLive =
-				target !== null &&
-				now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
-			const host = request.headers.host ?? null;
-			const port = host?.split(':').at(-1) ?? null;
-			setElementInstallCorsHeaders({request, response});
-			response.writeHead(200, {'Content-Type': 'application/json'});
-			response.end(
-				JSON.stringify({
-					type: 'remotion-studio',
-					projectName: getProjectName({
-						basename: path.basename,
-						gitSource,
-						resolvedRemotionRoot: remotionRoot,
-					}),
-					port: port === null ? null : Number(port),
-					lastFocusedAt: target?.lastFocusedAt ?? null,
-					canInstall: target !== null && target.canInstall && targetIsLive,
-					activeCompositionId: target?.compositionId ?? null,
-					readOnly: target?.readOnly ?? false,
-				}),
-			);
-			resolve();
-		}, ELEMENT_INSTALL_TARGET_RESPONSE_WAIT);
-	});
-};
-
-const handleRequestElementInstall = async ({
-	liveEventsServer,
-	request,
-	response,
-}: {
-	liveEventsServer: LiveEventsServer;
-	request: IncomingMessage;
-	response: ServerResponse;
-}) => {
-	if (!isAllowedElementInstallOrigin(request.headers.origin)) {
-		response.writeHead(403);
-		response.end(
-			JSON.stringify({success: false, reason: 'Origin not allowed'}),
-		);
-		return;
-	}
-
-	setElementInstallCorsHeaders({request, response});
-	response.setHeader('Content-Type', 'application/json');
-
-	try {
-		const body = await parseRequestBody(request);
-		const {mimeType, payload} = body as {
-			mimeType?: unknown;
-			payload?: unknown;
-		};
-		const parsed =
-			typeof mimeType === 'string' && typeof payload === 'string'
-				? StudioProtocolInternals.parseDragData({mimeType, payload})
-				: null;
-
-		if (parsed?.type !== 'element') {
-			response.writeHead(400);
-			response.end(
-				JSON.stringify({success: false, reason: 'Invalid Element payload'}),
-			);
-			return;
-		}
-
-		const target = getElementInstallTarget(null);
-		const now = Date.now();
-		const targetIsLive =
-			target !== null &&
-			now - target.updatedAt < ELEMENT_INSTALL_TARGET_MAX_AGE;
-		const targetWasRecentlyFocused =
-			target !== null &&
-			target.lastFocusedAt !== null &&
-			now - target.lastFocusedAt < ELEMENT_INSTALL_FOCUS_MAX_AGE;
-		if (
-			target === null ||
-			!target.canInstall ||
-			target.compositionFile === null ||
-			target.compositionId === null ||
-			!targetIsLive ||
-			!targetWasRecentlyFocused
-		) {
-			response.writeHead(409);
-			response.end(
-				JSON.stringify({
-					success: false,
-					reason: 'No focused writable Remotion Studio composition',
-				}),
-			);
-			return;
-		}
-
-		const installRequest: ElementInstallRequest = {
-			id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
-			clientId: target.clientId,
-			createdAt: Date.now(),
-			compositionFile: target.compositionFile,
-			compositionId: target.compositionId,
-			element: parsed.data.element,
-			position: null,
-		};
-
-		const delivered = liveEventsServer.sendEventToClientId(target.clientId, {
-			type: 'element-install-request',
-			request: installRequest,
-		});
-
-		if (delivered === false) {
-			response.writeHead(409);
-			response.end(
-				JSON.stringify({
-					success: false,
-					reason: 'The selected Remotion Studio tab is no longer connected',
-				}),
-			);
-			return;
-		}
-
-		focusBrowserTab({url: target.studioUrl}).catch(() => undefined);
-
-		response.writeHead(200);
-		response.end(JSON.stringify({success: true, status: 'sent'}));
-	} catch (err) {
-		response.writeHead(500);
-		response.end(
-			JSON.stringify({success: false, reason: (err as Error).message}),
-		);
-	}
 };
 
 const handleFallback = async ({
@@ -655,24 +434,27 @@ export const handleRoutes = ({
 	}
 
 	if (
-		url.pathname === '/api/element-install-target' ||
-		url.pathname === '/api/request-element-install'
+		url.pathname === '/api/studio-protocol' ||
+		url.pathname === '/api/studio-protocol/install'
 	) {
 		if (request.method === 'OPTIONS') {
-			return handleElementInstallOptions({request, response});
+			return handleStudioProtocolOptions({request, response});
 		}
 
-		if (url.pathname === '/api/element-install-target') {
-			return handleElementInstallTarget({
+		if (url.pathname === '/api/studio-protocol') {
+			return handleStudioProtocolDiscovery({
+				gitSource,
 				liveEventsServer,
+				remotionRoot,
 				request,
 				response,
-				remotionRoot,
-				gitSource,
 			});
 		}
 
-		return handleRequestElementInstall({
+		return handleStudioProtocolInstall({
+			focusStudioTab: (studioUrl) => {
+				focusBrowserTab({url: studioUrl}).catch(() => undefined);
+			},
 			liveEventsServer,
 			request,
 			response,

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -1,7 +1,9 @@
 import {expect, test} from 'bun:test';
 import {
 	clearElementInstallStateForTests,
+	consumeStudioProtocolTarget,
 	getElementInstallTarget,
+	issueStudioProtocolTarget,
 	updateElementInstallTarget,
 } from '../preview-server/element-install-state';
 
@@ -73,6 +75,66 @@ test('falls back to update recency when focus timestamps match', async () => {
 	});
 
 	expect(getElementInstallTarget(null)?.clientId).toBe('second-tab');
+});
+
+test('binds a single-use Studio Protocol token to the selected composition', () => {
+	clearElementInstallStateForTests();
+	updateElementInstallTarget({
+		requestId: 'protocol-request',
+		clientId: 'focused-tab',
+		compositionFile: '/project/src/main.tsx',
+		compositionId: 'Main',
+		canInstall: true,
+		lastFocusedAt: Date.now(),
+		readOnly: false,
+		studioUrl: 'http://localhost:3000/Main',
+	});
+	const selected = getElementInstallTarget('protocol-request');
+	if (selected === null) {
+		throw new Error('Expected an install target');
+	}
+
+	const issued = issueStudioProtocolTarget({now: Date.now(), target: selected});
+	expect(
+		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id})
+			?.compositionId,
+	).toBe('Main');
+	expect(
+		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id}),
+	).toBe(null);
+});
+
+test('invalidates a token if the selected tab changes compositions', () => {
+	clearElementInstallStateForTests();
+	updateElementInstallTarget({
+		requestId: 'protocol-request',
+		clientId: 'focused-tab',
+		compositionFile: '/project/src/main.tsx',
+		compositionId: 'Main',
+		canInstall: true,
+		lastFocusedAt: Date.now(),
+		readOnly: false,
+		studioUrl: 'http://localhost:3000/Main',
+	});
+	const selected = getElementInstallTarget('protocol-request');
+	if (selected === null) {
+		throw new Error('Expected an install target');
+	}
+
+	const issued = issueStudioProtocolTarget({now: Date.now(), target: selected});
+	updateElementInstallTarget({
+		requestId: null,
+		clientId: 'focused-tab',
+		compositionFile: '/project/src/other.tsx',
+		compositionId: 'Other',
+		canInstall: true,
+		lastFocusedAt: Date.now(),
+		readOnly: false,
+		studioUrl: 'http://localhost:3000/Other',
+	});
+	expect(
+		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id}),
+	).toBe(null);
 });
 
 test('can select a target for a specific request', () => {

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -125,6 +125,23 @@ test('discovers an exact Studio target and delivers one install request over HTT
 			targetId: descriptor.installTarget.id,
 			payload,
 		};
+		const invalidEnvelopeResponse = await fetch(
+			`${origin}/api/studio-protocol/install`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'http://localhost:4000',
+				},
+				body: JSON.stringify({...installBody, protocolVersion: 2}),
+			},
+		);
+		expect(invalidEnvelopeResponse.status).toBe(400);
+		expect(await invalidEnvelopeResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'unsupported-protocol'},
+		});
+
 		const invalidPayloadResponse = await fetch(
 			`${origin}/api/studio-protocol/install`,
 			{

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -1,0 +1,196 @@
+import {expect, test} from 'bun:test';
+import {createServer} from 'node:http';
+import {createElementPayload} from '@remotion/studio-protocol';
+import type {EventSourceEvent} from '@remotion/studio-shared';
+import {
+	clearElementInstallStateForTests,
+	updateElementInstallTarget,
+} from '../preview-server/element-install-state';
+import type {LiveEventsServer} from '../preview-server/live-events';
+import {handleStudioProtocolDiscovery} from '../preview-server/studio-protocol/handle-discovery';
+import {handleStudioProtocolInstall} from '../preview-server/studio-protocol/handle-install';
+import {handleStudioProtocolOptions} from '../preview-server/studio-protocol/origin-policy';
+
+const payload = createElementPayload({
+	dependencies: [],
+	dimensions: {width: 800, height: 200},
+	displayName: 'Lower Third',
+	durationInFrames: 90,
+	slug: 'lower-third',
+	sourceCode: 'export const LowerThird = () => null;',
+});
+
+test('discovers an exact Studio target and delivers one install request over HTTP', async () => {
+	clearElementInstallStateForTests();
+	const deliveredEvents: EventSourceEvent[] = [];
+	const liveEventsServer: LiveEventsServer = {
+		addNewClientListener: () => () => undefined,
+		closeConnections: () => Promise.resolve(),
+		router: () => Promise.resolve(),
+		sendEventToClient: (event) => {
+			if (event.type !== 'request-element-install-target') {
+				return;
+			}
+
+			updateElementInstallTarget({
+				requestId: event.requestId,
+				clientId: 'focused-studio-tab',
+				compositionFile: '/tmp/protocol-project/src/Composition.tsx',
+				compositionId: 'Main',
+				canInstall: true,
+				lastFocusedAt: Date.now(),
+				readOnly: false,
+				studioUrl: 'http://localhost:3000/Main',
+			});
+		},
+		sendEventToClientId: (clientId, event) => {
+			if (clientId !== 'focused-studio-tab') {
+				return false;
+			}
+
+			deliveredEvents.push(event);
+			return true;
+		},
+	};
+
+	const server = createServer((request, response) => {
+		const {pathname} = new URL(request.url ?? '/', 'http://localhost');
+		if (request.method === 'OPTIONS') {
+			handleStudioProtocolOptions({request, response}).catch((error) =>
+				response.destroy(error),
+			);
+			return;
+		}
+
+		if (pathname === '/api/studio-protocol') {
+			handleStudioProtocolDiscovery({
+				gitSource: null,
+				liveEventsServer,
+				remotionRoot: '/tmp/protocol-project',
+				request,
+				response,
+			}).catch((error) => response.destroy(error));
+			return;
+		}
+
+		handleStudioProtocolInstall({
+			focusStudioTab: () => undefined,
+			liveEventsServer,
+			request,
+			response,
+		}).catch((error) => response.destroy(error));
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+	try {
+		const address = server.address();
+		if (address === null || typeof address === 'string') {
+			throw new Error('Expected an HTTP server address');
+		}
+
+		const origin = `http://127.0.0.1:${address.port}`;
+		const preflight = await fetch(`${origin}/api/studio-protocol/install`, {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'http://localhost:4000',
+				'Access-Control-Request-Method': 'POST',
+			},
+		});
+		expect(preflight.status).toBe(204);
+		expect(preflight.headers.get('access-control-allow-origin')).toBe(
+			'http://localhost:4000',
+		);
+		const disallowedResponse = await fetch(`${origin}/api/studio-protocol`, {
+			headers: {Origin: 'https://example.com'},
+		});
+		expect(disallowedResponse.status).toBe(403);
+		expect(await disallowedResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'unsupported-origin'},
+		});
+
+		const discoveryResponse = await fetch(`${origin}/api/studio-protocol`, {
+			headers: {Origin: 'http://localhost:4000'},
+		});
+		expect(discoveryResponse.status).toBe(200);
+		expect(discoveryResponse.headers.get('cache-control')).toBe('no-store');
+		const descriptor = (await discoveryResponse.json()) as {
+			installTarget: {id: string; compositionId: string};
+		};
+		expect(descriptor.installTarget.compositionId).toBe('Main');
+
+		const installBody = {
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			targetId: descriptor.installTarget.id,
+			payload,
+		};
+		const invalidPayloadResponse = await fetch(
+			`${origin}/api/studio-protocol/install`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'http://localhost:4000',
+				},
+				body: JSON.stringify({...installBody, payload: {}}),
+			},
+		);
+		expect(invalidPayloadResponse.status).toBe(400);
+		expect(await invalidPayloadResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'invalid-payload'},
+		});
+		expect(deliveredEvents).toHaveLength(0);
+
+		const installResponse = await fetch(
+			`${origin}/api/studio-protocol/install`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'http://localhost:4000',
+				},
+				body: JSON.stringify(installBody),
+			},
+		);
+		expect(await installResponse.json()).toEqual({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'awaiting-confirmation',
+		});
+		expect(deliveredEvents).toHaveLength(1);
+		expect(deliveredEvents[0]).toMatchObject({
+			type: 'element-install-request',
+			request: {
+				clientId: 'focused-studio-tab',
+				compositionFile: '/tmp/protocol-project/src/Composition.tsx',
+				compositionId: 'Main',
+				element: {displayName: 'Lower Third'},
+			},
+		});
+
+		const replayResponse = await fetch(
+			`${origin}/api/studio-protocol/install`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'http://localhost:4000',
+				},
+				body: JSON.stringify(installBody),
+			},
+		);
+		expect(replayResponse.status).toBe(409);
+		expect(await replayResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'target-expired'},
+		});
+		expect(deliveredEvents).toHaveLength(1);
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+		clearElementInstallStateForTests();
+	}
+});


### PR DESCRIPTION
## Summary

- add `GET /api/studio-protocol` discovery and `POST /api/studio-protocol/install`
- restrict cross-origin access with explicit origin, CORS, and Private Network Access handling
- bind short-lived, single-use installation tokens to an exact Studio tab and composition snapshot
- remove the pre-protocol discovery and tokenless installation routes
- return structured protocol errors and add real HTTP integration and target-state tests

Part of #9771.

## Validation

- `bunx turbo run make test --filter='@remotion/studio-server' --no-update-notifier`
- `bunx turbo run test --filter='@remotion/studio' --no-update-notifier`
- `bun run build`
- `bun run stylecheck`
