### PR TITLE
Skills: Fix ambiguous embedded skill links

### DIFF
--- a/packages/skills/scripts/sync-embedded-skills.ts
+++ b/packages/skills/scripts/sync-embedded-skills.ts
@@ -70,7 +70,11 @@ for (const {parentSkill, skillNames} of embeddedSkillSets) {
 	for (const skillName of skillNames) {
 		skillContents = skillContents.replaceAll(
 			`../${skillName}/`,
-			`${skillName}/`,
+			`./${skillName}/`,
+		);
+		skillContents = skillContents.replaceAll(
+			`](${skillName}/`,
+			`](./${skillName}/`,
 		);
 	}
 

--- a/packages/skills/scripts/validate-links.ts
+++ b/packages/skills/scripts/validate-links.ts
@@ -176,18 +176,33 @@ const validateEmbeddedSkills = () => {
 
 		const parentSkillFile = path.join(parentRoot, 'SKILL.md');
 		const contents = readFileSync(parentSkillFile, 'utf-8');
-		const siblingSkillLinks = [...contents.matchAll(markdownLinkRegex)]
-			.map((match) => stripMarkdownTitle(match[1] as string))
-			.filter((link) =>
-				skillNames.some((skillName) => link.startsWith(`../${skillName}/`)),
-			);
+		const links = [...contents.matchAll(markdownLinkRegex)].map((match) =>
+			stripMarkdownTitle(match[1] as string),
+		);
 
-		for (const link of siblingSkillLinks) {
-			issues.push({
-				file: parentSkillFile,
-				link,
-				message: `Link from ${parentSkill} should point to the embedded copy, not a sibling skill folder`,
-			});
+		for (const link of links) {
+			const siblingSkill = skillNames.find((skillName) =>
+				link.startsWith(`../${skillName}/`),
+			);
+			if (siblingSkill) {
+				issues.push({
+					file: parentSkillFile,
+					link,
+					message: `Link from ${parentSkill} should point to the embedded copy, not a sibling skill folder`,
+				});
+				continue;
+			}
+
+			const ambiguousSkill = skillNames.find((skillName) =>
+				link.startsWith(`${skillName}/`),
+			);
+			if (ambiguousSkill) {
+				issues.push({
+					file: parentSkillFile,
+					link,
+					message: `Link to embedded skill "${ambiguousSkill}" must start with "./" so it resolves relative to ${parentSkill}`,
+				});
+			}
 		}
 	}
 

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -8,40 +8,40 @@ metadata:
 
 ## New project setup
 
-If no Remotion project currently exists, load [Create a new Remotion project](remotion-create/SKILL.md)
+If no Remotion project currently exists, load [Create a new Remotion project](./remotion-create/SKILL.md)
 
 ## React Markup Best Practices
 
-If you are writing Remotion React Markup, load [Remotion Markup Best Practices](remotion-markup/SKILL.md)
+If you are writing Remotion React Markup, load [Remotion Markup Best Practices](./remotion-markup/SKILL.md)
 
 ## Maps
 
-For static maps, animated routes and markers, geographic explainers, Mapbox, MapLibre, MapTiler, GeoJSON, or 3D geographic flyovers, load [Remotion Maps](remotion-maps/SKILL.md).
+For static maps, animated routes and markers, geographic explainers, Mapbox, MapLibre, MapTiler, GeoJSON, or 3D geographic flyovers, load [Remotion Maps](./remotion-maps/SKILL.md).
 
 ## Multimedia
 
-For achieving multimedia tasks in the browser, such as trimming, cropping videos, or getting metadata from them, load [Remotion Multimedia](remotion-multimedia/SKILL.md)
+For achieving multimedia tasks in the browser, such as trimming, cropping videos, or getting metadata from them, load [Remotion Multimedia](./remotion-multimedia/SKILL.md)
 
 ## Improving Interactivity
 
-By structuring the Remotion markup well, we can allow users to interactively change things in the Studio and write back to code. If relevant: [Interactivity Best Practices](remotion-interactivity/SKILL.md)
+By structuring the Remotion markup well, we can allow users to interactively change things in the Studio and write back to code. If relevant: [Interactivity Best Practices](./remotion-interactivity/SKILL.md)
 
 ## Rendering
 
-For advanced rendering beyond simple `npx remotion render`, see: [Rendering Best Practices](remotion-render/SKILL.md)
+For advanced rendering beyond simple `npx remotion render`, see: [Rendering Best Practices](./remotion-render/SKILL.md)
 
 ## Captions
 
-When working with Captions, load [Remotion Captions](remotion-captions/SKILL.md).
+When working with Captions, load [Remotion Captions](./remotion-captions/SKILL.md).
 
 ## Creating a SaaS, automation or application
 
-Use the [Remotion SaaS skill](remotion-saas/SKILL.md) for knowledge about Remotion-powered SaaS apps, such as `<Player>`, rendering on Lambda, Vercel, Cloudflare, via Express.js, client-side rendering, or for finding the right SaaS template.
+Use the [Remotion SaaS skill](./remotion-saas/SKILL.md) for knowledge about Remotion-powered SaaS apps, such as `<Player>`, rendering on Lambda, Vercel, Cloudflare, via Express.js, client-side rendering, or for finding the right SaaS template.
 
 ## Looking up Remotion APIs and documentation
 
-To find and read current Remotion documentation, load [Remotion Docs](remotion-docs/SKILL.md).
+To find and read current Remotion documentation, load [Remotion Docs](./remotion-docs/SKILL.md).
 
 ## Upgrading
 
-To upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills, load [Remotion Upgrade](remotion-upgrade/SKILL.md).
+To upgrade Remotion, related packages, compatible Mediabunny packages, and installed Remotion Agent Skills, load [Remotion Upgrade](./remotion-upgrade/SKILL.md).

--- a/packages/skills/skills/remotion-markup/SKILL.md
+++ b/packages/skills/skills/remotion-markup/SKILL.md
@@ -208,7 +208,7 @@ If a component does not support these props, wrap it in`<Sequence>` from `remoti
 
 ## Maps
 
-See [Remotion Maps](remotion-maps/SKILL.md) if wanting to include maps in the video.
+See [Remotion Maps](./remotion-maps/SKILL.md) if wanting to include maps in the video.
 
 ## Text highlights and annotations
 
@@ -267,7 +267,7 @@ When needing to visualize audio (spectrum bars, waveforms, bass-reactive effects
 
 ## Maps
 
-For static maps, animated routes and markers, geographic explainers, Mapbox, MapLibre, MapTiler, GeoJSON, or 3D geographic flyovers, load [Remotion Maps](remotion-maps/SKILL.md).
+For static maps, animated routes and markers, geographic explainers, Mapbox, MapLibre, MapTiler, GeoJSON, or 3D geographic flyovers, load [Remotion Maps](./remotion-maps/SKILL.md).
 
 ## Captions
 


### PR DESCRIPTION
## Summary

- make embedded skill links explicitly relative so agents resolve the embedded `REFERENCE.md`
- normalize ambiguous embedded links during skill syncing
- reject ambiguous embedded skill links during skill validation

## Verification

- `bun run build`
- `bun run stylecheck`
- red/green regression check against the link reported in the issue

Closes #9964
