### PR TITLE
`@remotion/web-renderer`: Preserve transforms for precomposited filters

### DIFF
--- a/packages/web-renderer/src/drawing/process-node.ts
+++ b/packages/web-renderer/src/drawing/process-node.ts
@@ -20,6 +20,7 @@ import {
 import {getPrecomposeRectForMask, handleMask} from './handle-mask';
 import {roundToExpandRect} from './round-to-expand-rect';
 import {scaleRect} from './scale-rect';
+import {setTransform} from './transform';
 import {transformDOMRect} from './transform-rect-with-matrix';
 
 export type ProcessNodeReturnValue =
@@ -190,25 +191,37 @@ export const processNode = async ({
 		}
 
 		const previousTransform = context.getTransform();
+		const is3DPrecomposition = precompositing.needs3DTransformViaWebGL;
 
-		context.setTransform(new DOMMatrix());
+		if (is3DPrecomposition) {
+			context.setTransform(new DOMMatrix());
+		} else {
+			// Preserve 2D rotation and skew instead of stretching the layer into
+			// the axis-aligned bounds of its transformed corners.
+			setTransform({
+				ctx: context,
+				transform: totalMatrix,
+				parentRect,
+				scale,
+			});
+		}
+
+		const destinationRect = is3DPrecomposition
+			? rectAfterTransforms
+			: precomposeRect;
+		const parentOffsetScale = is3DPrecomposition ? scale : 1;
 
 		const drawPrecomposedCanvas = () => {
-			// Source = full drawable (it always contains the precomposed content
-			// at its native size). Destination = `rectAfterTransforms`, so
-			// `drawImage` stretches when ancestor transforms (e.g. scale) make
-			// the destination smaller/larger than the layer canvas.
-			// See https://github.com/remotion-dev/remotion/issues/7199.
 			context.drawImage(
 				drawable,
 				0,
 				0,
 				drawable.width,
 				drawable.height,
-				rectAfterTransforms.left - parentRect.x * scale,
-				rectAfterTransforms.top - parentRect.y * scale,
-				rectAfterTransforms.width,
-				rectAfterTransforms.height,
+				destinationRect.left - parentRect.x * parentOffsetScale,
+				destinationRect.top - parentRect.y * parentOffsetScale,
+				destinationRect.width,
+				destinationRect.height,
 			);
 		};
 

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -41,6 +41,7 @@ import {issue7243SvgJapaneseText} from './fixtures/issue-7243-svg-japanese-text'
 import {issue7489Minimal} from './fixtures/issue-7489-minimal';
 import {issue8650LottieControlChars} from './fixtures/issue-8650-lottie-control-chars';
 import {issue9736BackgroundPosition} from './fixtures/issue-9736-background-position';
+import {issue9901RotatedDropShadow} from './fixtures/issue-9901-rotated-drop-shadow';
 import {lineHeight} from './fixtures/line-height';
 import {linearGradient} from './fixtures/linear-gradient';
 import {manyLayers} from './fixtures/many-layers';
@@ -215,6 +216,7 @@ export const Root: React.FC = () => {
 				<Composition {...issue7050Minimal} />
 				<Composition {...issue6211MaskWheel} />
 				<Composition {...issue7199ScaleAndDropShadow} />
+				<Composition {...issue9901RotatedDropShadow} />
 				<Composition {...issue7243SvgJapaneseText} />
 				<Composition {...issue7489Minimal} />
 			</Folder>

--- a/packages/web-renderer/src/test/fixtures/issue-9901-rotated-drop-shadow.tsx
+++ b/packages/web-renderer/src/test/fixtures/issue-9901-rotated-drop-shadow.tsx
@@ -1,0 +1,25 @@
+const Component: React.FC = () => {
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				left: 100,
+				top: 190,
+				width: 600,
+				height: 120,
+				backgroundColor: '#edf7ff',
+				filter: 'drop-shadow(0 14px 20px rgba(18, 45, 58, 0.28))',
+				rotate: '30deg',
+			}}
+		/>
+	);
+};
+
+export const issue9901RotatedDropShadow = {
+	component: Component,
+	id: 'issue-9901-rotated-drop-shadow',
+	width: 800,
+	height: 500,
+	fps: 30,
+	durationInFrames: 1,
+} as const;

--- a/packages/web-renderer/src/test/issue-9901-rotated-drop-shadow.test.tsx
+++ b/packages/web-renderer/src/test/issue-9901-rotated-drop-shadow.test.tsx
@@ -1,0 +1,29 @@
+import {expect, test} from 'vitest';
+import {renderStillOnWeb} from '../render-still-on-web';
+import '../symbol-dispose';
+import {issue9901RotatedDropShadow} from './fixtures/issue-9901-rotated-drop-shadow';
+
+test('issue-9901 preserves rotation when precompositing a drop-shadow', async () => {
+	const blob = await (
+		await renderStillOnWeb({
+			licenseKey: 'free-license',
+			composition: issue9901RotatedDropShadow,
+			frame: 0,
+			inputProps: {},
+		})
+	).blob({format: 'png'});
+
+	const image = await createImageBitmap(blob);
+	const canvas = new OffscreenCanvas(800, 500);
+	const context = canvas.getContext('2d');
+	if (!context) {
+		throw new Error('Could not get 2D context');
+	}
+
+	context.drawImage(image, 0, 0);
+	image.close();
+
+	// Inside the rotated pill, but outside the axis-aligned client-side result.
+	const rotatedPillPixel = context.getImageData(200, 80, 1, 1).data;
+	expect(Array.from(rotatedPillPixel)).toEqual([237, 247, 255, 255]);
+});


### PR DESCRIPTION
## Summary

- add a minimal rotated `drop-shadow()` reproduction for #9901
- preserve the original 2D affine transform when drawing a precomposited filter layer instead of stretching it into an axis-aligned bounding box
- keep the existing WebGL path for 3D precomposition unchanged

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testwebrenderer` (240 test files passed; 672 tests passed and 21 skipped)
- focused issue #9901, issue #7199, and 3D precomposition tests in Chromium, Firefox, and WebKit
- red/green verified by disconnecting and restoring the affine blit

Closes https://github.com/remotion-dev/remotion/issues/9901
