### PR TITLE
remotion.dev/convert: Make file drops full-screen

### DIFF
--- a/packages/convert/app/components/FileAvailable.tsx
+++ b/packages/convert/app/components/FileAvailable.tsx
@@ -12,7 +12,6 @@ import {Footer} from './Footer';
 import {VideoPlayer} from './MediaPlayer';
 import {Page} from './Page';
 import {Probe} from './Probe';
-import {ReplaceVideo} from './ReplaceVideo';
 import Transcribe from './transcribe/App';
 import {useProbe} from './use-probe';
 import type {VideoThumbnailRef} from './VideoThumbnail';
@@ -176,7 +175,6 @@ export const FileAvailable: React.FC<{
 				</div>
 				<div className="h-16" />
 				<Footer routeAction={routeAction} />
-				<ReplaceVideo setSrc={setSrc} />
 			</div>
 		</Page>
 	);

--- a/packages/convert/app/components/Main.tsx
+++ b/packages/convert/app/components/Main.tsx
@@ -6,6 +6,7 @@ import type {RouteAction} from '~/seo';
 import {getHeaderTitle} from '~/seo';
 import {FileAvailable} from './FileAvailable';
 import {PickFile} from './PickFile';
+import {ReplaceVideo} from './ReplaceVideo';
 
 export const Main: React.FC<{
 	readonly routeAction: RouteAction;
@@ -34,6 +35,7 @@ export const Main: React.FC<{
 						title={getHeaderTitle(routeAction)}
 					/>
 				)}
+				<ReplaceVideo src={src} setSrc={setSrc} />
 			</div>
 		</TitleProvider>
 	);

--- a/packages/convert/app/components/PickFile.tsx
+++ b/packages/convert/app/components/PickFile.tsx
@@ -35,12 +35,12 @@ export const PickFile: React.FC<{
 			}
 		};
 
-		document.body.addEventListener('dragover', onDragOver);
-		document.body.addEventListener('drop', onDrop);
+		document.addEventListener('dragover', onDragOver, {capture: true});
+		document.addEventListener('drop', onDrop, {capture: true});
 
 		return () => {
-			document.body.removeEventListener('dragover', onDragOver);
-			document.body.removeEventListener('drop', onDrop);
+			document.removeEventListener('dragover', onDragOver, {capture: true});
+			document.removeEventListener('drop', onDrop, {capture: true});
 		};
 	}, [setSrc]);
 

--- a/packages/convert/app/components/PickFile.tsx
+++ b/packages/convert/app/components/PickFile.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback} from 'react';
 import {SAMPLE_FILE_CONVERT, SAMPLE_FILE_TRANSCRIBE} from '~/lib/config';
 import type {Source} from '~/lib/convert-state';
 import type {RouteAction} from '~/seo';
@@ -21,28 +21,6 @@ export const PickFile: React.FC<{
 					: SAMPLE_FILE_CONVERT,
 		});
 	}, [setSrc, action]);
-
-	useEffect(() => {
-		const onDragOver = (e: DragEvent) => {
-			e.preventDefault();
-		};
-
-		const onDrop = (e: DragEvent) => {
-			e.preventDefault();
-			const file = e.dataTransfer?.files[0];
-			if (file) {
-				setSrc({type: 'file', file});
-			}
-		};
-
-		document.addEventListener('dragover', onDragOver, {capture: true});
-		document.addEventListener('drop', onDrop, {capture: true});
-
-		return () => {
-			document.removeEventListener('dragover', onDragOver, {capture: true});
-			document.removeEventListener('drop', onDrop, {capture: true});
-		};
-	}, [setSrc]);
 
 	return (
 		<div className="text-center items-center justify-center flex flex-col h-full w-full">

--- a/packages/convert/app/components/ReplaceVideo.tsx
+++ b/packages/convert/app/components/ReplaceVideo.tsx
@@ -11,8 +11,9 @@ import {
 } from './ui/dialog';
 
 export const ReplaceVideo: React.FC<{
+	readonly src: Source | null;
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
-}> = ({setSrc}) => {
+}> = ({src, setSrc}) => {
 	const [fileToReplace, setFileToReplace] = useState<File | null>(null);
 	const [dragging, setDragging] = useState(false);
 
@@ -23,7 +24,7 @@ export const ReplaceVideo: React.FC<{
 
 		const onDragOver = (e: DragEvent) => {
 			e.preventDefault();
-			setDragging(true);
+			setDragging(src !== null);
 		};
 
 		const onDragEnd = () => {
@@ -35,20 +36,24 @@ export const ReplaceVideo: React.FC<{
 			e.preventDefault();
 			const file = e.dataTransfer?.files[0];
 			if (file) {
-				setFileToReplace(file);
+				if (src === null) {
+					setSrc({type: 'file', file});
+				} else {
+					setFileToReplace(file);
+				}
 			}
 		};
 
-		document.body.addEventListener('dragover', onDragOver);
-		document.body.addEventListener('dragleave', onDragEnd);
-		document.body.addEventListener('drop', onDrop);
+		document.addEventListener('dragover', onDragOver, {capture: true});
+		document.addEventListener('dragleave', onDragEnd, {capture: true});
+		document.addEventListener('drop', onDrop, {capture: true});
 
 		return () => {
-			document.body.removeEventListener('dragleave', onDragEnd);
-			document.body.removeEventListener('dragover', onDragOver);
-			document.body.removeEventListener('drop', onDrop);
+			document.removeEventListener('dragleave', onDragEnd, {capture: true});
+			document.removeEventListener('dragover', onDragOver, {capture: true});
+			document.removeEventListener('drop', onDrop, {capture: true});
 		};
-	}, [fileToReplace]);
+	}, [fileToReplace, setSrc, src]);
 
 	const keepCurrent = useCallback(() => {
 		setFileToReplace(null);


### PR DESCRIPTION
## Summary

- listen for initial file drops on the document instead of the body
- capture drag and drop events so the full page remains a reliable drop target

## Verification

- `bun run build`
- `bun run stylecheck`
- browser regression check against drops targeted at the document root

Closes #9645
