### PR TITLE
`@remotion/promo-pages`: Fix pricing card alignment

### DIFF
--- a/packages/promo-pages/src/components/homepage/FreePricing.tsx
+++ b/packages/promo-pages/src/components/homepage/FreePricing.tsx
@@ -26,7 +26,7 @@ const Title: React.FC<{
 const Audience: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	return <div className={'fontbrand text-lg leading-none'}>{children}</div>;
+	return <div className={'fontbrand text-lg leading-snug'}>{children}</div>;
 };
 
 const BottomInfo: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({

--- a/packages/promo-pages/src/components/homepage/PricingBulletPoint.tsx
+++ b/packages/promo-pages/src/components/homepage/PricingBulletPoint.tsx
@@ -12,6 +12,8 @@ const greyCircle: React.CSSProperties = {
 	height: 20,
 	borderRadius: 10,
 	backgroundColor: 'var(--footer-border)',
+	flexShrink: 0,
+	marginTop: 4,
 };
 
 export const PricingBulletPoint: React.FC<{
@@ -28,6 +30,7 @@ export const PricingBulletPoint: React.FC<{
 			xmlns="http://www.w3.org/2000/svg"
 			style={{
 				flexShrink: 0,
+				marginTop: 4,
 			}}
 		>
 			<circle cx="10" cy="10" r="10" fill="#0B84F3" />

--- a/packages/promo-pages/src/components/homepage/PricingBulletPoint.tsx
+++ b/packages/promo-pages/src/components/homepage/PricingBulletPoint.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const container: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
-	alignItems: 'center',
+	alignItems: 'flex-start',
 	gap: '10px',
 };
 


### PR DESCRIPTION
## Summary

- improve the line height of wrapped pricing-card audience copy
- align pricing bullet checkmarks with the first line of multi-line text

## Verification

- `bun run build`
- `bun run stylecheck`
- visually verified the homepage pricing card at a 393px viewport

Closes #9891
