### PR TITLE
docs: document v5 premountFor default on Series.Sequence

### DIFF
--- a/packages/docs/docs/series.mdx
+++ b/packages/docs/docs/series.mdx
@@ -102,6 +102,7 @@ Whether this sequence should be shown in the timeline in the Studio. See [`showI
 ### `premountFor?`<AvailableFrom v="4.0.140"/>
 
 [Premount](/docs/player/premounting) the sequence for a set number of frames.
+From [v5.0](/docs/5-0-migration), the default value changes from `0` to `fps` (1 second).
 
 ### `ref?`<AvailableFrom v="3.3.4" />
 


### PR DESCRIPTION
## Problem

[`series.mdx`](/docs/series) documents `premountFor` on `<Series.Sequence>` but does not mention the Remotion 5.0 default. [`sequence.mdx`](/docs/sequence) and [`5-0-migration.mdx`](/docs/5-0-migration) already state that v5 changes the default from `0` to `fps` (1 second). Because `<Series.Sequence>` inherits from `<Sequence>`, readers of the Series docs miss this behavior change.

Self-sourced docs drift.

## Triage / Root cause

In v5, `Sequence.tsx` sets `effectivePremountFor = props.premountFor ?? fps` when v5 breaking changes are enabled. The migration guide and `sequence.mdx` document this, but `series.mdx` only says premounting is available without noting the new default.

## Fix

- Add the same v5.0 default note under `<Series.Sequence>` `premountFor`, matching `sequence.mdx`.

## Verification

- `python3 preflight_ship.py` against `upstream/main` (pass — fix marker absent on upstream)
- `bun run stylecheck` (245 tasks, all passed)

## Notes / Risks

- Docs-only change; no runtime behavior change.
- `<TransitionSeries.Sequence>` already links to `sequence#premountfor` for this prop.