### PR TITLE
docs: document v5 buffer-state defaults in buffer-state guide

### DIFF
--- a/packages/docs/docs/player/buffer-state.mdx
+++ b/packages/docs/docs/player/buffer-state.mdx
@@ -319,11 +319,11 @@ const MyApp: React.FC = () => {
 };
 ```
 
-## Upcoming changes in Remotion 5.0
+## Remotion 5.0
 
-In Remotion 5.0, it is planned that `<Html5Audio>`, `<Html5Video>`, and `<OffthreadVideo>` will automatically use the buffer state, but they can opt out of it.
+In Remotion 5.0, [`<Html5Audio>`](/docs/html5-audio), [`<Html5Video>`](/docs/html5-video), [`<OffthreadVideo>`](/docs/offthreadvideo), and [`<Img>`](/docs/img) automatically use the buffer state by default. Pass [`pauseWhenBuffering={false}`](/docs/html5-video#pausewhenbuffering) on video and audio components or [`pauseWhenLoading={false}`](/docs/img#pausewhenloading) on `<Img>` to opt out. See the [migration guide](/docs/5-0-migration).
 
-This does not change the behavior of [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), which already use the buffer state by default in Remotion 4.0.
+This does not change the behavior of [`<Video>`](/docs/media/video) and [`<Audio>`](/docs/media/audio) from [`@remotion/media`](/docs/media), which already use the buffer state by default since they were introduced.
 
 ## See also
 


### PR DESCRIPTION
## Problem

[`buffer-state.mdx`](/docs/player/buffer-state) still had an **"Upcoming changes in Remotion 5.0"** section describing `pauseWhenBuffering` / buffer-state integration as planned future work. The v5 migration guide and component docs (`html5-video.mdx`, `offthreadvideo.mdx`, `html5-audio.mdx`, `img.mdx`) already document the shipped defaults.

Self-sourced docs drift fix.

## Triage / Root cause

The buffer-state guide was written before v5 defaults were finalized and never updated when the migration guide and per-component pages were brought in line.

## Fix

- Rename the section to **Remotion 5.0** and document that `<Html5Audio>`, `<Html5Video>`, `<OffthreadVideo>`, and `<Img>` use the buffer state by default in v5.
- Link the opt-out props and the [v5 migration guide](/docs/5-0-migration).
- Clarify that `@remotion/media` `<Video>` / `<Audio>` behavior is unchanged (buffer state since introduction).

## Verification

- Preflight: confirmed stale `Upcoming changes in Remotion 5.0` text on `upstream/main`.
- Duplicate guard: `/home/ubuntu/fleet-ops/scripts/check-existing-pr.sh remotion-dev/remotion "buffer-state v5 pauseWhenBuffering defaults" --branch docs/v5-buffer-state-defaults` → exit 0.
- Diff reviewed against `packages/docs/docs/5-0-migration.mdx` media/buffer section.

## Notes / Risks

Docs-only; no runtime change. No overlapping open PR on this file.