### PR TITLE
Docs: Fix extractAudio docs for v5 getVideoMetadata removal

### DIFF
--- a/packages/docs/docs/renderer/extract-audio.mdx
+++ b/packages/docs/docs/renderer/extract-audio.mdx
@@ -42,7 +42,7 @@ The path to the video source from which the audio will be extracted.
 
 _string_
 
-The path where the extracted audio will be saved. The file extension must match the audio codec. In Remotion 5, [`getVideoMetadata()` from `@remotion/renderer`](/docs/5-0-migration#getvideometadata-has-been-removed-from-remotionrenderer) has been removed — use [Mediabunny to get video metadata](/docs/mediabunny/metadata) to determine the appropriate file extension.
+The path where the extracted audio will be saved. The file extension must match the audio codec. Use [Mediabunny to get video metadata](/docs/mediabunny/metadata) to determine the container and therefore the appropriate file extension.
 
 ### `logLevel?`
 

--- a/packages/docs/docs/renderer/extract-audio.mdx
+++ b/packages/docs/docs/renderer/extract-audio.mdx
@@ -13,12 +13,10 @@ Extracts the audio from a video source and saves it to the specified output path
 
 ```ts twoslash
 import {resolve} from 'node:path';
-import {extractAudio, getVideoMetadata} from '@remotion/renderer';
+import {extractAudio} from '@remotion/renderer';
 
 const videoSource = resolve(process.cwd(), '/Users/john/path-to-video.mp4');
-
-const videoMetadata = await getVideoMetadata(videoSource);
-const audioOutput = resolve(process.cwd(), `./output-audio-path.${videoMetadata.audioFileExtension}`);
+const audioOutput = resolve(process.cwd(), './output-audio-path.mp3');
 
 await extractAudio({
   videoSource,
@@ -40,11 +38,11 @@ _string_
 
 The path to the video source from which the audio will be extracted.
 
-### `outputPath`
+### `audioOutput`
 
 _string_
 
-The path where the extracted audio will be saved. The file extension must match the audio codec. To find the appropriate file extension, use [`getVideoMetadata()`](/docs/renderer/get-video-metadata) to read the field `audioFileExtension`.
+The path where the extracted audio will be saved. The file extension must match the audio codec. In Remotion 5, [`getVideoMetadata()` from `@remotion/renderer`](/docs/5-0-migration#getvideometadata-has-been-removed-from-remotionrenderer) has been removed — use [Mediabunny to get video metadata](/docs/mediabunny/metadata) to determine the appropriate file extension.
 
 ### `logLevel?`
 
@@ -65,4 +63,4 @@ The function returns a `Promise<void>`, which resolves once the audio extraction
 ## See also
 
 - [Source code for this function](https://github.com/remotion-dev/remotion/blob/main/packages/renderer/src/extract-audio.ts)
-- [`getVideoMetadata()`](/docs/renderer/get-video-metadata)
+- [Getting metadata using Mediabunny](/docs/mediabunny/metadata)


### PR DESCRIPTION
## Problem

[`extract-audio.mdx`](/docs/renderer/extract-audio) still showed an example importing `getVideoMetadata` from `@remotion/renderer` to derive the output file extension. That API throws in Remotion 5 (see [migration guide](/docs/5-0-migration#getvideometadata-has-been-removed-from-remotionrenderer)). The Arguments section also documented the wrong property name (`outputPath` instead of `audioOutput`).

Self-sourced docs drift fix.

## Triage / Root cause

The page was written when `getVideoMetadata()` from `@remotion/renderer` was the documented way to read `audioFileExtension`. v5 removed that export; the extract-audio docs were never updated.

## Fix

- Remove the `getVideoMetadata` import from the example and use a concrete output path.
- Rename the documented argument from `outputPath` to `audioOutput` to match the API.
- Point readers at Mediabunny and the v5 migration guide instead of the deprecated renderer page.

## Verification

- Preflight: confirmed stale example on `upstream/main`; fix marker absent.
- Duplicate guard: `check-existing-pr.sh remotion-dev/remotion "extract-audio getVideoMetadata stale" --branch docs/v5-getvideometadata-stale-refs` → exit 0.
- `bun run stylecheck` → 245 tasks successful.

## Notes / Risks

Docs-only; no runtime change. Other pages still link to `/docs/renderer/get-video-metadata` — follow-up PRs can update those separately.