### PR TITLE
`@remotion/studio`: Layer modals above floating sidebars

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -24,6 +24,52 @@ test.describe('visual mode', () => {
 		});
 	});
 
+	test('should layer modals above floating sidebars', async ({page}) => {
+		await page.setViewportSize({width: 1000, height: 700});
+		await page.goto(STUDIO_URL);
+
+		const toggleLeftSidebar = page.locator('[data-sidebar-toggle="left"]');
+		const compositionsTab = page.getByText('Compositions', {exact: true});
+		const waitForZIndexEffects = () =>
+			page.evaluate(
+				() =>
+					new Promise<void>((resolve) => {
+						requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+					}),
+			);
+
+		await expect(toggleLeftSidebar).toBeVisible({timeout: 15_000});
+		await toggleLeftSidebar.click();
+		await expect(compositionsTab).toBeVisible();
+
+		await page.mouse.click(500, 250);
+		await expect(compositionsTab).toBeVisible();
+
+		await page.setViewportSize({width: 800, height: 700});
+		await expect(compositionsTab).toBeVisible();
+		await waitForZIndexEffects();
+
+		await page.getByRole('button', {name: /Search/}).click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		expect(
+			await page.evaluate(
+				() =>
+					document.elementFromPoint(100, 100)?.closest('[role="dialog"]') !==
+					null,
+			),
+		).toBe(true);
+		await waitForZIndexEffects();
+
+		await page.mouse.click(790, 690);
+		await expect(dialog).toBeHidden();
+		await expect(compositionsTab).toBeVisible();
+		await waitForZIndexEffects();
+
+		await page.mouse.click(500, 250);
+		await expect(compositionsTab).toBeHidden();
+	});
+
 	test('should navigate to schema-test composition', async ({page}) => {
 		await navigateToSchemaTest(page);
 	});

--- a/packages/studio/src/components/ModalContainer.tsx
+++ b/packages/studio/src/components/ModalContainer.tsx
@@ -6,6 +6,7 @@ import {
 	WHITE_ALPHA_20,
 } from '../helpers/colors';
 import {HigherZIndex} from '../state/z-index';
+import {TopmostPortal} from './TopmostPortal';
 
 const padding = 20;
 
@@ -50,7 +51,7 @@ export const ModalContainer: React.FC<{
 		e.stopPropagation();
 	}, []);
 
-	return (
+	const modal = (
 		<div
 			className="css-reset"
 			style={backgroundOverlay}
@@ -67,4 +68,6 @@ export const ModalContainer: React.FC<{
 			</HigherZIndex>
 		</div>
 	);
+
+	return <TopmostPortal disabled={Boolean(noZIndex)}>{modal}</TopmostPortal>;
 };

--- a/packages/studio/src/components/TopmostPortal.tsx
+++ b/packages/studio/src/components/TopmostPortal.tsx
@@ -1,0 +1,42 @@
+import React, {useLayoutEffect, useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
+import {ZIndexContextProvider, useZIndex} from '../state/z-index';
+import {getPortal} from './Menu/portals';
+
+export const TopmostPortal: React.FC<{
+	readonly children: React.ReactNode;
+	readonly disabled: boolean;
+}> = ({children, disabled}) => {
+	const {currentZIndex, highestZIndex} = useZIndex();
+	const [host] = useState(() => document.createElement('div'));
+	const parentIndex = useRef(Math.max(currentZIndex, highestZIndex));
+	const wasDisabled = useRef(disabled);
+
+	// Keep the portal container stable when toggling visibility. Moving the host
+	// preserves mounted children such as the Ask AI iframe.
+	if (!disabled && wasDisabled.current) {
+		parentIndex.current = Math.max(currentZIndex, highestZIndex);
+	}
+
+	wasDisabled.current = disabled;
+
+	useLayoutEffect(() => {
+		host.style.display = disabled ? 'none' : '';
+		if (!disabled) {
+			getPortal(parentIndex.current).appendChild(host);
+		}
+	}, [disabled, host]);
+
+	useLayoutEffect(() => {
+		return () => host.remove();
+	}, [host]);
+
+	return ReactDOM.createPortal(
+		<ZIndexContextProvider
+			currentIndex={disabled ? currentZIndex : parentIndex.current}
+		>
+			{children}
+		</ZIndexContextProvider>,
+		host,
+	);
+};

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -17,6 +17,19 @@ const ZIndexContext = createContext<ZIndex>({
 	currentIndex: 0,
 });
 
+export const ZIndexContextProvider: React.FC<{
+	readonly currentIndex: number;
+	readonly children: React.ReactNode;
+}> = ({currentIndex, children}) => {
+	const value = useMemo((): ZIndex => {
+		return {currentIndex};
+	}, [currentIndex]);
+
+	return (
+		<ZIndexContext.Provider value={value}>{children}</ZIndexContext.Provider>
+	);
+};
+
 const margin: React.CSSProperties = {
 	margin: 'auto',
 };
@@ -136,19 +149,13 @@ export const HigherZIndex: React.FC<{
 		outsideClickButton,
 	]);
 
-	const value = useMemo((): ZIndex => {
-		return {
-			currentIndex,
-		};
-	}, [currentIndex]);
-
 	return (
-		<ZIndexContext.Provider value={value}>
+		<ZIndexContextProvider currentIndex={currentIndex}>
 			{disabled ? null : <EscapeHook onEscape={onEscape} />}
 			<div ref={containerRef} style={margin}>
 				{children}
 			</div>
-		</ZIndexContext.Provider>
+		</ZIndexContextProvider>
 	);
 };
 


### PR DESCRIPTION
## Summary

- layer Studio modals above floating sidebars using the existing ordered portal system
- keep logical z-index handling aligned so outside clicks dismiss only the topmost surface
- preserve mounted modal content while hidden, including the Ask AI iframe
- cover docked and floating sidebar dismissal behavior with an end-to-end regression test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep 'should layer modals above floating sidebars'`
