### PR TITLE
Docs: document v5 Cloud Run maxInstances default

### DIFF
--- a/packages/docs/docs/cloudrun/cli/services/deploy.mdx
+++ b/packages/docs/docs/cloudrun/cli/services/deploy.mdx
@@ -85,7 +85,12 @@ Any running instances, even if they are not performing a render, will be billabl
 
 ## `--maxInstances`
 
-The maximum number of service instances that can be create by GCP in response to incoming requests. Default: 100.
+The maximum number of service instances that can be create by GCP in response to incoming requests.
+
+| Remotion Version | Default |
+| ---------------- | ------- |
+| &lt;5.0.0        | 100     |
+| &gt;=5.0.0       | 5       |
 
 ## `--timeoutSeconds`
 

--- a/packages/docs/docs/cloudrun/deployservice.mdx
+++ b/packages/docs/docs/cloudrun/deployservice.mdx
@@ -60,7 +60,7 @@ The maximum number of service instances that can be create by GCP in response to
 | &lt;5.0.0        | 100     |
 | &gt;=5.0.0       | 5       |
 
-In Remotion 5.0, the default was reduced because the previous value exceeded the Cloud Run quota on some GCP accounts and caused deployments to fail. If you want the old scaling limit, pass `maxInstances: 100`. See the [v5 migration guide](/docs/5-0-migration#cloud-run-services-use-a-lower-maximum-instance-count).
+In Remotion 5.0, the [default is reduced](/docs/5-0-migration#cloud-run-services-use-a-lower-maximum-instance-count) because the previous value exceeded the Cloud Run quota on some GCP accounts and caused deployments to fail.  
 
 [Read more about the maximum instance limit here](/docs/cloudrun/instancecount#maximum-instance-count)
 

--- a/packages/docs/docs/cloudrun/deployservice.mdx
+++ b/packages/docs/docs/cloudrun/deployservice.mdx
@@ -53,7 +53,16 @@ Any running instances, even if they are not performing a render, will be billabl
 
 ### `maxInstances`
 
-The maximum number of service instances that can be create by GCP in response to incoming requests. The default is 100. [Read more about the maximum instance limit here](/docs/cloudrun/instancecount#maximum-instance-count)
+The maximum number of service instances that can be create by GCP in response to incoming requests.
+
+| Remotion Version | Default |
+| ---------------- | ------- |
+| &lt;5.0.0        | 100     |
+| &gt;=5.0.0       | 5       |
+
+In Remotion 5.0, the default was reduced because the previous value exceeded the Cloud Run quota on some GCP accounts and caused deployments to fail. If you want the old scaling limit, pass `maxInstances: 100`. See the [v5 migration guide](/docs/5-0-migration#cloud-run-services-use-a-lower-maximum-instance-count).
+
+[Read more about the maximum instance limit here](/docs/cloudrun/instancecount#maximum-instance-count)
 
 ### `timeoutSeconds`
 

--- a/packages/docs/docs/cloudrun/instancecount.mdx
+++ b/packages/docs/docs/cloudrun/instancecount.mdx
@@ -25,7 +25,14 @@ Any running instances, even if they are not performing a render, will be billabl
 
 ### Maximum instance count
 
-This is the maximum number of instances that can be created at one time, with the default set to 100. The maximum that can be set in GCP is also 100 - [more information around limits can be found here](https://cloud.google.com/run/docs/configuring/max-instances#limits). If the maximum number of instances is exceeded, further requests will fail with a `503 service unavailable` response. GCP provides Cloud Tasks for queueing requests, [which can be used in conjunction with Cloud Run](https://cloud.google.com/run/docs/triggering/using-tasks).
+This is the maximum number of instances that can be created at one time.
+
+| Remotion Version | Default |
+| ---------------- | ------- |
+| &lt;5.0.0        | 100     |
+| &gt;=5.0.0       | 5       |
+
+The maximum that can be set in GCP is also 100 - [more information around limits can be found here](https://cloud.google.com/run/docs/configuring/max-instances#limits). If the maximum number of instances is exceeded, further requests will fail with a `503 service unavailable` response. GCP provides Cloud Tasks for queueing requests, [which can be used in conjunction with Cloud Run](https://cloud.google.com/run/docs/triggering/using-tasks).
 
 :::note
 You may wish to provide a low maximum instance limit for certain tiers of your product, and have a higher instance limit for higher tier plans. This can be achieved by deploying multiple Cloud Run services and calling them within your product as required.


### PR DESCRIPTION
## Problem

Cloud Run documentation still states the default `maxInstances` is `100` in three places (`instancecount.mdx`, `deployservice.mdx`, CLI `deploy.mdx`), but Remotion 5 changed the default to `5` (`DEFAULT_MAX_INSTANCES` in `@remotion/cloudrun`). The v5 migration guide documents the change, but the Cloud Run reference pages do not — contributors following those pages get the wrong default.

Self-sourced docs drift fix.

## Triage / Root cause

`packages/cloudrun/src/shared/constants.ts` sets `DEFAULT_MAX_INSTANCES` to `5` when `ENABLE_V5_BREAKING_CHANGES` is true, otherwise `100`. The Cloud Run docs were never updated after the v5 migration entry landed.

## Fix

- Replace hardcoded "default 100" with a version table (`<5.0.0` → 100, `>=5.0.0` → 5) in all three Cloud Run docs that describe `maxInstances`.
- In `deployservice.mdx`, add a short note linking to the [v5 migration section](/docs/5-0-migration#cloud-run-services-use-a-lower-maximum-instance-count) and how to restore `maxInstances: 100`.

## Verification

```bash
python3 ../open-source/scripts/preflight_ship.py \
  --repo remotion-dev/remotion \
  --local . \
  --branch main \
  --file packages/docs/docs/cloudrun/instancecount.mdx \
  --must-contain 'with the default set to 100' \
  --must-not-contain '>=5.0.0' \
  --search 'cloudrun maxInstances default in:title,body'
# PREFLIGHT CLEAR

cd packages/docs && bun test src
# 137 pass
```

## Notes / Risks

- Docs-only; no runtime behavior change.
- Aligns with existing open PRs documenting other v5 defaults (#9963, #9757).