### PR TITLE
`@remotion/promo-pages`: Render homepage videos after hydration

### DIFF
--- a/packages/promo-pages/src/components/homepage/MakeVideosAgentically.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosAgentically.tsx
@@ -55,7 +55,7 @@ export const MakeVideosAgentically: React.FC<{
 	return (
 		<div ref={ref} className={'flex min-w-0 basis-0 flex-col flex-1'}>
 			<div className="flex aspect-square w-full items-start">
-				{showVideo ? (
+				{showVideo && src ? (
 					<video
 						ref={videoRef}
 						src={src}

--- a/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
@@ -35,7 +35,7 @@ export const MakeVideosInteractively: React.FC<{
 			}
 		>
 			<div className="flex aspect-square w-full items-start">
-				{showVideo ? (
+				{showVideo && src ? (
 					<video
 						src={src}
 						autoPlay

--- a/packages/promo-pages/src/components/homepage/MakeVideosProgrammatically.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosProgrammatically.tsx
@@ -29,7 +29,7 @@ export const MakeVideosProgrammatically: React.FC<{
 	return (
 		<div className={'flex min-w-0 basis-0 flex-col flex-1'}>
 			<div className="flex aspect-square w-full items-start">
-				{showVideo ? (
+				{showVideo && src ? (
 					<video
 						src={src}
 						muted

--- a/packages/promo-pages/src/components/homepage/use-transparent-video-source.ts
+++ b/packages/promo-pages/src/components/homepage/use-transparent-video-source.ts
@@ -8,7 +8,7 @@ export const useTransparentVideoSource = ({
 	readonly fallbackVideoSrc: string;
 	readonly videoSrc: string;
 }) => {
-	const [src, setSrc] = useState(videoSrc);
+	const [src, setSrc] = useState<string | null>(null);
 
 	useEffect(() => {
 		setSrc(isWebkit() ? fallbackVideoSrc : videoSrc);


### PR DESCRIPTION
## Summary

- Defer the six homepage videos until after hydration
- Keep the existing aspect-ratio containers as SSR placeholders
- Select the WebM or WebKit MP4 source after mounting

## Test plan

- `bun run build`
- `bun run stylecheck`
- Verified SSR card markup contains placeholders without video elements
- Verified client mounting selects WebM normally and MP4 on WebKit

Closes #9727
