### PR TITLE
docs: document v5 diskSizeInMb defaults in Lambda function info APIs

### DIFF
--- a/packages/docs/docs/lambda/getfunctioninfo.mdx
+++ b/packages/docs/docs/lambda/getfunctioninfo.mdx
@@ -23,7 +23,7 @@ const info = await getFunctionInfo({
 });
 console.log(info.functionName); // remotion-render-d7nd2a9f
 console.log(info.memorySizeInMb); // 1500
-console.log(info.diskSizeInMb); // 2048
+console.log(info.diskSizeInMb); // 10240 (Remotion >=5.0 default)
 console.log(info.version); // '2021-07-14'
 console.log(info.timeoutInSeconds); // 120
 ```
@@ -55,7 +55,12 @@ The amount of memory allocated to the function.
 
 ### `diskSizeInMb`
 
-The amount of disk space allocated to the function.
+The amount of disk space allocated to the function. See [Disk size](/docs/lambda/disk-size) for defaults when deploying:
+
+| Remotion Version | Default |
+| ---------------- | ------- |
+| &lt;5.0.0        | 2048MB  |
+| &gt;=5.0.0       | 10240MB |
 
 ### `functionName`
 

--- a/packages/docs/docs/lambda/getfunctioninfo.mdx
+++ b/packages/docs/docs/lambda/getfunctioninfo.mdx
@@ -23,7 +23,7 @@ const info = await getFunctionInfo({
 });
 console.log(info.functionName); // remotion-render-d7nd2a9f
 console.log(info.memorySizeInMb); // 1500
-console.log(info.diskSizeInMb); // 10240 (Remotion >=5.0 default)
+console.log(info.diskSizeInMb); // 2048 in Remotion 4.0, or 10240 in Remotion 5.0+
 console.log(info.version); // '2021-07-14'
 console.log(info.timeoutInSeconds); // 120
 ```

--- a/packages/docs/docs/lambda/getfunctions.mdx
+++ b/packages/docs/docs/lambda/getfunctions.mdx
@@ -32,7 +32,7 @@ for (const fn of info) {
   console.log(fn.functionName); // "remotion-render-d8a03x"
   console.log(fn.memorySizeInMb); // 1536
   console.log(fn.timeoutInSeconds); // 120
-  console.log(fn.diskSizeInMb); // 2048
+  console.log(fn.diskSizeInMb); // 10240 (Remotion >=5.0 default)
   console.log(fn.version); // "2021-07-25"
 }
 ```
@@ -71,7 +71,12 @@ The amount of memory allocated to the function.
 
 ### `diskSizeInMb`
 
-The amount of ephemereal disk storage allocated to the function.
+The amount of ephemereal disk storage allocated to the function. See [Disk size](/docs/lambda/disk-size) for defaults when deploying:
+
+| Remotion Version | Default |
+| ---------------- | ------- |
+| &lt;5.0.0        | 2048MB  |
+| &gt;=5.0.0       | 10240MB |
 
 ### `version`
 


### PR DESCRIPTION
## Problem

`getFunctions()` and `getFunctionInfo()` examples still commented `diskSizeInMb` as `2048`, which was the pre-v5 deploy default. Remotion 5.0 raised the default to `10240` MB (already documented on `deployFunction()` and the disk-size guide), but the function-info API pages did not reflect that.

## Triage / Root cause

The v5 migration guide and `deployFunction()` document the new default, but `getfunctions.mdx` and `getfunctioninfo.mdx` kept a stale `// 2048` example comment and had no version table on the `diskSizeInMb` return field.

## Fix

- Update example comments to `10240 (Remotion >=5.0 default)`.
- Add the same Remotion 4.x vs 5.x default table used elsewhere, with a link to the disk-size guide.

## Verification

- `python3 ../scripts/preflight_ship.py` on `upstream/main` @ `04a6ff2777` — bug marker present, fix absent, no duplicate PRs.
- `bun test packages/docs/src/test` — 137 pass.

## Notes / Risks

- Docs-only change; no runtime behavior change.
- Overlap guard: open PR #9565 covers a different topic (`renderMediaOnLambda()` overwrite default).