### PR TITLE
`remotion`: Fix nested HTML-in-canvas client rendering

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -180,12 +180,13 @@ declare global {
 	}
 }
 
+export type HtmlInCanvasPaintTarget = HTMLCanvasElement | OffscreenCanvas;
+
 export type HtmlInCanvasOnPaintParams = {
 	/**
-	 * The `OffscreenCanvas` from {@link HTMLCanvasElement.transferControlToOffscreen}
-	 * on the layout `<canvas>` (same logical canvas as the forwarded ref).
+	 * The canvas that receives the painted output.
 	 */
-	readonly canvas: OffscreenCanvas;
+	readonly canvas: HtmlInCanvasPaintTarget;
 	readonly element: HTMLDivElement;
 	readonly elementImage: ElementImage;
 	readonly pixelDensity: number;
@@ -195,6 +196,26 @@ export type HtmlInCanvasOnPaintParams = {
 // capability nor the chrome://flags toggle can change between calls.
 // SSR results are not cached so the check runs again once `document` exists.
 let cachedSupport: boolean | null = null;
+
+// `transferControlToOffscreen()` is one-shot, while React may rerun the layout
+// effect against the same canvas. Reuse the original transfer on later runs.
+const transferredOffscreenCanvases = new WeakMap<
+	HTMLCanvasElement,
+	OffscreenCanvas
+>();
+
+const getTransferredOffscreenCanvas = (
+	canvas: HTMLCanvasElement,
+): OffscreenCanvas => {
+	const existing = transferredOffscreenCanvases.get(canvas);
+	if (existing) {
+		return existing;
+	}
+
+	const offscreen = canvas.transferControlToOffscreen();
+	transferredOffscreenCanvases.set(canvas, offscreen);
+	return offscreen;
+};
 
 export const isHtmlInCanvasSupported = (): boolean => {
 	if (cachedSupport !== null) {
@@ -293,8 +314,6 @@ const isMissingPaintRecordError = (error: unknown): boolean => {
 const missingPaintRecordMessage =
 	'HtmlInCanvas: Expected the element to be inside the viewport during rendering, but Chrome had no cached paint record for it.';
 
-type HtmlInCanvasPaintTarget = HTMLCanvasElement | OffscreenCanvas;
-
 const resizePaintTarget = ({
 	target,
 	width,
@@ -311,6 +330,31 @@ const resizePaintTarget = ({
 	if (target.height !== height) {
 		target.height = height;
 	}
+};
+
+const installTransferToImageBitmapShim = (canvas: HTMLCanvasElement): void => {
+	if ('transferToImageBitmap' in canvas) {
+		return;
+	}
+
+	Object.defineProperty(canvas, 'transferToImageBitmap', {
+		configurable: true,
+		value: () => {
+			const scratch = new OffscreenCanvas(canvas.width, canvas.height);
+			const scratchContext = scratch.getContext('2d');
+			const canvasContext = canvas.getContext('2d');
+			if (!scratchContext || !canvasContext) {
+				throw new Error(
+					'Failed to acquire 2D context for transferToImageBitmap()',
+				);
+			}
+
+			scratchContext.drawImage(canvas, 0, 0);
+			const bitmap = scratch.transferToImageBitmap();
+			canvasContext.clearRect(0, 0, canvas.width, canvas.height);
+			return bitmap;
+		},
+	});
 };
 
 const defaultOnPaint = ({
@@ -403,11 +447,15 @@ const HtmlInCanvasContent = forwardRef<
 			);
 		}
 
-		const resolvedPixelDensity = resolveHtmlInCanvasPixelDensity(pixelDensity);
-		const canvasWidth = Math.ceil(width * resolvedPixelDensity);
-		const canvasHeight = Math.ceil(height * resolvedPixelDensity);
 		const {delayRender, continueRender, cancelRender} = useDelayRender();
 		const {isClientSideRendering, isRendering} = useRemotionEnvironment();
+		const browserPixelDensity =
+			typeof window === 'undefined' ? undefined : window.devicePixelRatio;
+		const resolvedPixelDensity = resolveHtmlInCanvasPixelDensity(
+			pixelDensity ?? browserPixelDensity,
+		);
+		const canvasWidth = Math.ceil(width * resolvedPixelDensity);
+		const canvasHeight = Math.ceil(height * resolvedPixelDensity);
 		const canRetryMissingPaintRecord = !isRendering || isClientSideRendering;
 		const usesDirectLayoutCanvas =
 			onPaint === undefined && onInit === undefined;
@@ -511,7 +559,10 @@ const HtmlInCanvasContent = forwardRef<
 
 						initializedRef.current = true;
 						try {
-							if (paintTarget instanceof HTMLCanvasElement) {
+							if (
+								paintTarget instanceof HTMLCanvasElement &&
+								!isClientSideRendering
+							) {
 								throw new Error(
 									'HtmlInCanvas: onInit requires an OffscreenCanvas paint target',
 								);
@@ -562,7 +613,10 @@ const HtmlInCanvasContent = forwardRef<
 				try {
 					const currentOnPaint = onPaintRef.current;
 					if (currentOnPaint) {
-						if (paintTarget instanceof HTMLCanvasElement) {
+						if (
+							paintTarget instanceof HTMLCanvasElement &&
+							!isClientSideRendering
+						) {
 							throw new Error(
 								'HtmlInCanvas: onPaint requires an OffscreenCanvas paint target',
 							);
@@ -616,6 +670,7 @@ const HtmlInCanvasContent = forwardRef<
 			delayRender,
 			resolvedPixelDensity,
 			canRetryMissingPaintRecord,
+			isClientSideRendering,
 		]);
 
 		// Default paint handlers draw synchronously on the layout canvas itself so
@@ -629,9 +684,14 @@ const HtmlInCanvasContent = forwardRef<
 
 			placeholder.layoutSubtree = true;
 
-			const paintTarget = usesDirectLayoutCanvas
-				? placeholder
-				: placeholder.transferControlToOffscreen();
+			if (isClientSideRendering && !usesDirectLayoutCanvas) {
+				installTransferToImageBitmapShim(placeholder);
+			}
+
+			const paintTarget =
+				isClientSideRendering || usesDirectLayoutCanvas
+					? placeholder
+					: getTransferredOffscreenCanvas(placeholder);
 
 			paintTargetRef.current = paintTarget;
 			resizePaintTarget({
@@ -659,6 +719,7 @@ const HtmlInCanvasContent = forwardRef<
 			canvasWidth,
 			canvasHeight,
 			usesDirectLayoutCanvas,
+			isClientSideRendering,
 		]);
 
 		const onPaintChangedRef = useRef(false);

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -473,6 +473,96 @@ test('<HtmlInCanvas> can use a higher backing density', async () => {
 	expect(transferControlToOffscreenCalls).toBe(1);
 });
 
+test('<HtmlInCanvas> defaults to the browser pixel density', async () => {
+	const originalPixelDensity = Object.getOwnPropertyDescriptor(
+		window,
+		'devicePixelRatio',
+	);
+	Object.defineProperty(window, 'devicePixelRatio', {
+		configurable: true,
+		value: 2,
+	});
+	let paintParams: HtmlInCanvasOnPaintParams | undefined;
+
+	try {
+		const {container} = render(
+			<SequenceTestWrapper onRegisterSequence={() => undefined}>
+				<HtmlInCanvas
+					width={50}
+					height={40}
+					onPaint={(params) => {
+						paintParams = params;
+					}}
+				>
+					<div>Test</div>
+				</HtmlInCanvas>
+			</SequenceTestWrapper>,
+		);
+
+		const canvas = container.querySelector('canvas')!;
+		expect(canvas.getAttribute('width')).toBe('100');
+		expect(canvas.getAttribute('height')).toBe('80');
+		canvas.dispatchEvent(new Event('paint'));
+
+		await waitFor(() => {
+			expect(paintParams?.pixelDensity).toBe(2);
+		});
+	} finally {
+		if (originalPixelDensity) {
+			Object.defineProperty(window, 'devicePixelRatio', originalPixelDensity);
+		} else {
+			Reflect.deleteProperty(window, 'devicePixelRatio');
+		}
+	}
+});
+
+test('<HtmlInCanvas> paints on the layout canvas during client-side rendering', async () => {
+	let paintCanvas: HtmlInCanvasOnPaintParams['canvas'] | undefined;
+	const {container} = render(
+		<SequenceTestWrapper
+			isClientSideRendering
+			onRegisterSequence={() => undefined}
+		>
+			<HtmlInCanvas
+				width={50}
+				height={50}
+				onPaint={({canvas: targetCanvas}) => {
+					paintCanvas = targetCanvas;
+				}}
+			>
+				<div>Test</div>
+			</HtmlInCanvas>
+		</SequenceTestWrapper>,
+	);
+
+	const canvas = container.querySelector('canvas')!;
+	canvas.dispatchEvent(new Event('paint'));
+
+	await waitFor(() => {
+		expect(paintCanvas).toBe(canvas);
+	});
+	expect(transferControlToOffscreenCalls).toBe(0);
+	expect('transferToImageBitmap' in canvas).toBe(true);
+});
+
+test('<HtmlInCanvas> reuses an OffscreenCanvas when its layout effect reruns', async () => {
+	const onPaint = () => undefined;
+	const {container} = render(
+		<React.StrictMode>
+			<SequenceTestWrapper onRegisterSequence={() => undefined}>
+				<HtmlInCanvas width={50} height={50} onPaint={onPaint}>
+					<div>Test</div>
+				</HtmlInCanvas>
+			</SequenceTestWrapper>
+		</React.StrictMode>,
+	);
+
+	await waitFor(() => {
+		expect(container.querySelector('canvas')).not.toBeNull();
+	});
+	expect(transferControlToOffscreenCalls).toBe(1);
+});
+
 test('<HtmlInCanvas> does not apply pixel density to the live DOM transform', async () => {
 	const {container} = render(
 		<SequenceTestWrapper onRegisterSequence={() => undefined}>

--- a/packages/docs/docs/remotion/html-in-canvas.mdx
+++ b/packages/docs/docs/remotion/html-in-canvas.mdx
@@ -76,10 +76,10 @@ Logical height of the canvas and the inner layout area, in pixels. Must be a pos
 
 _number_
 
-Controls the backing bitmap density. Default: `1`.
+Controls the backing bitmap density. Default: `window.devicePixelRatio`.
 
 Set a higher value to paint to a higher-resolution backing canvas while keeping the logical canvas size unchanged.  
-This is useful to counteract quality loss when the canvas is scaled up – for example via the [`scale`](/docs/scaling) render option, or on a high-DPI display in the preview. Pass [`usePixelDensity()`](/docs/use-pixel-density) to use the render `scale` while rendering and `window.devicePixelRatio` while previewing.
+By default, `<HtmlInCanvas>` uses `window.devicePixelRatio` so previews and client-side renders use the same backing density. Pass a number to override it, or [`usePixelDensity()`](/docs/use-pixel-density) to follow the render [`scale`](/docs/scaling) while rendering.
 
 ### `children`
 
@@ -122,7 +122,7 @@ The callback receives:
 
 #### `canvas`
 
-An [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) with backing dimensions `width * pixelDensity` × `height * pixelDensity`, rounded up.  
+An [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas), or the layout [`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) during a client-side render, with backing dimensions `width * pixelDensity` × `height * pixelDensity`, rounded up.
 You should paint to this canvas.
 
 #### `element`
@@ -137,11 +137,11 @@ You should paint this image to the canvas.
 
 #### `pixelDensity`
 
-The resolved pixel density. It is `1` by default, or the number passed to `pixelDensity`.
+The resolved pixel density. It is `window.devicePixelRatio` by default, or the number passed to `pixelDensity`.
 
 ### `onInit?`
 
-Runs once before the first paint. Use it to create GPU contexts or other resources tied to the [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas). Must return a cleanup function, or a `Promise` that resolves to one. The cleanup runs on unmount.
+Runs once before the first paint. Use it to create GPU contexts or other resources tied to the callback canvas. Must return a cleanup function, or a `Promise` that resolves to one. The cleanup runs on unmount.
 
 The argument object matches [`onPaint`](#onpaint) (`canvas`, `element`, `elementImage`). The `elementImage` passed here is only for initialization — capture again inside [`onPaint`](#onpaint) for each frame.
 

--- a/packages/example/src/HtmlInCanvas/docs-demo-2d-blur.tsx
+++ b/packages/example/src/HtmlInCanvas/docs-demo-2d-blur.tsx
@@ -23,7 +23,7 @@ export const HtmlInCanvasDocsDemo2DBlur: React.FC = () => {
 	const {width, height, fps} = useVideoConfig();
 
 	const onPaint: HtmlInCanvasOnPaint = useCallback(
-		({canvas, element, elementImage}) => {
+		({canvas, element, elementImage, pixelDensity}) => {
 			const ctx = canvas.getContext('2d');
 			if (!ctx) {
 				throw new Error('Failed to acquire 2D context');
@@ -34,7 +34,7 @@ export const HtmlInCanvasDocsDemo2DBlur: React.FC = () => {
 				BLUR_MIN_PX + (BLUR_MAX_PX - BLUR_MIN_PX) * (0.5 + 0.5 * Math.sin(t));
 
 			ctx.reset();
-			ctx.filter = `blur(${blurPx}px)`;
+			ctx.filter = `blur(${blurPx * pixelDensity}px)`;
 			const transform = ctx.drawElementImage(elementImage, 0, 0);
 			element.style.transform = transform.toString();
 		},

--- a/packages/web-renderer/src/html-in-canvas.ts
+++ b/packages/web-renderer/src/html-in-canvas.ts
@@ -59,8 +59,9 @@ const runNestedHtmlInCanvasProbe = (): Promise<boolean> => {
 	inner.layoutSubtree = true;
 	outer.width = 4;
 	outer.height = 4;
-	inner.width = 4;
-	inner.height = 4;
+	const pixelDensity = window.devicePixelRatio;
+	inner.width = Math.ceil(4 * pixelDensity);
+	inner.height = Math.ceil(4 * pixelDensity);
 
 	Object.assign(outer.style, {
 		display: 'block',
@@ -119,7 +120,13 @@ const runNestedHtmlInCanvasProbe = (): Promise<boolean> => {
 		inner.addEventListener('paint', () => {
 			try {
 				innerCtx.reset();
-				const transform = innerCtx.drawElementImage(innerTarget, 0, 0, 4, 4);
+				const transform = innerCtx.drawElementImage(
+					innerTarget,
+					0,
+					0,
+					inner.width,
+					inner.height,
+				);
 				innerTarget.style.transform = transform.toString();
 				innerPainted = true;
 				requestAnimationFrame(() => outer.requestPaint!());
@@ -169,14 +176,16 @@ export const supportsNestedHtmlInCanvas = (): Promise<boolean> => {
 	return nestedHtmlInCanvasSupport;
 };
 
-const countLayoutSubtreeCanvases = (element: HTMLElement): number => {
+const getLayoutSubtreeCanvases = (
+	element: HTMLElement,
+): HTMLCanvasWithLayoutSubtree[] => {
 	return Array.from(element.querySelectorAll('canvas')).filter(
 		(canvas) => (canvas as HTMLCanvasWithLayoutSubtree).layoutSubtree === true,
-	).length;
+	) as HTMLCanvasWithLayoutSubtree[];
 };
 
 export const containsLayoutSubtreeCanvas = (element: HTMLElement): boolean => {
-	return countLayoutSubtreeCanvases(element) > 0;
+	return getLayoutSubtreeCanvases(element).length > 0;
 };
 
 export type HtmlInCanvasContext = {
@@ -286,9 +295,10 @@ export const drawWithHtmlInCanvas = async ({
 	// Each nested layout canvas needs one paint to run its async effect and a
 	// second paint to propagate the completed bitmap to its parent. One final
 	// cycle records the fully composed tree on the web renderer's root canvas.
-	const nestedPaintCycles = useElementImage
-		? countLayoutSubtreeCanvases(element) * 2 + 1
-		: 0;
+	const nestedCanvases = useElementImage
+		? getLayoutSubtreeCanvases(element).reverse()
+		: [];
+	const nestedPaintCycles = useElementImage ? nestedCanvases.length * 2 + 1 : 0;
 	for (let i = 0; i < nestedPaintCycles; i++) {
 		await new Promise<void>((resolve) =>
 			requestAnimationFrame(() => resolve()),
@@ -297,30 +307,47 @@ export const drawWithHtmlInCanvas = async ({
 		await waitForPaint(layoutCanvas);
 	}
 
-	ctx.reset();
-	if (useElementImage) {
-		if (typeof layoutCanvas.captureElementImage !== 'function') {
-			throw new Error('canvas.captureElementImage() is unavailable');
-		}
-
-		const elementImage = layoutCanvas.captureElementImage(element);
-		try {
-			ctx.drawElementImage(elementImage, 0, 0, scaledWidth, scaledHeight);
-		} finally {
-			elementImage.close();
-		}
-	} else {
-		ctx.drawElementImage(element, 0, 0, scaledWidth, scaledHeight);
+	// Chromium can drop an already-painted nested canvas backing store while
+	// recursively capturing layoutSubtree nodes. Capture finished child canvases
+	// as ordinary canvases, then restore their layout behavior for future paints.
+	for (const canvas of nestedCanvases) {
+		canvas.layoutSubtree = false;
 	}
 
-	const offscreen = new OffscreenCanvas(scaledWidth, scaledHeight);
-	const offCtx = offscreen.getContext('2d');
-	if (!offCtx) {
-		throw new Error('Could not get offscreen context');
-	}
+	try {
+		if (nestedCanvases.length > 0) {
+			await waitForPaint(layoutCanvas);
+		}
 
-	offCtx.drawImage(layoutCanvas, 0, 0);
-	return offCtx;
+		ctx.reset();
+		if (useElementImage) {
+			if (typeof layoutCanvas.captureElementImage !== 'function') {
+				throw new Error('canvas.captureElementImage() is unavailable');
+			}
+
+			const elementImage = layoutCanvas.captureElementImage(element);
+			try {
+				ctx.drawElementImage(elementImage, 0, 0, scaledWidth, scaledHeight);
+			} finally {
+				elementImage.close();
+			}
+		} else {
+			ctx.drawElementImage(element, 0, 0, scaledWidth, scaledHeight);
+		}
+
+		const offscreen = new OffscreenCanvas(scaledWidth, scaledHeight);
+		const offCtx = offscreen.getContext('2d');
+		if (!offCtx) {
+			throw new Error('Could not get offscreen context');
+		}
+
+		offCtx.drawImage(layoutCanvas, 0, 0);
+		return offCtx;
+	} finally {
+		for (const canvas of nestedCanvases) {
+			canvas.layoutSubtree = true;
+		}
+	}
 };
 
 export const teardownHtmlInCanvas = ({

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -2,6 +2,7 @@ import {Internals} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {createScaffold} from '../create-scaffold';
 import {
+	drawWithHtmlInCanvas,
 	setForceDisableHtmlInCanvasForTesting,
 	supportsNativeHtmlInCanvas,
 	supportsNestedHtmlInCanvas,
@@ -115,6 +116,56 @@ test('retries a transient missing nested paint record during a client-side rende
 	}
 
 	expect(simulatedMissingRecord).toBe(true);
+});
+
+test('captures painted nested canvases without layoutSubtree recursion', async () => {
+	const layoutCanvas = document.createElement('canvas') as HTMLCanvasElement & {
+		captureElementImage: (element: Element) => ElementImage;
+		layoutSubtree: boolean;
+		requestPaint: () => void;
+	};
+	const element = document.createElement('div');
+	const nestedCanvas = document.createElement('canvas') as HTMLCanvasElement & {
+		layoutSubtree: boolean;
+	};
+	nestedCanvas.layoutSubtree = true;
+	element.appendChild(nestedCanvas);
+	layoutCanvas.layoutSubtree = true;
+	layoutCanvas.requestPaint = () => {
+		layoutCanvas.dispatchEvent(new Event('paint'));
+	};
+
+	let capturedWithoutLayoutSubtree = false;
+	layoutCanvas.captureElementImage = () => {
+		capturedWithoutLayoutSubtree = nestedCanvas.layoutSubtree === false;
+		return {
+			close: () => undefined,
+			height: 1,
+			width: 1,
+		};
+	};
+
+	const drawElementImage = vi.fn(() => new DOMMatrix());
+	const reset = vi.fn();
+	await drawWithHtmlInCanvas({
+		element,
+		htmlInCanvasContext: {
+			ctx: {
+				drawElementImage,
+				reset,
+			} as unknown as CanvasRenderingContext2D,
+			layoutCanvas,
+		},
+		scaledHeight: 40,
+		scaledWidth: 50,
+		useElementImage: true,
+		waitForRenderReady: () => Promise.resolve(),
+	});
+
+	expect(capturedWithoutLayoutSubtree).toBe(true);
+	expect(nestedCanvas.layoutSubtree).toBe(true);
+	expect(drawElementImage).toHaveBeenCalledTimes(1);
+	expect(reset).toHaveBeenCalledTimes(1);
 });
 
 test('keeps a scaffold without HTML-in-canvas hidden', () => {


### PR DESCRIPTION
## Summary
- preserve custom `<HtmlInCanvas onPaint>` output during client-side rendering by painting on the layout canvas, while retaining OffscreenCanvas-compatible bitmap transfer behavior and guarding one-shot transfers
- make backing stores and the nested-support probe DPR-aware so previews and browser renders use consistent density
- prevent Chromium from dropping painted nested canvas pixels by temporarily disabling `layoutSubtree` only while the outer `ElementImage` is captured, then restoring it
- add focused core and browser regressions and update the API documentation/example

## Why each change is needed

### Match preview and render pixel density

On Chromium 152 at DPR 2, nested `layoutSubtree` canvas backing stores are rasterized at `1 / devicePixelRatio`. A DPR-sized backing store is therefore required during client-side rendering to preserve the expected logical dimensions, and the native nesting support probe must use the same geometry to avoid a false negative.

Applying DPR only during rendering made preview and export behavior diverge: preview callbacks received `pixelDensity: 1`, while client-side renders received `pixelDensity: 2`. Pixel-based operations such as `ctx.filter = blur(...)` consequently produced different visual results. Defaulting both paths to `window.devicePixelRatio` keeps backing dimensions and the callback's resolved `pixelDensity` consistent. An explicit `pixelDensity` prop still overrides the default.

### Keep custom painting on the layout canvas

Custom paint handlers cannot draw an `ElementImage` captured from the DOM layout canvas onto a separately transferred `OffscreenCanvas`; Chromium throws `InvalidStateError` because the source belongs to a different canvas. Client-side rendering therefore keeps custom painting on the layout canvas and provides the bitmap-transfer compatibility method there.

### Capture completed nested canvases as ordinary canvases

Even after correcting DPR, the outer capture remained fully transparent. Chromium can omit an already-painted nested canvas backing store while recursively capturing a `layoutSubtree`. Temporarily setting completed child canvases to `layoutSubtree = false` during the outer `captureElementImage()` call preserves their pixels, after which the flag is restored in `finally`.

### Reuse one-shot OffscreenCanvas transfers

React may replay the layout effect against the same canvas. Since `transferControlToOffscreen()` can only be called once per element, the transferred canvas is cached and reused.

## Test plan
- [x] `cd packages/core && bun test src/test/html-in-canvas.test.tsx`
- [x] `cd packages/web-renderer && bunx vitest src/test/html-in-canvas.test.tsx --browser.name=chromium --run`
- [x] `bun run build`
- [x] `bun run stylecheck`
- [x] manually verified a blurred nested `<HtmlInCanvas>` still in Electron 44 / Chromium 152 on a DPR 2 display

Made with [Cursor](https://cursor.com)