### PR TITLE
docs: document v5 maps rendering defaults in maps.mdx

### DIFF
--- a/packages/docs/docs/maps.mdx
+++ b/packages/docs/docs/maps.mdx
@@ -292,6 +292,16 @@ map.addLayer({
 
 ## Rendering
 
+### Remotion 5.0
+
+In Remotion 5.0, headless rendering uses the [`angle`](/docs/gl-options) OpenGL backend by default, so you do not need to pass [`--gl=angle`](/docs/cli/render#--gl) for map animations. Use single concurrency for WebGL-heavy map renders:
+
+```sh
+npx remotion render <composition-id> out/video.mp4 --concurrency=1
+```
+
+### Remotion 4.0
+
 Render map animations with [`--gl=angle`](/docs/gl-options) to enable the GPU. Use single concurrency for WebGL-heavy map renders:
 
 ```sh


### PR DESCRIPTION
## Problem

`maps.mdx` still tells all users to pass `--gl=angle` to enable GPU rendering for map animations. In Remotion 5.0, headless rendering defaults to the `angle` OpenGL backend, so this flag is redundant for v5 users.

Part of the remaining work tracked in #9524 (maps.mdx checklist item).

## Triage / Root cause

The Rendering section in `packages/docs/docs/maps.mdx` predates the v5 ANGLE default (#9498 / #9536). Sibling pages (`gpu.mdx`, `skia.mdx`) already have v5 subsections in open PRs; maps was still version-neutral.

## Fix

- Add a **Remotion 5.0** subsection: note `angle` is the default, show render command without `--gl=angle`, keep `--concurrency=1` for WebGL-heavy maps.
- Retitle existing guidance as **Remotion 4.0** (unchanged content).

## Verification

- `bun run stylecheck` — exit 0
- Preflight against `upstream/main`: bug marker present, fix marker absent, no maps-specific duplicate PR

## Notes / Risks

- Docs-only; no runtime behavior change.
- Related open PRs on the same tracking issue: #9963 (gpu.mdx), #9969 (skia.mdx) — separate files, no overlap.