### PR TITLE
`@remotion/studio`: Improve narrow preview layout

### DIFF
--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -64,6 +64,7 @@ export const EditorContent: React.FC<{
 			minFlex={0.2}
 			defaultFlex={0.75}
 			maxFlexerSize={null}
+			minFlexerSize={null}
 			maxAntiFlexerSize={null}
 		>
 			<SplitterElement sticky={null} type="flexer">

--- a/packages/studio/src/components/FullscreenToggle.tsx
+++ b/packages/studio/src/components/FullscreenToggle.tsx
@@ -17,7 +17,9 @@ const accessibilityLabel = [
 	.filter(NoReactInternals.truthy)
 	.join(' ');
 
-export const FullScreenToggle: React.FC<{}> = () => {
+export const FullScreenToggle: React.FC<{
+	readonly hidden: boolean;
+}> = ({hidden}) => {
 	const keybindings = useKeybinding();
 	const {setSize} = useContext(Internals.PreviewSizeContext);
 
@@ -49,8 +51,16 @@ export const FullScreenToggle: React.FC<{}> = () => {
 		};
 	}, [keybindings, onClick]);
 
-	return (
+	return hidden ? (
+		<button
+			id="fullscreen-toggle"
+			type="button"
+			style={{display: 'none'}}
+			onClick={onClick}
+		/>
+	) : (
 		<ControlButton
+			id="fullscreen-toggle"
 			title={accessibilityLabel}
 			aria-label={accessibilityLabel}
 			onClick={onClick}

--- a/packages/studio/src/components/InlineAction.tsx
+++ b/packages/studio/src/components/InlineAction.tsx
@@ -64,6 +64,7 @@ export const InlineAction = ({
 			style={style}
 			tabIndex={tabIndex}
 			title={title}
+			aria-label={title}
 		>
 			{renderAction(hovered ? WHITE : unhoveredColor)}
 		</button>

--- a/packages/studio/src/components/LoopToggle.tsx
+++ b/packages/studio/src/components/LoopToggle.tsx
@@ -5,15 +5,21 @@ import {ControlButton} from './ControlButton';
 
 const accessibilityLabel = 'Loop video';
 
+export const toggleLoop = (
+	setLoop: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+	setLoop((currentLoop) => {
+		persistLoopOption(!currentLoop);
+		return !currentLoop;
+	});
+};
+
 export const LoopToggle: React.FC<{
 	readonly loop: boolean;
 	readonly setLoop: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({loop, setLoop}) => {
 	const onClick = useCallback(() => {
-		setLoop((c) => {
-			persistLoopOption(!c);
-			return !c;
-		});
+		toggleLoop(setLoop);
 	}, [setLoop]);
 
 	return (

--- a/packages/studio/src/components/Menu/MenuSubItem.tsx
+++ b/packages/studio/src/components/Menu/MenuSubItem.tsx
@@ -2,7 +2,7 @@ import {PlayerInternals} from '@remotion/player';
 import type {PointerEvent} from 'react';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
-import {WHITE_ALPHA_06, LIGHT_TEXT, TRANSPARENT} from '../../helpers/colors';
+import {LIGHT_TEXT, TRANSPARENT, WHITE_ALPHA_06} from '../../helpers/colors';
 import {useMobileLayout} from '../../helpers/mobile-layout';
 import {areKeyboardShortcutsDisabled} from '../../helpers/use-keybinding';
 import {CaretRight} from '../../icons/caret';
@@ -12,6 +12,8 @@ import type {SubMenu} from '../NewComposition/ComboBox';
 import {MENU_ITEM_CLASSNAME} from './is-menu-item';
 import {getPortal} from './portals';
 import {
+	MAX_MENU_WIDTH,
+	MAX_MOBILE_MENU_WIDTH,
 	MENU_VERTICAL_PADDING,
 	SUBMENU_LEFT_INSET,
 	menuContainerTowardsBottom,
@@ -143,10 +145,19 @@ export const MenuSubItem: React.FC<{
 		}
 
 		const left = size.left + size.width + SUBMENU_LEFT_INSET;
+		const minSpaceRequired = mobileLayout
+			? MAX_MOBILE_MENU_WIDTH
+			: MAX_MENU_WIDTH;
+		const canOpenOnRight =
+			size.windowSize.width - size.left - size.width >= minSpaceRequired;
 
 		return {
 			...menuContainerTowardsBottom,
-			left: mobileLayout ? left * 0.7 : left,
+			...(canOpenOnRight
+				? {left}
+				: {
+						right: size.windowSize.width - size.left + SUBMENU_LEFT_INSET,
+					}),
 			top: size.top - MENU_VERTICAL_PADDING,
 		};
 	}, [mobileLayout, selected, size, subMenu, subMenuActivated]);

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -35,7 +35,14 @@ export const PlayPause: React.FC<{
 	readonly loop: boolean;
 	readonly bufferStateDelayInMilliseconds: number;
 	readonly muted: boolean;
-}> = ({playbackRate, loop, bufferStateDelayInMilliseconds, muted}) => {
+	readonly hideNavigationControls: boolean;
+}> = ({
+	playbackRate,
+	loop,
+	bufferStateDelayInMilliseconds,
+	muted,
+	hideNavigationControls,
+}) => {
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const [showBufferIndicator, setShowBufferState] = useState<boolean>(false);
@@ -245,22 +252,26 @@ export const PlayPause: React.FC<{
 
 	return (
 		<>
-			<ControlButton
-				aria-label="Jump to beginning"
-				title="Jump to beginning"
-				disabled={!videoConfig || isFirstFrame}
-				onClick={jumpToStart}
-			>
-				<JumpToStart style={backStyle} />
-			</ControlButton>
-			<ControlButton
-				aria-label="Step back one frame"
-				title="Step back one frame"
-				disabled={!videoConfig || isFirstFrame}
-				onClick={oneFrameBack}
-			>
-				<StepBack style={forwardBackStyle} />
-			</ControlButton>
+			{hideNavigationControls ? null : (
+				<ControlButton
+					aria-label="Jump to beginning"
+					title="Jump to beginning"
+					disabled={!videoConfig || isFirstFrame}
+					onClick={jumpToStart}
+				>
+					<JumpToStart style={backStyle} />
+				</ControlButton>
+			)}
+			{hideNavigationControls ? null : (
+				<ControlButton
+					aria-label="Step back one frame"
+					title="Step back one frame"
+					disabled={!videoConfig || isFirstFrame}
+					onClick={oneFrameBack}
+				>
+					<StepBack style={forwardBackStyle} />
+				</ControlButton>
+			)}
 
 			<ControlButton
 				aria-label={playing ? 'Pause' : 'Play'}
@@ -279,14 +290,16 @@ export const PlayPause: React.FC<{
 				)}
 			</ControlButton>
 
-			<ControlButton
-				aria-label="Step forward one frame"
-				title="Step forward one frame"
-				disabled={!videoConfig || isLastFrame}
-				onClick={oneFrameForward}
-			>
-				<StepForward style={forwardBackStyle} />
-			</ControlButton>
+			{hideNavigationControls ? null : (
+				<ControlButton
+					aria-label="Step forward one frame"
+					title="Step forward one frame"
+					disabled={!videoConfig || isLastFrame}
+					onClick={oneFrameForward}
+				>
+					<StepForward style={forwardBackStyle} />
+				</ControlButton>
+			)}
 		</>
 	);
 };

--- a/packages/studio/src/components/PlaybackRateSelector.tsx
+++ b/packages/studio/src/components/PlaybackRateSelector.tsx
@@ -19,18 +19,15 @@ const accessibilityLabel = 'Change the playback rate';
 
 const comboStyle: React.CSSProperties = {width: 64};
 
-export const PlaybackRateSelector: React.FC<{
+type PlaybackRateMenuItemsProps = {
 	readonly playbackRate: number;
 	readonly setPlaybackRate: React.Dispatch<React.SetStateAction<number>>;
-}> = ({playbackRate, setPlaybackRate}) => {
-	const {canvasContent} = useContext(Internals.CompositionManager);
-	const isStill = useIsStill();
-	const style = useMemo(() => {
-		return {
-			padding: CONTROL_BUTTON_PADDING - 2,
-		};
-	}, []);
+};
 
+export const usePlaybackRateMenuItems = ({
+	playbackRate,
+	setPlaybackRate,
+}: PlaybackRateMenuItemsProps) => {
 	const items: ComboboxValue[] = useMemo(() => {
 		const divider: ComboboxValue = {
 			type: 'divider',
@@ -61,6 +58,28 @@ export const PlaybackRateSelector: React.FC<{
 		return [...values.slice(0, middle), divider, ...values.slice(middle)];
 	}, [playbackRate, setPlaybackRate]);
 
+	return {
+		items,
+		selectedId: String(playbackRate),
+	};
+};
+
+export const PlaybackRateSelector: React.FC<PlaybackRateMenuItemsProps> = ({
+	playbackRate,
+	setPlaybackRate,
+}) => {
+	const {canvasContent} = useContext(Internals.CompositionManager);
+	const isStill = useIsStill();
+	const {items, selectedId} = usePlaybackRateMenuItems({
+		playbackRate,
+		setPlaybackRate,
+	});
+	const style = useMemo(() => {
+		return {
+			padding: CONTROL_BUTTON_PADDING - 2,
+		};
+	}, []);
+
 	if (isStill || canvasContent === null || canvasContent.type === 'asset') {
 		return null;
 	}
@@ -71,7 +90,7 @@ export const PlaybackRateSelector: React.FC<{
 				size="compact"
 				title={accessibilityLabel}
 				style={comboStyle}
-				selectedId={String(playbackRate)}
+				selectedId={selectedId}
 				values={items}
 			/>
 		</div>

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -1,17 +1,7 @@
-import React, {
-	useCallback,
-	useContext,
-	useEffect,
-	useRef,
-	useState,
-} from 'react';
+import React, {useCallback, useContext, useState} from 'react';
 import {Internals} from 'remotion';
 import {checkFullscreenSupport} from '../helpers/check-fullscreen-support';
-import {
-	BACKGROUND,
-	BACKGROUND__TRANSPARENT,
-	BORDER_BLACK_ALPHA_50,
-} from '../helpers/colors';
+import {BACKGROUND, BORDER_BLACK_ALPHA_50} from '../helpers/colors';
 import {
 	useIsStill,
 	useIsVideoComposition,
@@ -30,6 +20,7 @@ import {PlaybackKeyboardShortcutsManager} from './PlaybackKeyboardShortcutsManag
 import {PlaybackRatePersistor} from './PlaybackRatePersistor';
 import {PlaybackRateSelector} from './PlaybackRateSelector';
 import {PlayPause} from './PlayPause';
+import {PreviewToolbarOverflowButton} from './PreviewToolbarOverflowButton';
 import {RenderButton} from './RenderButton';
 import {SizeSelector} from './SizeSelector';
 import {SnappingToggle} from './SnappingToggle';
@@ -40,6 +31,7 @@ const TOOLBAR_HEIGHT = 40;
 
 const container: React.CSSProperties = {
 	display: 'flex',
+	position: 'relative',
 	justifyContent: 'center',
 	borderTop: BORDER_BLACK_ALPHA_50,
 	alignItems: 'center',
@@ -48,32 +40,14 @@ const container: React.CSSProperties = {
 	height: TOOLBAR_HEIGHT,
 };
 
-const mobileContainer: React.CSSProperties = {
-	...container,
-	position: 'relative',
-	overflowX: 'auto',
-	justifyContent: 'flex-start',
-};
-const scrollIndicatorLeft: React.CSSProperties = {
-	position: 'fixed',
-	display: 'none',
+const centeredPlayButton: React.CSSProperties = {
+	position: 'absolute',
+	left: '50%',
 	top: 0,
-	left: 0,
-	width: 40,
-	height: '100%',
-	pointerEvents: 'none',
-	background: `linear-gradient(to right, ${BACKGROUND}, ${BACKGROUND__TRANSPARENT})`,
-};
-
-const scrollIndicatorRight: React.CSSProperties = {
-	position: 'fixed',
-	display: 'none',
-	top: 0,
-	right: 0,
-	width: 40,
-	height: '100%',
-	pointerEvents: 'none',
-	background: `linear-gradient(to left, ${BACKGROUND}, ${BACKGROUND__TRANSPARENT})`,
+	height: TOOLBAR_HEIGHT,
+	display: 'flex',
+	alignItems: 'center',
+	transform: 'translateX(-50%)',
 };
 
 const sideContainer: React.CSSProperties = {
@@ -82,14 +56,6 @@ const sideContainer: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
-};
-
-const mobileSideContainer: React.CSSProperties = {
-	height: 30,
-	display: 'flex',
-	flexDirection: 'row',
-	alignItems: 'center',
-	flexShrink: 0,
 };
 
 const padding: React.CSSProperties = {
@@ -125,130 +91,55 @@ export const PreviewToolbar: React.FC<{
 	const {setPlayerMuted} = useContext(Internals.SetMediaVolumeContext);
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const isVideoComposition = useIsVideoComposition();
-	const previewToolbarRef = useRef<HTMLDivElement | null>(null);
-	const leftScrollIndicatorRef = useRef<HTMLDivElement | null>(null);
-	const rightScrollIndicatorRef = useRef<HTMLDivElement | null>(null);
 
 	const isStill = useIsStill();
 
 	const [loop, setLoop] = useState(loadLoopOption());
 
 	const isFullscreenSupported = checkFullscreenSupport();
-
 	const isMobileLayout = useMobileLayout();
-
-	useEffect(() => {
-		if (!isMobileLayout) {
-			// The indicators are `position: fixed` and are shown/placed
-			// imperatively by the scroll handler below. Without this reset,
-			// leaving the mobile layout (window resized past the breakpoint)
-			// leaves them visible at stale viewport coordinates — an orphaned
-			// grey gradient rectangle floating over the canvas.
-			if (leftScrollIndicatorRef.current) {
-				leftScrollIndicatorRef.current.style.display = 'none';
-			}
-
-			if (rightScrollIndicatorRef.current) {
-				rightScrollIndicatorRef.current.style.display = 'none';
-			}
-
-			return;
-		}
-
-		if (previewToolbarRef.current) {
-			const updateScrollableIndicatorProps = (target: HTMLDivElement) => {
-				const boundingBox = target.getBoundingClientRect();
-				const {scrollLeft, scrollWidth, clientWidth} = target;
-				const scrollRight = scrollWidth - clientWidth - scrollLeft;
-				if (
-					!leftScrollIndicatorRef.current ||
-					!rightScrollIndicatorRef.current
-				) {
-					return;
-				}
-
-				if (scrollLeft !== 0) {
-					Object.assign(leftScrollIndicatorRef.current.style, {
-						display: 'block',
-						height: `${boundingBox.height}px`,
-						top: `${boundingBox.top}px`,
-						left: `${boundingBox.left}px`,
-					});
-				} else {
-					Object.assign(leftScrollIndicatorRef.current.style, {
-						display: 'none',
-					});
-				}
-
-				if (scrollRight !== 0) {
-					const itemWidth = rightScrollIndicatorRef.current?.clientWidth || 0;
-					Object.assign(rightScrollIndicatorRef.current.style, {
-						display: 'block',
-						height: `${boundingBox.height}px`,
-						top: `${boundingBox.top}px`,
-						left: `${boundingBox.left + boundingBox.width - itemWidth}px`,
-					});
-				} else {
-					Object.assign(rightScrollIndicatorRef.current.style, {
-						display: 'none',
-					});
-				}
-			};
-
-			const previewToolbar = previewToolbarRef.current;
-			const scrollHandler = () => {
-				updateScrollableIndicatorProps(previewToolbar);
-			};
-
-			previewToolbar.addEventListener('scroll', scrollHandler);
-			scrollHandler();
-			return () => {
-				previewToolbar.removeEventListener('scroll', scrollHandler);
-			};
-		}
-	});
+	const playPause = (
+		<PreviewToolbarControl>
+			<PlayPause
+				bufferStateDelayInMilliseconds={bufferStateDelayInMilliseconds}
+				loop={loop}
+				playbackRate={playbackRate}
+				muted={playerMuted}
+				hideNavigationControls={isMobileLayout}
+			/>
+		</PreviewToolbarControl>
+	);
 
 	return (
-		<div
-			ref={previewToolbarRef}
-			style={isMobileLayout ? mobileContainer : container}
-			className="css-reset"
-		>
-			<div ref={leftScrollIndicatorRef} style={scrollIndicatorLeft} />
+		<div style={container} className="css-reset">
+			<div style={sideContainer}>
+				<div style={padding} />
+				<PreviewToolbarControl>
+					<TimelineZoomControls />
+				</PreviewToolbarControl>
+			</div>
+			<Flex />
 			{isMobileLayout ? null : (
-				<>
-					<div style={sideContainer}>
-						<div style={padding} />
-						<PreviewToolbarControl>
-							<TimelineZoomControls />
-						</PreviewToolbarControl>
-					</div>
-					<Flex />
-					<PreviewToolbarControl>
-						<SizeSelector />
-					</PreviewToolbarControl>
-					{isStill || isVideoComposition ? (
-						<PreviewToolbarControl>
-							<PlaybackRateSelector
-								setPlaybackRate={setPlaybackRate}
-								playbackRate={playbackRate}
-							/>
-						</PreviewToolbarControl>
-					) : null}
-				</>
+				<PreviewToolbarControl>
+					<SizeSelector />
+				</PreviewToolbarControl>
 			)}
+			{!isMobileLayout && (isStill || isVideoComposition) ? (
+				<PreviewToolbarControl>
+					<PlaybackRateSelector
+						setPlaybackRate={setPlaybackRate}
+						playbackRate={playbackRate}
+					/>
+				</PreviewToolbarControl>
+			) : null}
 
-			{isVideoComposition ? (
+			{isVideoComposition && isMobileLayout ? (
+				<div style={centeredPlayButton}>{playPause}</div>
+			) : null}
+			{isVideoComposition && !isMobileLayout ? (
 				<>
 					<Spacing x={2} />
-					<PreviewToolbarControl>
-						<PlayPause
-							bufferStateDelayInMilliseconds={bufferStateDelayInMilliseconds}
-							loop={loop}
-							playbackRate={playbackRate}
-							muted={playerMuted}
-						/>
-					</PreviewToolbarControl>
+					{playPause}
 					<Spacing x={2} />
 					<PreviewToolbarControl>
 						<LoopToggle loop={loop} setLoop={setLoop} />
@@ -265,13 +156,17 @@ export const PreviewToolbar: React.FC<{
 			) : null}
 			{canvasContent?.type === 'composition' ? (
 				<>
-					<PreviewToolbarControl>
-						<CheckboardToggle />
-					</PreviewToolbarControl>
-					<PreviewToolbarControl>
-						<OutlineToggle />
-					</PreviewToolbarControl>
-					{readOnlyStudio ? null : (
+					{isMobileLayout ? null : (
+						<PreviewToolbarControl>
+							<CheckboardToggle />
+						</PreviewToolbarControl>
+					)}
+					{isMobileLayout ? null : (
+						<PreviewToolbarControl>
+							<OutlineToggle />
+						</PreviewToolbarControl>
+					)}
+					{readOnlyStudio || isMobileLayout ? null : (
 						<PreviewToolbarControl>
 							<SnappingToggle />
 						</PreviewToolbarControl>
@@ -281,37 +176,47 @@ export const PreviewToolbar: React.FC<{
 			<Spacing x={1} />
 			{canvasContent && isFullscreenSupported ? (
 				<PreviewToolbarControl>
-					<FullScreenToggle />
+					<FullScreenToggle hidden={isMobileLayout} />
 				</PreviewToolbarControl>
 			) : null}
 			<Flex />
-			{isMobileLayout && (
-				<>
-					<PreviewToolbarControl>
-						<SizeSelector />
-					</PreviewToolbarControl>
-					{isStill || isVideoComposition ? (
-						<PreviewToolbarControl>
-							<PlaybackRateSelector
-								setPlaybackRate={setPlaybackRate}
-								playbackRate={playbackRate}
-							/>
-						</PreviewToolbarControl>
-					) : null}
-				</>
-			)}
-			<div style={isMobileLayout ? mobileSideContainer : sideContainer}>
+			<div style={sideContainer}>
 				<Flex />
-				{!isMobileLayout && <FpsCounter playbackSpeed={playbackRate} />}
+				<FpsCounter playbackSpeed={playbackRate} />
 				<Spacing x={2} />
 				<PreviewToolbarControl>
-					<RenderButton readOnlyStudio={readOnlyStudio} size="compact" />
+					<RenderButton
+						readOnlyStudio={readOnlyStudio}
+						size="compact"
+						hidden={isMobileLayout}
+					/>
 				</PreviewToolbarControl>
+				{isMobileLayout ? (
+					<>
+						{isVideoComposition ? (
+							<PreviewToolbarControl>
+								<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
+							</PreviewToolbarControl>
+						) : null}
+						<PreviewToolbarControl>
+							<PreviewToolbarOverflowButton
+								readOnlyStudio={readOnlyStudio}
+								showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
+								showPlaybackRate={isVideoComposition}
+								showLoop={isVideoComposition}
+								showCompositionControls={canvasContent?.type === 'composition'}
+								playbackRate={playbackRate}
+								setPlaybackRate={setPlaybackRate}
+								loop={loop}
+								setLoop={setLoop}
+							/>
+						</PreviewToolbarControl>
+					</>
+				) : null}
 				<Spacing x={1.5} />
 			</div>
 			<PlaybackKeyboardShortcutsManager setPlaybackRate={setPlaybackRate} />
 			<PlaybackRatePersistor />
-			<div ref={rightScrollIndicatorRef} style={scrollIndicatorRight} />
 		</div>
 	);
 };

--- a/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
+++ b/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
@@ -1,0 +1,271 @@
+import type {SVGProps} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {WHITE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {Checkmark} from '../icons/Checkmark';
+import {EllipsisIcon} from '../icons/ellipsis';
+import {CheckerboardContext} from '../state/checkerboard';
+import {EditorShowOutlinesContext} from '../state/editor-outlines';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineDropdown} from './InlineDropdown';
+import {toggleLoop} from './LoopToggle';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+import {usePlaybackRateMenuItems} from './PlaybackRateSelector';
+import {usePreviewSizeMenuItems} from './SizeSelector';
+
+const clickButton = (id: string) => {
+	(document.getElementById(id) as HTMLButtonElement | null)?.click();
+};
+
+export const PreviewToolbarOverflowButton: React.FC<{
+	readonly readOnlyStudio: boolean;
+	readonly showFullscreen: boolean;
+	readonly showPlaybackRate: boolean;
+	readonly showLoop: boolean;
+	readonly showCompositionControls: boolean;
+	readonly playbackRate: number;
+	readonly setPlaybackRate: React.Dispatch<React.SetStateAction<number>>;
+	readonly loop: boolean;
+	readonly setLoop: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({
+	readOnlyStudio,
+	showFullscreen,
+	showPlaybackRate,
+	showLoop,
+	showCompositionControls,
+	playbackRate,
+	setPlaybackRate,
+	loop,
+	setLoop,
+}) => {
+	const video = Internals.useVideo();
+	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
+	const {editorShowOutlines, setEditorShowOutlines} = useContext(
+		EditorShowOutlinesContext,
+	);
+	const {
+		items: previewSizeItems,
+		selectedId: selectedPreviewSize,
+		zoomable,
+	} = usePreviewSizeMenuItems();
+	const {items: playbackRateItems, selectedId: selectedPlaybackRate} =
+		usePlaybackRateMenuItems({playbackRate, setPlaybackRate});
+
+	const iconStyle: SVGProps<SVGSVGElement> = useMemo(() => {
+		return {
+			style: {
+				width: 14,
+				height: 14,
+				flexShrink: 0,
+			},
+		};
+	}, []);
+
+	const renderAction: RenderInlineAction = useCallback(
+		(color) => <EllipsisIcon fill={color} svgProps={iconStyle} />,
+		[iconStyle],
+	);
+
+	const renderItems = useMemo((): ComboboxValue[] => {
+		if (readOnlyStudio) {
+			return [
+				{
+					type: 'item',
+					id: 'client-render',
+					label: 'Render on web',
+					value: 'client-render',
+					onClick: () => clickButton('render-modal-button-client'),
+					keyHint: null,
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: null,
+				},
+				{
+					type: 'item',
+					id: 'render-command',
+					label: 'Render via CLI',
+					value: 'render-command',
+					onClick: () => clickButton('render-modal-button-command'),
+					keyHint: null,
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: null,
+				},
+			];
+		}
+
+		return [
+			{
+				type: 'item',
+				id: 'server-render',
+				label: 'Server-side render',
+				value: 'server-render',
+				onClick: () => clickButton('render-modal-button-server'),
+				keyHint: null,
+				leftItem: null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			},
+			{
+				type: 'item',
+				id: 'client-render',
+				label: 'Client-side render',
+				value: 'client-render',
+				onClick: () => clickButton('render-modal-button-client'),
+				keyHint: null,
+				leftItem: null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			},
+		];
+	}, [readOnlyStudio]);
+
+	const values = useMemo((): ComboboxValue[] => {
+		const items: ComboboxValue[] = [];
+
+		if (zoomable) {
+			items.push({
+				type: 'item',
+				id: 'preview-size',
+				label: 'Preview Size',
+				value: 'preview-size',
+				onClick: () => undefined,
+				keyHint: null,
+				leftItem: null,
+				subMenu: {
+					items: previewSizeItems,
+					leaveLeftSpace: true,
+					preselectIndex: previewSizeItems.findIndex(
+						(item) => item.id === selectedPreviewSize,
+					),
+				},
+				quickSwitcherLabel: null,
+			});
+		}
+
+		if (showPlaybackRate) {
+			items.push({
+				type: 'item',
+				id: 'playback-rate',
+				label: 'Playback Rate',
+				value: 'playback-rate',
+				onClick: () => undefined,
+				keyHint: null,
+				leftItem: null,
+				subMenu: {
+					items: playbackRateItems,
+					leaveLeftSpace: true,
+					preselectIndex: playbackRateItems.findIndex(
+						(item) => item.id === selectedPlaybackRate,
+					),
+				},
+				quickSwitcherLabel: null,
+			});
+		}
+
+		if (showLoop) {
+			items.push({
+				type: 'item',
+				id: 'loop',
+				label: 'Loop',
+				value: 'loop',
+				onClick: () => toggleLoop(setLoop),
+				keyHint: null,
+				leftItem: loop ? <Checkmark /> : null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
+		}
+
+		if (showCompositionControls) {
+			items.push({
+				type: 'item',
+				id: 'checkerboard',
+				label: 'Transparency as checkerboard',
+				value: 'checkerboard',
+				onClick: () => setCheckerboard((current) => !current),
+				keyHint: areKeyboardShortcutsDisabled() ? null : 'T',
+				leftItem: checkerboard ? <Checkmark /> : null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
+			items.push({
+				type: 'item',
+				id: 'outlines',
+				label: 'Outlines',
+				value: 'outlines',
+				onClick: () => setEditorShowOutlines((current) => !current),
+				keyHint: null,
+				leftItem: editorShowOutlines ? <Checkmark /> : null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
+		}
+
+		if (showFullscreen) {
+			items.push({
+				type: 'item',
+				id: 'fullscreen',
+				label: 'Fullscreen',
+				value: 'fullscreen',
+				onClick: () => clickButton('fullscreen-toggle'),
+				keyHint: areKeyboardShortcutsDisabled() ? null : 'F',
+				leftItem: null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
+		}
+
+		if (video) {
+			items.push({
+				type: 'item',
+				id: 'render',
+				label: 'Render',
+				value: 'render',
+				onClick: () => undefined,
+				keyHint: null,
+				leftItem: null,
+				subMenu: {
+					items: renderItems,
+					leaveLeftSpace: false,
+					preselectIndex: 0,
+				},
+				quickSwitcherLabel: null,
+			});
+		}
+
+		return items;
+	}, [
+		previewSizeItems,
+		playbackRateItems,
+		renderItems,
+		selectedPlaybackRate,
+		selectedPreviewSize,
+		showFullscreen,
+		showLoop,
+		showPlaybackRate,
+		showCompositionControls,
+		loop,
+		checkerboard,
+		editorShowOutlines,
+		setCheckerboard,
+		setEditorShowOutlines,
+		setLoop,
+		video,
+		zoomable,
+	]);
+
+	if (values.length === 0) {
+		return null;
+	}
+
+	return (
+		<InlineDropdown
+			renderAction={renderAction}
+			values={values}
+			title="More actions"
+			unhoveredColor={WHITE}
+		/>
+	);
+};

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -15,10 +15,10 @@ import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
+	BLACK_ALPHA_60,
 	CURRENT_COLOR,
 	CURRENT_COLOR_LOWERCASE,
 	INPUT_BACKGROUND,
-	BLACK_ALPHA_60,
 	TRANSPARENT,
 	WHITE,
 } from '../helpers/colors';
@@ -160,7 +160,8 @@ const getInitialRenderType = (readOnlyStudio: boolean): RenderType => {
 export const RenderButton: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly size?: 'default' | 'compact';
-}> = ({readOnlyStudio, size: controlSize = 'default'}) => {
+	readonly hidden: boolean;
+}> = ({readOnlyStudio, size: controlSize = 'default', hidden}) => {
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();
 	const {setSelectedModal} = useContext(ModalsContext);
 	const [preferredRenderType, setPreferredRenderType] = useState<RenderType>(
@@ -552,49 +553,66 @@ export const RenderButton: React.FC<{
 				onClick={openClientRenderModal}
 				type="button"
 			/>
-			<div ref={containerRef} style={containerStyle} title={tooltip}>
+			<button
+				style={{display: 'none'}}
+				id="render-modal-button-command"
+				onClick={() => openServerRenderModal(true)}
+				type="button"
+			/>
+			{hidden ? (
 				<button
-					type="button"
-					style={
-						controlSize === 'compact' ? compactMainButtonStyle : mainButtonStyle
-					}
+					style={{display: 'none'}}
 					onClick={onClick}
 					id="render-modal-button"
-				>
-					<Row
-						align="center"
+					type="button"
+				/>
+			) : (
+				<div ref={containerRef} style={containerStyle} title={tooltip}>
+					<button
+						type="button"
 						style={
 							controlSize === 'compact'
-								? compactMainButtonContent
-								: mainButtonContent
+								? compactMainButtonStyle
+								: mainButtonStyle
 						}
+						onClick={onClick}
+						id="render-modal-button"
 					>
-						<ThinRenderIcon
-							fill={CURRENT_COLOR_LOWERCASE}
-							svgProps={iconStyle}
-						/>
-						<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
-						<span style={controlSize === 'compact' ? compactLabel : label}>
-							{renderLabel}
-						</span>
-					</Row>
-				</button>
-				<div style={dividerStyle} />
-				<button
-					ref={dropdownRef}
-					type="button"
-					style={
-						controlSize === 'compact'
-							? compactDropdownTriggerStyle
-							: dropdownTriggerStyle
-					}
-					className={MENU_INITIATOR_CLASSNAME}
-					onPointerDown={onPointerDown}
-					onClick={onClickDropdown}
-				>
-					<CaretDown />
-				</button>
-			</div>
+						<Row
+							align="center"
+							style={
+								controlSize === 'compact'
+									? compactMainButtonContent
+									: mainButtonContent
+							}
+						>
+							<ThinRenderIcon
+								fill={CURRENT_COLOR_LOWERCASE}
+								svgProps={iconStyle}
+							/>
+							<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
+							<span style={controlSize === 'compact' ? compactLabel : label}>
+								{renderLabel}
+							</span>
+						</Row>
+					</button>
+					<div style={dividerStyle} />
+					<button
+						ref={dropdownRef}
+						type="button"
+						style={
+							controlSize === 'compact'
+								? compactDropdownTriggerStyle
+								: dropdownTriggerStyle
+						}
+						className={MENU_INITIATOR_CLASSNAME}
+						onPointerDown={onPointerDown}
+						onClick={onClickDropdown}
+					>
+						<CaretDown />
+					</button>
+				</div>
+			)}
 			{portalStyle
 				? ReactDOM.createPortal(
 						<div style={fullScreenOverlay}>

--- a/packages/studio/src/components/SizeSelector.tsx
+++ b/packages/studio/src/components/SizeSelector.tsx
@@ -76,14 +76,9 @@ export const getUniqueSizes = (size: PreviewSize) => {
 
 const zoomableFileTypes: AssetFileType[] = ['video', 'image'];
 
-export const SizeSelector: React.FC = () => {
+export const usePreviewSizeMenuItems = () => {
 	const {size, setSize} = useContext(Internals.PreviewSizeContext);
 	const {canvasContent} = useContext(Internals.CompositionManager);
-	const style = useMemo(() => {
-		return {
-			padding: CONTROL_BUTTON_PADDING - 2,
-		};
-	}, []);
 
 	const zoomable = useMemo(() => {
 		if (!canvasContent) {
@@ -132,6 +127,21 @@ export const SizeSelector: React.FC = () => {
 		});
 	}, [setSize, size]);
 
+	return {
+		items,
+		selectedId: String(size.size),
+		zoomable,
+	};
+};
+
+export const SizeSelector: React.FC = () => {
+	const {items, selectedId, zoomable} = usePreviewSizeMenuItems();
+	const style = useMemo(() => {
+		return {
+			padding: CONTROL_BUTTON_PADDING - 2,
+		};
+	}, []);
+
 	if (!zoomable) {
 		return null;
 	}
@@ -142,7 +152,7 @@ export const SizeSelector: React.FC = () => {
 				size="compact"
 				title={accessibilityLabel}
 				style={comboStyle}
-				selectedId={String(size.size)}
+				selectedId={selectedId}
 				values={items}
 			/>
 		</div>

--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -6,7 +6,8 @@ import type {
 	SplitterOrientation,
 	TSplitterContext,
 } from './SplitterContext';
-import {SplitterContext} from './SplitterContext';
+import {getClampedSplitterFlex, SplitterContext} from './SplitterContext';
+import {SPLITTER_HANDLE_SIZE} from './SplitterHandle';
 
 const containerRow: React.CSSProperties = {
 	display: 'flex',
@@ -28,6 +29,7 @@ export const SplitterContainer: React.FC<{
 	readonly maxFlex: number;
 	readonly minFlex: number;
 	readonly maxFlexerSize: number | null;
+	readonly minFlexerSize: number | null;
 	readonly maxAntiFlexerSize: number | null;
 	readonly id: string;
 	readonly defaultFlex: number;
@@ -39,6 +41,7 @@ export const SplitterContainer: React.FC<{
 	maxFlex,
 	minFlex,
 	maxFlexerSize,
+	minFlexerSize,
 	maxAntiFlexerSize,
 	id,
 }) => {
@@ -49,10 +52,27 @@ export const SplitterContainer: React.FC<{
 
 	const ref = useRef<HTMLDivElement>(null);
 	const isDragging = useRef<SplitterDragState>(false);
+	const size = PlayerInternals.useElementSize(ref, {
+		triggerOnWindowResize: true,
+		shouldApplyCssTransforms: true,
+	});
+	const availableSize = size
+		? (orientation === 'vertical' ? size.width : size.height) -
+			SPLITTER_HANDLE_SIZE
+		: null;
+	const effectiveFlexValue = getClampedSplitterFlex({
+		availableSize,
+		flexValue,
+		maxAntiFlexerSize,
+		maxFlex,
+		maxFlexerSize,
+		minFlex,
+		minFlexerSize,
+	});
 
 	const value: TSplitterContext = useMemo(() => {
 		return {
-			flexValue,
+			flexValue: effectiveFlexValue,
 			ref,
 			setFlexValue,
 			isDragging,
@@ -61,16 +81,18 @@ export const SplitterContainer: React.FC<{
 			maxFlex,
 			minFlex,
 			maxFlexerSize,
+			minFlexerSize,
 			maxAntiFlexerSize,
 			defaultFlex,
 			persistFlex,
 		};
 	}, [
 		defaultFlex,
-		flexValue,
+		effectiveFlexValue,
 		id,
 		maxFlex,
 		maxFlexerSize,
+		minFlexerSize,
 		maxAntiFlexerSize,
 		minFlex,
 		orientation,

--- a/packages/studio/src/components/Splitter/SplitterContext.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContext.tsx
@@ -12,6 +12,7 @@ export type TSplitterContext = {
 	maxFlex: number;
 	minFlex: number;
 	maxFlexerSize: number | null;
+	minFlexerSize: number | null;
 	maxAntiFlexerSize: number | null;
 	defaultFlex: number;
 	id: string;
@@ -25,6 +26,56 @@ export type TSplitterContext = {
 	>;
 };
 
+type SplitterFlexBounds = Pick<
+	TSplitterContext,
+	| 'maxAntiFlexerSize'
+	| 'maxFlex'
+	| 'maxFlexerSize'
+	| 'minFlex'
+	| 'minFlexerSize'
+> & {
+	readonly availableSize: number | null;
+};
+
+export const getSplitterFlexBounds = ({
+	availableSize,
+	maxAntiFlexerSize,
+	maxFlex,
+	maxFlexerSize,
+	minFlex,
+	minFlexerSize,
+}: SplitterFlexBounds) => {
+	if (availableSize === null || availableSize <= 0) {
+		return {minFlex, maxFlex};
+	}
+
+	const minimum = Math.min(
+		1,
+		Math.max(
+			minFlex,
+			minFlexerSize === null ? 0 : minFlexerSize / availableSize,
+			maxAntiFlexerSize === null ? 0 : 1 - maxAntiFlexerSize / availableSize,
+		),
+	);
+	const maximum = Math.max(
+		minimum,
+		Math.min(
+			maxFlex,
+			maxFlexerSize === null ? 1 : maxFlexerSize / availableSize,
+		),
+	);
+
+	return {minFlex: minimum, maxFlex: maximum};
+};
+
+export const getClampedSplitterFlex = ({
+	flexValue,
+	...bounds
+}: SplitterFlexBounds & {readonly flexValue: number}) => {
+	const {minFlex, maxFlex} = getSplitterFlexBounds(bounds);
+	return Math.min(maxFlex, Math.max(minFlex, flexValue));
+};
+
 export const SplitterContext = React.createContext<TSplitterContext>({
 	flexValue: 1,
 	ref: {current: null},
@@ -34,6 +85,7 @@ export const SplitterContext = React.createContext<TSplitterContext>({
 	maxFlex: 1,
 	minFlex: 1,
 	maxFlexerSize: null,
+	minFlexerSize: null,
 	maxAntiFlexerSize: null,
 	defaultFlex: 1,
 	id: '--',

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -4,7 +4,7 @@ import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
 } from '../ForceSpecificCursor';
-import {SplitterContext} from './SplitterContext';
+import {getSplitterFlexBounds, SplitterContext} from './SplitterContext';
 
 export const SPLITTER_HANDLE_SIZE = 3;
 
@@ -62,20 +62,14 @@ export const SplitterHandle: React.FC<{
 				(dragContext.orientation === 'vertical'
 					? containerWidth
 					: containerHeight) - SPLITTER_HANDLE_SIZE;
-			const minFlex =
-				dragContext.maxAntiFlexerSize === null || availableSize <= 0
-					? dragContext.minFlex
-					: Math.max(
-							dragContext.minFlex,
-							1 - dragContext.maxAntiFlexerSize / availableSize,
-						);
-			const maxFlex =
-				dragContext.maxFlexerSize === null || availableSize <= 0
-					? dragContext.maxFlex
-					: Math.min(
-							dragContext.maxFlex,
-							dragContext.maxFlexerSize / availableSize,
-						);
+			const {minFlex, maxFlex} = getSplitterFlexBounds({
+				availableSize,
+				maxAntiFlexerSize: dragContext.maxAntiFlexerSize,
+				maxFlex: dragContext.maxFlex,
+				maxFlexerSize: dragContext.maxFlexerSize,
+				minFlex: dragContext.minFlex,
+				minFlexerSize: dragContext.minFlexerSize,
+			});
 			const startFlex = Math.min(
 				maxFlex,
 				Math.max(minFlex, dragContext.flexValue),

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -48,6 +48,8 @@ import {TimelineWidthProvider} from './TimelineWidthProvider';
 import {useResolvedStack} from './use-resolved-stack';
 import {useTimelineAssetDrop} from './use-timeline-asset-drop';
 
+const MIN_TIMELINE_LABELS_WIDTH = 240;
+
 const container: React.CSSProperties = {
 	minHeight: '100%',
 	flex: 1,
@@ -326,6 +328,7 @@ const TimelineInner: React.FC = () => {
 									maxFlex={0.5}
 									minFlex={0.15}
 									maxFlexerSize={null}
+									minFlexerSize={MIN_TIMELINE_LABELS_WIDTH}
 									maxAntiFlexerSize={null}
 								>
 									<SplitterElement

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -114,6 +114,7 @@ const TopPanelInner: React.FC<{
 						maxFlex={0.4}
 						defaultFlex={0.2}
 						maxFlexerSize={MAX_SIDEBAR_WIDTH}
+						minFlexerSize={null}
 						maxAntiFlexerSize={null}
 						id="sidebar-to-preview"
 						orientation="vertical"
@@ -141,6 +142,7 @@ const TopPanelInner: React.FC<{
 								maxFlex={0.8}
 								defaultFlex={0.7}
 								maxFlexerSize={null}
+								minFlexerSize={null}
 								maxAntiFlexerSize={MAX_SIDEBAR_WIDTH}
 								id="canvas-to-right-sidebar"
 								orientation="vertical"

--- a/packages/studio/src/test/splitter-flex-bounds.test.ts
+++ b/packages/studio/src/test/splitter-flex-bounds.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'bun:test';
+import {getClampedSplitterFlex} from '../components/Splitter/SplitterContext';
+
+const getTimelineLabelsWidth = (availableSize: number, flexValue: number) => {
+	return (
+		getClampedSplitterFlex({
+			availableSize,
+			flexValue,
+			maxAntiFlexerSize: null,
+			maxFlex: 0.5,
+			maxFlexerSize: null,
+			minFlex: 0.15,
+			minFlexerSize: 240,
+		}) * availableSize
+	);
+};
+
+test('keeps the timeline labels pane at least 240px wide while resizing', () => {
+	expect(getTimelineLabelsWidth(1600, 0.2)).toBe(320);
+	expect(getTimelineLabelsWidth(1000, 0.2)).toBe(240);
+	expect(getTimelineLabelsWidth(800, 0.2)).toBe(240);
+	expect(getTimelineLabelsWidth(400, 0.2)).toBe(240);
+	expect(getTimelineLabelsWidth(1000, 0.8)).toBe(500);
+});


### PR DESCRIPTION
## Summary

- keep the preview toolbar on the wide layout structure at every viewport width
- move secondary narrow-layout controls into an overflow menu while keeping playback centered
- enforce a 240px minimum for the timeline labels pane through the splitter constraints

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- manually resized the narrow Studio toolbar and timeline splitter

Closes #9440
