### PR TITLE
`@remotion/cli`: Detect outdated Remotion skills

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -243,6 +243,7 @@
         "minimist": "1.2.6",
         "prompts": "2.4.2",
         "remotion": "workspace:*",
+        "semver": "7.5.3",
       },
       "devDependencies": {
         "@remotion/enable-scss": "workspace:*",
@@ -254,6 +255,7 @@
         "@types/node": "catalog:",
         "@types/prettier": "2.7.2",
         "@types/prompts": "2.4.9",
+        "@types/semver": "7.5.3",
         "@typescript/native-preview": "catalog:",
         "eslint": "catalog:",
         "react": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
 		"dotenv": "17.3.1",
 		"minimist": "1.2.6",
 		"prompts": "2.4.2",
+		"semver": "7.5.3",
 		"remotion": "workspace:*"
 	},
 	"peerDependencies": {
@@ -56,6 +57,7 @@
 		"@types/minimist": "1.2.2",
 		"@types/prompts": "2.4.9",
 		"@types/prettier": "2.7.2",
+		"@types/semver": "7.5.3",
 		"@types/node": "catalog:",
 		"@remotion/zod-types": "workspace:*",
 		"@remotion/tailwind-v4": "workspace:*",

--- a/packages/cli/src/detect-outdated-remotion-skills.ts
+++ b/packages/cli/src/detect-outdated-remotion-skills.ts
@@ -1,0 +1,129 @@
+import {existsSync, readFileSync} from 'node:fs';
+import {homedir} from 'node:os';
+import path from 'node:path';
+import {VERSION} from 'remotion/version';
+import semver from 'semver';
+import {remotionSkillNames} from './remotion-skill-names';
+import type {RemotionSkillName} from './remotion-skill-names';
+
+export type RemotionSkillsScope = 'project' | 'global';
+
+export type RemotionSkillsStatus =
+	| {
+			type: 'not-installed';
+			scope: RemotionSkillsScope;
+			skillsDirectory: string;
+	  }
+	| {
+			type: 'up-to-date';
+			scope: RemotionSkillsScope;
+			skillsDirectory: string;
+	  }
+	| {
+			type: 'outdated';
+			scope: RemotionSkillsScope;
+			skillsDirectory: string;
+			outdatedSkillNames: RemotionSkillName[];
+	  };
+
+export const parseRemotionSkillVersion = (contents: string): string | null => {
+	const frontmatter = contents.match(
+		/^---\r?\n(?<frontmatter>[\s\S]*?)\r?\n---(?:\r?\n|$)/,
+	)?.groups?.frontmatter;
+	if (!frontmatter) {
+		return null;
+	}
+
+	return (
+		frontmatter.match(
+			/^version:\s*(?<quote>['"]?)(?<version>[^\s'"]+)\k<quote>\s*$/m,
+		)?.groups?.version ?? null
+	);
+};
+
+const readRemotionSkill = (
+	skillFile: string,
+): {installed: boolean; version: string | null} => {
+	if (!existsSync(skillFile)) {
+		return {installed: false, version: null};
+	}
+
+	try {
+		return {
+			installed: true,
+			version: parseRemotionSkillVersion(readFileSync(skillFile, 'utf8')),
+		};
+	} catch {
+		return {installed: true, version: null};
+	}
+};
+
+const getStatusForSkillsDirectory = ({
+	currentVersion,
+	scope,
+	skillsDirectory,
+}: {
+	currentVersion: string;
+	scope: RemotionSkillsScope;
+	skillsDirectory: string;
+}): RemotionSkillsStatus => {
+	const installedSkills = new Map<
+		RemotionSkillName,
+		{installed: boolean; version: string | null}
+	>();
+	for (const skillName of remotionSkillNames) {
+		installedSkills.set(
+			skillName,
+			readRemotionSkill(path.join(skillsDirectory, skillName, 'SKILL.md')),
+		);
+	}
+
+	if ([...installedSkills.values()].every((skill) => !skill.installed)) {
+		return {type: 'not-installed', scope, skillsDirectory};
+	}
+
+	const outdatedSkillNames = remotionSkillNames.filter((skillName) => {
+		const skill = installedSkills.get(skillName);
+		return (
+			!skill?.installed ||
+			skill.version === null ||
+			semver.valid(skill.version) === null ||
+			semver.lt(skill.version, currentVersion)
+		);
+	});
+
+	if (outdatedSkillNames.length > 0) {
+		return {type: 'outdated', scope, skillsDirectory, outdatedSkillNames};
+	}
+
+	return {type: 'up-to-date', scope, skillsDirectory};
+};
+
+export const detectOutdatedRemotionSkills = ({
+	currentVersion = VERSION,
+	cwd = process.cwd(),
+	homeDirectory = homedir(),
+}: {
+	currentVersion?: string;
+	cwd?: string;
+	homeDirectory?: string;
+} = {}): {
+	project: RemotionSkillsStatus;
+	global: RemotionSkillsStatus;
+} => {
+	const projectSkillsDirectory = path.join(cwd, '.agents', 'skills');
+	const globalSkillsDirectory = path.join(homeDirectory, '.agents', 'skills');
+
+	return {
+		project: getStatusForSkillsDirectory({
+			currentVersion,
+			scope: 'project',
+			skillsDirectory: projectSkillsDirectory,
+		}),
+		global: getStatusForSkillsDirectory({
+			currentVersion,
+			scope: 'global',
+			skillsDirectory: globalSkillsDirectory,
+		}),
+	};
+};

--- a/packages/cli/src/remotion-skill-names.ts
+++ b/packages/cli/src/remotion-skill-names.ts
@@ -1,0 +1,15 @@
+export const remotionSkillNames = [
+	'remotion-best-practices',
+	'remotion-captions',
+	'remotion-create',
+	'remotion-docs',
+	'remotion-interactivity',
+	'remotion-maps',
+	'remotion-markup',
+	'remotion-multimedia',
+	'remotion-render',
+	'remotion-saas',
+	'remotion-upgrade',
+] as const;
+
+export type RemotionSkillName = (typeof remotionSkillNames)[number];

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -2,20 +2,7 @@ import {spawn} from 'node:child_process';
 import type {LogLevel} from '@remotion/renderer';
 import {chalk} from './chalk';
 import {Log} from './log';
-
-const remotionSkillNames = [
-	'remotion-best-practices',
-	'remotion-captions',
-	'remotion-create',
-	'remotion-docs',
-	'remotion-interactivity',
-	'remotion-maps',
-	'remotion-markup',
-	'remotion-multimedia',
-	'remotion-render',
-	'remotion-saas',
-	'remotion-upgrade',
-];
+import {remotionSkillNames} from './remotion-skill-names';
 
 export const printSkillsHelp = (logLevel: LogLevel) => {
 	Log.info({indent: false, logLevel}, chalk.blue('remotion skills'));

--- a/packages/cli/src/test/detect-outdated-remotion-skills.test.ts
+++ b/packages/cli/src/test/detect-outdated-remotion-skills.test.ts
@@ -1,0 +1,174 @@
+import {expect, test} from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {VERSION} from 'remotion/version';
+import {
+	detectOutdatedRemotionSkills,
+	parseRemotionSkillVersion,
+} from '../detect-outdated-remotion-skills';
+import {remotionSkillNames} from '../remotion-skill-names';
+import type {RemotionSkillName} from '../remotion-skill-names';
+
+const writeSkill = ({
+	skillsDirectory,
+	skillName,
+	version,
+}: {
+	skillsDirectory: string;
+	skillName: RemotionSkillName;
+	version: string | null;
+}) => {
+	const skillDirectory = path.join(skillsDirectory, skillName);
+	mkdirSync(skillDirectory, {recursive: true});
+	writeFileSync(
+		path.join(skillDirectory, 'SKILL.md'),
+		`---\nname: ${skillName}\ndescription: Test skill\n${version === null ? '' : `version: ${version}\n`}---\n`,
+	);
+};
+
+test('detects project and global Remotion skill versions without a lockfile', () => {
+	const temporaryDirectory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-skills-status-'),
+	);
+	const projectDirectory = path.join(temporaryDirectory, 'project');
+	const homeDirectory = path.join(temporaryDirectory, 'home');
+	const projectSkillsDirectory = path.join(
+		projectDirectory,
+		'.agents',
+		'skills',
+	);
+	const globalSkillsDirectory = path.join(homeDirectory, '.agents', 'skills');
+
+	try {
+		mkdirSync(projectDirectory, {recursive: true});
+		writeFileSync(
+			path.join(projectDirectory, 'skills-lock.json'),
+			JSON.stringify({
+				version: 1,
+				skills: Object.fromEntries(
+					remotionSkillNames.map((skillName) => [
+						skillName,
+						{computedHash: 'ignored'},
+					]),
+				),
+			}),
+		);
+
+		expect(
+			detectOutdatedRemotionSkills({
+				currentVersion: '4.0.502',
+				cwd: projectDirectory,
+				homeDirectory,
+			}),
+		).toEqual({
+			project: {
+				type: 'not-installed',
+				scope: 'project',
+				skillsDirectory: projectSkillsDirectory,
+			},
+			global: {
+				type: 'not-installed',
+				scope: 'global',
+				skillsDirectory: globalSkillsDirectory,
+			},
+		});
+
+		const firstSkill = remotionSkillNames[0];
+		writeSkill({
+			skillsDirectory: projectSkillsDirectory,
+			skillName: firstSkill,
+			version: '4.0.502',
+		});
+		expect(
+			detectOutdatedRemotionSkills({
+				currentVersion: '4.0.502',
+				cwd: projectDirectory,
+				homeDirectory,
+			}).project,
+		).toEqual({
+			type: 'outdated',
+			scope: 'project',
+			skillsDirectory: projectSkillsDirectory,
+			outdatedSkillNames: remotionSkillNames.slice(1),
+		});
+
+		for (const skillName of remotionSkillNames) {
+			writeSkill({
+				skillsDirectory: projectSkillsDirectory,
+				skillName,
+				version: '4.0.502',
+			});
+			writeSkill({
+				skillsDirectory: globalSkillsDirectory,
+				skillName,
+				version: '4.0.503',
+			});
+		}
+
+		const currentStatuses = detectOutdatedRemotionSkills({
+			currentVersion: '4.0.502',
+			cwd: projectDirectory,
+			homeDirectory,
+		});
+		expect(currentStatuses.project.type).toBe('up-to-date');
+		expect(currentStatuses.global.type).toBe('up-to-date');
+
+		const lastSkill = remotionSkillNames.at(-1) as RemotionSkillName;
+		writeSkill({
+			skillsDirectory: projectSkillsDirectory,
+			skillName: firstSkill,
+			version: null,
+		});
+		writeSkill({
+			skillsDirectory: projectSkillsDirectory,
+			skillName: lastSkill,
+			version: '4.0.501',
+		});
+		expect(
+			detectOutdatedRemotionSkills({
+				currentVersion: '4.0.502',
+				cwd: projectDirectory,
+				homeDirectory,
+			}).project,
+		).toEqual({
+			type: 'outdated',
+			scope: 'project',
+			skillsDirectory: projectSkillsDirectory,
+			outdatedSkillNames: [firstSkill, lastSkill],
+		});
+	} finally {
+		rmSync(temporaryDirectory, {recursive: true, force: true});
+	}
+});
+
+test('all source Remotion skills match the current Remotion version', () => {
+	const skillsDirectory = path.join(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'skills',
+		'skills',
+	);
+	const sourceSkillNames = readdirSync(skillsDirectory, {withFileTypes: true})
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+	expect(sourceSkillNames).toEqual([...remotionSkillNames].sort());
+
+	for (const skillName of remotionSkillNames) {
+		const contents = readFileSync(
+			path.join(skillsDirectory, skillName, 'SKILL.md'),
+			'utf8',
+		);
+		expect(parseRemotionSkillVersion(contents)).toBe(VERSION);
+	}
+});

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-best-practices
 description: Router for all Remotion skills
+version: 4.0.502
 metadata:
   tags: remotion, video, react, animation, composition
 ---

--- a/packages/skills/skills/remotion-captions/SKILL.md
+++ b/packages/skills/skills/remotion-captions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-captions
 description: Transcribing, displaying and animating captions
+version: 4.0.502
 metadata:
   tags: subtitles, captions, remotion, json
 ---

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-create
 description: Create a new Remotion video
+version: 4.0.502
 metadata:
   tags: remotion
 ---

--- a/packages/skills/skills/remotion-docs/SKILL.md
+++ b/packages/skills/skills/remotion-docs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-docs
 description: Search Remotion documentation
+version: 4.0.502
 metadata:
   tags: remotion, docs, documentation, search
 ---

--- a/packages/skills/skills/remotion-interactivity/SKILL.md
+++ b/packages/skills/skills/remotion-interactivity/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-interactivity
 description: Structure Remotion markup for interactivity
+version: 4.0.502
 metadata:
   tags: remotion, interactivity, studio, visual mode
 ---

--- a/packages/skills/skills/remotion-maps/SKILL.md
+++ b/packages/skills/skills/remotion-maps/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-maps
 description: Remotion Map animation knowledge
+version: 4.0.502
 ---
 
 # Remotion Maps

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-markup
 description: Content, animation and effects best practices
+version: 4.0.502
 metadata:
   tags: remotion, react, markup
 ---

--- a/packages/skills/skills/remotion-multimedia/SKILL.md
+++ b/packages/skills/skills/remotion-multimedia/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-multimedia
 description: Interacting with Mediabunny
+version: 4.0.502
 metadata:
   tags: remotion, mediabunny, multimedia, video, audio
 ---

--- a/packages/skills/skills/remotion-render/SKILL.md
+++ b/packages/skills/skills/remotion-render/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-render
 description: Export a Remotion video
+version: 4.0.502
 metadata:
   tags: remotion, render
 ---

--- a/packages/skills/skills/remotion-saas/SKILL.md
+++ b/packages/skills/skills/remotion-saas/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-saas
 description: Build an app with Remotion
+version: 4.0.502
 metadata:
   tags: remotion, saas, player, rendering, templates, lambda
 ---

--- a/packages/skills/skills/remotion-upgrade/SKILL.md
+++ b/packages/skills/skills/remotion-upgrade/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remotion-upgrade
 description: Upgrade Remotion, and related packages
+version: 4.0.502
 ---
 
 # Upgrade Remotion

--- a/set-version.ts
+++ b/set-version.ts
@@ -96,6 +96,28 @@ for (const dir of [path.join('cloudrun', 'container'), ...dirs]) {
 	}
 }
 
+const skillsRoot = path.join(process.cwd(), 'packages', 'skills', 'skills');
+for (const skillName of readdirSync(skillsRoot)) {
+	const skillFile = path.join(skillsRoot, skillName, 'SKILL.md');
+	if (!existsSync(skillFile)) {
+		continue;
+	}
+
+	const contents = readFileSync(skillFile, 'utf8');
+	const frontmatterEnd = contents.indexOf('\n---', 4);
+	if (frontmatterEnd === -1) {
+		throw new Error(`No frontmatter found in ${skillFile}`);
+	}
+
+	const frontmatter = contents.slice(0, frontmatterEnd);
+	const versionPattern = /^version:.*$/m;
+	const updatedFrontmatter = versionPattern.test(frontmatter)
+		? frontmatter.replace(versionPattern, `version: ${version}`)
+		: `${frontmatter}\nversion: ${version}`;
+	writeFileSync(skillFile, updatedFrontmatter + contents.slice(frontmatterEnd));
+	console.log('setting version for', path.join('skills', skillName));
+}
+
 const kimiCodePluginManifestPath = path.join(
 	process.cwd(),
 	'packages',


### PR DESCRIPTION
## Summary

- add the current Remotion version to every Remotion skill frontmatter
- keep skill frontmatter versions in sync through the existing release version script
- detect project-local and global Remotion skill installations directly from installed `SKILL.md` files
- accept skill versions equal to or newer than Remotion; treat missing, invalid, or older versions as outdated
- disregard `skills-lock.json` entirely

## Test plan

- `bun test packages/cli/src/test/skills.test.ts packages/cli/src/test/detect-outdated-remotion-skills.test.ts`
- `bun run build`
- `bun run stylecheck`
- install a versioned local skill with the pinned `skills@1.5.20` CLI

Depends on #9940
Closes #9937