### PR TITLE
`@remotion/studio`: Remove splitter hover state

### DIFF
--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -79,7 +79,6 @@ export const SplitterHandle: React.FC<{
 			forceSpecificCursor(
 				dragContext.orientation === 'horizontal' ? 'row-resize' : 'col-resize',
 			);
-			current.classList.add('remotion-splitter-active');
 
 			const getNewValue = (ev: PointerEvent, clamp: boolean) => {
 				if (!dragContext.ref.current) {
@@ -103,7 +102,6 @@ export const SplitterHandle: React.FC<{
 			endDrag = () => {
 				dragContext.isDragging.current = false;
 				stopForcingSpecificCursor();
-				current.classList.remove('remotion-splitter-active');
 				window.removeEventListener('pointermove', onPointerMove);
 				window.removeEventListener('pointerup', onPointerUp);
 				window.removeEventListener('pointercancel', onPointerCancel);
@@ -163,55 +161,6 @@ export const SplitterHandle: React.FC<{
 		return () => {
 			current.removeEventListener('pointerdown', onPointerDown);
 			endDrag?.();
-		};
-	}, []);
-
-	useEffect(() => {
-		const {current} = ref;
-		if (!current) {
-			return;
-		}
-
-		let isMouseDown = false;
-
-		const onMouseDown = () => {
-			isMouseDown = true;
-		};
-
-		const onMouseUp = () => {
-			isMouseDown = false;
-		};
-
-		const onMouseEnter = (e: MouseEvent) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			if (isMouseDown) {
-				return;
-			}
-
-			current.classList.add('remotion-splitter-hover');
-		};
-
-		const onMouseLeave = (e: MouseEvent) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			current.classList.remove('remotion-splitter-hover');
-		};
-
-		current.addEventListener('mouseenter', onMouseEnter);
-		current.addEventListener('mouseleave', onMouseLeave);
-		window.addEventListener('mousedown', onMouseDown);
-		window.addEventListener('mouseup', onMouseUp);
-
-		return () => {
-			current.removeEventListener('mouseenter', onMouseEnter);
-			current.removeEventListener('mouseleave', onMouseLeave);
-			window.removeEventListener('mousedown', onMouseDown);
-			window.removeEventListener('mouseup', onMouseUp);
 		};
 	}, []);
 

--- a/packages/studio/src/helpers/inject-css.ts
+++ b/packages/studio/src/helpers/inject-css.ts
@@ -11,11 +11,8 @@ import {
 } from './colors';
 
 const makeDefaultGlobalCSS = () => {
-	const unhoveredDragAreaFactor = 2;
-	const fromMiddle = 50 / unhoveredDragAreaFactor;
-
-	const hoveredDragAreaFactor = 6;
-	const fromMiddleHovered = 50 / hoveredDragAreaFactor;
+	const dragAreaFactor = 2;
+	const fromMiddle = 50 / dragAreaFactor;
 
 	return `
 	  html {
@@ -36,51 +33,27 @@ const makeDefaultGlobalCSS = () => {
   }
 
   .remotion-splitter-horizontal {
-	    transform: scaleY(${unhoveredDragAreaFactor});
-	    background: linear-gradient(
-	      to bottom,
-	      ${TRANSPARENT} ${50 - fromMiddle}%,
-	      ${BLACK} ${50 - fromMiddle}%,
-	      ${BLACK} ${50 + fromMiddle}%,
-	      ${TRANSPARENT} ${50 + fromMiddle}%
-	    );
-	  }
-
-  .remotion-splitter-horizontal.remotion-splitter-active, .remotion-splitter-horizontal.remotion-splitter-hover {
-	    background: linear-gradient(
-	      to bottom,
-	      ${TRANSPARENT} ${50 - fromMiddleHovered}%,
-	      var(--remotion-cli-internals-blue) ${50 - fromMiddleHovered}%,
-	      var(--remotion-cli-internals-blue) ${50 + fromMiddleHovered}%,
-	      ${TRANSPARENT} ${50 + fromMiddleHovered}%
-	    );
     cursor: row-resize;
-    transform: scaleY(${hoveredDragAreaFactor});
-    z-index: 1000;
+    transform: scaleY(${dragAreaFactor});
+    background: linear-gradient(
+      to bottom,
+      ${TRANSPARENT} ${50 - fromMiddle}%,
+      ${BLACK} ${50 - fromMiddle}%,
+      ${BLACK} ${50 + fromMiddle}%,
+      ${TRANSPARENT} ${50 + fromMiddle}%
+    );
   }
 
   .remotion-splitter-vertical {
-	    transform: scaleX(${unhoveredDragAreaFactor});
-	    background: linear-gradient(
-	      to right,
-	      ${TRANSPARENT} ${50 - fromMiddle}%,
-	      ${BLACK} ${50 - fromMiddle}%,
-	      ${BLACK} ${50 + fromMiddle}%,
-	      ${TRANSPARENT} ${50 + fromMiddle}%
-	    );
-	  }
-
-  .remotion-splitter-vertical.remotion-splitter-active, .remotion-splitter-vertical.remotion-splitter-hover {
-	    background: linear-gradient(
-	      to right,
-	      ${TRANSPARENT} ${50 - fromMiddleHovered}%,
-	      var(--remotion-cli-internals-blue) ${50 - fromMiddleHovered}%,
-	      var(--remotion-cli-internals-blue) ${50 + fromMiddleHovered}%,
-	      ${TRANSPARENT} ${50 + fromMiddleHovered}%
-	    );
-    transform: scaleX(${hoveredDragAreaFactor});
     cursor: col-resize;
-    z-index: 1000;
+    transform: scaleX(${dragAreaFactor});
+    background: linear-gradient(
+      to right,
+      ${TRANSPARENT} ${50 - fromMiddle}%,
+      ${BLACK} ${50 - fromMiddle}%,
+      ${BLACK} ${50 + fromMiddle}%,
+      ${TRANSPARENT} ${50 + fromMiddle}%
+    );
   }
 
   input::-webkit-outer-spin-button,


### PR DESCRIPTION
## Summary

- keep the existing thin black Studio splitter dividers
- remove the blue hover and active splitter styles
- remove the redundant hover state listeners and class toggles

## Testing

- `bun run build`
- `bun run stylecheck`
