### PR TITLE
`@remotion/studio-protocol`: Adopt the protocol in Remotion Elements

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -102,12 +102,6 @@
 	gap: 10px;
 }
 
-.poweredBy {
-	margin: 8px 0 0;
-	font-size: 0.75rem;
-	color: var(--ifm-color-emphasis-600);
-}
-
 .successStatus,
 .errorStatus {
 	margin: 12px 0 0;

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -102,6 +102,12 @@
 	gap: 10px;
 }
 
+.poweredBy {
+	margin: 8px 0 0;
+	font-size: 0.75rem;
+	color: var(--ifm-color-emphasis-600);
+}
+
 .successStatus,
 .errorStatus {
 	margin: 12px 0 0;

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -196,10 +196,6 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									Drag into Studio
 								</PlainButton>
 							</div>
-							<p className={styles.poweredBy}>
-								Powered by the{' '}
-								<a href="/docs/studio-protocol">Remotion Studio Protocol</a>
-							</p>
 							{installStatus.type === 'success' ||
 							installStatus.type === 'error' ? (
 								<p

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -1,6 +1,7 @@
 import {
-	StudioProtocolInternals,
-	type ComponentDimensions,
+	createElementPayload,
+	installInStudio,
+	setStudioDragData,
 } from '@remotion/studio-protocol';
 import React, {
 	useCallback,
@@ -11,7 +12,7 @@ import React, {
 } from 'react';
 import {BlueButton, PlainButton} from '../../../components/layout/Button';
 import type {ElementDefinition} from './element-definitions';
-import {setElementDragData, setElementDragImage} from './element-drag-data';
+import {setElementDragImage} from './element-drag-data';
 import {getElementDimensionsLabel} from './element-utils';
 import {ElementPreview} from './ElementPreview';
 import {
@@ -57,12 +58,12 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const {height: previewHeight, width: previewWidth} =
 		getElementPreviewDimensions(definition);
 
-	const dragData = useMemo(() => {
+	const elementPayload = useMemo(() => {
 		if (!sourceCode) {
 			return null;
 		}
 
-		const dimensions: ComponentDimensions | null =
+		const dimensions =
 			elementWidth !== null && elementHeight !== null
 				? {
 						width: elementWidth,
@@ -70,8 +71,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 					}
 				: null;
 
-		return StudioProtocolInternals.makeDragData({
-			type: 'element',
+		return createElementPayload({
 			dependencies,
 			dimensions,
 			displayName,
@@ -90,16 +90,16 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	]);
 
 	const installElement = useCallback(async () => {
-		if (dragData === null) {
+		if (elementPayload === null) {
 			return;
 		}
 
 		setInstallStatus({type: 'installing'});
-		const result = await StudioProtocolInternals.installInStudio(dragData);
+		const result = await installInStudio({payload: elementPayload});
 		if (!result.success) {
 			setInstallStatus({
 				type: 'error',
-				message: result.reason,
+				message: result.message,
 			});
 			return;
 		}
@@ -107,12 +107,10 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 		const {target} = result;
 		setInstallStatus({
 			type: 'success',
-			message: `Sent to ${target.projectName ?? 'Remotion Studio'}${
-				target.activeCompositionId ? ` / ${target.activeCompositionId}` : ''
-			}. Confirm the install in Studio.`,
-			studioUrl: target.origin,
+			message: `Sent to ${target.projectName ?? 'Remotion Studio'} / ${target.compositionId}. Confirm the installation in Studio.`,
+			studioUrl: target.studioOrigin,
 		});
-	}, [dragData]);
+	}, [elementPayload]);
 
 	const PreviewComponent = useMemo(() => {
 		return () => <ElementPreviewComposition definition={definition} />;
@@ -165,7 +163,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				className={styles.actionsColumn}
 			>
 				<div className={styles.useIt}>
-					{dragData === null ? null : (
+					{elementPayload === null ? null : (
 						<>
 							<div className={styles.actionRow}>
 								<BlueButton
@@ -178,16 +176,16 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 								>
 									{installStatus.type === 'installing'
 										? 'Finding Studio…'
-										: 'Install Element'}
+										: 'Install in Studio'}
 								</BlueButton>
 								<PlainButton
 									draggable
 									fullWidth
 									loading={false}
 									onDragStart={(event) => {
-										setElementDragData({
+										setStudioDragData({
 											dataTransfer: event.dataTransfer,
-											dragData,
+											payload: elementPayload,
 										});
 										setElementDragImage(event.dataTransfer);
 									}}
@@ -198,6 +196,10 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									Drag into Studio
 								</PlainButton>
 							</div>
+							<p className={styles.poweredBy}>
+								Powered by the{' '}
+								<a href="/docs/studio-protocol">Remotion Studio Protocol</a>
+							</p>
 							{installStatus.type === 'success' ||
 							installStatus.type === 'error' ? (
 								<p

--- a/packages/docs/src/components/Elements/element-drag-data.ts
+++ b/packages/docs/src/components/Elements/element-drag-data.ts
@@ -1,5 +1,3 @@
-import type {ConstructedDragData} from '@remotion/studio-protocol';
-
 const ELEMENT_ICON_PATH =
 	'M3 3.5C3 2.67157 3.67157 2 4.5 2H11.5C12.3284 2 13 2.67157 13 3.5V12.5C13 13.3284 12.3284 14 11.5 14H4.5C3.67157 14 3 13.3284 3 12.5V3.5ZM4.5 3.5V6H11.5V3.5H4.5ZM11.5 7.5H4.5V12.5H11.5V7.5Z';
 
@@ -30,17 +28,6 @@ const makeElementDragImage = () => {
 	wrapper.appendChild(svg);
 
 	return wrapper;
-};
-
-export const setElementDragData = ({
-	dataTransfer,
-	dragData,
-}: {
-	readonly dataTransfer: DataTransfer;
-	readonly dragData: ConstructedDragData;
-}) => {
-	dataTransfer.effectAllowed = 'copy';
-	dataTransfer.setData(dragData.mimeType, dragData.payload);
 };
 
 export const setElementDragImage = (dataTransfer: DataTransfer) => {


### PR DESCRIPTION
## Summary

- migrate the official Remotion Elements page to `createElementPayload()`, `setStudioDragData()`, and `installInStudio()`
- preserve the user-facing **Install in Studio** and **Drag into Studio** actions
- report the selected project and composition using the stable installation result
- add secondary “Powered by the Remotion Studio Protocol” branding

This keeps the public v1 adoption narrowly scoped to official Remotion Elements.

Part of #9771.

## Validation

- `bun run build`
- `bun run stylecheck`
