### PR TITLE
Docs: document v5 TransitionSeries layout="none" removal

### DIFF
--- a/packages/docs/docs/transitions/transitionseries.mdx
+++ b/packages/docs/docs/transitions/transitionseries.mdx
@@ -85,13 +85,16 @@ export const OverlayExample: React.FC = () => {
 
 Inherits the [`from`](/docs/sequence#from), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), and [`style`](/docs/sequence#style) props from [`<Sequence>`](/docs/sequence).
 
-The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>`, `<TransitionSeries.Transition>`, and `<TransitionSeries.Overlay>` components.
+The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>`, `<TransitionSeries.Transition>`, and `<TransitionSeries.Overlay>` components.  
+`layout="none"` is deprecated and throws from Remotion 5.0.0 on.  
+Transition scenes must stay absolutely positioned. Remove the `layout` prop or keep the default `absolute-fill`. See the [v5 migration guide](/docs/5-0-migration).
 
 ### `<TransitionSeries.Sequence>`
 
-Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
+Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`premountFor`](/docs/sequence#premountfor) and [`postmountFor`](/docs/sequence#postmountfor) props from [`<Sequence>`](/docs/sequence).
 
-From <AvailableFrom v="5.0.0" inline />, `layout="none"` is not supported on `<TransitionSeries>` or `<TransitionSeries.Sequence>`. Transition scenes must stay absolutely positioned. Remove the `layout` prop or keep the default `absolute-fill`. See the [v5 migration guide](/docs/5-0-migration).
+`layout="none"` is deprecated and throws from Remotion 5.0.0 on.  
+Transition scenes must stay absolutely positioned. Remove the `layout` prop or keep the default `absolute-fill`. See the [v5 migration guide](/docs/5-0-migration).
 
 The [`trimBefore`](/docs/sequence#trimbefore) prop is supported from <AvailableFrom v="4.0.497" inline />.
 

--- a/packages/docs/docs/transitions/transitionseries.mdx
+++ b/packages/docs/docs/transitions/transitionseries.mdx
@@ -91,6 +91,8 @@ The `<TransitionSeries>` component can only contain `<TransitionSeries.Sequence>
 
 Inherits the [`durationInFrames`](/docs/sequence#durationinframes), [`name`](/docs/sequence#name), [`className`](/docs/sequence#classname), [`style`](/docs/sequence#style), [`showInTimeline`](/docs/sequence#showintimeline), [`freeze`](/docs/sequence#freeze), [`premountFor`](/docs/sequence#premountfor), [`postmountFor`](/docs/sequence#postmountfor) and [`layout`](/docs/sequence#layout) props from [`<Sequence>`](/docs/sequence).
 
+From <AvailableFrom v="5.0.0" inline />, `layout="none"` is not supported on `<TransitionSeries>` or `<TransitionSeries.Sequence>`. Transition scenes must stay absolutely positioned. Remove the `layout` prop or keep the default `absolute-fill`. See the [v5 migration guide](/docs/5-0-migration).
+
 The [`trimBefore`](/docs/sequence#trimbefore) prop is supported from <AvailableFrom v="4.0.497" inline />.
 
 As children, put the contents of your scene.


### PR DESCRIPTION
## Problem

`<TransitionSeries>` and `<TransitionSeries.Sequence>` inherit the `layout` prop from `<Sequence>`, but in Remotion 5.0 passing `layout="none"` throws at runtime. The dedicated transitionseries doc did not mention this v5 break, so readers could copy a valid-looking Sequence pattern and hit a TypeError.

## Triage / Root cause

In v5, `TransitionSeries` enforces absolute positioning and rejects any `layout` value other than `absolute-fill` (`packages/transitions/src/TransitionSeries.tsx`). The migration guide already documents the break, but `packages/docs/docs/transitions/transitionseries.mdx` only listed `layout` as an inherited prop.

## Fix

- Add a v5 note under `<TransitionSeries.Sequence>` explaining that `layout="none"` is unsupported.
- Point readers to the v5 migration guide for the required action (remove the prop).

## Verification

- `~/.bun/bin/bun test packages/docs/src/test` — 137 pass, 0 fail
- `python3 /home/ubuntu/Projects/open-source/scripts/preflight_ship.py --repo remotion-dev/remotion --local /home/ubuntu/Projects/open-source/remotion --branch main --file packages/docs/docs/transitions/transitionseries.mdx --must-not-contain 'layout="none" is not supported on \`<TransitionSeries>\`' --search 'TransitionSeries layout none v5'`

## Notes / Risks

Docs-only, one file, one logical change. No runtime behavior change.