### PR TITLE
`@remotion/cli`: Update skills during Remotion upgrades

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,7 +49,8 @@ import {
 	versionsCommand,
 } from './versions';
 
-const {packageManagerOption, versionFlagOption} = BrowserSafeApis.options;
+const {packageManagerOption, skipSkillsOption, versionFlagOption} =
+	BrowserSafeApis.options;
 
 export const cli = async () => {
 	const [command, ...args] = parsedCli._;
@@ -121,6 +122,7 @@ export const cli = async () => {
 				version:
 					versionFlagOption.getValue({commandLine: parsedCli}).value ??
 					undefined,
+				skipSkills: skipSkillsOption.getValue({commandLine: parsedCli}).value,
 				logLevel,
 				args,
 			});
@@ -144,7 +146,10 @@ export const cli = async () => {
 				args: additionalArgs,
 			});
 		} else if (command === 'skills') {
-			await skillsCommand(args, logLevel);
+			await skillsCommand(args, logLevel, {
+				cwd: process.cwd(),
+				environment: process.env,
+			});
 		} else if (command === VERSIONS_COMMAND) {
 			await versionsCommand(remotionRoot, logLevel);
 		} else if (command === BROWSER_COMMAND) {

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -80,6 +80,7 @@ const {
 	sampleRateOption,
 	previewSampleRateOption,
 	rspackOption,
+	skipSkillsOption,
 } = BrowserSafeApis.options;
 
 export type CommandLineOptions = {
@@ -196,6 +197,7 @@ export type CommandLineOptions = {
 	[rspackOption.cliFlag]: TypeOfOption<typeof rspackOption> | null;
 	'experimental-rspack'?: unknown;
 	[isProductionOption.cliFlag]: TypeOfOption<typeof isProductionOption> | null;
+	[skipSkillsOption.cliFlag]: TypeOfOption<typeof skipSkillsOption>;
 };
 
 export const BooleanFlags = [
@@ -222,6 +224,7 @@ export const BooleanFlags = [
 	forceNewStudioOption.cliFlag,
 	bundleCacheOption.cliFlag,
 	rspackOption.cliFlag,
+	skipSkillsOption.cliFlag,
 ];
 
 export const parsedCli = minimist<CommandLineOptions>(process.argv.slice(2), {

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -26,7 +26,17 @@ export const printSkillsHelp = (logLevel: LogLevel) => {
 	);
 };
 
-export const skillsCommand = (args: string[], logLevel: LogLevel) => {
+export const skillsCommand = (
+	args: string[],
+	logLevel: LogLevel,
+	{
+		cwd,
+		environment,
+	}: {
+		cwd: string;
+		environment: NodeJS.ProcessEnv;
+	},
+) => {
 	const subcommand = args[0];
 	const restArgs = args.slice(1);
 
@@ -56,6 +66,8 @@ export const skillsCommand = (args: string[], logLevel: LogLevel) => {
 				];
 
 	const child = spawn(command, fullArgs, {
+		cwd,
+		env: environment,
 		stdio: 'inherit',
 	});
 

--- a/packages/cli/src/test/remotion-upgrade-skill.test.ts
+++ b/packages/cli/src/test/remotion-upgrade-skill.test.ts
@@ -1,0 +1,33 @@
+import {expect, test} from 'bun:test';
+import {readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+
+test('the upgrade skill update command lists every public Remotion skill', () => {
+	const skillsDirectory = path.join(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'skills',
+		'skills',
+	);
+	const publicSkillNames = readdirSync(skillsDirectory, {withFileTypes: true})
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+	const upgradeSkill = readFileSync(
+		path.join(skillsDirectory, 'remotion-upgrade', 'SKILL.md'),
+		'utf8',
+	);
+	const updateCommand = upgradeSkill.match(
+		/^\s*npx skills update (?<skillNames>.+) --yes\s*$/m,
+	);
+
+	if (!updateCommand?.groups?.skillNames) {
+		throw new Error('Could not find the skills update command');
+	}
+
+	expect(updateCommand.groups.skillNames.split(/\s+/).sort()).toEqual(
+		publicSkillNames,
+	);
+});

--- a/packages/cli/src/test/update-remotion-skills.test.ts
+++ b/packages/cli/src/test/update-remotion-skills.test.ts
@@ -1,0 +1,128 @@
+import {expect, test} from 'bun:test';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {remotionSkillNames} from '../remotion-skill-names';
+import {updateRemotionSkills} from '../update-remotion-skills';
+
+const writeRecognizedSkill = (skillsDirectory: string) => {
+	const skillName = remotionSkillNames[0];
+	const skillDirectory = path.join(skillsDirectory, skillName);
+	mkdirSync(skillDirectory, {recursive: true});
+	writeFileSync(
+		path.join(skillDirectory, 'SKILL.md'),
+		`---\nname: ${skillName}\ndescription: Test skill\nversion: 4.0.501\n---\n`,
+	);
+};
+
+test('updates only recognized project and global Remotion skills unless skipped', async () => {
+	const temporaryDirectory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-upgrade-skills-'),
+	);
+	const projectDirectory = path.join(temporaryDirectory, 'project');
+	const homeDirectory = path.join(temporaryDirectory, 'home');
+	const fakeNpxDirectory = path.join(temporaryDirectory, 'bin');
+	const outputFile = path.join(temporaryDirectory, 'calls.jsonl');
+	const fakeNpxPath = path.join(
+		fakeNpxDirectory,
+		process.platform === 'win32' ? 'npx.cmd' : 'npx',
+	);
+	const fakeNpxScript = `import {appendFileSync} from 'node:fs';
+appendFileSync(process.env.REMOTION_SKILLS_TEST_OUTPUT, JSON.stringify({args: process.argv.slice(2), cwd: process.cwd()}) + '\\n');
+`;
+
+	try {
+		mkdirSync(projectDirectory, {recursive: true});
+		mkdirSync(fakeNpxDirectory, {recursive: true});
+		writeRecognizedSkill(path.join(projectDirectory, '.agents', 'skills'));
+		writeRecognizedSkill(path.join(homeDirectory, '.agents', 'skills'));
+
+		if (process.platform === 'win32') {
+			const fakeNpxScriptPath = path.join(temporaryDirectory, 'fake-npx.mjs');
+			writeFileSync(fakeNpxScriptPath, fakeNpxScript);
+			writeFileSync(
+				fakeNpxPath,
+				`@"${process.execPath}" "${fakeNpxScriptPath}" %*\r\n`,
+			);
+		} else {
+			writeFileSync(fakeNpxPath, `#!${process.execPath}\n${fakeNpxScript}`);
+			chmodSync(fakeNpxPath, 0o755);
+		}
+
+		const environment = {
+			...process.env,
+			PATH: `${fakeNpxDirectory}${path.delimiter}${process.env.PATH}`,
+			REMOTION_SKILLS_TEST_OUTPUT: outputFile,
+		};
+
+		await updateRemotionSkills({
+			currentVersion: '4.0.502',
+			cwd: projectDirectory,
+			homeDirectory,
+			skipSkills: true,
+			logLevel: 'error',
+			environment,
+		});
+		expect(existsSync(outputFile)).toBe(false);
+
+		await updateRemotionSkills({
+			currentVersion: '4.0.502',
+			cwd: projectDirectory,
+			homeDirectory,
+			skipSkills: false,
+			logLevel: 'error',
+			environment,
+		});
+
+		const calls = readFileSync(outputFile, 'utf8')
+			.trim()
+			.split('\n')
+			.map((line) => JSON.parse(line));
+		const canonicalProjectDirectory = realpathSync(projectDirectory);
+		expect(calls).toEqual([
+			{
+				args: [
+					'--loglevel=error',
+					'skills',
+					'update',
+					...remotionSkillNames,
+					'--project',
+					'--yes',
+				],
+				cwd: canonicalProjectDirectory,
+			},
+			{
+				args: [
+					'--loglevel=error',
+					'skills',
+					'update',
+					...remotionSkillNames,
+					'--global',
+					'--yes',
+				],
+				cwd: canonicalProjectDirectory,
+			},
+		]);
+
+		await updateRemotionSkills({
+			currentVersion: '4.0.502',
+			cwd: path.join(temporaryDirectory, 'unrecognized-project'),
+			homeDirectory: path.join(temporaryDirectory, 'unrecognized-home'),
+			skipSkills: false,
+			logLevel: 'error',
+			environment,
+		});
+		expect(readFileSync(outputFile, 'utf8').trim().split('\n')).toHaveLength(2);
+	} finally {
+		rmSync(temporaryDirectory, {recursive: true, force: true});
+	}
+});

--- a/packages/cli/src/test/update-remotion-skills.test.ts
+++ b/packages/cli/src/test/update-remotion-skills.test.ts
@@ -24,7 +24,7 @@ const writeRecognizedSkill = (skillsDirectory: string) => {
 	);
 };
 
-test('updates only recognized project and global Remotion skills unless skipped', async () => {
+test('updates only recognized project-local Remotion skills unless skipped', async () => {
 	const temporaryDirectory = mkdtempSync(
 		path.join(tmpdir(), 'remotion-upgrade-skills-'),
 	);
@@ -60,6 +60,7 @@ appendFileSync(process.env.REMOTION_SKILLS_TEST_OUTPUT, JSON.stringify({args: pr
 
 		const environment = {
 			...process.env,
+			HOME: homeDirectory,
 			PATH: `${fakeNpxDirectory}${path.delimiter}${process.env.PATH}`,
 			REMOTION_SKILLS_TEST_OUTPUT: outputFile,
 		};
@@ -100,17 +101,6 @@ appendFileSync(process.env.REMOTION_SKILLS_TEST_OUTPUT, JSON.stringify({args: pr
 				],
 				cwd: canonicalProjectDirectory,
 			},
-			{
-				args: [
-					'--loglevel=error',
-					'skills',
-					'update',
-					...remotionSkillNames,
-					'--global',
-					'--yes',
-				],
-				cwd: canonicalProjectDirectory,
-			},
 		]);
 
 		await updateRemotionSkills({
@@ -121,7 +111,7 @@ appendFileSync(process.env.REMOTION_SKILLS_TEST_OUTPUT, JSON.stringify({args: pr
 			logLevel: 'error',
 			environment,
 		});
-		expect(readFileSync(outputFile, 'utf8').trim().split('\n')).toHaveLength(2);
+		expect(readFileSync(outputFile, 'utf8').trim().split('\n')).toHaveLength(1);
 	} finally {
 		rmSync(temporaryDirectory, {recursive: true, force: true});
 	}

--- a/packages/cli/src/update-remotion-skills.ts
+++ b/packages/cli/src/update-remotion-skills.ts
@@ -1,0 +1,52 @@
+import type {LogLevel} from '@remotion/renderer';
+import {detectOutdatedRemotionSkills} from './detect-outdated-remotion-skills';
+import {Log} from './log';
+import {skillsCommand} from './skills';
+
+export const updateRemotionSkills = async ({
+	currentVersion,
+	cwd,
+	homeDirectory,
+	skipSkills,
+	logLevel,
+	environment,
+}: {
+	currentVersion: string;
+	cwd: string;
+	homeDirectory: string;
+	skipSkills: boolean;
+	logLevel: LogLevel;
+	environment: NodeJS.ProcessEnv;
+}) => {
+	if (skipSkills) {
+		return;
+	}
+
+	const skillsStatuses = detectOutdatedRemotionSkills({
+		currentVersion,
+		cwd,
+		homeDirectory,
+	});
+
+	if (skillsStatuses.project.type === 'outdated') {
+		Log.info(
+			{indent: false, logLevel},
+			'Updating project Remotion Agent Skills...',
+		);
+		await skillsCommand(['update', '--project'], logLevel, {
+			cwd,
+			environment,
+		});
+	}
+
+	if (skillsStatuses.global.type === 'outdated') {
+		Log.info(
+			{indent: false, logLevel},
+			'Updating global Remotion Agent Skills...',
+		);
+		await skillsCommand(['update', '--global'], logLevel, {
+			cwd,
+			environment,
+		});
+	}
+};

--- a/packages/cli/src/update-remotion-skills.ts
+++ b/packages/cli/src/update-remotion-skills.ts
@@ -38,15 +38,4 @@ export const updateRemotionSkills = async ({
 			environment,
 		});
 	}
-
-	if (skillsStatuses.global.type === 'outdated') {
-		Log.info(
-			{indent: false, logLevel},
-			'Updating global Remotion Agent Skills...',
-		);
-		await skillsCommand(['update', '--global'], logLevel, {
-			cwd,
-			environment,
-		});
-	}
 };

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -1,4 +1,5 @@
 import {execSync, spawn} from 'node:child_process';
+import {homedir} from 'node:os';
 import {RenderInternals, type LogLevel} from '@remotion/renderer';
 import {StudioServerInternals} from '@remotion/studio-server';
 import {
@@ -12,6 +13,7 @@ import {chalk} from './chalk';
 import {EXTRA_PACKAGES} from './extra-packages';
 import {listOfRemotionPackages} from './list-of-remotion-packages';
 import {Log} from './log';
+import {updateRemotionSkills} from './update-remotion-skills';
 
 export const resolveExtraPackageVersions = (
 	dependencies: Record<string, string>,
@@ -110,12 +112,14 @@ export const upgradeCommand = async ({
 	remotionRoot,
 	packageManager,
 	version,
+	skipSkills,
 	logLevel,
 	args,
 }: {
 	remotionRoot: string;
 	packageManager: string | undefined;
 	version: string | undefined;
+	skipSkills: boolean;
 	logLevel: LogLevel;
 	args: string[];
 }) => {
@@ -247,6 +251,15 @@ export const upgradeCommand = async ({
 			logLevel,
 		});
 	}
+
+	await updateRemotionSkills({
+		currentVersion: targetVersion,
+		cwd: remotionRoot,
+		homeDirectory: homedir(),
+		skipSkills,
+		logLevel,
+		environment: process.env,
+	});
 
 	Log.info({indent: false, logLevel}, '⏫ Remotion has been upgraded!');
 	Log.info({indent: false, logLevel}, 'https://remotion.dev/changelog');

--- a/packages/docs/docs/cli/upgrade.mdx
+++ b/packages/docs/docs/cli/upgrade.mdx
@@ -9,7 +9,7 @@ Upgrades all Remotion-related packages.
 
 If `mediabunny` is installed, it will also be upgraded to the version [compatible with the new Remotion version](/docs/mediabunny/version).
 
-If Remotion Agent Skills are installed locally or globally, they will also be updated. Directories without recognized Remotion skills are left unchanged.
+If Remotion Agent Skills are installed in the project's `.agents/skills` directory, they will also be updated. Directories without recognized Remotion skills are left unchanged. Global skills are not updated.
 
 ```
 npx remotion upgrade

--- a/packages/docs/docs/cli/upgrade.mdx
+++ b/packages/docs/docs/cli/upgrade.mdx
@@ -9,6 +9,8 @@ Upgrades all Remotion-related packages.
 
 If `mediabunny` is installed, it will also be upgraded to the version [compatible with the new Remotion version](/docs/mediabunny/version).
 
+If Remotion Agent Skills are installed locally or globally, they will also be updated. Directories without recognized Remotion skills are left unchanged.
+
 ```
 npx remotion upgrade
 ```
@@ -22,6 +24,10 @@ npx remotion upgrade
 ### `--version`<AvailableFrom v="4.0.15"/>
 
 <Options id="version" />
+
+### `--skip-skills`<AvailableFrom v="4.0.503"/>
+
+<Options id="skip-skills" />
 
 ## Package manager support
 

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -77,6 +77,7 @@ import {runsOption} from './runs';
 import {sampleRateOption} from './sample-rate';
 import {scaleOption} from './scale';
 import {separateAudioOption} from './separate-audio';
+import {skipSkillsOption} from './skip-skills';
 import {stillFrameOption} from './still-frame';
 import {stillImageFormatOption} from './still-image-format';
 import {throwIfSiteExistsOption} from './throw-if-site-exists';
@@ -172,6 +173,7 @@ export const allOptions = {
 	rspackOption,
 	outDirOption,
 	packageManagerOption,
+	skipSkillsOption,
 	sampleRateOption,
 	webpackPollOption,
 	stillFrameOption,

--- a/packages/renderer/src/options/skip-skills.tsx
+++ b/packages/renderer/src/options/skip-skills.tsx
@@ -1,0 +1,31 @@
+import type {AnyRemotionOption} from './option';
+
+const cliFlag = 'skip-skills' as const;
+
+export const skipSkillsOption = {
+	name: 'Skip Skills',
+	cliFlag,
+	description: () => (
+		<>Do not update installed Remotion Agent Skills while upgrading Remotion.</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/cli/upgrade#--skip-skills',
+	getValue: ({commandLine}) => {
+		if (commandLine[cliFlag]) {
+			return {
+				source: 'cli',
+				value: true,
+			};
+		}
+
+		return {
+			source: 'default',
+			value: false,
+		};
+	},
+	setConfig: () => {
+		throw new Error('Cannot skip updating skills via config file');
+	},
+	type: false as boolean,
+	id: cliFlag,
+} satisfies AnyRemotionOption<boolean>;

--- a/packages/skills/skills/remotion-upgrade/SKILL.md
+++ b/packages/skills/skills/remotion-upgrade/SKILL.md
@@ -13,7 +13,7 @@ version: 4.0.502
    npx remotion upgrade
    ```
 
-   This also updates installed Remotion skills. Skip the manual upgrade below.
+   This also updates project-local Remotion skills. Skip the manual upgrade below.
 
 3. If `@remotion/cli` is not available, upgrade manually:
    - Get the latest stable Remotion version with `npm view remotion version`.

--- a/packages/skills/skills/remotion-upgrade/SKILL.md
+++ b/packages/skills/skills/remotion-upgrade/SKILL.md
@@ -13,17 +13,17 @@ version: 4.0.502
    npx remotion upgrade
    ```
 
-   Skip the manual package upgrade below.
+   This also updates installed Remotion skills. Skip the manual upgrade below.
 
 3. If `@remotion/cli` is not available, upgrade manually:
    - Get the latest stable Remotion version with `npm view remotion version`.
    - Find every installed `remotion` and `@remotion/*` dependency across the project and upgrade them all to that exact version. Preserve their dependency sections and the project's workspace or catalog conventions.
    - Read the current [Mediabunny compatibility page](https://www.remotion.dev/docs/mediabunny/version) and determine the Mediabunny version compatible with the target Remotion version. Upgrade every installed `mediabunny` and `@mediabunny/*` package to the documented compatible version.
    - Run the project's package manager to update its lockfile.
-4. Update the installed Remotion skills:
+4. If `@remotion/cli` is not available, update the installed Remotion skills:
 
    ```bash
-   npx remotion skills update
+   npx skills update remotion-best-practices remotion-captions remotion-create remotion-docs remotion-interactivity remotion-maps remotion-markup remotion-multimedia remotion-render remotion-saas remotion-upgrade --yes
    ```
 
 5. Review the manifest and lockfile diff. Ensure all Remotion packages use one version and all installed Mediabunny packages use the compatible version. If the CLI is available, run `npx remotion versions` as an additional check.


### PR DESCRIPTION
## Summary

- automatically update recognized project-local Remotion Agent Skills during `remotion upgrade`
- add `--skip-skills` as an explicit opt-out
- document the behavior and update the bundled Remotion upgrade skill
- keep the manual upgrade command in sync with all public Remotion skills in CI

## Test plan

- `bun test packages/cli/src/test/update-remotion-skills.test.ts packages/cli/src/test/detect-outdated-remotion-skills.test.ts packages/cli/src/test/skills.test.ts packages/cli/src/test/upgrade-protocols.test.ts`
- `bun test packages/cli/src/test/remotion-upgrade-skill.test.ts`
- `bun run build`
- `bun run stylecheck`

Depends on #9942

Closes #9945

## Preview

- [Upgrade CLI documentation](https://remotion-git-codex-upgrade-remotion-skills-remotion.vercel.app/docs/cli/upgrade)
