### PR TITLE
`@remotion/studio`: Refine Element installation confirmation

### DIFF
--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -59,6 +59,7 @@ import {EditorRulers} from './EditorRuler';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 import {getEffectDragData} from './effect-drag-and-drop';
 import {subscribeToElementInstallRequests} from './element-install-request';
+import {ElementInstallConfirmation} from './ElementInstallConfirmation';
 import {handleDrop} from './handle-drop';
 import {
 	hasSvgFile,
@@ -76,59 +77,7 @@ import {useSvgImportDialog} from './SvgImportDialog';
 import {getCurrentFrame} from './Timeline/imperative-state';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
 
-const elementInstallCompositionIdStyle: React.CSSProperties = {
-	fontFamily: 'monospace',
-	fontSize: 13,
-};
-
 const elementInstallDependencyIgnoreList = ['react', 'react-dom', 'remotion'];
-
-const elementInstallDependencyListStyle: React.CSSProperties = {
-	marginTop: 8,
-	marginBottom: 0,
-	paddingLeft: 24,
-	listStyleType: 'disc',
-};
-
-const elementInstallDependencyStyle: React.CSSProperties = {
-	color: 'inherit',
-	fontFamily: 'monospace',
-	fontSize: 13,
-	lineHeight: 1.5,
-};
-
-const elementInstallCodeDetailsStyle: React.CSSProperties = {
-	marginTop: 12,
-	fontSize: 13,
-};
-
-const elementInstallCodeSummaryStyle: React.CSSProperties = {
-	cursor: 'pointer',
-	fontSize: 13,
-	fontWeight: 500,
-};
-
-const elementInstallCodeBlockStyle: React.CSSProperties = {
-	marginTop: 8,
-	marginBottom: 0,
-	maxHeight: 240,
-	overflow: 'auto',
-	padding: 12,
-	borderRadius: 6,
-	backgroundColor: 'rgba(255, 255, 255, 0.06)',
-	fontSize: 12,
-	lineHeight: 1.5,
-	whiteSpace: 'pre',
-};
-
-const makeSourceControlsVisible = (sourceCode: string) => {
-	return sourceCode.replace(
-		/[\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g,
-		(character) => {
-			return `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0')}`;
-		},
-	);
-};
 
 const getContainerStyle = (
 	editorZoomGestures: boolean,
@@ -936,76 +885,24 @@ export const Canvas: React.FC<{
 			);
 			const sourceLabel =
 				activeElementInstallRequest.source.type === 'studio-protocol'
-					? `Requested by ${activeElementInstallRequest.source.origin}`
+					? activeElementInstallRequest.source.origin
 					: 'Unverified drag-and-drop payload';
 			const accepted = await confirm({
 				title: 'Install Element',
 				message: (
-					<>
-						<strong>{sourceLabel}</strong>
-						<br />
-						<br />
-						Install “{activeElementInstallRequest.element.displayName}” into{' '}
-						<code style={elementInstallCompositionIdStyle}>
-							{activeElementInstallRequest.compositionId}
-						</code>{' '}
-						as <code>{preflight.plan.filePath}</code>?
-						{preflight.plan.expectedFileState.exists ? (
-							<>
-								<br />
-								<br />
-								This replaces the existing Element source file.
-							</>
-						) : null}
-						<br />
-						<br />
-						Accepted source code and package lifecycle scripts run with this
-						project&apos;s access to files and the network.
-						{dependenciesToReview.length > 0 ? (
-							<>
-								<br />
-								<br />
-								Declared dependencies:
-								<ul style={elementInstallDependencyListStyle}>
-									{dependenciesToReview.map((packageName) => (
-										<li key={packageName} style={elementInstallDependencyStyle}>
-											{packageName}{' '}
-											{missingPackages.includes(packageName)
-												? '(will install)'
-												: '(already installed)'}
-										</li>
-									))}
-								</ul>
-							</>
-						) : null}
-						{ignoredDependencies.length > 0 ? (
-							<details style={elementInstallCodeDetailsStyle}>
-								<summary style={elementInstallCodeSummaryStyle}>
-									Already available in this project (
-									{ignoredDependencies.length})
-								</summary>
-								<ul style={elementInstallDependencyListStyle}>
-									{ignoredDependencies.map((packageName) => (
-										<li key={packageName} style={elementInstallDependencyStyle}>
-											{packageName}
-										</li>
-									))}
-								</ul>
-							</details>
-						) : null}
-						<details style={elementInstallCodeDetailsStyle}>
-							<summary style={elementInstallCodeSummaryStyle}>
-								Review Element source
-							</summary>
-							<pre style={elementInstallCodeBlockStyle}>
-								<code>
-									{makeSourceControlsVisible(
-										activeElementInstallRequest.element.sourceCode,
-									)}
-								</code>
-							</pre>
-						</details>
-					</>
+					<ElementInstallConfirmation
+						displayName={activeElementInstallRequest.element.displayName}
+						sourceLabel={sourceLabel}
+						sourceIsUnverified={
+							activeElementInstallRequest.source.type === 'drag-and-drop'
+						}
+						compositionId={activeElementInstallRequest.compositionId}
+						filePath={preflight.plan.filePath}
+						overwritesExistingFile={preflight.plan.expectedFileState.exists}
+						dependenciesToReview={dependenciesToReview}
+						missingPackages={missingPackages}
+						sourceCode={activeElementInstallRequest.element.sourceCode}
+					/>
 				),
 				confirmLabel: 'Install',
 				cancelLabel: 'Cancel',

--- a/packages/studio/src/components/ConfirmationDialog.tsx
+++ b/packages/studio/src/components/ConfirmationDialog.tsx
@@ -20,9 +20,13 @@ const content: React.CSSProperties = {
 	padding: 16,
 	fontSize: 14,
 	flex: 1,
-	minWidth: 420,
-	maxWidth: 560,
+	width: 'min(600px, calc(100vw - 40px))',
+	minWidth: 0,
 	lineHeight: 1.4,
+};
+
+const footerStyle: React.CSSProperties = {
+	minWidth: 0,
 };
 
 export const useConfirmationDialog = (): ConfirmationDialogFunction => {
@@ -126,7 +130,7 @@ export const ConfirmationDialog: React.FC<{
 			<ModalHeader title={state.title} onClose={onCancel} />
 			<form onSubmit={onSubmit}>
 				<div style={content}>{state.message}</div>
-				<ModalFooterContainer>
+				<ModalFooterContainer style={footerStyle}>
 					<Row align="center">
 						<Flex />
 						<Button onClick={onCancel} style={cancelStyle}>

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -1,0 +1,410 @@
+import React from 'react';
+import {
+	INPUT_BACKGROUND,
+	LIGHT_TEXT,
+	WARNING_COLOR,
+	WHITE,
+	WHITE_ALPHA_08,
+	WHITE_ALPHA_12,
+} from '../helpers/colors';
+import {WarningTriangle} from './NewComposition/ValidationMessage';
+
+const container: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 20,
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: 1.5,
+};
+
+const introductionStyle: React.CSSProperties = {
+	margin: 0,
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: 1.5,
+};
+
+const elementNameStyle: React.CSSProperties = {
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	fontWeight: 600,
+	lineHeight: 1.5,
+};
+
+const sourceStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'baseline',
+	gap: 8,
+	minWidth: 0,
+	flexWrap: 'wrap',
+};
+
+const sourceLabelStyle: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const sourceValueStyle: React.CSSProperties = {
+	minWidth: 0,
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 500,
+	lineHeight: 1.4,
+	overflowWrap: 'anywhere',
+};
+
+const unverifiedSourceValueStyle: React.CSSProperties = {
+	...sourceValueStyle,
+	color: WARNING_COLOR,
+};
+
+const sectionStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 10,
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'baseline',
+	justifyContent: 'space-between',
+	gap: 12,
+	minWidth: 0,
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+	margin: 0,
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 600,
+	lineHeight: 1.4,
+};
+
+const sectionDescriptionStyle: React.CSSProperties = {
+	margin: 0,
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	lineHeight: 1.4,
+};
+
+const metadataStyle: React.CSSProperties = {
+	margin: 0,
+	borderTop: `1px solid ${WHITE_ALPHA_08}`,
+	borderBottom: `1px solid ${WHITE_ALPHA_08}`,
+};
+
+const metadataRowStyle: React.CSSProperties = {
+	display: 'grid',
+	gridTemplateColumns: '100px minmax(0, 1fr)',
+	alignItems: 'baseline',
+	gap: 12,
+	paddingTop: 9,
+	paddingBottom: 9,
+};
+
+const metadataRowWithBorderStyle: React.CSSProperties = {
+	...metadataRowStyle,
+	borderTop: `1px solid ${WHITE_ALPHA_08}`,
+};
+
+const metadataTermStyle: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const metadataDescriptionStyle: React.CSSProperties = {
+	margin: 0,
+	minWidth: 0,
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 400,
+	lineHeight: 1.4,
+	overflowWrap: 'anywhere',
+};
+
+const codeStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'monospace',
+	fontSize: 12,
+	lineHeight: 1.4,
+};
+
+const overwriteStyle: React.CSSProperties = {
+	color: WARNING_COLOR,
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const dependencyListStyle: React.CSSProperties = {
+	margin: 0,
+	padding: 0,
+	borderTop: `1px solid ${WHITE_ALPHA_08}`,
+	listStyleType: 'none',
+};
+
+const dependencyRowStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'baseline',
+	justifyContent: 'space-between',
+	gap: 16,
+	minWidth: 0,
+	paddingTop: 8,
+	paddingBottom: 8,
+	borderBottom: `1px solid ${WHITE_ALPHA_08}`,
+};
+
+const dependencyNameStyle: React.CSSProperties = {
+	minWidth: 0,
+	color: WHITE,
+	fontFamily: 'monospace',
+	fontSize: 12,
+	lineHeight: 1.4,
+	overflowWrap: 'anywhere',
+};
+
+const dependencyInstallStatusStyle: React.CSSProperties = {
+	flexShrink: 0,
+	color: WARNING_COLOR,
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const dependencyAvailableStatusStyle: React.CSSProperties = {
+	...dependencyInstallStatusStyle,
+	color: LIGHT_TEXT,
+};
+
+const warningStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'flex-start',
+	gap: 10,
+	minWidth: 0,
+};
+
+const warningIconStyle: React.CSSProperties = {
+	width: 16,
+	height: 16,
+	marginTop: 1,
+	flexShrink: 0,
+	fill: WARNING_COLOR,
+};
+
+const warningMessageStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 2,
+	minWidth: 0,
+};
+
+const warningTitleStyle: React.CSSProperties = {
+	margin: 0,
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 600,
+	lineHeight: 1.4,
+};
+
+const warningDescriptionStyle: React.CSSProperties = {
+	margin: 0,
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 400,
+	lineHeight: 1.5,
+};
+
+const sourceDetailsStyle: React.CSSProperties = {
+	paddingTop: 2,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: 1.4,
+};
+
+const sourceSummaryStyle: React.CSSProperties = {
+	cursor: 'pointer',
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	fontWeight: 500,
+	lineHeight: 1.4,
+};
+
+const sourceCodeBlockStyle: React.CSSProperties = {
+	marginTop: 10,
+	marginBottom: 0,
+	maxHeight: 240,
+	overflow: 'auto',
+	padding: 12,
+	border: `1px solid ${WHITE_ALPHA_12}`,
+	borderRadius: 6,
+	backgroundColor: INPUT_BACKGROUND,
+	color: WHITE,
+	fontFamily: 'monospace',
+	fontSize: 12,
+	lineHeight: 1.5,
+	whiteSpace: 'pre',
+};
+
+const sourceCodeStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'inherit',
+	fontSize: 'inherit',
+	lineHeight: 'inherit',
+};
+
+const makeSourceControlsVisible = (sourceCode: string) => {
+	return sourceCode.replace(
+		/[\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g,
+		(character) => {
+			return `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0')}`;
+		},
+	);
+};
+
+export const ElementInstallConfirmation: React.FC<{
+	readonly displayName: string;
+	readonly sourceLabel: string;
+	readonly sourceIsUnverified: boolean;
+	readonly compositionId: string;
+	readonly filePath: string;
+	readonly overwritesExistingFile: boolean;
+	readonly dependenciesToReview: string[];
+	readonly missingPackages: string[];
+	readonly sourceCode: string;
+}> = ({
+	displayName,
+	sourceLabel,
+	sourceIsUnverified,
+	compositionId,
+	filePath,
+	overwritesExistingFile,
+	dependenciesToReview,
+	missingPackages,
+	sourceCode,
+}) => {
+	return (
+		<div style={container}>
+			<div style={sectionStyle}>
+				<p style={introductionStyle}>
+					Review what will be added to your project before installing{' '}
+					<span style={elementNameStyle}>{displayName}</span>.
+				</p>
+				<div style={sourceStyle}>
+					<div style={sourceLabelStyle}>Request source</div>
+					<div
+						style={
+							sourceIsUnverified ? unverifiedSourceValueStyle : sourceValueStyle
+						}
+					>
+						{sourceLabel}
+					</div>
+				</div>
+			</div>
+
+			<section style={sectionStyle} aria-labelledby="element-install-location">
+				<div style={sectionHeaderStyle}>
+					<h3 id="element-install-location" style={sectionTitleStyle}>
+						Installation
+					</h3>
+				</div>
+				<dl style={metadataStyle}>
+					<div style={metadataRowStyle}>
+						<dt style={metadataTermStyle}>Composition</dt>
+						<dd style={metadataDescriptionStyle}>
+							<code style={codeStyle}>{compositionId}</code>
+						</dd>
+					</div>
+					<div style={metadataRowWithBorderStyle}>
+						<dt style={metadataTermStyle}>Destination</dt>
+						<dd style={metadataDescriptionStyle}>
+							<code style={codeStyle}>{filePath}</code>
+						</dd>
+					</div>
+					{overwritesExistingFile ? (
+						<div style={metadataRowWithBorderStyle}>
+							<dt style={metadataTermStyle}>File change</dt>
+							<dd style={overwriteStyle}>Replace existing source file</dd>
+						</div>
+					) : null}
+				</dl>
+			</section>
+
+			<section
+				style={sectionStyle}
+				aria-labelledby="element-install-dependencies"
+			>
+				<div style={sectionHeaderStyle}>
+					<h3 id="element-install-dependencies" style={sectionTitleStyle}>
+						Element dependencies
+					</h3>
+					<p style={sectionDescriptionStyle}>
+						{missingPackages.length === 0
+							? 'No packages will be installed.'
+							: `${missingPackages.length} package${missingPackages.length === 1 ? '' : 's'} will be installed.`}
+					</p>
+				</div>
+				{dependenciesToReview.length > 0 ? (
+					<ul style={dependencyListStyle} role="list">
+						{dependenciesToReview.map((packageName) => {
+							const willInstall = missingPackages.includes(packageName);
+							return (
+								<li key={packageName} style={dependencyRowStyle}>
+									<div style={dependencyNameStyle}>{packageName}</div>
+									<div
+										style={
+											willInstall
+												? dependencyInstallStatusStyle
+												: dependencyAvailableStatusStyle
+										}
+									>
+										{willInstall ? 'Will install' : 'Available'}
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				) : null}
+			</section>
+
+			<div style={warningStyle}>
+				<WarningTriangle style={warningIconStyle} />
+				<div style={warningMessageStyle}>
+					<p style={warningTitleStyle}>Review before installing</p>
+					<p style={warningDescriptionStyle}>
+						This adds executable source code to your project. Package lifecycle
+						scripts may also run during installation, with access to your files
+						and the network.
+					</p>
+				</div>
+			</div>
+
+			<details style={sourceDetailsStyle}>
+				<summary style={sourceSummaryStyle}>Review Element source</summary>
+				<pre style={sourceCodeBlockStyle}>
+					<code style={sourceCodeStyle}>
+						{makeSourceControlsVisible(sourceCode)}
+					</code>
+				</pre>
+			</details>
+		</div>
+	);
+};

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -4,7 +4,6 @@ import {
 	LIGHT_TEXT,
 	WARNING_COLOR,
 	WHITE,
-	WHITE_ALPHA_08,
 	WHITE_ALPHA_12,
 } from '../helpers/colors';
 import {WarningTriangle} from './NewComposition/ValidationMessage';
@@ -15,55 +14,8 @@ const container: React.CSSProperties = {
 	gap: 20,
 	color: WHITE,
 	fontFamily: 'sans-serif',
-	fontSize: 14,
-	lineHeight: 1.5,
-};
-
-const introductionStyle: React.CSSProperties = {
-	margin: 0,
-	color: LIGHT_TEXT,
-	fontFamily: 'sans-serif',
-	fontSize: 14,
-	lineHeight: 1.5,
-};
-
-const elementNameStyle: React.CSSProperties = {
-	color: WHITE,
-	fontFamily: 'sans-serif',
-	fontSize: 14,
-	fontWeight: 600,
-	lineHeight: 1.5,
-};
-
-const sourceStyle: React.CSSProperties = {
-	display: 'flex',
-	alignItems: 'baseline',
-	gap: 8,
-	minWidth: 0,
-	flexWrap: 'wrap',
-};
-
-const sourceLabelStyle: React.CSSProperties = {
-	color: LIGHT_TEXT,
-	fontFamily: 'sans-serif',
-	fontSize: 12,
-	fontWeight: 500,
-	lineHeight: 1.4,
-};
-
-const sourceValueStyle: React.CSSProperties = {
-	minWidth: 0,
-	color: WHITE,
-	fontFamily: 'sans-serif',
 	fontSize: 13,
-	fontWeight: 500,
-	lineHeight: 1.4,
-	overflowWrap: 'anywhere',
-};
-
-const unverifiedSourceValueStyle: React.CSSProperties = {
-	...sourceValueStyle,
-	color: WARNING_COLOR,
+	lineHeight: 1.5,
 };
 
 const sectionStyle: React.CSSProperties = {
@@ -72,35 +24,20 @@ const sectionStyle: React.CSSProperties = {
 	gap: 10,
 };
 
-const sectionHeaderStyle: React.CSSProperties = {
-	display: 'flex',
-	alignItems: 'baseline',
-	justifyContent: 'space-between',
-	gap: 12,
-	minWidth: 0,
-};
-
 const sectionTitleStyle: React.CSSProperties = {
 	margin: 0,
 	color: WHITE,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 600,
-	lineHeight: 1.4,
-};
-
-const sectionDescriptionStyle: React.CSSProperties = {
-	margin: 0,
-	color: LIGHT_TEXT,
-	fontFamily: 'sans-serif',
-	fontSize: 12,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
 const metadataStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 8,
 	margin: 0,
-	borderTop: `1px solid ${WHITE_ALPHA_08}`,
-	borderBottom: `1px solid ${WHITE_ALPHA_08}`,
 };
 
 const metadataRowStyle: React.CSSProperties = {
@@ -108,21 +45,14 @@ const metadataRowStyle: React.CSSProperties = {
 	gridTemplateColumns: '100px minmax(0, 1fr)',
 	alignItems: 'baseline',
 	gap: 12,
-	paddingTop: 9,
-	paddingBottom: 9,
-};
-
-const metadataRowWithBorderStyle: React.CSSProperties = {
-	...metadataRowStyle,
-	borderTop: `1px solid ${WHITE_ALPHA_08}`,
 };
 
 const metadataTermStyle: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
-	fontSize: 12,
+	fontSize: 13,
 	fontWeight: 500,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
 const metadataDescriptionStyle: React.CSSProperties = {
@@ -132,29 +62,37 @@ const metadataDescriptionStyle: React.CSSProperties = {
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 400,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 	overflowWrap: 'anywhere',
+};
+
+const unverifiedSourceStyle: React.CSSProperties = {
+	...metadataDescriptionStyle,
+	color: WARNING_COLOR,
 };
 
 const codeStyle: React.CSSProperties = {
 	color: 'inherit',
 	fontFamily: 'monospace',
-	fontSize: 12,
-	lineHeight: 1.4,
+	fontSize: 13,
+	lineHeight: 1.5,
 };
 
 const overwriteStyle: React.CSSProperties = {
+	margin: 0,
 	color: WARNING_COLOR,
 	fontFamily: 'sans-serif',
-	fontSize: 12,
+	fontSize: 13,
 	fontWeight: 500,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
 const dependencyListStyle: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 8,
 	margin: 0,
 	padding: 0,
-	borderTop: `1px solid ${WHITE_ALPHA_08}`,
 	listStyleType: 'none',
 };
 
@@ -164,17 +102,14 @@ const dependencyRowStyle: React.CSSProperties = {
 	justifyContent: 'space-between',
 	gap: 16,
 	minWidth: 0,
-	paddingTop: 8,
-	paddingBottom: 8,
-	borderBottom: `1px solid ${WHITE_ALPHA_08}`,
 };
 
 const dependencyNameStyle: React.CSSProperties = {
 	minWidth: 0,
 	color: WHITE,
 	fontFamily: 'monospace',
-	fontSize: 12,
-	lineHeight: 1.4,
+	fontSize: 13,
+	lineHeight: 1.5,
 	overflowWrap: 'anywhere',
 };
 
@@ -182,12 +117,12 @@ const dependencyInstallStatusStyle: React.CSSProperties = {
 	flexShrink: 0,
 	color: WARNING_COLOR,
 	fontFamily: 'sans-serif',
-	fontSize: 12,
+	fontSize: 13,
 	fontWeight: 500,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
-const dependencyAvailableStatusStyle: React.CSSProperties = {
+const dependencyInstalledStatusStyle: React.CSSProperties = {
 	...dependencyInstallStatusStyle,
 	color: LIGHT_TEXT,
 };
@@ -207,24 +142,9 @@ const warningIconStyle: React.CSSProperties = {
 	fill: WARNING_COLOR,
 };
 
-const warningMessageStyle: React.CSSProperties = {
-	display: 'flex',
-	flexDirection: 'column',
-	gap: 2,
-	minWidth: 0,
-};
-
-const warningTitleStyle: React.CSSProperties = {
-	margin: 0,
-	color: WHITE,
-	fontFamily: 'sans-serif',
-	fontSize: 13,
-	fontWeight: 600,
-	lineHeight: 1.4,
-};
-
 const warningDescriptionStyle: React.CSSProperties = {
 	margin: 0,
+	minWidth: 0,
 	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
@@ -236,7 +156,7 @@ const sourceDetailsStyle: React.CSSProperties = {
 	paddingTop: 2,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
 const sourceSummaryStyle: React.CSSProperties = {
@@ -245,7 +165,7 @@ const sourceSummaryStyle: React.CSSProperties = {
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 500,
-	lineHeight: 1.4,
+	lineHeight: 1.5,
 };
 
 const sourceCodeBlockStyle: React.CSSProperties = {
@@ -303,66 +223,51 @@ export const ElementInstallConfirmation: React.FC<{
 }) => {
 	return (
 		<div style={container}>
-			<div style={sectionStyle}>
-				<p style={introductionStyle}>
-					Review what will be added to your project before installing{' '}
-					<span style={elementNameStyle}>{displayName}</span>.
-				</p>
-				<div style={sourceStyle}>
-					<div style={sourceLabelStyle}>Request source</div>
-					<div
+			<dl style={metadataStyle} aria-label="Installation details">
+				<div style={metadataRowStyle}>
+					<dt style={metadataTermStyle}>Element</dt>
+					<dd style={metadataDescriptionStyle}>{displayName}</dd>
+				</div>
+				<div style={metadataRowStyle}>
+					<dt style={metadataTermStyle}>Request source</dt>
+					<dd
 						style={
-							sourceIsUnverified ? unverifiedSourceValueStyle : sourceValueStyle
+							sourceIsUnverified
+								? unverifiedSourceStyle
+								: metadataDescriptionStyle
 						}
 					>
 						{sourceLabel}
-					</div>
+					</dd>
 				</div>
-			</div>
-
-			<section style={sectionStyle} aria-labelledby="element-install-location">
-				<div style={sectionHeaderStyle}>
-					<h3 id="element-install-location" style={sectionTitleStyle}>
-						Installation
-					</h3>
+				<div style={metadataRowStyle}>
+					<dt style={metadataTermStyle}>Composition</dt>
+					<dd style={metadataDescriptionStyle}>
+						<code style={codeStyle}>{compositionId}</code>
+					</dd>
 				</div>
-				<dl style={metadataStyle}>
+				<div style={metadataRowStyle}>
+					<dt style={metadataTermStyle}>Destination</dt>
+					<dd style={metadataDescriptionStyle}>
+						<code style={codeStyle}>{filePath}</code>
+					</dd>
+				</div>
+				{overwritesExistingFile ? (
 					<div style={metadataRowStyle}>
-						<dt style={metadataTermStyle}>Composition</dt>
-						<dd style={metadataDescriptionStyle}>
-							<code style={codeStyle}>{compositionId}</code>
-						</dd>
+						<dt style={metadataTermStyle}>File change</dt>
+						<dd style={overwriteStyle}>Replace existing source file</dd>
 					</div>
-					<div style={metadataRowWithBorderStyle}>
-						<dt style={metadataTermStyle}>Destination</dt>
-						<dd style={metadataDescriptionStyle}>
-							<code style={codeStyle}>{filePath}</code>
-						</dd>
-					</div>
-					{overwritesExistingFile ? (
-						<div style={metadataRowWithBorderStyle}>
-							<dt style={metadataTermStyle}>File change</dt>
-							<dd style={overwriteStyle}>Replace existing source file</dd>
-						</div>
-					) : null}
-				</dl>
-			</section>
+				) : null}
+			</dl>
 
-			<section
-				style={sectionStyle}
-				aria-labelledby="element-install-dependencies"
-			>
-				<div style={sectionHeaderStyle}>
+			{dependenciesToReview.length > 0 ? (
+				<section
+					style={sectionStyle}
+					aria-labelledby="element-install-dependencies"
+				>
 					<h3 id="element-install-dependencies" style={sectionTitleStyle}>
-						Element dependencies
+						Dependencies
 					</h3>
-					<p style={sectionDescriptionStyle}>
-						{missingPackages.length === 0
-							? 'No packages will be installed.'
-							: `${missingPackages.length} package${missingPackages.length === 1 ? '' : 's'} will be installed.`}
-					</p>
-				</div>
-				{dependenciesToReview.length > 0 ? (
 					<ul style={dependencyListStyle} role="list">
 						{dependenciesToReview.map((packageName) => {
 							const willInstall = missingPackages.includes(packageName);
@@ -373,32 +278,29 @@ export const ElementInstallConfirmation: React.FC<{
 										style={
 											willInstall
 												? dependencyInstallStatusStyle
-												: dependencyAvailableStatusStyle
+												: dependencyInstalledStatusStyle
 										}
 									>
-										{willInstall ? 'Will install' : 'Available'}
+										{willInstall ? 'Will be installed' : 'Installed'}
 									</div>
 								</li>
 							);
 						})}
 					</ul>
-				) : null}
-			</section>
+				</section>
+			) : null}
 
 			<div style={warningStyle}>
 				<WarningTriangle style={warningIconStyle} />
-				<div style={warningMessageStyle}>
-					<p style={warningTitleStyle}>Review before installing</p>
-					<p style={warningDescriptionStyle}>
-						This adds executable source code to your project. Package lifecycle
-						scripts may also run during installation, with access to your files
-						and the network.
-					</p>
-				</div>
+				<p style={warningDescriptionStyle}>
+					This adds executable source code to your project. Package lifecycle
+					scripts may also run during installation, with access to your files
+					and the network.
+				</p>
 			</div>
 
 			<details style={sourceDetailsStyle}>
-				<summary style={sourceSummaryStyle}>Review Element source</summary>
+				<summary style={sourceSummaryStyle}>Source code</summary>
 				<pre style={sourceCodeBlockStyle}>
 					<code style={sourceCodeStyle}>
 						{makeSourceControlsVisible(sourceCode)}

--- a/packages/studio/src/components/ModalFooter.tsx
+++ b/packages/studio/src/components/ModalFooter.tsx
@@ -11,6 +11,11 @@ const content: React.CSSProperties = {
 
 export const ModalFooterContainer: React.FC<{
 	readonly children: React.ReactNode;
-}> = ({children}) => {
-	return <div style={{...content, borderTop: BORDER_BLACK}}>{children}</div>;
+	readonly style?: React.CSSProperties;
+}> = ({children, style}) => {
+	return (
+		<div style={{...content, ...style, borderTop: BORDER_BLACK}}>
+			{children}
+		</div>
+	);
 };


### PR DESCRIPTION
## Summary

- Present the Element, request source, composition, destination, and overwrite state in one compact metadata table.
- Remove repeated review/install headings and divider lines, and normalize visible modal text sizing under the Studio CSS reset.
- Label dependencies as `Installed` or `Will be installed`, while keeping routine installed baseline dependencies out of the review.
- Keep the executable-code warning and a collapsible, independently scrollable source preview.
- Make the confirmation dialog responsive without introducing an internal modal scrollbar.

## Stack

Layer 6 of 6. Based on #9929.

## Validation

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #9772.
