### PR TITLE
`@remotion/studio`: Fix source stack resolution in Safari

### DIFF
--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -13,6 +13,31 @@ const originalJsx = JsxRuntime.jsx;
 const originalJsxs = JsxRuntime.jsxs;
 const originalJsxDev = JsxRuntimeDev.jsxDEV;
 
+const getSourceFileName = (fileName: string) => {
+	if (typeof window === 'undefined' || !window.remotion_cwd) {
+		return fileName;
+	}
+
+	const normalizedFileName = fileName.replaceAll('\\', '/');
+	const normalizedRoot = window.remotion_cwd
+		.replaceAll('\\', '/')
+		.replace(/\/+$/, '');
+	const shouldCompareCaseInsensitive =
+		/^[a-z]:\//i.test(normalizedFileName) || /^[a-z]:\//i.test(normalizedRoot);
+	const comparableFileName = shouldCompareCaseInsensitive
+		? normalizedFileName.toLowerCase()
+		: normalizedFileName;
+	const comparableRoot = shouldCompareCaseInsensitive
+		? normalizedRoot.toLowerCase()
+		: normalizedRoot;
+
+	if (!comparableFileName.startsWith(`${comparableRoot}/`)) {
+		return normalizedFileName;
+	}
+
+	return `./${normalizedFileName.slice(normalizedRoot.length + 1)}`;
+};
+
 const enableProxy = <
 	T extends
 		| typeof React.createElement
@@ -39,7 +64,7 @@ const enableProxy = <
 					typeof source.fileName === 'string' &&
 					typeof source.lineNumber === 'number' &&
 					typeof source.columnNumber === 'number'
-						? `Error\n    at remotionOriginalSource (${studioOriginalSourcePrefix}${encodeURIComponent(source.fileName)}:${source.lineNumber}:${source.columnNumber})`
+						? `Error\n    at remotionOriginalSource (${studioOriginalSourcePrefix}${encodeURIComponent(getSourceFileName(source.fileName))}:${source.lineNumber}:${source.columnNumber})`
 						: new Error().stack;
 				const newProps = props?.[internalStackProp]
 					? {...props}

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -6,6 +6,7 @@ import {Internals} from 'remotion';
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
 const sequenceComponent = Internals.getSequenceComponent();
 const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;
+const studioOriginalSourcePrefix = 'studio-original://';
 
 const originalCreateElement = React.createElement;
 const originalJsx = JsxRuntime.jsx;
@@ -20,6 +21,7 @@ const enableProxy = <
 >(
 	api: T,
 	isCreateElement: boolean,
+	sourceArgumentIndex: number | null,
 ): T => {
 	return new Proxy(api, {
 		apply(target, thisArg, argArray) {
@@ -30,11 +32,20 @@ const enableProxy = <
 						? props?.children
 						: rest
 					: props?.children;
+				const source =
+					sourceArgumentIndex === null ? null : argArray[sourceArgumentIndex];
+				const stack =
+					source &&
+					typeof source.fileName === 'string' &&
+					typeof source.lineNumber === 'number' &&
+					typeof source.columnNumber === 'number'
+						? `Error\n    at remotionOriginalSource (${studioOriginalSourcePrefix}${encodeURIComponent(source.fileName)}:${source.lineNumber}:${source.columnNumber})`
+						: new Error().stack;
 				const newProps = props?.[internalStackProp]
 					? {...props}
 					: {
 							...(props ?? {}),
-							[internalStackProp]: new Error().stack,
+							[internalStackProp]: stack,
 						};
 				if (first === sequenceComponent) {
 					newProps._remotionInternalSingleChildComponent =
@@ -49,7 +60,7 @@ const enableProxy = <
 	});
 };
 
-React.createElement = enableProxy(originalCreateElement, true);
-JsxRuntime.jsx = enableProxy(originalJsx, false);
-JsxRuntime.jsxs = enableProxy(originalJsxs, false);
-JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false);
+React.createElement = enableProxy(originalCreateElement, true, null);
+JsxRuntime.jsx = enableProxy(originalJsx, false, null);
+JsxRuntime.jsxs = enableProxy(originalJsxs, false, null);
+JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false, 4);

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test';
 import React from 'react';
