### PR TITLE
`@remotion/studio-server`: Resolve composition source locations

### DIFF
--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -361,9 +361,6 @@ const findReExportTargets = ({
 	recast.types.visit(ast, {
 		visitExportNamedDeclaration(astPath) {
 			const node = astPath.node as ExportNamedDeclaration;
-			if (typeof node.source?.value !== 'string') {
-				return false;
-			}
 
 			for (const specifier of node.specifiers) {
 				if (specifier.type !== 'ExportSpecifier') {
@@ -377,6 +374,18 @@ const findReExportTargets = ({
 
 				const localName = getSpecifierLocalName(specifier);
 				if (!localName) {
+					continue;
+				}
+
+				if (typeof node.source?.value !== 'string') {
+					const importTarget = findImportTarget({
+						ast,
+						componentName: localName,
+					});
+					if (importTarget) {
+						targets.push(importTarget);
+					}
+
 					continue;
 				}
 
@@ -479,7 +488,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node);
+				location = locationFromNode(node) ?? locationFromNode(node.id);
 				return false;
 			}
 
@@ -493,7 +502,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node);
+				location = locationFromNode(node) ?? locationFromNode(node.id);
 				return false;
 			}
 

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -377,6 +377,8 @@ const findReExportTargets = ({
 					continue;
 				}
 
+				// Support barrel files that import a component and export it in a
+				// separate declaration. See https://github.com/remotion-dev/remotion/issues/9172.
 				if (typeof node.source?.value !== 'string') {
 					const importTarget = findImportTarget({
 						ast,
@@ -466,6 +468,9 @@ const findLocalSymbolLocation = ({
 }): SourceLocation | null => {
 	let location: SourceLocation | null = null;
 
+	// Recast can omit the declaration location for exported functions and
+	// classes, including components resolved through barrel files. The identifier
+	// keeps its location. See https://github.com/remotion-dev/remotion/issues/9172.
 	recast.types.visit(ast, {
 		visitVariableDeclarator(astPath) {
 			if (location) {

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -474,7 +474,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id.type === 'Identifier' && node.id.name === name) {
-				location = locationFromNode(node);
+				location = locationFromNode(node.id);
 				return false;
 			}
 
@@ -488,7 +488,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node) ?? locationFromNode(node.id);
+				location = locationFromNode(node.id);
 				return false;
 			}
 
@@ -502,7 +502,7 @@ const findLocalSymbolLocation = ({
 
 			const {node} = astPath;
 			if (node.id?.name === name) {
-				location = locationFromNode(node) ?? locationFromNode(node.id);
+				location = locationFromNode(node.id);
 				return false;
 			}
 

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -85,6 +85,86 @@ test('resolves recursively through re-exported composition components', async ()
 	}
 });
 
+test('resolves composition components that are imported and then exported', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {ImportedOne, ImportedTwo, LocalComp} from './Barrel';",
+				'export const RemotionRoot = () => {',
+				'\treturn <>',
+				'\t\t<Composition id="imported-one" component={ImportedOne} />',
+				'\t\t<Composition id="imported-two" component={ImportedTwo} />',
+				'\t\t<Composition id="local" component={LocalComp} />',
+				'\t</>;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Barrel.tsx'),
+			[
+				"import {ImportedOne} from './ImportedOne';",
+				"import {ImportedTwo as ImportedTwoLocal} from './ImportedTwo';",
+				'',
+				'export function LocalComp() {',
+				'\treturn <div>local</div>;',
+				'}',
+				'',
+				'export {ImportedOne, ImportedTwoLocal as ImportedTwo};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'ImportedOne.tsx'),
+			[
+				'',
+				'export function ImportedOne() {',
+				'\treturn <div>one</div>;',
+				'}',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'ImportedTwo.tsx'),
+			[
+				'',
+				'',
+				'export function ImportedTwo() {',
+				'\treturn <div>two</div>;',
+				'}',
+				'',
+			].join('\n'),
+		);
+
+		const locations = await Promise.all(
+			['imported-one', 'imported-two', 'local'].map((compositionId) =>
+				resolveCompositionComponent({
+					remotionRoot: tempDir,
+					compositionFile: 'Root.tsx',
+					compositionId,
+				}),
+			),
+		);
+
+		expect(
+			locations.map(({source, line, canAddSequence}) => ({
+				source,
+				line,
+				canAddSequence,
+			})),
+		).toEqual([
+			{source: 'ImportedOne.tsx', line: 2, canAddSequence: true},
+			{source: 'ImportedTwo.tsx', line: 3, canAddSequence: true},
+			{source: 'Barrel.tsx', line: 4, canAddSequence: true},
+		]);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('resolves through fallback re-export branch after cycle', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
## Summary

- resolve components that are imported and then re-exported from a barrel file
- use identifier locations for function and class declarations when declaration locations are unavailable
- add regression coverage for direct, aliased, and local exports

## Testing

- `bun test packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/9172
