### PR TITLE
`@remotion/studio`: Improve unsymbolicated error overlay

### DIFF
--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -1,5 +1,5 @@
-import {expect, test} from '@playwright/test';
 import fs from 'fs';
+import {expect, test} from '@playwright/test';
 import {errorOverlayE2eFile, STUDIO_URL} from './constants.mts';
 import {readStudioLogs, stripAnsi} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
@@ -27,7 +27,8 @@ test.describe('error overlay dismissal', () => {
 		await stopStudio();
 	});
 
-	test('error UI toggles with the underlying runtime error across HMR cycles', async ({
+	test('error overlay remains useful without symbolication and recovers across HMR cycles', async ({
+		context,
 		page,
 	}) => {
 		const originalContent = fs.readFileSync(errorOverlayE2eFile, 'utf-8');
@@ -64,6 +65,51 @@ test.describe('error overlay dismissal', () => {
 				)
 				.toBe(true);
 		};
+
+		await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+			origin: STUDIO_URL,
+		});
+		await page.goto(`${STUDIO_URL}/error-overlay-unsymbolicated-e2e`);
+		await expect(page.getByText('Expected defaults').first()).toBeVisible({
+			timeout: 15_000,
+		});
+		await expect(
+			page.getByText('Could not symbolicate the stack trace: Failed to fetch'),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Copy Stacktrace'}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: /Search GitHub Issues/}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: /Ask on Discord/}),
+		).toBeVisible();
+
+		const rawStack = page.getByLabel('Unsymbolicated stack trace');
+		await expect(rawStack).toContainText(
+			'webpack-internal:///cannot-symbolicate.js',
+		);
+		await expect
+			.poll(() =>
+				page.evaluate(
+					() =>
+						document.documentElement.scrollWidth ===
+						document.documentElement.clientWidth,
+				),
+			)
+			.toBe(true);
+		expect(
+			await rawStack.evaluate(
+				(element) => element.scrollWidth > element.clientWidth,
+			),
+		).toBe(true);
+
+		await page.getByRole('button', {name: 'Copy Stacktrace'}).click();
+		await expect(page.getByRole('button', {name: 'Copied!'})).toBeVisible();
+		expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+			'webpack-internal:///cannot-symbolicate.js',
+		);
 
 		await page.goto(`${STUDIO_URL}/error-overlay-e2e`);
 		await expect(page).toHaveURL(/error-overlay-e2e/, {timeout: 15_000});

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {Composition, Folder} from 'remotion';
 import {EffectKeyframeE2e} from './EffectKeyframeE2e';
-import {ErrorOverlayRepro} from './ErrorOverlayE2e/ErrorOverlayRepro';
+import {
+	ErrorOverlayRepro,
+	UnsymbolicatedErrorOverlayRepro,
+} from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
 import {Issue8216} from './Issue8216/Issue8216';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
@@ -71,6 +74,14 @@ export const E2eTestRoot: React.FC = () => {
 				<Composition
 					id="error-overlay-e2e"
 					component={ErrorOverlayRepro}
+					width={400}
+					height={400}
+					fps={30}
+					durationInFrames={30}
+				/>
+				<Composition
+					id="error-overlay-unsymbolicated-e2e"
+					component={UnsymbolicatedErrorOverlayRepro}
 					width={400}
 					height={400}
 					fps={30}

--- a/packages/example/src/ErrorOverlayE2e/ErrorOverlayRepro.tsx
+++ b/packages/example/src/ErrorOverlayE2e/ErrorOverlayRepro.tsx
@@ -20,3 +20,13 @@ export const ErrorOverlayRepro: React.FC = () => {
 		</AbsoluteFill>
 	);
 };
+
+export const UnsymbolicatedErrorOverlayRepro: React.FC = () => {
+	const error = new TypeError('Expected defaults');
+	error.stack = [
+		'TypeError: Expected defaults',
+		'    at unsymbolicatedErrorOverlayRepro (webpack-internal:///cannot-symbolicate.js:1:1)',
+		'    at aDeliberatelyLongFunctionNameToTestHorizontalOverflow (webpack-internal:///this-is-a-deliberately-long-file-name-that-must-not-widen-the-error-overlay-beyond-the-viewport.js:2:3)',
+	].join('\n');
+	throw error;
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -425,16 +425,6 @@ export const Index: React.FC = () => {
 
 	return (
 		<>
-			<Folder name="error-overlay">
-				<Composition
-					id="error-overlay-unsymbolicated-e2e"
-					component={UnsymbolicatedErrorOverlayRepro}
-					width={400}
-					height={400}
-					fps={30}
-					durationInFrames={30}
-				/>
-			</Folder>
 			<Composition
 				id="switzerland-map"
 				lazyComponent={() => import('./SwitzerlandMap/SwitzerlandMap')}
@@ -2884,6 +2874,16 @@ export const Index: React.FC = () => {
 				fps={30}
 				durationInFrames={30}
 			/>
+			<Folder name="error-overlay">
+				<Composition
+					id="error-overlay-unsymbolicated-e2e"
+					component={UnsymbolicatedErrorOverlayRepro}
+					width={400}
+					height={400}
+					fps={30}
+					durationInFrames={30}
+				/>
+			</Folder>
 			<Composition
 				id="browser-test"
 				component={BrowserTest}

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -44,6 +44,7 @@ import {EasingVisualizer} from './EasingVisualizer/EasingVisualizer';
 import {EffectCopySource, EffectCopyTarget} from './EffectCopyTestbed';
 import {EmojiTestbed} from './Emoji';
 import {ErrorOnFrame10} from './ErrorOnFrame10';
+import {UnsymbolicatedErrorOverlayRepro} from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {Expert} from './Expert';
 import {FontDemo} from './Fonts';
 import {FractionalSequenceVideo} from './FractionalSequenceVideo';
@@ -424,6 +425,16 @@ export const Index: React.FC = () => {
 
 	return (
 		<>
+			<Folder name="error-overlay">
+				<Composition
+					id="error-overlay-unsymbolicated-e2e"
+					component={UnsymbolicatedErrorOverlayRepro}
+					width={400}
+					height={400}
+					fps={30}
+					durationInFrames={30}
+				/>
+			</Folder>
 			<Composition
 				id="switzerland-map"
 				lazyComponent={() => import('./SwitzerlandMap/SwitzerlandMap')}

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
@@ -3,6 +3,11 @@ import React, {useMemo} from 'react';
 import {MediaPlaybackError} from 'remotion';
 import {Spacing} from '../../components/layout';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../../components/Menu/is-menu-item';
+import {
+	ERROR_CODE_FRAME_BACKGROUND,
+	WHITE,
+	WHITE_ALPHA_60,
+} from '../../helpers/colors';
 import type {ErrorRecord} from '../react-overlay/listen-to-runtime-errors';
 import {AskOnDiscord} from './AskOnDiscord';
 import {CalculateMetadataErrorExplainer} from './CalculateMetadataErrorExplainer';
@@ -22,6 +27,30 @@ const stack: React.CSSProperties = {
 	marginBottom: '10vh',
 };
 
+const rawStack: React.CSSProperties = {
+	backgroundColor: ERROR_CODE_FRAME_BACKGROUND,
+	boxSizing: 'border-box',
+	color: WHITE,
+	fontFamily: 'monospace',
+	fontSize: 14,
+	lineHeight: 1.7,
+	marginBottom: 0,
+	marginTop: 17,
+	maxWidth: '100%',
+	overflowX: 'auto',
+	padding: 12,
+	whiteSpace: 'pre',
+};
+
+const symbolicationFailureStyle: React.CSSProperties = {
+	color: WHITE_ALPHA_60,
+	fontFamily: 'SF Pro Text, sans-serif',
+	fontSize: 14,
+	lineHeight: 1.5,
+	marginBottom: '10vh',
+	marginTop: 24,
+};
+
 const spacer: React.CSSProperties = {
 	width: 5,
 	display: 'inline-block',
@@ -35,14 +64,17 @@ export const ErrorDisplay: React.FC<{
 	readonly onRetry: OnRetry;
 	readonly canHaveDismissButton: boolean;
 	readonly calculateMetadata: boolean;
+	readonly symbolicationFailure: string | null;
 }> = ({
 	display,
 	keyboardShortcuts,
 	onRetry,
 	canHaveDismissButton,
 	calculateMetadata,
+	symbolicationFailure,
 }) => {
 	const highestLineNumber = Math.max(
+		0,
 		...display.stackFrames
 			.map((s) => s.originalScriptCode)
 			.flat(1)
@@ -140,20 +172,36 @@ export const ErrorDisplay: React.FC<{
 					<MediaPlaybackErrorExplainer src={display.error.src} />
 				</>
 			) : null}
-			<div style={stack} className={HORIZONTAL_SCROLLBAR_CLASSNAME}>
-				{display.stackFrames.map((s, i) => {
-					return (
-						<StackElement
-							// eslint-disable-next-line react/no-array-index-key
-							key={i}
-							isFirst={i === 0}
-							s={s}
-							lineNumberWidth={lineNumberWidth}
-							defaultFunctionName={'(anonymous function)'}
-						/>
-					);
-				})}
-			</div>
+			{display.stackFrames.length > 0 ? (
+				<div style={stack} className={HORIZONTAL_SCROLLBAR_CLASSNAME}>
+					{display.stackFrames.map((s, i) => {
+						return (
+							<StackElement
+								// eslint-disable-next-line react/no-array-index-key
+								key={i}
+								isFirst={i === 0}
+								s={s}
+								lineNumberWidth={lineNumberWidth}
+								defaultFunctionName={'(anonymous function)'}
+							/>
+						);
+					})}
+				</div>
+			) : (
+				<>
+					<pre
+						aria-label="Unsymbolicated stack trace"
+						className={HORIZONTAL_SCROLLBAR_CLASSNAME}
+						style={rawStack}
+					>
+						{display.error.stack ??
+							'Check the Terminal and browser console for error messages.'}
+					</pre>
+					{symbolicationFailure ? (
+						<div style={symbolicationFailureStyle}>{symbolicationFailure}</div>
+					) : null}
+				</>
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorLoader.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorLoader.tsx
@@ -1,6 +1,5 @@
 import {getLocationFromBuildError} from '@remotion/studio-shared';
 import React, {useEffect, useState} from 'react';
-import {WHITE} from '../../helpers/colors';
 import {wasErrorLoggedByServer} from '../error-origin';
 import type {ErrorRecord} from '../react-overlay/listen-to-runtime-errors';
 import {getErrorRecord} from '../react-overlay/listen-to-runtime-errors';
@@ -18,19 +17,7 @@ const container: React.CSSProperties = {
 	marginRight: 'auto',
 	fontFamily: 'SF Pro Text, sans-serif',
 	paddingTop: '5vh',
-};
-
-const errorWhileErrorStyle: React.CSSProperties = {
-	color: WHITE,
-	lineHeight: 1.5,
-	whiteSpace: 'pre',
-};
-
-const errorWhileSymbolicatingStyle: React.CSSProperties = {
-	color: WHITE,
-	lineHeight: 1.5,
-	marginTop: 24,
-	opacity: 0.7,
+	boxSizing: 'border-box',
 };
 
 type State =
@@ -155,19 +142,14 @@ export const ErrorLoader: React.FC<{
 	if (state.type === 'error') {
 		return (
 			<div style={container}>
-				<ErrorTitle
-					symbolicating={false}
-					name={error.name}
-					message={error.message}
+				<ErrorDisplay
+					keyboardShortcuts={keyboardShortcuts}
+					display={{error, contextSize: 0, stackFrames: []}}
+					onRetry={onRetry}
 					canHaveDismissButton={canHaveDismissButton}
+					calculateMetadata={calculateMetadata}
+					symbolicationFailure={`Could not symbolicate the stack trace: ${state.err.message}`}
 				/>
-				<div style={errorWhileErrorStyle}>
-					{error.stack ??
-						'Check the Terminal and browser console for error messages.'}
-				</div>
-				<div style={errorWhileSymbolicatingStyle}>
-					Could not symbolicate the stack trace: {state.err.message}
-				</div>
 			</div>
 		);
 	}
@@ -175,15 +157,14 @@ export const ErrorLoader: React.FC<{
 	if (state.type === 'no-record') {
 		return (
 			<div style={container}>
-				<ErrorTitle
-					symbolicating={false}
-					name={error.name}
-					message={error.message}
+				<ErrorDisplay
+					keyboardShortcuts={keyboardShortcuts}
+					display={{error, contextSize: 0, stackFrames: []}}
+					onRetry={onRetry}
 					canHaveDismissButton={canHaveDismissButton}
+					calculateMetadata={calculateMetadata}
+					symbolicationFailure="Could not symbolicate the stack trace."
 				/>
-				<div style={errorWhileErrorStyle}>
-					Check the Terminal and browser console for error messages.
-				</div>
 			</div>
 		);
 	}
@@ -196,6 +177,7 @@ export const ErrorLoader: React.FC<{
 				onRetry={onRetry}
 				canHaveDismissButton={canHaveDismissButton}
 				calculateMetadata={calculateMetadata}
+				symbolicationFailure={null}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary

- Preserve useful error overlay actions when stack symbolication fails
- Show the raw stack trace in a constrained, horizontally scrollable code block
- Add a deterministic example composition and end-to-end regression coverage

## Testing

- `bunx playwright test e2e/error-overlay.test.mts`
- `bun run build`
- `bun run stylecheck`

Closes #9857
