### PR TITLE
`@remotion/browser-studio`: Include config in downloaded projects

### DIFF
--- a/packages/browser-studio/src/templates/blank.ts
+++ b/packages/browser-studio/src/templates/blank.ts
@@ -88,6 +88,18 @@ export const MyComponent: React.FC<Props> = () => {
   "exclude": ["remotion.config.ts"]
 }
 `,
+	'/project/remotion.config.ts': `/**
+ * Note: When using the Node.JS APIs, the config file
+ * doesn't apply. Instead, pass options directly to the APIs.
+ *
+ * All configuration options: https://remotion.dev/docs/config
+ */
+
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg");
+Config.setOverwriteOutput(true);
+`,
 } as const;
 
 export const createBlankTemplateProject = (): VirtualProject => ({

--- a/packages/browser-studio/src/test/download-project.test.ts
+++ b/packages/browser-studio/src/test/download-project.test.ts
@@ -55,6 +55,9 @@ test('downloads the current Browser Studio project as a runnable archive', async
 	expect(strFromU8(files['tsconfig.json'])).toBe(
 		project.files['/project/tsconfig.json'],
 	);
+	expect(strFromU8(files['remotion.config.ts'])).toBe(
+		project.files['/project/remotion.config.ts'],
+	);
 	expect(files['public/logo.bin']).toEqual(new Uint8Array([0, 127, 128, 255]));
 	expect(Object.keys(files).every((path) => !path.startsWith('/project'))).toBe(
 		true,

--- a/packages/browser-studio/src/test/template-blank.test.ts
+++ b/packages/browser-studio/src/test/template-blank.test.ts
@@ -32,6 +32,9 @@ test('blank template virtual files match the source template', () => {
 	expect(readTemplateFile('tsconfig.json')).toBe(
 		blankTemplateFiles['/project/tsconfig.json'],
 	);
+	expect(readTemplateFile('remotion.config.ts')).toBe(
+		blankTemplateFiles['/project/remotion.config.ts'],
+	);
 });
 
 test('createBlankTemplateProject points to the virtual entry point', () => {


### PR DESCRIPTION
## Summary

- add the default `remotion.config.ts` to the blank Browser Studio virtual filesystem
- include the config automatically in downloaded project archives
- cover template parity and archive contents in tests

## Testing

- `bun test packages/browser-studio/src/test/template-blank.test.ts packages/browser-studio/src/test/download-project.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9820
