### PR TITLE
`@remotion/studio-protocol`: Allow secure third-party installation requests

### DIFF
--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -150,9 +150,7 @@ const isAllowedOrigin = (origin: string | null): boolean => {
 	try {
 		const parsed = new URL(origin);
 		return (
-			(parsed.protocol === 'https:' &&
-				(parsed.hostname === 'remotion.dev' ||
-					parsed.hostname === 'www.remotion.dev')) ||
+			parsed.protocol === 'https:' ||
 			(parsed.protocol === 'http:' &&
 				(parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'))
 		);
@@ -268,7 +266,7 @@ export const installInStudioWithDependencies = async (
 	if (!isAllowedOrigin(dependencies.pageOrigin)) {
 		return failure(
 			'unsupported-origin',
-			'Install in Studio is only supported on remotion.dev and local development origins.',
+			'Install in Studio is only supported on HTTPS websites and local development origins.',
 		);
 	}
 

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -303,7 +303,7 @@ test('reports a truncated install response as invalid', async () => {
 	});
 });
 
-test('does not probe Studio from an unsupported origin', async () => {
+test('does not probe Studio from a non-loopback HTTP origin', async () => {
 	let requests = 0;
 	const result = await installInStudioWithDependencies(elementPayload, {
 		...dependencies,
@@ -311,14 +311,14 @@ test('does not probe Studio from an unsupported origin', async () => {
 			requests++;
 			return Promise.resolve(new Response(null, {status: 404}));
 		},
-		pageOrigin: 'https://example.com',
+		pageOrigin: 'http://example.com',
 	});
 
 	expect(result).toEqual({
 		success: false,
 		code: 'unsupported-origin',
 		message:
-			'Install in Studio is only supported on remotion.dev and local development origins.',
+			'Install in Studio is only supported on HTTPS websites and local development origins.',
 	});
 	expect(requests).toBe(0);
 });

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -19,6 +19,7 @@ const targetsByClientId = new Map<string, ElementInstallTarget>();
 
 type StudioProtocolTarget = {
 	readonly id: string;
+	readonly origin: string;
 	readonly target: ElementInstallTarget;
 	readonly expiresAt: number;
 };
@@ -73,9 +74,11 @@ export const getElementInstallTarget = (requestId: string | null) => {
 
 export const issueStudioProtocolTarget = ({
 	now,
+	origin,
 	target,
 }: {
 	readonly now: number;
+	readonly origin: string;
 	readonly target: ElementInstallTarget;
 }) => {
 	for (const [id, existing] of studioProtocolTargets) {
@@ -86,6 +89,7 @@ export const issueStudioProtocolTarget = ({
 
 	const issued: StudioProtocolTarget = {
 		id: randomUUID(),
+		origin,
 		target: {...target},
 		expiresAt: now + STUDIO_PROTOCOL_TARGET_MAX_AGE,
 	};
@@ -95,14 +99,20 @@ export const issueStudioProtocolTarget = ({
 
 export const consumeStudioProtocolTarget = ({
 	now,
+	origin,
 	targetId,
 }: {
 	readonly now: number;
+	readonly origin: string;
 	readonly targetId: string;
 }): ElementInstallTarget | null => {
 	const issued = studioProtocolTargets.get(targetId);
 	studioProtocolTargets.delete(targetId);
-	if (issued === undefined || issued.expiresAt <= now) {
+	if (
+		issued === undefined ||
+		issued.expiresAt <= now ||
+		issued.origin !== origin
+	) {
 		return null;
 	}
 

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -10,7 +10,7 @@ import {
 } from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {
-	isAllowedStudioProtocolOrigin,
+	getAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
 } from './origin-policy';
 import {writeStudioProtocolError} from './protocol-response';
@@ -77,7 +77,8 @@ export const handleStudioProtocolDiscovery = ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	if (!isAllowedStudioProtocolOrigin(request.headers.origin)) {
+	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',
 			message: 'Origin not allowed',
@@ -103,7 +104,13 @@ export const handleStudioProtocolDiscovery = ({
 			const now = Date.now();
 			const target = getLiveInstallableTarget(requestId);
 			const issued =
-				target === null ? null : issueStudioProtocolTarget({now, target});
+				target === null
+					? null
+					: issueStudioProtocolTarget({
+							now,
+							origin: requestOrigin,
+							target,
+						});
 			response.writeHead(200, {
 				'Cache-Control': 'no-store',
 				'Content-Type': 'application/json',

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -7,7 +7,7 @@ import type {getElementInstallTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {parseRequestBody, RequestBodyTooLargeError} from '../parse-body';
 import {
-	isAllowedStudioProtocolOrigin,
+	getAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
 } from './origin-policy';
 import {writeStudioProtocolError} from './protocol-response';
@@ -80,11 +80,8 @@ export const handleStudioProtocolInstall = async ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const requestOrigin = request.headers.origin;
-	if (
-		typeof requestOrigin !== 'string' ||
-		!isAllowedStudioProtocolOrigin(requestOrigin)
-	) {
+	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',
 			message: 'Origin not allowed',
@@ -155,6 +152,7 @@ export const handleStudioProtocolInstall = async ({
 
 	const target = consumeStudioProtocolTarget({
 		now: Date.now(),
+		origin: requestOrigin,
 		targetId: parsedRequest.data.targetId,
 	});
 	if (target === null) {
@@ -172,7 +170,7 @@ export const handleStudioProtocolInstall = async ({
 			element: payload.element,
 			focusStudioTab,
 			liveEventsServer,
-			origin: new URL(requestOrigin).origin,
+			origin: requestOrigin,
 			target,
 		})
 	) {

--- a/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
@@ -1,25 +1,30 @@
 import type {IncomingMessage, ServerResponse} from 'node:http';
 
-export const isAllowedStudioProtocolOrigin = (
+export const getAllowedStudioProtocolOrigin = (
 	origin: string | undefined,
-): boolean => {
+): string | null => {
 	if (!origin) {
-		return false;
+		return null;
 	}
 
 	try {
 		const url = new URL(origin);
-		return (
-			(url.protocol === 'https:' &&
-				(url.hostname === 'remotion.dev' ||
-					url.hostname === 'www.remotion.dev')) ||
-			(url.protocol === 'http:' &&
-				(url.hostname === 'localhost' || url.hostname === '127.0.0.1'))
-		);
+		const isLoopbackHttp =
+			url.protocol === 'http:' &&
+			(url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+		if (url.protocol !== 'https:' && !isLoopbackHttp) {
+			return null;
+		}
+
+		return url.origin;
 	} catch {
-		return false;
+		return null;
 	}
 };
+
+export const isAllowedStudioProtocolOrigin = (
+	origin: string | undefined,
+): boolean => getAllowedStudioProtocolOrigin(origin) !== null;
 
 export const setStudioProtocolCorsHeaders = ({
 	request,
@@ -28,13 +33,16 @@ export const setStudioProtocolCorsHeaders = ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): void => {
-	const {origin} = request.headers;
-	if (typeof origin !== 'string' || !isAllowedStudioProtocolOrigin(origin)) {
+	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	if (origin === null) {
 		return;
 	}
 
 	response.setHeader('Access-Control-Allow-Origin', origin);
-	response.setHeader('Vary', 'Origin');
+	response.setHeader(
+		'Vary',
+		'Origin, Access-Control-Request-Headers, Access-Control-Request-Private-Network',
+	);
 	response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
 	response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 	response.setHeader('Access-Control-Max-Age', '600');
@@ -50,7 +58,7 @@ export const handleStudioProtocolOptions = ({
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
 	response.writeHead(
-		isAllowedStudioProtocolOrigin(request.headers.origin) ? 204 : 403,
+		getAllowedStudioProtocolOrigin(request.headers.origin) === null ? 403 : 204,
 	);
 	response.end();
 	return Promise.resolve();

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -94,13 +94,55 @@ test('binds a single-use Studio Protocol token to the selected composition', () 
 		throw new Error('Expected an install target');
 	}
 
-	const issued = issueStudioProtocolTarget({now: Date.now(), target: selected});
+	const issued = issueStudioProtocolTarget({
+		now: Date.now(),
+		origin: 'https://example.com',
+		target: selected,
+	});
 	expect(
-		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id})
-			?.compositionId,
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://example.com',
+			targetId: issued.id,
+		})?.compositionId,
 	).toBe('Main');
 	expect(
-		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id}),
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://example.com',
+			targetId: issued.id,
+		}),
+	).toBe(null);
+});
+
+test('rejects a token from another origin', () => {
+	clearElementInstallStateForTests();
+	updateElementInstallTarget({
+		requestId: 'protocol-request',
+		clientId: 'focused-tab',
+		compositionFile: '/project/src/main.tsx',
+		compositionId: 'Main',
+		canInstall: true,
+		lastFocusedAt: Date.now(),
+		readOnly: false,
+		studioUrl: 'http://localhost:3000/Main',
+	});
+	const selected = getElementInstallTarget('protocol-request');
+	if (selected === null) {
+		throw new Error('Expected an install target');
+	}
+
+	const issued = issueStudioProtocolTarget({
+		now: Date.now(),
+		origin: 'https://example.com',
+		target: selected,
+	});
+	expect(
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://other.example',
+			targetId: issued.id,
+		}),
 	).toBe(null);
 });
 
@@ -121,7 +163,11 @@ test('invalidates a token if the selected tab changes compositions', () => {
 		throw new Error('Expected an install target');
 	}
 
-	const issued = issueStudioProtocolTarget({now: Date.now(), target: selected});
+	const issued = issueStudioProtocolTarget({
+		now: Date.now(),
+		origin: 'https://example.com',
+		target: selected,
+	});
 	updateElementInstallTarget({
 		requestId: null,
 		clientId: 'focused-tab',
@@ -133,7 +179,11 @@ test('invalidates a token if the selected tab changes compositions', () => {
 		studioUrl: 'http://localhost:3000/Other',
 	});
 	expect(
-		consumeStudioProtocolTarget({now: Date.now(), targetId: issued.id}),
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://example.com',
+			targetId: issued.id,
+		}),
 	).toBe(null);
 });
 

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -170,16 +170,16 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		const preflight = await fetch(`${origin}/api/studio-protocol/install`, {
 			method: 'OPTIONS',
 			headers: {
-				Origin: 'http://localhost:4000',
+				Origin: 'https://example.com',
 				'Access-Control-Request-Method': 'POST',
 			},
 		});
 		expect(preflight.status).toBe(204);
 		expect(preflight.headers.get('access-control-allow-origin')).toBe(
-			'http://localhost:4000',
+			'https://example.com',
 		);
 		const disallowedResponse = await fetch(`${origin}/api/studio-protocol`, {
-			headers: {Origin: 'https://example.com'},
+			headers: {Origin: 'http://example.com'},
 		});
 		expect(disallowedResponse.status).toBe(403);
 		expect(await disallowedResponse.json()).toMatchObject({
@@ -188,7 +188,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		});
 
 		const discoveryResponse = await fetch(`${origin}/api/studio-protocol`, {
-			headers: {Origin: 'http://localhost:4000'},
+			headers: {Origin: 'https://example.com'},
 		});
 		expect(discoveryResponse.status).toBe(200);
 		expect(discoveryResponse.headers.get('cache-control')).toBe('no-store');
@@ -257,7 +257,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Origin: 'http://localhost:4000',
+					Origin: 'https://example.com',
 				},
 				body: JSON.stringify(installBody),
 			},
@@ -277,7 +277,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 				element: {displayName: 'Lower Third'},
 				source: {
 					type: 'studio-protocol',
-					origin: 'http://localhost:4000',
+					origin: 'https://example.com',
 				},
 			},
 		});
@@ -288,7 +288,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Origin: 'http://localhost:4000',
+					Origin: 'https://example.com',
 				},
 				body: JSON.stringify(installBody),
 			},


### PR DESCRIPTION
## Summary

- Allow Studio discovery and installation requests from HTTPS origins and loopback HTTP origins only.
- Reflect the exact approved origin in CORS responses instead of using a wildcard.
- Bind short-lived, single-use installation tokens to the requesting origin, Studio client, composition, and target state.
- Preserve Studio Protocol version 1 and existing discovery metadata.

## Stack

Layer 4 of 6. Based on #9927.

## Validation

- `bun run build`
- `bun run stylecheck`
- Studio Protocol client, origin-policy, route, and token-state tests

Part of #9772.
