### PR TITLE
`@remotion/cli`: Add `Config.setRspack()`

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -219,9 +219,13 @@ declare global {
 		 */
 		readonly setAllowHtmlInCanvasEnabled: (enabled: boolean) => void;
 		/**
-		 * Enable experimental Rspack bundler instead of Webpack.
+		 * Enable the Rspack bundler instead of Webpack.
 		 * @param enabled Boolean whether to enable the Rspack bundler
 		 * @default false
+		 */
+		readonly setRspack: (enabled: boolean) => void;
+		/**
+		 * @deprecated Use `setRspack()` instead: https://www.remotion.dev/docs/config#setrspack
 		 */
 		readonly setExperimentalRspackEnabled: (enabled: boolean) => void;
 		/**
@@ -738,6 +742,7 @@ export const Config: FlatConfig = {
 	setKeyboardShortcutsEnabled: keyboardShortcutsOption.setConfig,
 	setInteractivityEnabled: interactivityOption.setConfig,
 	setAllowHtmlInCanvasEnabled,
+	setRspack: rspackOption.setConfig,
 	setExperimentalRspackEnabled: rspackOption.setConfig,
 	setNumberOfSharedAudioTags: numberOfSharedAudioTagsOption.setConfig,
 	setWebpackPollingInMilliseconds: webpackPollOption.setConfig,

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -5,6 +5,12 @@ import {parsedCli} from './parsed-cli';
 const {licenseKeyOption} = BrowserSafeApis.options;
 
 export const parseCommandLine = () => {
+	if (parsedCli['experimental-rspack'] !== undefined) {
+		throw new Error(
+			'The --experimental-rspack flag has been removed. Use --rspack from now on.',
+		);
+	}
+
 	if (parsedCli.png) {
 		throw new Error(
 			'The --png flag has been removed. Use --sequence --image-format=png from now on.',

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -78,6 +78,7 @@ const {
 	browserOption,
 	sampleRateOption,
 	previewSampleRateOption,
+	rspackOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
@@ -190,6 +191,8 @@ export type CommandLineOptions = {
 	[previewSampleRateOption.cliFlag]: TypeOfOption<
 		typeof previewSampleRateOption
 	>;
+	[rspackOption.cliFlag]: TypeOfOption<typeof rspackOption> | null;
+	'experimental-rspack'?: unknown;
 	[isProductionOption.cliFlag]: TypeOfOption<typeof isProductionOption> | null;
 };
 
@@ -216,6 +219,7 @@ export const BooleanFlags = [
 	isProductionOption.cliFlag,
 	forceNewStudioOption.cliFlag,
 	bundleCacheOption.cliFlag,
+	rspackOption.cliFlag,
 ];
 
 export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
@@ -237,6 +241,7 @@ export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {
 		[isProductionOption.cliFlag]: null,
 		[forceNewStudioOption.cliFlag]: null,
 		[mutedOption.cliFlag]: null,
+		[rspackOption.cliFlag]: null,
 	},
 }) as CommandLineOptions & {
 	_: string[];

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -166,12 +166,10 @@ export const studioCommand = async (
 	const rspackOverride = ConfigInternals.getRspackOverrideFn();
 	const webpackOverride = ConfigInternals.getWebpackOverrideFn();
 
-	if (useRspack) {
-		Log.warn(
-			{indent: false, logLevel},
-			'Enabling experimental Rspack bundler.',
-		);
-	}
+	Log.verbose(
+		{indent: false, logLevel},
+		`Using ${useRspack ? 'Rspack' : 'Webpack'} bundler.`,
+	);
 
 	const getStudioRuntimeConfig = () => ({
 		maxTimelineTracks: ConfigInternals.getMaxTimelineTracks(),

--- a/packages/cli/src/test/boolean-flag-defaults.test.ts
+++ b/packages/cli/src/test/boolean-flag-defaults.test.ts
@@ -15,6 +15,7 @@ const {
 	keyboardShortcutsOption,
 	overwriteOption,
 	reproOption,
+	rspackOption,
 } = BrowserSafeApis.options;
 
 test('config-backed boolean flags default to null when absent', () => {
@@ -30,4 +31,5 @@ test('config-backed boolean flags default to null when absent', () => {
 	expect(parsedCli[reproOption.cliFlag]).toEqual(null);
 	expect(parsedCli[isProductionOption.cliFlag]).toEqual(null);
 	expect(parsedCli[forceNewStudioOption.cliFlag]).toEqual(null);
+	expect(parsedCli[rspackOption.cliFlag]).toEqual(null);
 });

--- a/packages/cli/src/test/config-reset.test.ts
+++ b/packages/cli/src/test/config-reset.test.ts
@@ -13,6 +13,24 @@ test('Studio render defaults keep the startup log level', () => {
 	expect(getRenderDefaults('warn').logLevel).toBe('warn');
 });
 
+test('Rspack can be configured using the current and deprecated APIs', () => {
+	ConfigInternals.resetConfigOptions();
+
+	expect(
+		BrowserSafeApis.options.rspackOption.getValue({commandLine: {}}).value,
+	).toBe(false);
+
+	Config.setRspack(true);
+	expect(
+		BrowserSafeApis.options.rspackOption.getValue({commandLine: {}}).value,
+	).toBe(true);
+
+	Config.setExperimentalRspackEnabled(false);
+	expect(
+		BrowserSafeApis.options.rspackOption.getValue({commandLine: {}}).value,
+	).toBe(false);
+});
+
 test('reset config options restores defaults before reloading config', async () => {
 	ConfigInternals.resetConfigOptions();
 

--- a/packages/cli/src/test/parse-command-line.test.ts
+++ b/packages/cli/src/test/parse-command-line.test.ts
@@ -1,0 +1,15 @@
+import {afterEach, expect, test} from 'bun:test';
+import {parseCommandLine} from '../parse-command-line';
+import {parsedCli} from '../parsed-cli';
+
+afterEach(() => {
+	Reflect.deleteProperty(parsedCli, 'experimental-rspack');
+});
+
+test('the --experimental-rspack flag is rejected in favor of --rspack', () => {
+	parsedCli['experimental-rspack'] = true;
+
+	expect(() => parseCommandLine()).toThrow(
+		'The --experimental-rspack flag has been removed. Use --rspack from now on.',
+	);
+});

--- a/packages/docs/docs/cli/benchmark.mdx
+++ b/packages/docs/docs/cli/benchmark.mdx
@@ -179,9 +179,9 @@ Inherited from [`npx remotion render`](/docs/cli/render#--audio-bitrate)
 
 <Options cli id="binaries-directory" />
 
-### `--experimental-rspack`<AvailableFrom v="4.0.426" />
+### `--rspack`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ### ~~`--ffmpeg-executable`~~
 

--- a/packages/docs/docs/cli/bundle.mdx
+++ b/packages/docs/docs/cli/bundle.mdx
@@ -44,6 +44,6 @@ From <AvailableFrom v="4.0.497" inline />, bundles created by this command are r
 
 <Options id="disable-git-source" />
 
-### `--experimental-rspack`<AvailableFrom v="4.0.426" />
+### `--rspack`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />

--- a/packages/docs/docs/cli/render.mdx
+++ b/packages/docs/docs/cli/render.mdx
@@ -252,9 +252,9 @@ Not to be confused with the [`--timeout` flag when deploying a Lambda function](
 
 <Options cli id="binaries-directory" />
 
-### `--experimental-rspack`<AvailableFrom v="4.0.426" />
+### `--rspack`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ### `--sample-rate`<AvailableFrom v="4.0.448" />
 

--- a/packages/docs/docs/cli/still.mdx
+++ b/packages/docs/docs/cli/still.mdx
@@ -140,9 +140,9 @@ Not to be confused with the [`--timeout` flag when deploying a Lambda function](
 
 <Options cli id="binaries-directory" />
 
-### `--experimental-rspack`<AvailableFrom v="4.0.426" />
+### `--rspack`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ### ~~`--ffmpeg-executable`~~
 

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -57,9 +57,9 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 
 <Options id="disable-interactivity" />
 
-### `--experimental-rspack`<AvailableFrom v="4.0.426" />
+### `--rspack`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ### `--webpack-poll`<AvailableFrom v="3.3.11" />
 

--- a/packages/docs/docs/cloudrun/deploysite.mdx
+++ b/packages/docs/docs/cloudrun/deploysite.mdx
@@ -119,7 +119,7 @@ Ignore an error that gets thrown if you pass an entry point file which does not 
 
 #### `rspack?`<AvailableFrom v="4.0.426"/>
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ## Return value
 

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -235,7 +235,7 @@ From Remotion v4.0.491, this method is a no-op and can be removed from your conf
 
 ## `setRspack()`<AvailableFrom v="4.0.502" />
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
@@ -243,7 +243,7 @@ import {Config} from '@remotion/cli/config';
 Config.setRspack(true);
 ```
 
-The [command line flag](/docs/cli/studio#--experimental-rspack) `--experimental-rspack` will take precedence over this option.
+The [command line flag](/docs/cli/studio#--rspack) `--rspack` will take precedence over this option.
 
 ## ~~`setExperimentalRspackEnabled()`~~<AvailableFrom v="4.0.426" />
 

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -62,7 +62,7 @@ Config.overrideWebpackConfig((currentConfiguration) => {
 
 ## `overrideRspackConfig()`<AvailableFrom v="4.0.498" />
 
-Overrides the Rspack configuration. It is only called when [Rspack](/docs/config#setexperimentalrspackenabled) is enabled.
+Overrides the Rspack configuration. It is only called when [Rspack](/docs/config#setrspack) is enabled.
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
@@ -233,17 +233,25 @@ The [command line flag](/docs/cli/studio#--disable-interactivity) `--disable-int
 From Remotion v4.0.491, this method is a no-op and can be removed from your config file. [`@remotion/web-renderer`](/docs/web-renderer) automatically uses HTML-in-canvas when the browser supports nested captures.
 :::
 
-## `setExperimentalRspackEnabled()`<AvailableFrom v="4.0.426" />
+## `setRspack()`<AvailableFrom v="4.0.502" />
 
-Use [Rspack](/docs/bundlers#enable-rspack) instead of Webpack for CLI commands that bundle your project. Default `false`.
+<Options id="experimental-rspack" />
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 // ---cut---
-Config.setExperimentalRspackEnabled(true);
+Config.setRspack(true);
 ```
 
 The [command line flag](/docs/cli/studio#--experimental-rspack) `--experimental-rspack` will take precedence over this option.
+
+## ~~`setExperimentalRspackEnabled()`~~<AvailableFrom v="4.0.426" />
+
+:::info Deprecated
+Use [`setRspack()`](/docs/config#setrspack) instead.
+:::
+
+`setExperimentalRspackEnabled()` is an alias for `setRspack()`.
 
 ## `setWebpackPollingInMilliseconds()`<AvailableFrom v="3.3.11" />
 

--- a/packages/docs/docs/lambda/deploysite.mdx
+++ b/packages/docs/docs/lambda/deploysite.mdx
@@ -130,7 +130,7 @@ Ignore an error that gets thrown if you pass an entry point file which does not 
 
 #### `rspack?`<AvailableFrom v="4.0.426"/>
 
-<Options id="experimental-rspack" />
+<Options id="rspack" />
 
 ### `privacy?`
 

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -29,10 +29,10 @@ import {Config} from '@remotion/cli/config';
 Config.setRspack(true);
 ```
 
-To enable it for one command, use the `--experimental-rspack` flag:
+To enable it for one command, use the `--rspack` flag:
 
 ```bash
-npx remotion studio --experimental-rspack
+npx remotion studio --rspack
 ```
 
 The flag is also available for other commands that bundle your project, such as [`render`](/docs/cli/render), [`still`](/docs/cli/still), and [`bundle`](/docs/cli/bundle).

--- a/packages/docs/docs/overwriting-webpack-config.mdx
+++ b/packages/docs/docs/overwriting-webpack-config.mdx
@@ -26,7 +26,7 @@ Enable Rspack for CLI commands in [`remotion.config.ts`](/docs/config):
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
 
-Config.setExperimentalRspackEnabled(true);
+Config.setRspack(true);
 ```
 
 To enable it for one command, use the `--experimental-rspack` flag:

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -2,7 +2,7 @@ import {Config} from '@remotion/cli/config';
 import {bundlerOverride} from './src/webpack-override.mjs';
 
 Config.setOverwriteOutput(true);
-Config.setExperimentalRspackEnabled(true);
+Config.setRspack(true);
 Config.overrideBundlerConfig(async (config) => {
 	await new Promise((resolve) => {
 		setTimeout(resolve, 10);

--- a/packages/renderer/src/options/rspack.tsx
+++ b/packages/renderer/src/options/rspack.tsx
@@ -2,10 +2,10 @@ import type {AnyRemotionOption} from './option';
 
 let rspackEnabled = false;
 
-const cliFlag = 'experimental-rspack' as const;
+const cliFlag = 'rspack' as const;
 
 export const rspackOption = {
-	name: 'Experimental Rspack',
+	name: 'Rspack',
 	cliFlag,
 	description: () => (
 		<>Uses Rspack instead of Webpack as the bundler for the Studio or bundle.</>
@@ -14,8 +14,7 @@ export const rspackOption = {
 	docLink: null,
 	type: false as boolean,
 	getValue: ({commandLine}) => {
-		if (commandLine[cliFlag] !== undefined) {
-			rspackEnabled = true;
+		if (commandLine[cliFlag] !== undefined && commandLine[cliFlag] !== null) {
 			return {
 				value: commandLine[cliFlag] as boolean,
 				source: 'cli',

--- a/packages/renderer/src/test/boolean-option-precedence.test.ts
+++ b/packages/renderer/src/test/boolean-option-precedence.test.ts
@@ -11,6 +11,7 @@ import {isProductionOption} from '../options/is-production';
 import {keyboardShortcutsOption} from '../options/keyboard-shortcuts';
 import {overwriteOption} from '../options/overwrite';
 import {reproOption} from '../options/repro';
+import {rspackOption} from '../options/rspack';
 
 test('boolean options respect config if CLI flag is absent', () => {
 	overwriteOption.setConfig(false);
@@ -134,4 +135,13 @@ test('boolean options respect config if CLI flag is absent', () => {
 		forceNewStudioOption.getValue({commandLine: {'force-new': false}}).value,
 	).toEqual(false);
 	forceNewStudioOption.setConfig(false);
+
+	rspackOption.setConfig(true);
+	expect(rspackOption.getValue({commandLine: {rspack: null}}).value).toEqual(
+		true,
+	);
+	expect(rspackOption.getValue({commandLine: {rspack: false}}).value).toEqual(
+		false,
+	);
+	rspackOption.setConfig(false);
 });


### PR DESCRIPTION
## Summary

- add `Config.setRspack()` as the canonical config-file API
- keep `Config.setExperimentalRspackEnabled()` as a deprecated compatibility alias
- rename the CLI flag to `--rspack`
- reject `--experimental-rspack` with a migration error
- replace the experimental Studio warning with a verbose log of the selected bundler
- update the Rspack documentation and test coverage

Closes #9786.

## Testing

- focused CLI and renderer option tests
- manual CLI checks for `--rspack` and `--experimental-rspack`
- `bun run build`
- `bun run stylecheck`
- `bun run prewarm-twoslash` in `packages/docs`
- `bun test src` in `packages/docs`
- `bun run build-docs` in `packages/docs`
- `bun run render-cards` in `packages/docs`

Red/green verified for the new config setter and the removed CLI flag error.

## Preview

- [Configuration file](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/config)
- [Webpack and Rspack](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/bundlers)
- [Studio CLI](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cli/studio)
- [Render CLI](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cli/render)
- [Still CLI](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cli/still)
- [Bundle CLI](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cli/bundle)
- [Benchmark CLI](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cli/benchmark)
- [Lambda deploySite()](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/lambda/deploysite)
- [Cloud Run deploySite()](https://remotion-git-codex-set-rspack-remotion.vercel.app/docs/cloudrun/deploysite)
