### PR TITLE
`@remotion/bundler`: Resolve source stacks in Safari

### DIFF
--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -11,6 +11,48 @@ const originalCreateElement = React.createElement;
 const originalJsx = JsxRuntime.jsx;
 const originalJsxs = JsxRuntime.jsxs;
 const originalJsxDev = JsxRuntimeDev.jsxDEV;
+const originalSourcePrefix = 'browser-studio-original://';
+
+const getStack = (source: unknown): string | undefined => {
+	if (!source || typeof source !== 'object') {
+		return new Error().stack;
+	}
+
+	const {
+		fileName,
+		lineNumber,
+		columnNumber,
+	}: {
+		fileName?: unknown;
+		lineNumber?: unknown;
+		columnNumber?: unknown;
+	} = source;
+
+	if (
+		typeof fileName !== 'string' ||
+		typeof lineNumber !== 'number' ||
+		typeof columnNumber !== 'number'
+	) {
+		return new Error().stack;
+	}
+
+	const normalizedFileName = fileName.replaceAll('\\', '/');
+	const normalizedRoot = window.remotion_cwd
+		.replaceAll('\\', '/')
+		.replace(/\/$/, '');
+	const caseInsensitive = window.remotion_fileSystemPlatform === 'win32';
+	const comparableFileName = caseInsensitive
+		? normalizedFileName.toLowerCase()
+		: normalizedFileName;
+	const comparableRoot = caseInsensitive
+		? normalizedRoot.toLowerCase()
+		: normalizedRoot;
+	const sourceFileName = comparableFileName.startsWith(`${comparableRoot}/`)
+		? `./${normalizedFileName.slice(normalizedRoot.length + 1)}`
+		: normalizedFileName;
+
+	return `Error\n    at originalSource (${originalSourcePrefix}${encodeURIComponent(sourceFileName)}:${lineNumber}:${columnNumber})`;
+};
 
 const enableProxy = <
 	T extends
@@ -20,6 +62,7 @@ const enableProxy = <
 >(
 	api: T,
 	isCreateElement: boolean,
+	sourceArgumentIndex: number | null,
 ): T => {
 	return new Proxy(api, {
 		apply(target, thisArg, argArray) {
@@ -30,11 +73,13 @@ const enableProxy = <
 						? props?.children
 						: rest
 					: props?.children;
+				const source =
+					sourceArgumentIndex === null ? null : argArray[sourceArgumentIndex];
 				const newProps = props?.[internalStackProp]
 					? {...props}
 					: {
 							...(props ?? {}),
-							[internalStackProp]: new Error().stack,
+							[internalStackProp]: getStack(source),
 						};
 				if (first === sequenceComponent) {
 					newProps._remotionInternalSingleChildComponent =
@@ -49,7 +94,7 @@ const enableProxy = <
 	});
 };
 
-React.createElement = enableProxy(originalCreateElement, true);
-JsxRuntime.jsx = enableProxy(originalJsx, false);
-JsxRuntime.jsxs = enableProxy(originalJsxs, false);
-JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false);
+React.createElement = enableProxy(originalCreateElement, true, null);
+JsxRuntime.jsx = enableProxy(originalJsx, false, null);
+JsxRuntime.jsxs = enableProxy(originalJsxs, false, null);
+JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false, 4);

--- a/packages/example/e2e/safari-stack-resolution.test.mts
+++ b/packages/example/e2e/safari-stack-resolution.test.mts
@@ -1,0 +1,42 @@
+import {expect, test, webkit} from '@playwright/test';
+import {STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test('resolves editable component stacks in Safari', async () => {
+	await startStudio();
+	const browser = await webkit.launch({headless: true});
+
+	try {
+		const page = await browser.newPage();
+		const subscription = page.waitForRequest(
+			(request) => {
+				if (!request.url().includes('/api/subscribe-to-sequence-props')) {
+					return false;
+				}
+
+				const body = request.postDataJSON() as {fileName: string};
+				return body.fileName === './src/NewVideo.tsx';
+			},
+			{timeout: 15_000},
+		);
+
+		await page.goto(`${STUDIO_URL}/NewVideo`);
+		const request = await subscription;
+		const body = request.postDataJSON() as {
+			column: number;
+			componentIdentity: string;
+			fileName: string;
+			line: number;
+		};
+
+		expect(body).toMatchObject({
+			componentIdentity: 'dev.remotion.media.Video',
+			fileName: './src/NewVideo.tsx',
+		});
+		expect(body.line).toBeGreaterThan(0);
+		expect(body.column).toBeGreaterThan(0);
+	} finally {
+		await browser.close();
+		await stopStudio();
+	}
+});


### PR DESCRIPTION
## Summary

- use JSX development source metadata when capturing editable component locations
- normalize emitted source paths relative to the Remotion project
- add a WebKit regression test for sequence-props subscriptions

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/setup-sequence-stack-traces.test.ts` in `packages/bundler`
- `bunx playwright test e2e/safari-stack-resolution.test.mts` in `packages/example`

Closes #9960
