### PR TITLE
Enable Rspack as default for new projects

### DIFF
--- a/packages/it-tests/src/templates/validate-templates.test.ts
+++ b/packages/it-tests/src/templates/validate-templates.test.ts
@@ -235,6 +235,15 @@ describe('Templates should be valid', () => {
 			expect(contents).not.toContain('setExperimentalRspackEnabled');
 		});
 
+		it(`${template.shortName} should enable Rspack`, async () => {
+			const {contents, entryPoint} = await findFile([
+				getFileForTemplate(template, 'remotion.config.ts'),
+				getFileForTemplate(template, 'remotion.config.js'),
+			]);
+			expect(entryPoint).toBeTruthy();
+			expect(contents).toContain('Config.setRspack(true)');
+		});
+
 		it(`${template.shortName} should use good tsconfig values`, async () => {
 			if (template.shortName.includes('JavaScript')) {
 				return;

--- a/packages/skia/src/enable.ts
+++ b/packages/skia/src/enable.ts
@@ -1,12 +1,15 @@
 import fs from 'fs';
-import type {WebpackOverrideFn} from '@remotion/bundler';
+import type {BundlerConfiguration, BundlerName} from '@remotion/bundler';
 import {webpack} from '@remotion/bundler';
 
 /**
  * @description A function that modifies the default Webpack configuration to make the necessary changes to support Skia.
  * @see [Documentation](https://www.remotion.dev/docs/skia/enable-skia)
  */
-export const enableSkia: WebpackOverrideFn = (currentConfiguration) => {
+export const enableSkia = <Configuration extends BundlerConfiguration>(
+	currentConfiguration: Configuration,
+	{bundler}: {bundler: BundlerName} = {bundler: 'webpack'},
+): Configuration => {
 	const newExtensions = [
 		'.web.js',
 		'.web.ts',
@@ -18,6 +21,10 @@ export const enableSkia: WebpackOverrideFn = (currentConfiguration) => {
 
 	return {
 		...currentConfiguration,
+		ignoreWarnings: [
+			...(currentConfiguration.ignoreWarnings ?? []),
+			...(bundler === 'rspack' ? [/react-native-reanimated/] : []),
+		],
 		plugins: [
 			...(currentConfiguration.plugins ?? []),
 			new (class CopySkiaPlugin {
@@ -59,11 +66,15 @@ export const enableSkia: WebpackOverrideFn = (currentConfiguration) => {
 			extensions: deduplicatedExtensions,
 			alias: {
 				...currentConfiguration.resolve?.alias,
-				'react-native-reanimated': "require('react-native-reanimated')",
-				'react-native-reanimated/lib/reanimated2/core':
-					"require('react-native-reanimated/lib/reanimated2/core')",
+				...(bundler === 'webpack'
+					? {
+							'react-native-reanimated': "require('react-native-reanimated')",
+							'react-native-reanimated/lib/reanimated2/core':
+								"require('react-native-reanimated/lib/reanimated2/core')",
+						}
+					: {}),
 				'react-native/Libraries/Image/AssetRegistry': false,
 			},
 		},
-	};
+	} as Configuration;
 };

--- a/packages/studio-server/src/helpers/resolve-file-inside-project.ts
+++ b/packages/studio-server/src/helpers/resolve-file-inside-project.ts
@@ -13,6 +13,8 @@ const formatOutsideProjectError = ({
 }) =>
 	`Cannot ${action} a file outside the project: "${fileName}" resolves to "${absolutePath}", but the project root is "${remotionRoot}".`;
 
+export class FileOutsideProjectError extends Error {}
+
 export const resolveFileInsideProject = ({
 	remotionRoot,
 	fileName,
@@ -31,7 +33,7 @@ export const resolveFileInsideProject = ({
 		fileRelativeToRoot.startsWith(`..${path.sep}`) ||
 		path.isAbsolute(fileRelativeToRoot)
 	) {
-		throw new Error(
+		throw new FileOutsideProjectError(
 			formatOutsideProjectError({
 				action,
 				fileName,

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -37,7 +37,10 @@ import {getAstNodePath} from '../../helpers/get-ast-node-path';
 import {toImportAgnosticNodePath} from '../../helpers/import-agnostic-node-path';
 import {parseBorderRadiusShorthand} from '../../helpers/parse-border-radius-shorthand';
 import {parseKeyframeEasingExpression} from '../../helpers/parse-keyframe-easing-expression';
-import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
+import {
+	FileOutsideProjectError,
+	resolveFileInsideProject,
+} from '../../helpers/resolve-file-inside-project';
 import {parseVideoConfigNumericExpression} from '../../helpers/video-config-numeric-expression';
 import {
 	getVideoConfigIdentifierValues,
@@ -1494,6 +1497,7 @@ export const computeSequencePropsStatusFromFilenameByLocation = ({
 		};
 	} catch (err) {
 		if (
+			err instanceof FileOutsideProjectError ||
 			err instanceof JsxElementIdentityMismatchError ||
 			err instanceof JsxElementNotFoundAtLocationError
 		) {

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -129,6 +129,33 @@ export const Fallback = () => <><Sequence name="First" /><Sequence name="Fallbac
 	}
 });
 
+test('computeSequencePropsStatus should ignore source locations outside the project', () => {
+	const remotionRoot = mkdtempSync(
+		path.join(tmpdir(), 'remotion-jsx-location-'),
+	);
+
+	try {
+		expect(
+			computeSequencePropsStatusFromFilenameByLocation({
+				fileName: '../studio/RefreshCompositionOverlay.js',
+				line: 1,
+				column: 1,
+				componentIdentity: null,
+				keys: [],
+				effects: [],
+				remotionRoot,
+				logLevel: 'info',
+				videoConfigValues,
+			}),
+		).toEqual({
+			success: false,
+			status: {canUpdate: false, reason: 'not-found'},
+		});
+	} finally {
+		rmSync(remotionRoot, {recursive: true, force: true});
+	}
+});
+
 test('computeSequencePropsStatus should treat staticFile() asset props as static', () => {
 	const input = `import {Img, staticFile} from 'remotion';
 

--- a/packages/template-audiogram/remotion.config.ts
+++ b/packages/template-audiogram/remotion.config.ts
@@ -7,5 +7,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-blank/remotion.config.ts
+++ b/packages/template-blank/remotion.config.ts
@@ -7,5 +7,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-code-hike/remotion.config.ts
+++ b/packages/template-code-hike/remotion.config.ts
@@ -1,4 +1,28 @@
 import {Config} from '@remotion/cli/config';
+import {createRequire} from 'node:module';
 
+const projectRequire = createRequire(process.cwd() + '/package.json');
+
+Config.setRspack(true);
 Config.setVideoImageFormat('jpeg');
 Config.setOverwriteOutput(true);
+
+Config.overrideRspackConfig((config) => {
+	return {
+		...config,
+		resolve: {
+			...config.resolve,
+			alias: {
+				...config.resolve?.alias,
+				'@code-hike/lighter': projectRequire.resolve(
+					'@code-hike/lighter/dist/index.esm.mjs',
+				),
+				https: false,
+			},
+		},
+		ignoreWarnings: [
+			...(config.ignoreWarnings ?? []),
+			/Critical dependency: the request of a dependency is an expression/,
+		],
+	};
+});

--- a/packages/template-electron/remotion.config.ts
+++ b/packages/template-electron/remotion.config.ts
@@ -7,5 +7,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-helloworld/remotion.config.ts
+++ b/packages/template-helloworld/remotion.config.ts
@@ -5,5 +5,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-javascript/remotion.config.js
+++ b/packages/template-javascript/remotion.config.js
@@ -5,4 +5,5 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");

--- a/packages/template-music-visualization/remotion.config.ts
+++ b/packages/template-music-visualization/remotion.config.ts
@@ -7,5 +7,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-next-app-tailwind/remotion.config.ts
+++ b/packages/template-next-app-tailwind/remotion.config.ts
@@ -6,6 +6,7 @@
 import { Config } from "@remotion/cli/config";
 import { webpackOverride } from "./src/remotion/webpack-override.mjs";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 
-Config.overrideWebpackConfig(webpackOverride);
+Config.overrideBundlerConfig(webpackOverride);

--- a/packages/template-next-app/remotion.config.ts
+++ b/packages/template-next-app/remotion.config.ts
@@ -5,4 +5,5 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");

--- a/packages/template-next-pages/remotion.config.ts
+++ b/packages/template-next-pages/remotion.config.ts
@@ -5,4 +5,5 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");

--- a/packages/template-overlay/remotion.config.ts
+++ b/packages/template-overlay/remotion.config.ts
@@ -6,6 +6,7 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("png");
 Config.setPixelFormat("yuva444p10le");
 Config.setCodec("prores");

--- a/packages/template-prompt-to-motion-graphics/remotion.config.ts
+++ b/packages/template-prompt-to-motion-graphics/remotion.config.ts
@@ -6,6 +6,7 @@
 import { Config } from "@remotion/cli/config";
 import { webpackOverride } from "./src/remotion/webpack-override.mjs";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 
-Config.overrideWebpackConfig(webpackOverride);
+Config.overrideBundlerConfig(webpackOverride);

--- a/packages/template-prompt-to-video/remotion.config.ts
+++ b/packages/template-prompt-to-video/remotion.config.ts
@@ -5,5 +5,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-prompt-to-video/src/Root.tsx
+++ b/packages/template-prompt-to-video/src/Root.tsx
@@ -13,6 +13,7 @@ export const RemotionRoot: React.FC = () => {
     <>
       {timelines.map((storyName) => (
         <Composition
+          key={storyName}
           id={storyName}
           component={AIVideo}
           fps={FPS}

--- a/packages/template-react-router/remotion.config.ts
+++ b/packages/template-react-router/remotion.config.ts
@@ -7,6 +7,7 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
 Config.setEntryPoint("app/remotion/index.ts");

--- a/packages/template-recorder/remotion.config.ts
+++ b/packages/template-recorder/remotion.config.ts
@@ -1,5 +1,6 @@
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
 Config.setAskAIEnabled(false);

--- a/packages/template-render-server/remotion.config.ts
+++ b/packages/template-render-server/remotion.config.ts
@@ -5,5 +5,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-skia/remotion.config.ts
+++ b/packages/template-skia/remotion.config.ts
@@ -7,11 +7,12 @@
 import {enableSkia} from '@remotion/skia/enable';
 import {Config} from '@remotion/cli/config';
 
+Config.setRspack(true);
 Config.setVideoImageFormat('jpeg');
 Config.setOverwriteOutput(true);
 
-Config.overrideWebpackConfig((config) => {
-	return enableSkia(config);
+Config.overrideBundlerConfig((config, context) => {
+	return enableSkia(config, context);
 });
 
 Config.setConcurrency(2);

--- a/packages/template-stargazer/remotion.config.ts
+++ b/packages/template-stargazer/remotion.config.ts
@@ -5,5 +5,6 @@ import { Config } from "@remotion/cli/config";
  * doesn't apply. Instead, pass options directly to the APIs
  */
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setDelayRenderTimeoutInMilliseconds(1200000);

--- a/packages/template-still/remotion.config.ts
+++ b/packages/template-still/remotion.config.ts
@@ -6,5 +6,6 @@
  */
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-three/remotion.config.ts
+++ b/packages/template-three/remotion.config.ts
@@ -7,5 +7,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setChromiumOpenGlRenderer("angle");
 Config.setVideoImageFormat("jpeg");

--- a/packages/template-three/src/Root.tsx
+++ b/packages/template-three/src/Root.tsx
@@ -30,7 +30,7 @@ export const RemotionRoot: React.FC = () => {
         schema={myCompSchema}
         defaultProps={{
           deviceType: "phone",
-          phoneColor: "rgba(110, 152, 191, 0.00)" as const,
+          phoneColor: "rgb(110, 152, 191)" as const,
           baseScale: 1,
           mediaMetadata: null,
           videoSrc: null,

--- a/packages/template-tiktok/remotion.config.ts
+++ b/packages/template-tiktok/remotion.config.ts
@@ -5,5 +5,6 @@
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);

--- a/packages/template-tiktok/src/CaptionedVideo/index.tsx
+++ b/packages/template-tiktok/src/CaptionedVideo/index.tsx
@@ -69,6 +69,12 @@ export const CaptionedVideo: React.FC<{
   const fetchSubtitles = useCallback(async () => {
     try {
       await loadFont();
+      if (!getFileExists(subtitlesFile)) {
+        setSubtitles([]);
+        continueRender(handle);
+        return;
+      }
+
       const res = await fetch(subtitlesFile);
       const data = (await res.json()) as Caption[];
       setSubtitles(data);

--- a/packages/template-vercel/remotion.config.ts
+++ b/packages/template-vercel/remotion.config.ts
@@ -6,5 +6,6 @@
 import { Config } from "@remotion/cli/config";
 import { enableTailwind } from "@remotion/tailwind-v4";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
-Config.overrideWebpackConfig(enableTailwind);
+Config.overrideBundlerConfig(enableTailwind);


### PR DESCRIPTION
## Summary

- Enable Rspack in all 22 public template configuration files
- Make the Skia, Code Hike, Tailwind, and Vercel template overrides Rspack-compatible
- Fix warnings uncovered by Studio smoke testing and add regression coverage for template configuration and outside-project source locations

## QA

- `bun run build`
- `bun run stylecheck`
- Template validation and Electron template tests: 286 passing
- Studio server regression suite: 54 passing
- Production Rspack bundle matrix: 22/22 templates passing without bundler warnings or errors
- Isolated Studio browser smoke tests: 22/22 previews loaded without console, page, or server warnings; Skia rendered a non-zero-size canvas
- Stargazer was tested with deterministic cached fixture data because GitHub's external API was unavailable during QA

Closes #7841
