### PR TITLE
docs: document v5 visualizeAudio optimizeFor default

### DIFF
--- a/packages/docs/docs/visualize-audio.mdx
+++ b/packages/docs/docs/visualize-audio.mdx
@@ -49,6 +49,8 @@ _`"accuracy" | "speed"`_
 
 Default `"accuracy"`. When set to `"speed"`, a faster Fast Fourier transform is used. Recommended for Remotion Lambda and when using a high number of samples. Read [user](https://discord.com/channels/809501355504959528/1189048518988550264/1190228606287360030) [experiences](https://discord.com/channels/809501355504959528/1155110845488046111/1155111360481480725) [here](https://github.com/remotion-dev/remotion/issues/2925).
 
+From [v5.0](/docs/5-0-migration), the default value changes from `"accuracy"` to `"speed"`.
+
 ### `dataOffsetInSeconds`<AvailableFrom v="4.0.268" />
 
 The amount of seconds the audio is offset, pass this parameter if you are using [`useWindowedAudioData()`](/docs/use-windowed-audio-data).


### PR DESCRIPTION
## Problem

The [`visualizeAudio()`](/docs/visualize-audio) docs still describe `"accuracy"` as the default for `optimizeFor`, but Remotion 5.0 switches the default to `"speed"` (see [`5-0-migration`](/docs/5-0-migration) and `packages/media-utils/src/visualize-audio.ts`).

Self-sourced docs drift fix.

## Triage / Root cause

In `visualizeAudio()`, the default is chosen from `ENABLE_V5_BREAKING_CHANGES`:

```ts
optimizeFor = NoReactInternals.ENABLE_V5_BREAKING_CHANGES ? 'speed' : 'accuracy'
```

The option page did not mention the v5 default change, unlike other v5 default updates (e.g. `premountFor` on the Sequence docs).

## Fix

Add the same v5 migration note used on [`sequence.mdx`](/docs/sequence#premountfor) under the `optimizeFor` option in `visualize-audio.mdx`.

## Verification

- Preflight: `scripts/preflight_ship.py` against `upstream/main` — bug marker present, no duplicate PRs
- `bun run stylecheck` — 245 tasks passed (includes `docs:lint` + `docs:formatting`)

## Notes / Risks

Docs-only change; no runtime behavior change.