### PR TITLE
`@remotion/studio-server`: Import staticFile when changing media sources

### DIFF
--- a/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
+++ b/packages/studio-server/src/codemods/update-sequence-props/update-sequence-props.ts
@@ -23,6 +23,7 @@ import {
 	getCssShorthandsForUpdates,
 	type CssShorthandProperty,
 } from '../../helpers/css-shorthand-properties';
+import {ensureNamedImports} from '../../helpers/imports';
 import {
 	parseVideoConfigNumericExpression,
 	updateVideoConfigNumericExpression,
@@ -48,6 +49,30 @@ export type SequencePropUpdate = {
 	value: unknown;
 	defaultValue: unknown | null;
 	googleFont?: GoogleFontSourceEdit | null;
+};
+
+const ensureImportsForUpdates = ({
+	ast,
+	updates,
+}: {
+	ast: File;
+	updates: SequencePropUpdate[];
+}) => {
+	if (
+		updates.some(
+			({value, defaultValue}) =>
+				typeof value === 'string' &&
+				value.startsWith(NoReactInternals.FILE_TOKEN) &&
+				(defaultValue === null ||
+					JSON.stringify(value) !== JSON.stringify(defaultValue)),
+		)
+	) {
+		ensureNamedImports({
+			ast,
+			importedNames: new Set(['staticFile']),
+			sourcePath: 'remotion',
+		});
+	}
 };
 
 export type RemovedProp = {
@@ -1057,6 +1082,7 @@ export const updateSequencePropsAst = ({
 		schema,
 		videoConfigValues: videoConfigIdentifierValues,
 	});
+	ensureImportsForUpdates({ast, updates});
 	applyGoogleFontSourceEdits({ast, updates});
 
 	return {
@@ -1099,6 +1125,7 @@ export const updateMultipleSequenceProps = async ({
 			});
 		},
 	);
+	ensureImportsForUpdates({ast, updates: allUpdates});
 	applyGoogleFontSourceEdits({ast, updates: allUpdates});
 
 	const {output, formatted} = await formatFileContent({

--- a/packages/studio-server/src/test/update-sequence-props.test.ts
+++ b/packages/studio-server/src/test/update-sequence-props.test.ts
@@ -300,6 +300,43 @@ export const Example = () => {
 	expect(output).toContain(`src={staticFile('folder/new image.png')}`);
 });
 
+test('updateMultipleSequenceProps should import staticFile() when changing a remote asset to a local asset', async () => {
+	const input = `import {Video} from '@remotion/media';
+
+export const Example = () => {
+	return <Video src="https://example.com/old.mp4" />;
+};
+`;
+	const {output, results} = await updateMultipleSequenceProps({
+		input,
+		changes: [
+			{
+				nodePath: lineColumnToNodePath(input, 4),
+				updates: [
+					{
+						key: 'src',
+						value: 'remotion-file:folder/new%20video.mp4',
+						defaultValue: null,
+					},
+				],
+				schema: {
+					src: {
+						type: 'asset',
+						default: undefined,
+						keyframable: false,
+					},
+				},
+				videoConfigValues: null,
+			},
+		],
+		prettierConfigOverride: null,
+	});
+
+	expect(results[0].oldValueStrings[0]).toBe('"https://example.com/old.mp4"');
+	expect(output).toContain("import {staticFile} from 'remotion';");
+	expect(output).toContain(`src={staticFile('folder/new video.mp4')}`);
+});
+
 test('updateSequenceProps should remove attribute when value equals default', async () => {
 	const {output, oldValueStrings} = await updateSequenceProps({
 		videoConfigValues: null,


### PR DESCRIPTION
## Summary

- add the `staticFile` import when a sequence-prop codemod replaces a remote media URL with a local asset token
- cover the batched Studio save path with a regression test for persisted executable source

## Test plan

- `bun test src/test/update-sequence-props.test.ts` in `packages/studio-server` (28 pass)
- red/green regression verification by disconnecting the batched import pass
- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/studio-server` (489 pass; 3 unrelated existing failures in `log-effect-update.test.ts` and `log-update.test.ts`)

Closes #9876
