### PR TITLE
Internal: Add `/canvas-capture-extension` skill

### DIFF
--- a/.agents/skills/canvas-capture-extension/SKILL.md
+++ b/.agents/skills/canvas-capture-extension/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: canvas-capture-extension
+description: Rebuild, install, and reload the private Remotion Canvas Capture unpacked Chrome extension. Use when the extension needs to be restored after a Codex worktree was deleted, rebuilt after source changes, moved to its durable install directory, or reloaded in Chrome or Chrome Canary.
+---
+
+# Canvas Capture Extension
+
+Build the extension from `packages/canvas-capture-extension`, but always install
+the unpacked copy outside the checkout so deleting a worktree cannot break it.
+
+## Rebuild and install
+
+1. Locate a Remotion checkout containing
+   `packages/canvas-capture-extension/package.json`. Prefer the current checkout;
+   otherwise use `/Users/jonathanburger/remotion`.
+2. Run:
+
+   ```bash
+   .agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh \
+     --repo <remotion-checkout>
+   ```
+
+   The script builds with Bun and installs the three unpacked-extension files in
+   `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
+
+3. Confirm that the installed directory contains `manifest.json`,
+   `background.js`, and `content.js`.
+
+## Reload in Chrome
+
+- Open `chrome://extensions` manually in Chrome or Chrome Canary.
+- Enable **Developer mode** on `chrome://extensions`.
+- If **Remotion Canvas Capture** already points to the durable directory, click
+  **Reload**.
+- If Chrome shows the deleted worktree path, remove that broken entry, choose
+  **Load unpacked**, and select:
+
+  ```text
+  /Users/jonathanburger/Applications/Remotion Canvas Capture Extension
+  ```
+
+  This one-time move changes the extension ID because Chrome derives unpacked
+  extension identity from its absolute path.
+
+- Keep loading future builds from the durable directory, never from a
+  worktree-local `dist` directory.
+- Enable `chrome://flags/#canvas-draw-element` and restart Chrome when the
+  experimental HTML-in-canvas API is unavailable.
+
+Do not edit Chrome's `Preferences` or `Secure Preferences` files to move or
+reload the extension, and do not automate the Chrome UI. Let the user use
+Chrome's extensions page so its integrity metadata stays valid.

--- a/.agents/skills/canvas-capture-extension/agents/openai.yaml
+++ b/.agents/skills/canvas-capture-extension/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Canvas Capture Extension'
+  short_description: 'Rebuild and reload the local Chrome extension'
+  default_prompt: 'Use $canvas-capture-extension to rebuild and reload the Remotion Canvas Capture extension.'

--- a/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
+++ b/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_dir=""
+install_dir="/Users/jonathanburger/Applications/Remotion Canvas Capture Extension"
+
+usage() {
+	printf '%s\n' "Usage: rebuild-extension.sh [--repo PATH] [--install-dir PATH]"
+}
+
+while (($# > 0)); do
+	case "$1" in
+	--repo)
+		repo_dir="${2:?--repo requires a path}"
+		shift 2
+		;;
+	--install-dir)
+		install_dir="${2:?--install-dir requires a path}"
+		shift 2
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		printf 'Unknown argument: %s\n' "$1" >&2
+		exit 1
+		;;
+	esac
+done
+
+if [[ -z "$repo_dir" ]]; then
+	candidate_repo="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+	if [[ -f "$candidate_repo/packages/canvas-capture-extension/package.json" ]]; then
+		repo_dir="$candidate_repo"
+	elif [[ -f /Users/jonathanburger/remotion/packages/canvas-capture-extension/package.json ]]; then
+		repo_dir="/Users/jonathanburger/remotion"
+	else
+		printf '%s\n' 'Could not find a Remotion checkout containing packages/canvas-capture-extension.' >&2
+		exit 1
+	fi
+fi
+
+package_dir="$repo_dir/packages/canvas-capture-extension"
+dist_dir="$package_dir/dist"
+
+if [[ ! -f "$package_dir/package.json" || ! -f "$package_dir/manifest.json" ]]; then
+	printf 'Not a canvas capture extension source directory: %s\n' "$package_dir" >&2
+	exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+	printf '%s\n' 'Bun is required to build the extension.' >&2
+	exit 1
+fi
+
+(
+	cd "$package_dir"
+	bun run make
+)
+
+for required_file in manifest.json background.js content.js; do
+	if [[ ! -f "$dist_dir/$required_file" ]]; then
+		printf 'Build did not produce %s\n' "$dist_dir/$required_file" >&2
+		exit 1
+	fi
+done
+
+mkdir -p "$install_dir"
+for extension_file in manifest.json background.js content.js; do
+	cp "$dist_dir/$extension_file" "$install_dir/$extension_file"
+done
+
+printf 'Installed Remotion Canvas Capture in %s\n' "$install_dir"
+printf '%s\n' 'Open chrome://extensions manually, then click Reload or choose Load unpacked for this directory.'


### PR DESCRIPTION
## Summary

- add an internal `$canvas-capture-extension` skill for restoring the unpacked Chrome extension after a worktree is removed
- add a deterministic rebuild script that copies the generated extension into `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`
- document the manual Chrome reload and one-time migration away from a deleted worktree path

## Testing

- rebuilt and installed the extension with the bundled script
- validated the skill with `quick_validate.py`
- `bash -n .agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh`
- `bun run build`
- `bun run stylecheck`
