### PR TITLE
`@remotion/web-renderer`: Preserve nested canvas geometry across pixel densities

### DIFF
--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -122,7 +122,7 @@ The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: '
 [`<ThreeCanvas>`](/docs/three-canvas) from [`@remotion/three`](/docs/three) is <a style={{color: 'green'}}>supported</a>.  
 [`<SkiaCanvas>`](/docs/skia/skia-canvas) from [`@remotion/skia`](/docs/skia) is <a style={{color: 'green'}}>supported</a>.  
 [`<AnimatedImage>`](/docs/animatedimage) is <a style={{color: 'green'}}>supported</a> when rendering in Chrome.  
-[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
+[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`pixelDensity`](/docs/remotion/html-in-canvas#pixeldensity), [`onPaint`](/docs/remotion/html-in-canvas#onpaint), and [`onInit`](/docs/remotion/html-in-canvas#oninit) options. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
 [`<OffthreadVideo>`](/docs/offthreadvideo) is <a style={{color: 'red'}}>not supported</a>.  
  → Use [`<Video>`](/docs/media/video) instead.  
 [`<Html5Video>`](/docs/html5-video) is <a style={{color: 'red'}}>not supported</a>.  

--- a/packages/web-renderer/src/html-in-canvas.ts
+++ b/packages/web-renderer/src/html-in-canvas.ts
@@ -192,6 +192,30 @@ export const containsLayoutSubtreeCanvas = (element: HTMLElement): boolean => {
 	return countLayoutSubtreeCanvases(element) > 0;
 };
 
+export const containsLayoutSubtreeCanvasWithNonDefaultPixelDensity = (
+	element: HTMLElement,
+): boolean => {
+	return Array.from(element.querySelectorAll('canvas')).some((canvas) => {
+		if ((canvas as HTMLCanvasWithLayoutSubtree).layoutSubtree !== true) {
+			return false;
+		}
+
+		const computedStyle = getComputedStyle(canvas);
+		const cssWidth = Number.parseFloat(computedStyle.width);
+		const cssHeight = Number.parseFloat(computedStyle.height);
+		if (cssWidth <= 0 || cssHeight <= 0) {
+			return false;
+		}
+
+		const horizontalDensity = canvas.width / cssWidth;
+		const verticalDensity = canvas.height / cssHeight;
+		return (
+			Math.abs(horizontalDensity - 1) > 0.001 ||
+			Math.abs(verticalDensity - 1) > 0.001
+		);
+	});
+};
+
 export type HtmlInCanvasContext = {
 	layoutCanvas: HTMLCanvasWithLayoutSubtree;
 	ctx: Canvas2DWithDrawElement;

--- a/packages/web-renderer/src/take-screenshot.ts
+++ b/packages/web-renderer/src/take-screenshot.ts
@@ -5,6 +5,7 @@ import {containsUrlMaskImage} from './drawing/mask-image';
 import type {HtmlInCanvasContext} from './html-in-canvas';
 import {
 	containsLayoutSubtreeCanvas,
+	containsLayoutSubtreeCanvasWithNonDefaultPixelDensity,
 	drawWithHtmlInCanvas,
 } from './html-in-canvas';
 import type {InternalState} from './internal-state';
@@ -50,6 +51,13 @@ export const createLayer = async ({
 				native: false,
 				reason:
 					'URL masks are loaded by the built-in DOM composer to guarantee deterministic rendering.',
+				shouldWarn: false,
+			});
+		} else if (containsLayoutSubtreeCanvasWithNonDefaultPixelDensity(element)) {
+			onHtmlInCanvasLayerOutcome({
+				native: false,
+				reason:
+					'A nested HTML-in-canvas bitmap has a non-default pixel density.',
 				shouldWarn: false,
 			});
 		} else {

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -49,6 +49,7 @@ import {maskImage} from './fixtures/mask-image';
 import {maskImageUrl} from './fixtures/mask-image-url';
 import {multiLevelTransformOrigins} from './fixtures/multi-level-transform-origins';
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
+import {nestedHtmlInCanvasPixelDensity} from './fixtures/nested-html-in-canvas-pixel-density';
 import {nestedTranslateScale} from './fixtures/nested-translate-scale';
 import {objectFit} from './fixtures/object-fit';
 import {opacityInherited} from './fixtures/opacity-inherited';
@@ -132,6 +133,7 @@ export const Root: React.FC = () => {
 			<Composition {...objectFit} />
 			<Composition {...nestedTranslateScale} />
 			<Composition {...nestedHtmlInCanvas} />
+			<Composition {...nestedHtmlInCanvasPixelDensity} />
 			<Composition {...scaledTranslatedSvg} />
 			<Composition {...svgExplicitDimensions} />
 			<Composition {...flexPositionedScaled} />

--- a/packages/web-renderer/src/test/fixtures/nested-html-in-canvas-pixel-density.tsx
+++ b/packages/web-renderer/src/test/fixtures/nested-html-in-canvas-pixel-density.tsx
@@ -1,0 +1,48 @@
+import {AbsoluteFill, HtmlInCanvas} from 'remotion';
+
+const Component: React.FC = () => {
+	return (
+		<HtmlInCanvas
+			width={200}
+			height={100}
+			pixelDensity={2}
+			onPaint={({canvas, element, elementImage}) => {
+				const context = canvas.getContext('2d');
+				if (!context) {
+					throw new Error('Could not get context');
+				}
+
+				context.reset();
+				const transform = context.drawElementImage(
+					elementImage,
+					0,
+					0,
+					canvas.width,
+					canvas.height,
+				);
+				element.style.transform = transform.toString();
+			}}
+		>
+			<AbsoluteFill style={{backgroundColor: 'red'}}>
+				<div
+					style={{
+						backgroundColor: 'lime',
+						height: 20,
+						marginLeft: 40,
+						marginTop: 30,
+						width: 40,
+					}}
+				/>
+			</AbsoluteFill>
+		</HtmlInCanvas>
+	);
+};
+
+export const nestedHtmlInCanvasPixelDensity = {
+	component: Component,
+	durationInFrames: 1,
+	fps: 30,
+	height: 100,
+	id: 'nested-html-in-canvas-pixel-density',
+	width: 200,
+} as const;

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -10,6 +10,7 @@ import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
+import {nestedHtmlInCanvasPixelDensity} from './fixtures/nested-html-in-canvas-pixel-density';
 import {testImage} from './utils';
 
 setForceDisableHtmlInCanvasForTesting(false);
@@ -46,6 +47,77 @@ test('captures three nested HTML-in-canvas effect layers natively', async () => 
 		await testImage({blob, testId: 'nested-html-in-canvas'});
 	} finally {
 		warn.mockRestore();
+	}
+});
+
+const getLimeBounds = async (blob: Blob) => {
+	const image = document.createElement('img');
+	const objectUrl = URL.createObjectURL(blob);
+	image.src = objectUrl;
+	await image.decode();
+
+	const canvas = new OffscreenCanvas(image.naturalWidth, image.naturalHeight);
+	const context = canvas.getContext('2d');
+	if (!context) {
+		throw new Error('Could not get context');
+	}
+
+	context.drawImage(image, 0, 0);
+	const imageData = context.getImageData(
+		0,
+		0,
+		image.naturalWidth,
+		image.naturalHeight,
+	).data;
+	URL.revokeObjectURL(objectUrl);
+
+	let minX = image.naturalWidth;
+	let minY = image.naturalHeight;
+	let maxX = -1;
+	let maxY = -1;
+	for (let y = 0; y < image.naturalHeight; y++) {
+		for (let x = 0; x < image.naturalWidth; x++) {
+			const index = (y * image.naturalWidth + x) * 4;
+			if (
+				imageData[index] === 0 &&
+				imageData[index + 1] === 255 &&
+				imageData[index + 2] === 0 &&
+				imageData[index + 3] === 255
+			) {
+				minX = Math.min(minX, x);
+				minY = Math.min(minY, y);
+				maxX = Math.max(maxX, x);
+				maxY = Math.max(maxY, y);
+			}
+		}
+	}
+
+	return [minX, minY, maxX, maxY];
+};
+
+test('keeps nested HTML-in-canvas geometry independent of its pixel density', async () => {
+	const supportsNesting = await supportsNestedHtmlInCanvas();
+	if (!supportsNesting) {
+		return;
+	}
+
+	for (const scale of [1, 2]) {
+		const result = await renderStillOnWeb({
+			composition: nestedHtmlInCanvasPixelDensity,
+			frame: 0,
+			inputProps: {},
+			licenseKey: 'free-license',
+			scale,
+		});
+		const blob = await result.blob({format: 'png'});
+		const bounds = await getLimeBounds(blob);
+
+		expect(bounds).toEqual([
+			40 * scale,
+			30 * scale,
+			80 * scale - 1,
+			50 * scale - 1,
+		]);
 	}
 });
 


### PR DESCRIPTION
## Summary

- detect nested HTML-in-canvas backing stores whose pixel density cannot be normalized by Chromium native capture
- fall back to the DOM composer for those frames so geometry stays stable across device pixel ratios
- add browser coverage at render scales 1 and 2 and document `pixelDensity` support

## Testing

- `bun run build`
- `bun run stylecheck`
- browser tests for `src/test/html-in-canvas.test.tsx` in Chromium, Firefox, and WebKit
- Chrome Canary with `deviceScaleFactor: 2`

## Preview

- [Client-side rendering limitations](https://remotion-git-codex-fix-web-renderer-pixel-density-remotion.vercel.app/docs/client-side-rendering/limitations)
