### PR TITLE
`@remotion/studio`: Allow seeking in read-only Studio

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -27,4 +27,25 @@ test.describe('visual mode', () => {
 	test('should navigate to schema-test composition', async ({page}) => {
 		await navigateToSchemaTest(page);
 	});
+
+	test('should seek in read-only Studio', async ({page}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'remotion_isReadOnlyStudio', {
+				configurable: false,
+				get: () => true,
+				set: () => undefined,
+			});
+		});
+
+		await page.goto(`${STUDIO_URL}/schema-test`);
+		await expect(
+			page.getByRole('button', {name: '0', exact: true}),
+		).toBeVisible({timeout: 15_000});
+
+		await page.locator('[data-timeline-scrubber]').click();
+
+		await expect(
+			page.getByRole('button', {name: '75', exact: true}),
+		).toBeVisible();
+	});
 });

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -8,7 +8,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
-import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
@@ -85,7 +85,7 @@ export const TimelineDragHandler: React.FC = () => {
 			style={containerStyle}
 			{...{[TIMELINE_SCRUBBER_ATTR]: true}}
 		>
-			{video && isStudioInteractivityEnabled() ? (
+			{video && isStudioSelectionEnabled() ? (
 				<TimelineDragHandlerInnerMemo />
 			) : null}
 		</div>


### PR DESCRIPTION
## Summary

- allow timeline scrubbing in read-only Studio
- keep source-mutating timeline interactions disabled
- add an end-to-end regression test for seeking in read-only mode

## Testing

- `bunx playwright test e2e/studio.test.mts --grep 'seek in read-only Studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9902
