### PR TITLE
`@remotion/studio`: Skip Visual Mode subscriptions for library code

### DIFF
--- a/packages/browser-studio/src/templates/blank.ts
+++ b/packages/browser-studio/src/templates/blank.ts
@@ -97,6 +97,7 @@ export const MyComponent: React.FC<Props> = () => {
 
 import { Config } from "@remotion/cli/config";
 
+Config.setRspack(true);
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
 `,

--- a/packages/core/src/loading-indicator.tsx
+++ b/packages/core/src/loading-indicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AbsoluteFill} from './AbsoluteFill.js';
+import {AbsoluteFillElement} from './AbsoluteFillElement.js';
 
 const rotate: React.CSSProperties = {
 	transform: `rotate(90deg)`,
@@ -19,7 +19,7 @@ const container: React.CSSProperties = {
 
 export const Loading: React.FC = () => {
 	return (
-		<AbsoluteFill style={container} id="remotion-comp-loading">
+		<AbsoluteFillElement style={container} id="remotion-comp-loading">
 			<style type="text/css">{`
 				@keyframes anim {
 					from {
@@ -49,6 +49,6 @@ export const Loading: React.FC = () => {
 				/>
 			</svg>
 			<p style={label}>Resolving {'<Suspense>'}...</p>
-		</AbsoluteFill>
+		</AbsoluteFillElement>
 	);
 };

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -14,6 +14,7 @@ import type {
 import {Img, imgSchema} from '../Img.js';
 import {Interactive} from '../Interactive.js';
 import {Internals} from '../internals.js';
+import {Loading} from '../loading-indicator.js';
 import type {OverrideIdToNodePaths} from '../sequence-node-path.js';
 import {OverrideIdsToNodePathsGettersContext} from '../sequence-node-path.js';
 import {Sequence} from '../Sequence.js';
@@ -1299,6 +1300,24 @@ test('AbsoluteFill is an interactive sequence while preserving its div contract'
 		'style.backgroundColor',
 	]);
 	expect(registeredSequences[0]?.controls?.schema).toHaveProperty('children');
+});
+
+test('Loading indicator does not register an interactive sequence', () => {
+	const registeredSequences: TSequence[] = [];
+
+	const {container, getByText} = render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Loading />
+		</SequenceTestWrapper>,
+	);
+
+	expect(getByText('Resolving <Suspense>...')).toBeTruthy();
+	expect(container.querySelector('#remotion-comp-loading')).toBeTruthy();
+	expect(registeredSequences).toHaveLength(0);
 });
 
 test('Interactive elements inherit trimBefore from Sequence', () => {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -28,6 +28,36 @@ test.describe('visual mode', () => {
 		await navigateToSchemaTest(page);
 	});
 
+	test('should not subscribe to package-owned sequence props', async ({
+		page,
+	}) => {
+		const subscriptionSources: string[] = [];
+		page.on('request', (request) => {
+			if (!request.url().includes('/api/subscribe-to-sequence-props')) {
+				return;
+			}
+
+			const body = request.postDataJSON() as {fileName: string};
+			subscriptionSources.push(body.fileName);
+		});
+
+		await page.goto(`${STUDIO_URL}/package-absolute-fill`);
+		await expect
+			.poll(
+				() =>
+					subscriptionSources.filter((source) =>
+						source.startsWith('./src/LightLeak/'),
+					).length,
+				{timeout: 15_000},
+			)
+			.toBeGreaterThan(0);
+
+		await page.waitForTimeout(500);
+		expect(subscriptionSources.some((source) => source.startsWith('../'))).toBe(
+			false,
+		);
+	});
+
 	test('should seek in read-only Studio', async ({page}) => {
 		await page.addInitScript(() => {
 			Object.defineProperty(window, 'remotion_isReadOnlyStudio', {

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -7,6 +7,7 @@ import {
 } from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
 import {Issue8216} from './Issue8216/Issue8216';
+import {LightLeakExample} from './LightLeak';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
 import {NewVideoComp} from './NewVideo';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
@@ -60,6 +61,14 @@ export const E2eTestRoot: React.FC = () => {
 					durationInFrames={90}
 				/>
 			</Folder>
+			<Composition
+				id="package-absolute-fill"
+				component={LightLeakExample}
+				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
 			<Folder name="lost-node-path">
 				<Composition
 					id="lost-node-path-e2e"

--- a/packages/studio/src/components/Timeline/should-subscribe-to-source-file.ts
+++ b/packages/studio/src/components/Timeline/should-subscribe-to-source-file.ts
@@ -1,0 +1,9 @@
+export const shouldSubscribeToSourceFile = (source: string): boolean => {
+	const normalized = source.replaceAll('\\', '/');
+
+	if (normalized === '..' || normalized.startsWith('../')) {
+		return false;
+	}
+
+	return !normalized.split('/').includes('node_modules');
+};

--- a/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
@@ -13,6 +13,7 @@ import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {ExpandedTracksSetterContext} from '../ExpandedTracksProvider';
 import {acquireSequencePropsSubscription} from './sequence-props-subscription-store';
+import {shouldSubscribeToSourceFile} from './should-subscribe-to-source-file';
 
 export const useSequencePropsSubscription = ({
 	originalLocation,
@@ -75,6 +76,7 @@ export const useSequencePropsSubscription = ({
 		if (
 			!clientId ||
 			!locationSource ||
+			!shouldSubscribeToSourceFile(locationSource) ||
 			!locationLine ||
 			locationColumn === null ||
 			!schema ||

--- a/packages/studio/src/test/should-subscribe-to-source-file.test.ts
+++ b/packages/studio/src/test/should-subscribe-to-source-file.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'bun:test';
+import {shouldSubscribeToSourceFile} from '../components/Timeline/should-subscribe-to-source-file';
+
+test('only subscribes to project-owned source files', () => {
+	for (const source of [
+		'./src/Composition.tsx',
+		'src/Composition.tsx',
+		'packages/video/src/Composition.tsx',
+	]) {
+		expect(shouldSubscribeToSourceFile(source)).toBe(true);
+	}
+
+	for (const source of [
+		'..',
+		'../light-leaks/dist/esm/index.mjs',
+		'..\\light-leaks\\dist\\esm\\index.mjs',
+		'./node_modules/@remotion/starburst/dist/esm/index.mjs',
+		'C:\\project\\node_modules\\@remotion\\starburst\\dist\\index.mjs',
+	]) {
+		expect(shouldSubscribeToSourceFile(source)).toBe(false);
+	}
+});


### PR DESCRIPTION
## Summary

- render the internal Suspense loading indicator without registering an interactive sequence
- skip Visual Mode sequence-props subscriptions for source files outside the project and inside `node_modules`
- cover the behavior with unit, core context, and browser E2E regressions

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts -g 'should not subscribe to package-owned sequence props'`

Closes #9932