+import JsxRuntimeDev from 'react/jsx-dev-runtime';
 import {Internals} from 'remotion';
 
 test('injects a namespaced source stack without conflicting with application props', async () => {
@@ -26,4 +27,23 @@ test('injects a namespaced source stack without conflicting with application pro
 			readonly _remotionInternalStack: string;
 		};
 	expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
+
+	const sourceElement = JsxRuntimeDev.jsxDEV(
+		Component,
+		{stack: 'application-stack'},
+		undefined,
+		false,
+		{
+			fileName: '/project/src/Video.tsx',
+			lineNumber: 12,
+			columnNumber: 4,
+		},
+		undefined,
+	);
+	const sourceProps = sourceElement.props as typeof sourceElement.props & {
+		readonly _remotionInternalStack: string;
+	};
+	expect(sourceProps._remotionInternalStack).toBe(
+		'Error\n    at remotionOriginalSource (studio-original://%2Fproject%2Fsrc%2FVideo.tsx:12:4)',
+	);
 });

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -28,22 +28,31 @@ test('injects a namespaced source stack without conflicting with application pro
 		};
 	expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
 
-	const sourceElement = JsxRuntimeDev.jsxDEV(
-		Component,
-		{stack: 'application-stack'},
-		undefined,
-		false,
-		{
-			fileName: '/project/src/Video.tsx',
-			lineNumber: 12,
-			columnNumber: 4,
-		},
-		undefined,
-	);
-	const sourceProps = sourceElement.props as typeof sourceElement.props & {
-		readonly _remotionInternalStack: string;
-	};
-	expect(sourceProps._remotionInternalStack).toBe(
-		'Error\n    at remotionOriginalSource (studio-original://%2Fproject%2Fsrc%2FVideo.tsx:12:4)',
-	);
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {remotion_cwd: '/project'},
+	});
+
+	try {
+		const sourceElement = JsxRuntimeDev.jsxDEV(
+			Component,
+			{stack: 'application-stack'},
+			undefined,
+			false,
+			{
+				fileName: '/project/src/Video.tsx',
+				lineNumber: 12,
+				columnNumber: 4,
+			},
+			undefined,
+		);
+		const sourceProps = sourceElement.props as typeof sourceElement.props & {
+			readonly _remotionInternalStack: string;
+		};
+		expect(sourceProps._remotionInternalStack).toBe(
+			'Error\n    at remotionOriginalSource (studio-original://.%2Fsrc%2FVideo.tsx:12:4)',
+		);
+	} finally {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
 });

--- a/packages/studio/src/components/Timeline/TimelineStack/get-stack.ts
+++ b/packages/studio/src/components/Timeline/TimelineStack/get-stack.ts
@@ -8,6 +8,7 @@ import {
 const traceMapCache: Partial<Record<string, TraceMap>> = {};
 const traceMapPromises: Partial<Record<string, Promise<TraceMap>>> = {};
 const browserStudioOriginalSourcePrefix = 'browser-studio-original://';
+const studioOriginalSourcePrefix = 'studio-original://';
 
 const getSourceMapCache = async (fileName: string) => {
 	if (traceMapCache[fileName]) {
@@ -45,12 +46,17 @@ export const getOriginalLocationFromStack = async (
 		return null;
 	}
 
-	if (location.fileName.startsWith(browserStudioOriginalSourcePrefix)) {
+	const originalSourcePrefix = [
+		browserStudioOriginalSourcePrefix,
+		studioOriginalSourcePrefix,
+	].find((prefix) => location.fileName.startsWith(prefix));
+
+	if (originalSourcePrefix) {
 		return {
 			column: location.columnNumber,
 			line: location.lineNumber,
 			source: decodeURIComponent(
-				location.fileName.slice(browserStudioOriginalSourcePrefix.length),
+				location.fileName.slice(originalSourcePrefix.length),
 			),
 		};
 	}

--- a/packages/studio/src/test/get-original-location-from-stack.test.ts
+++ b/packages/studio/src/test/get-original-location-from-stack.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from 'bun:test';
+import {getOriginalLocationFromStack} from '../components/Timeline/TimelineStack/get-stack';
+
+test('resolves compiler-provided Studio source locations', async () => {
+	const location = await getOriginalLocationFromStack(
+		'Error\n    at remotionOriginalSource (studio-original://%2Fproject%2Fsrc%2FVideo.tsx:12:4)',
+		'sequence',
+	);
+
+	expect(location).toEqual({
+		column: 4,
+		line: 12,
+		source: '/project/src/Video.tsx',
+	});
+});


### PR DESCRIPTION
## Summary

- use the compiler-provided `jsxDEV` source location when recording Studio component stacks
- resolve encoded Studio source locations without relying on browser-specific stack formatting
- add regression coverage for source capture and resolution

## Testing

- `bun run build`
- `bun run stylecheck`
- focused Bundler and Studio regression tests
- verified the `NewVideo` component request in WebKit and Chromium

Closes #9960
