### PR TITLE
`@remotion/cli`: Warn about mismatched bundler override

### DIFF
--- a/packages/cli/src/get-config-file-name.ts
+++ b/packages/cli/src/get-config-file-name.ts
@@ -1,6 +1,7 @@
 import {existsSync} from 'node:fs';
 import path from 'node:path';
 import {BrowserSafeApis} from '@remotion/renderer/client';
+import {ConfigInternals} from './config';
 import {
 	executeConfigFile,
 	loadConfigFile,
@@ -10,7 +11,7 @@ import type {PreparedConfigFile} from './load-config';
 import {Log} from './log';
 import {parsedCli} from './parsed-cli';
 
-const {configOption} = BrowserSafeApis.options;
+const {configOption, logLevelOption, rspackOption} = BrowserSafeApis.options;
 
 const defaultConfigFileJavascript = 'remotion.config.js';
 const defaultConfigFileTypescript = 'remotion.config.ts';
@@ -18,13 +19,51 @@ let loadedConfigFile: PreparedConfigFile | null = null;
 
 export const getLoadedConfigFile = () => loadedConfigFile?.resolved ?? null;
 
+const warnAboutBundlerOverride = () => {
+	const useRspack = rspackOption.getValue({commandLine: parsedCli}).value;
+	const hasWebpackOverride =
+		ConfigInternals.getWebpackOverrideFn() !==
+		ConfigInternals.defaultOverrideFunction;
+	const hasRspackOverride =
+		ConfigInternals.getRspackOverrideFn() !==
+		ConfigInternals.defaultRspackOverrideFunction;
+
+	if (
+		(useRspack && !hasWebpackOverride) ||
+		(!useRspack && !hasRspackOverride)
+	) {
+		return;
+	}
+
+	const selectedBundler = useRspack ? 'Rspack' : 'Webpack';
+	const ignoredBundler = useRspack ? 'Webpack' : 'Rspack';
+	const selectedOverride = useRspack
+		? 'overrideRspackConfig'
+		: 'overrideWebpackConfig';
+	const ignoredOverride = useRspack
+		? 'overrideWebpackConfig'
+		: 'overrideRspackConfig';
+	const logLevel = logLevelOption.getValue({commandLine: parsedCli}).value;
+
+	Log.warn(
+		{indent: false, logLevel},
+		`You have selected ${selectedBundler} as the bundler, but Config.${ignoredOverride}() was called. The ${ignoredBundler} override will be ignored. Use Config.${selectedOverride}() or Config.overrideBundlerConfig() instead.`,
+	);
+};
+
 const loadInitialConfigFile = async (
 	remotionRoot: string,
 	configFileName: string,
 	isJavascript: boolean,
 ) => {
 	try {
-		return await loadConfigFile(remotionRoot, configFileName, isJavascript);
+		const config = await loadConfigFile(
+			remotionRoot,
+			configFileName,
+			isJavascript,
+		);
+		warnAboutBundlerOverride();
+		return config;
 	} catch (error) {
 		Log.error(
 			{indent: false, logLevel: 'error'},
@@ -114,6 +153,7 @@ export const reloadConfig = async ({
 	try {
 		executeConfigFile(nextConfigFile);
 		loadedConfigFile = nextConfigFile;
+		warnAboutBundlerOverride();
 		return true;
 	} catch (error) {
 		resetConfigOptions();

--- a/packages/cli/src/test/config-reload.test.ts
+++ b/packages/cli/src/test/config-reload.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, expect, test} from 'bun:test';
+import {afterEach, expect, spyOn, test} from 'bun:test';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
@@ -66,4 +66,60 @@ test('an invalid config reload keeps the previous configuration', async () => {
 		}),
 	).toBe(true);
 	expect(ConfigInternals.getStudioPort()).toBe(6789);
+});
+
+test('warns when the bundler-specific override does not match the selected bundler', async () => {
+	process.env.PATCH_BUN_DEVELOPMENT = '1';
+	Object.assign(globalThis, {
+		require: createRequire(path.join(__dirname, '..', 'load-config.ts')),
+	});
+	temporaryDirectory = mkdtempSync(path.join(tmpdir(), 'remotion-config-'));
+	const warn = spyOn(console, 'warn').mockImplementation(() => undefined);
+
+	try {
+		writeConfig(
+			`const {Config} = require('@remotion/cli/config'); Config.overrideWebpackConfig((config) => config); Config.setRspack(true);`,
+		);
+		await loadConfig(temporaryDirectory);
+		expect(warn.mock.calls.flat().join(' ')).toContain(
+			'You have selected Rspack as the bundler, but Config.overrideWebpackConfig() was called. The Webpack override will be ignored. Use Config.overrideRspackConfig() or Config.overrideBundlerConfig() instead.',
+		);
+
+		warn.mockClear();
+		writeConfig(
+			`const {Config} = require('@remotion/cli/config'); Config.setRspack(false); Config.overrideRspackConfig((config) => config);`,
+		);
+		expect(
+			await reloadConfig({
+				resetConfigOptions: ConfigInternals.resetConfigOptions,
+			}),
+		).toBe(true);
+		expect(warn.mock.calls.flat().join(' ')).toContain(
+			'You have selected Webpack as the bundler, but Config.overrideRspackConfig() was called. The Rspack override will be ignored. Use Config.overrideWebpackConfig() or Config.overrideBundlerConfig() instead.',
+		);
+
+		warn.mockClear();
+		writeConfig(
+			`const {Config} = require('@remotion/cli/config'); Config.setRspack(true); Config.overrideRspackConfig((config) => config); Config.overrideBundlerConfig((config) => config);`,
+		);
+		expect(
+			await reloadConfig({
+				resetConfigOptions: ConfigInternals.resetConfigOptions,
+			}),
+		).toBe(true);
+		expect(warn.mock.calls.length).toBe(0);
+
+		warn.mockClear();
+		writeConfig(
+			`const {Config} = require('@remotion/cli/config'); Config.setRspack(false); Config.overrideWebpackConfig((config) => config); Config.overrideBundlerConfig((config) => config);`,
+		);
+		expect(
+			await reloadConfig({
+				resetConfigOptions: ConfigInternals.resetConfigOptions,
+			}),
+		).toBe(true);
+		expect(warn.mock.calls.length).toBe(0);
+	} finally {
+		warn.mockRestore();
+	}
 });


### PR DESCRIPTION
## Summary

- warn when the selected bundler does not match a configured bundler-specific override
- validate both initial config loads and Studio config reloads
- keep matching overrides and `Config.overrideBundlerConfig()` warning-free

## Testing

- `bun test packages/cli/src/test/config-reload.test.ts`
- red/green regression verification
- `bun run build`
- `bun run stylecheck`

Closes #9802
