### PR TITLE
Skills: Stash local changes when updating from upstream

### DIFF
--- a/.agents/skills/update-from-upstream-main/SKILL.md
+++ b/.agents/skills/update-from-upstream-main/SKILL.md
@@ -17,7 +17,16 @@ Update from the canonical `remotion-dev/remotion` repository while preserving lo
    git remote -v
    ```
 
-   Stop and report the state if the working tree contains uncommitted changes, the current checkout is detached, or an operation such as a merge or rebase is already in progress. Do not stash or discard changes automatically.
+   Stop and report the state if the current checkout is detached or an operation such as a merge or rebase is already in progress.
+
+   If the working tree contains staged, unstaged, or untracked changes, stash them automatically before continuing:
+
+   ```bash
+   git stash push --include-untracked --message "update-from-upstream-main: preserve local changes"
+   git rev-parse stash@{0}
+   ```
+
+   Record the created stash's commit ID so the same entry can be restored later. Verify that the working tree is clean before fetching. If stashing fails or leaves changes behind, stop without starting the update. Do not include ignored files unless the user explicitly asks.
 
 2. Select the canonical remote whose URL points to `remotion-dev/remotion`. Prefer `upstream` when it exists; otherwise use `origin`. If neither remote points to the canonical repository, stop and ask before adding or changing a remote.
 
@@ -54,14 +63,22 @@ Update from the canonical `remotion-dev/remotion` repository while preserving lo
    git commit --no-edit
    ```
 
-6. Validate the result. Always run `git diff --check`. If conflicts were resolved or the combined changes could affect behavior, run the relevant package tests. For broad changes, run:
+6. If step 1 created a stash, reapply it after the upstream update is complete:
+
+   ```bash
+   git stash apply --index <recorded-stash-commit>
+   ```
+
+   Reapply the stash before reporting success or before stopping after a fetch or merge failure, provided no Git operation is still in progress. If applying the stash causes conflicts, resolve them deliberately without rerunning `git stash apply`. The stash entry remains as a recovery copy. After confirming that all stashed changes, including untracked files and their staged state, were restored, find the entry with the recorded commit ID in `git stash list --format='%gd %H'` and drop only that entry. Never pop or drop a pre-existing stash.
+
+7. Validate the result. Always run `git diff --check` and `git diff --cached --check`. If conflicts were resolved or the combined changes could affect behavior, run the relevant package tests. For broad changes, run:
 
    ```bash
    bun run build
    bun run stylecheck
    ```
 
-7. Push only when the user asked to update a published branch or pull request. Use a normal push and stop if it is rejected:
+8. Push only when the user asked to update a published branch or pull request. Use a normal push and stop if it is rejected:
 
    ```bash
    git push <canonical-remote> HEAD
@@ -69,4 +86,4 @@ Update from the canonical `remotion-dev/remotion` repository while preserving lo
 
    Never force-push.
 
-8. Report the previous and new commit, whether the update was a fast-forward or merge, any conflicts resolved, validation performed, and whether the branch was pushed.
+9. Report the previous and new commit, whether the update was a fast-forward or merge, whether local changes were stashed and successfully reapplied, any conflicts resolved, validation performed, and whether the branch was pushed.


### PR DESCRIPTION
## Summary

- automatically stash staged, unstaged, and untracked changes before syncing from upstream main
- reapply the exact created stash while leaving pre-existing stashes untouched
- validate both staged and unstaged diffs after restoring local work

## Testing

- `bunx oxfmt .agents/skills/update-from-upstream-main/SKILL.md --write`
- `bun run build`
- `bun run stylecheck`
- `quick_validate.py .agents/skills/update-from-upstream-main`