### PR TITLE
docs: document v5 Skia rendering defaults in skia.mdx

### DIFF
--- a/packages/docs/docs/skia/skia.mdx
+++ b/packages/docs/docs/skia/skia.mdx
@@ -110,6 +110,12 @@ pnpm create video --skia
 
 ## Rendering
 
+### Remotion 5.0
+
+In Remotion 5.0, headless rendering uses the [`angle`](/docs/gl-options) OpenGL backend by default, so you do not need to pass [`--gl=angle`](/docs/cli/render#--gl) for Skia exports. Some Skia effects still rely on advanced GPU features; if performance is poor on a machine without a compatible GPU, see [Using the GPU](/docs/gpu) and [Using WebGL and WebGPU during renders](/docs/webgl).
+
+### Remotion 4.0
+
 By default Remotion rendering are done on the CPU. Some Skia effects rely on advanced GPU features, which may be slow to run on the CPU depending on the kind of effect you are using. If your Skia export is extremely slow, we found that enabling the GPU via the `--gl=angle` option improves things substantially. Please check out the documentation on [GPU rendering](/docs/gpu).
 
 ```sh


### PR DESCRIPTION
## Problem

`packages/docs/docs/skia/skia.mdx` still tells readers to pass `--gl=angle` to enable GPU acceleration for Skia exports. That guidance matches Remotion 4.0 but contradicts Remotion 5.0, where ANGLE is already the default headless renderer (see `webgl.mdx` and `5-0-migration.mdx`).

Follow-up for #9524 — the `skia/skia.mdx` item listed under "Remaining after #9949".

## Triage / Root cause

The canonical v5 renderer docs landed in #9949, and #9963 updates `gpu.mdx`, but `skia/skia.mdx` was not updated and still reads as if `--gl=angle` is required setup for Skia exports.

## Fix

- Add a **Remotion 5.0** subsection explaining ANGLE is the default and `--gl=angle` is no longer required for Skia exports.
- Move the existing CPU/`--gl=angle` guidance under **Remotion 4.0** unchanged.

## Verification

- `python3 scripts/preflight_ship.py` — clear against current `upstream/main`
- `bun run stylecheck` — 245 tasks, exit 0
- `/home/ubuntu/fleet-ops/scripts/check-existing-pr.sh remotion-dev/remotion "skia.mdx v5 angle" --branch docs/v5-skia-angle-default` — exit 0

## Notes / Risks

- Complements open #9963 (`gpu.mdx`); does not overlap file scope.
- Local Linux pre-commit hook hits a known Bun `ENOENT` on `--filter docs format`; formatting was run manually in `packages/docs` and full `stylecheck` passed.