### PR TITLE
remotion.dev/convert: Open canvas captures directly

### DIFF
--- a/.agents/skills/canvas-capture-extension/SKILL.md
+++ b/.agents/skills/canvas-capture-extension/SKILL.md
@@ -24,7 +24,7 @@ the unpacked copy outside the checkout so deleting a worktree cannot break it.
    `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
 
 3. Confirm that the installed directory contains `manifest.json`,
-   `background.js`, and `content.js`.
+   `background.js`, `content.js`, and `receiver.js`.
 
 ## Reload in Chrome
 

--- a/.agents/skills/canvas-capture-extension/SKILL.md
+++ b/.agents/skills/canvas-capture-extension/SKILL.md
@@ -20,7 +20,7 @@ the unpacked copy outside the checkout so deleting a worktree cannot break it.
      --repo <remotion-checkout>
    ```
 
-   The script builds with Bun and installs the three unpacked-extension files in
+   The script builds with Bun and installs the four unpacked-extension files in
    `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
 
 3. Confirm that the installed directory contains `manifest.json`,

--- a/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
+++ b/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
@@ -61,7 +61,7 @@ fi
 	bun run make
 )
 
-for required_file in manifest.json background.js content.js; do
+for required_file in manifest.json background.js content.js receiver.js; do
 	if [[ ! -f "$dist_dir/$required_file" ]]; then
 		printf 'Build did not produce %s\n' "$dist_dir/$required_file" >&2
 		exit 1
@@ -69,7 +69,7 @@ for required_file in manifest.json background.js content.js; do
 done
 
 mkdir -p "$install_dir"
-for extension_file in manifest.json background.js content.js; do
+for extension_file in manifest.json background.js content.js receiver.js; do
 	cp "$dist_dir/$extension_file" "$install_dir/$extension_file"
 done
 

--- a/packages/canvas-capture-extension/README.md
+++ b/packages/canvas-capture-extension/README.md
@@ -9,6 +9,6 @@ Record an element—or a whole webpage—as a high-resolution WebM using Chromiu
 3. Select `packages/canvas-capture-extension/dist`.
 4. Enable `chrome://flags/#canvas-draw-element` and restart Chrome if HTML-in-canvas is not already enabled.
 
-Click the extension icon on a webpage to open the recorder. Set the output scale, select an area (the extension picks the deepest DOM element containing it and encodes only the drawn crop using Mediabunny's `CropRectangle` transform) or choose **Whole page**, then press **Record**. Press **Stop and open in Convert** to load the recording in [remotion.dev/convert](https://remotion.dev/convert) without downloading it first.
+Click the extension icon on a webpage to open the recorder. Set the output scale, select an area (the extension picks the deepest DOM element containing it and encodes only the drawn crop using Mediabunny's `CropRectangle` transform) or choose **Whole page**, then press **Record**. Press **Stop and open in Convert** to load the recording in [remotion.dev/convert](https://remotion.dev/convert) without downloading it first, or **Stop and download WebM** to save it directly.
 
 The chosen element is temporarily placed inside a `layoutSubtree` canvas while recording and restored afterward. Websites that rely on direct-child CSS selectors may look different during capture. Chrome's own pages and the Chrome Web Store do not allow extension script injection.

--- a/packages/canvas-capture-extension/README.md
+++ b/packages/canvas-capture-extension/README.md
@@ -9,6 +9,6 @@ Record an element—or a whole webpage—as a high-resolution WebM using Chromiu
 3. Select `packages/canvas-capture-extension/dist`.
 4. Enable `chrome://flags/#canvas-draw-element` and restart Chrome if HTML-in-canvas is not already enabled.
 
-Click the extension icon on a webpage to open the recorder. Set the output scale, select an area (the extension picks the deepest DOM element containing it and encodes only the drawn crop using Mediabunny's `CropRectangle` transform) or choose **Whole page**, then press **Record**. Press **Stop and save WebM** to download the recording.
+Click the extension icon on a webpage to open the recorder. Set the output scale, select an area (the extension picks the deepest DOM element containing it and encodes only the drawn crop using Mediabunny's `CropRectangle` transform) or choose **Whole page**, then press **Record**. Press **Stop and open in Convert** to load the recording in [remotion.dev/convert](https://remotion.dev/convert) without downloading it first.
 
 The chosen element is temporarily placed inside a `layoutSubtree` canvas while recording and restored afterward. Websites that rely on direct-child CSS selectors may look different during capture. Chrome's own pages and the Chrome Web Store do not allow extension script injection.

--- a/packages/canvas-capture-extension/bundle.ts
+++ b/packages/canvas-capture-extension/bundle.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import {build} from 'bun';
 
 const output = await build({
-	entrypoints: ['src/background.ts', 'src/content.ts'],
+	entrypoints: ['src/background.ts', 'src/content.ts', 'src/receiver.ts'],
 	outdir: 'dist',
 	naming: '[name].js',
 	target: 'browser',

--- a/packages/canvas-capture-extension/manifest.json
+++ b/packages/canvas-capture-extension/manifest.json
@@ -3,11 +3,18 @@
 	"name": "Remotion Canvas Capture",
 	"description": "Record any element on a webpage as a high-resolution WebM.",
 	"version": "0.1.0",
-	"permissions": ["activeTab", "scripting"],
+	"permissions": ["activeTab", "scripting", "storage", "unlimitedStorage"],
 	"action": {
 		"default_title": "Open Remotion Canvas Capture"
 	},
 	"background": {
 		"service_worker": "background.js"
-	}
+	},
+	"content_scripts": [
+		{
+			"matches": ["https://remotion.dev/convert*"],
+			"js": ["receiver.js"],
+			"run_at": "document_start"
+		}
+	]
 }

--- a/packages/canvas-capture-extension/src/background.ts
+++ b/packages/canvas-capture-extension/src/background.ts
@@ -19,3 +19,20 @@ chrome.action.onClicked.addListener((tab) => {
 
 	open().catch(() => undefined);
 });
+
+chrome.runtime.onMessage.addListener((message) => {
+	if (
+		typeof message !== 'object' ||
+		message === null ||
+		!('type' in message) ||
+		message.type !== 'remotion-canvas-capture-open-convert' ||
+		!('captureId' in message) ||
+		typeof message.captureId !== 'string'
+	) {
+		return;
+	}
+
+	const url = new URL('https://remotion.dev/convert');
+	url.searchParams.set('canvas-capture', message.captureId);
+	return chrome.tabs.create({url: url.toString()});
+});

--- a/packages/canvas-capture-extension/src/capture.ts
+++ b/packages/canvas-capture-extension/src/capture.ts
@@ -283,7 +283,12 @@ export class ElementCapture {
 			}
 
 			this.#draw();
-			await this.#recorder.stopRecording();
+			const file = await this.#recorder.stopRecording();
+			if (!file) {
+				throw new Error('No canvas recording was available to open.');
+			}
+
+			return file;
 		} finally {
 			this.restore();
 		}

--- a/packages/canvas-capture-extension/src/chrome.d.ts
+++ b/packages/canvas-capture-extension/src/chrome.d.ts
@@ -10,8 +10,11 @@ declare const chrome: {
 	};
 	readonly runtime: {
 		readonly onMessage: {
-			addListener: (listener: (message: unknown) => void) => void;
+			addListener: (
+				listener: (message: unknown) => void | Promise<unknown>,
+			) => void;
 		};
+		sendMessage: (message: unknown) => Promise<unknown>;
 	};
 	readonly scripting: {
 		executeScript: (options: {
@@ -20,6 +23,14 @@ declare const chrome: {
 		}) => Promise<void>;
 	};
 	readonly tabs: {
+		create: (options: {readonly url: string}) => Promise<unknown>;
 		sendMessage: (tabId: number, message: unknown) => Promise<unknown>;
+	};
+	readonly storage: {
+		readonly local: {
+			get: (key: string) => Promise<Record<string, unknown>>;
+			remove: (keys: string | readonly string[]) => Promise<void>;
+			set: (items: Record<string, unknown>) => Promise<void>;
+		};
 	};
 };

--- a/packages/canvas-capture-extension/src/content.ts
+++ b/packages/canvas-capture-extension/src/content.ts
@@ -1,4 +1,5 @@
 import {type CaptureCrop, ElementCapture} from './capture';
+import {openCaptureInConvert} from './handoff';
 import {isHtmlInCanvasAvailable} from './recorder';
 import {
 	findLowestElementContainingRectangle,
@@ -243,7 +244,9 @@ const createController = (): ExtensionController => {
 		closeButton.disabled = finalizing;
 		recordButton.disabled =
 			!isSupported || finalizing || (!selectedElement && !wholePage);
-		recordButton.textContent = isRecording ? 'Stop and save WebM' : 'Record';
+		recordButton.textContent = isRecording
+			? 'Stop and open in Convert'
+			: 'Record';
 		recordButton.classList.toggle('recording', isRecording);
 		updateHighlight();
 	};
@@ -345,8 +348,10 @@ const createController = (): ExtensionController => {
 				updateControls();
 				const currentCapture = capture;
 				try {
-					await currentCapture.stop();
-					setStatus('WebM saved. Ready to record again.');
+					const file = await currentCapture.stop();
+					setStatus('Opening recording in Remotion Convert…');
+					await openCaptureInConvert(file);
+					setStatus('Recording opened. Ready to record again.');
 				} catch (error) {
 					setStatus(
 						error instanceof Error ? error.message : String(error),

--- a/packages/canvas-capture-extension/src/content.ts
+++ b/packages/canvas-capture-extension/src/content.ts
@@ -24,6 +24,17 @@ const createButton = (label: string) => {
 	return button;
 };
 
+const downloadFile = (file: File) => {
+	const url = URL.createObjectURL(file);
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = file.name;
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	URL.revokeObjectURL(url);
+};
+
 const describeElement = (element: Element) => {
 	const id = element.id ? `#${element.id}` : '';
 	const className =
@@ -170,10 +181,19 @@ const createController = (): ExtensionController => {
 
 	const recordButton = createButton('Record');
 	recordButton.className = 'record';
+	const downloadButton = createButton('Stop and download WebM');
+	downloadButton.style.display = 'none';
 	const status = document.createElement('div');
 	status.className = 'status';
 
-	panel.append(header, scaleLabel, targetRow, recordButton, status);
+	panel.append(
+		header,
+		scaleLabel,
+		targetRow,
+		recordButton,
+		downloadButton,
+		status,
+	);
 
 	const selectionLayer = document.createElement('div');
 	selectionLayer.className = 'selection-layer';
@@ -248,6 +268,8 @@ const createController = (): ExtensionController => {
 			? 'Stop and open in Convert'
 			: 'Record';
 		recordButton.classList.toggle('recording', isRecording);
+		downloadButton.style.display = isRecording ? 'block' : 'none';
+		downloadButton.disabled = finalizing;
 		updateHighlight();
 	};
 
@@ -340,29 +362,38 @@ const createController = (): ExtensionController => {
 	selectionLayer.addEventListener('pointerup', finishSelection);
 	wholePageButton.addEventListener('click', selectWholePage);
 
+	const finishRecording = async (destination: 'convert' | 'download') => {
+		if (!capture) {
+			return;
+		}
+
+		finalizing = true;
+		setStatus('Finalizing WebM…');
+		updateControls();
+		const currentCapture = capture;
+		try {
+			const file = await currentCapture.stop();
+			if (destination === 'convert') {
+				setStatus('Opening recording in Remotion Convert…');
+				await openCaptureInConvert(file);
+				setStatus('Recording opened. Ready to record again.');
+			} else {
+				downloadFile(file);
+				setStatus('WebM downloaded. Ready to record again.');
+			}
+		} catch (error) {
+			setStatus(error instanceof Error ? error.message : String(error), true);
+		} finally {
+			capture = null;
+			finalizing = false;
+			updateControls();
+		}
+	};
+
 	recordButton.addEventListener('click', () => {
 		const toggle = async () => {
 			if (capture) {
-				finalizing = true;
-				setStatus('Finalizing WebM…');
-				updateControls();
-				const currentCapture = capture;
-				try {
-					const file = await currentCapture.stop();
-					setStatus('Opening recording in Remotion Convert…');
-					await openCaptureInConvert(file);
-					setStatus('Recording opened. Ready to record again.');
-				} catch (error) {
-					setStatus(
-						error instanceof Error ? error.message : String(error),
-						true,
-					);
-				} finally {
-					capture = null;
-					finalizing = false;
-					updateControls();
-				}
-
+				await finishRecording('convert');
 				return;
 			}
 
@@ -401,6 +432,12 @@ const createController = (): ExtensionController => {
 		};
 
 		toggle().catch((error) => {
+			setStatus(error instanceof Error ? error.message : String(error), true);
+		});
+	});
+
+	downloadButton.addEventListener('click', () => {
+		finishRecording('download').catch((error) => {
 			setStatus(error instanceof Error ? error.message : String(error), true);
 		});
 	});

--- a/packages/canvas-capture-extension/src/handoff.ts
+++ b/packages/canvas-capture-extension/src/handoff.ts
@@ -1,0 +1,63 @@
+const STORAGE_PREFIX = 'remotion-canvas-capture:';
+const CHUNK_SIZE = 1024 * 1024;
+
+type StoredCaptureMetadata = {
+	readonly filename: string;
+	readonly mimeType: string;
+	readonly chunks: number;
+};
+
+const getMetadataKey = (captureId: string) =>
+	`${STORAGE_PREFIX}${captureId}:metadata`;
+
+const getChunkKey = (captureId: string, index: number) =>
+	`${STORAGE_PREFIX}${captureId}:chunk:${index}`;
+
+const toBase64 = (bytes: Uint8Array) => {
+	let binary = '';
+	const batchSize = 32_768;
+
+	for (let offset = 0; offset < bytes.length; offset += batchSize) {
+		binary += String.fromCharCode(
+			...bytes.subarray(offset, offset + batchSize),
+		);
+	}
+
+	return btoa(binary);
+};
+
+export const openCaptureInConvert = async (file: File) => {
+	const captureId = crypto.randomUUID();
+	const chunkCount = Math.ceil(file.size / CHUNK_SIZE);
+	const storedKeys: string[] = [];
+
+	try {
+		for (let index = 0; index < chunkCount; index++) {
+			const key = getChunkKey(captureId, index);
+			const bytes = new Uint8Array(
+				await file
+					.slice(index * CHUNK_SIZE, (index + 1) * CHUNK_SIZE)
+					.arrayBuffer(),
+			);
+			await chrome.storage.local.set({[key]: toBase64(bytes)});
+			storedKeys.push(key);
+		}
+
+		const metadata: StoredCaptureMetadata = {
+			filename: file.name,
+			mimeType: file.type,
+			chunks: chunkCount,
+		};
+		const metadataKey = getMetadataKey(captureId);
+		await chrome.storage.local.set({[metadataKey]: metadata});
+		storedKeys.push(metadataKey);
+
+		await chrome.runtime.sendMessage({
+			type: 'remotion-canvas-capture-open-convert',
+			captureId,
+		});
+	} catch (error) {
+		await chrome.storage.local.remove(storedKeys).catch(() => undefined);
+		throw error;
+	}
+};

--- a/packages/canvas-capture-extension/src/receiver.ts
+++ b/packages/canvas-capture-extension/src/receiver.ts
@@ -1,0 +1,111 @@
+const STORAGE_PREFIX = 'remotion-canvas-capture:';
+const MESSAGE_PREFIX = 'remotion-canvas-capture';
+
+type StoredCaptureMetadata = {
+	readonly filename: string;
+	readonly mimeType: string;
+	readonly chunks: number;
+};
+
+const captureId = new URL(window.location.href).searchParams.get(
+	'canvas-capture',
+);
+let isDelivering = false;
+
+const getMetadataKey = (id: string) => `${STORAGE_PREFIX}${id}:metadata`;
+const getChunkKey = (id: string, index: number) =>
+	`${STORAGE_PREFIX}${id}:chunk:${index}`;
+
+const removeCaptureParameter = () => {
+	const url = new URL(window.location.href);
+	url.searchParams.delete('canvas-capture');
+	window.history.replaceState(
+		null,
+		'',
+		`${url.pathname}${url.search}${url.hash}`,
+	);
+};
+
+const deliverCapture = async (id: string) => {
+	const metadataKey = getMetadataKey(id);
+	const storedMetadata = await chrome.storage.local.get(metadataKey);
+	const metadata = storedMetadata[metadataKey] as
+		| StoredCaptureMetadata
+		| undefined;
+
+	if (
+		!metadata ||
+		typeof metadata.filename !== 'string' ||
+		typeof metadata.mimeType !== 'string' ||
+		!Number.isSafeInteger(metadata.chunks) ||
+		metadata.chunks < 0
+	) {
+		throw new Error('The canvas capture could not be found.');
+	}
+
+	window.postMessage(
+		{
+			type: `${MESSAGE_PREFIX}-start`,
+			captureId: id,
+			filename: metadata.filename,
+			mimeType: metadata.mimeType,
+			chunks: metadata.chunks,
+		},
+		window.location.origin,
+	);
+
+	for (let index = 0; index < metadata.chunks; index++) {
+		const key = getChunkKey(id, index);
+		const storedChunk = await chrome.storage.local.get(key);
+		const chunk = storedChunk[key];
+		if (typeof chunk !== 'string') {
+			throw new Error(`Canvas capture chunk ${index + 1} is missing.`);
+		}
+
+		window.postMessage(
+			{
+				type: `${MESSAGE_PREFIX}-chunk`,
+				captureId: id,
+				index,
+				data: chunk,
+			},
+			window.location.origin,
+		);
+		await chrome.storage.local.remove(key);
+	}
+
+	window.postMessage(
+		{type: `${MESSAGE_PREFIX}-complete`, captureId: id},
+		window.location.origin,
+	);
+	await chrome.storage.local.remove(metadataKey);
+	removeCaptureParameter();
+};
+
+if (captureId) {
+	window.addEventListener('message', (event) => {
+		if (
+			isDelivering ||
+			event.source !== window ||
+			event.origin !== window.location.origin ||
+			typeof event.data !== 'object' ||
+			event.data === null ||
+			event.data.type !== `${MESSAGE_PREFIX}-ready` ||
+			event.data.captureId !== captureId
+		) {
+			return;
+		}
+
+		isDelivering = true;
+		deliverCapture(captureId).catch((error) => {
+			window.postMessage(
+				{
+					type: `${MESSAGE_PREFIX}-error`,
+					captureId,
+					message: error instanceof Error ? error.message : String(error),
+				},
+				window.location.origin,
+			);
+		});
+	});
+}

--- a/packages/canvas-capture-extension/src/recorder.ts
+++ b/packages/canvas-capture-extension/src/recorder.ts
@@ -166,17 +166,6 @@ const getCursorForElement = (element: Element | null): string => {
 	return 'auto';
 };
 
-const downloadBlob = (blob: Blob, filename: string) => {
-	const url = URL.createObjectURL(blob);
-	const anchor = document.createElement('a');
-	anchor.href = url;
-	anchor.download = filename;
-	document.body.appendChild(anchor);
-	anchor.click();
-	document.body.removeChild(anchor);
-	URL.revokeObjectURL(url);
-};
-
 const addFrame = (recording: RecordingState) => {
 	const elapsedInSeconds = Math.max(
 		0,
@@ -206,7 +195,7 @@ const addFrame = (recording: RecordingState) => {
 const finalizeRecording = async (
 	recording: RecordingState,
 	filename: string,
-) => {
+): Promise<File> => {
 	addFrame(recording);
 	await recording.lastFramePromise;
 
@@ -261,7 +250,7 @@ const finalizeRecording = async (
 		throw new Error('Mediabunny remux did not return an output buffer.');
 	}
 
-	downloadBlob(new Blob([remuxTarget.buffer], {type: 'video/webm'}), filename);
+	return new File([remuxTarget.buffer], filename, {type: 'video/webm'});
 };
 
 export class CanvasCaptureRecorder {
@@ -326,15 +315,15 @@ export class CanvasCaptureRecorder {
 		};
 	};
 
-	stopRecording = async () => {
+	stopRecording = async (): Promise<File | null> => {
 		const recording = this.#recording;
 		if (!recording || recording.isFinalizing) {
-			return;
+			return null;
 		}
 
 		recording.isFinalizing = true;
 		try {
-			await finalizeRecording(recording, this.#options.getFilename());
+			return await finalizeRecording(recording, this.#options.getFilename());
 		} catch (err) {
 			await recording.output.cancel().catch(() => undefined);
 			throw err;

--- a/packages/convert/app/components/Main.tsx
+++ b/packages/convert/app/components/Main.tsx
@@ -2,6 +2,7 @@ import {useLocation} from '@remix-run/react';
 import React, {useState} from 'react';
 import type {Source} from '~/lib/convert-state';
 import {TitleProvider} from '~/lib/title-context';
+import {useCanvasCapture} from '~/lib/use-canvas-capture';
 import type {RouteAction} from '~/seo';
 import {getHeaderTitle} from '~/seo';
 import {FileAvailable} from './FileAvailable';
@@ -17,6 +18,7 @@ export const Main: React.FC<{
 	const [src, setSrc] = useState<Source | null>(() => {
 		return url.has('url') ? {type: 'url', url: url.get('url') as string} : null;
 	});
+	useCanvasCapture(setSrc);
 
 	return (
 		<TitleProvider routeAction={routeAction}>

--- a/packages/convert/app/lib/use-canvas-capture.ts
+++ b/packages/convert/app/lib/use-canvas-capture.ts
@@ -1,0 +1,97 @@
+import {useEffect} from 'react';
+import type {Source} from './convert-state';
+
+const MESSAGE_PREFIX = 'remotion-canvas-capture';
+
+type IncomingCapture = {
+	readonly captureId: string;
+	readonly filename: string;
+	readonly mimeType: string;
+	readonly chunks: Array<ArrayBuffer | null>;
+};
+
+const decodeBase64 = (value: string) => {
+	const binary = atob(value);
+	const buffer = new ArrayBuffer(binary.length);
+	const bytes = new Uint8Array(buffer);
+	for (let index = 0; index < binary.length; index++) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+
+	return buffer;
+};
+
+export const useCanvasCapture = (
+	setSrc: React.Dispatch<React.SetStateAction<Source | null>>,
+) => {
+	useEffect(() => {
+		const captureId = new URL(window.location.href).searchParams.get(
+			'canvas-capture',
+		);
+		if (!captureId) {
+			return;
+		}
+
+		let incoming: IncomingCapture | null = null;
+
+		const onMessage = (event: MessageEvent) => {
+			if (
+				event.source !== window ||
+				event.origin !== window.location.origin ||
+				typeof event.data !== 'object' ||
+				event.data === null ||
+				event.data.captureId !== captureId
+			) {
+				return;
+			}
+
+			if (
+				event.data.type === `${MESSAGE_PREFIX}-start` &&
+				typeof event.data.filename === 'string' &&
+				typeof event.data.mimeType === 'string' &&
+				Number.isSafeInteger(event.data.chunks) &&
+				event.data.chunks >= 0
+			) {
+				incoming = {
+					captureId,
+					filename: event.data.filename,
+					mimeType: event.data.mimeType,
+					chunks: Array.from({length: event.data.chunks}, () => null),
+				};
+				return;
+			}
+
+			if (
+				event.data.type === `${MESSAGE_PREFIX}-chunk` &&
+				incoming &&
+				Number.isSafeInteger(event.data.index) &&
+				event.data.index >= 0 &&
+				event.data.index < incoming.chunks.length &&
+				typeof event.data.data === 'string'
+			) {
+				incoming.chunks[event.data.index] = decodeBase64(event.data.data);
+				return;
+			}
+
+			if (
+				event.data.type === `${MESSAGE_PREFIX}-complete` &&
+				incoming &&
+				incoming.chunks.every((chunk) => chunk !== null)
+			) {
+				const file = new File(incoming.chunks, incoming.filename, {
+					type: incoming.mimeType,
+				});
+				setSrc({type: 'file', file});
+				incoming = null;
+			}
+		};
+
+		window.addEventListener('message', onMessage);
+		window.postMessage(
+			{type: `${MESSAGE_PREFIX}-ready`, captureId},
+			window.location.origin,
+		);
+
+		return () => window.removeEventListener('message', onMessage);
+	}, [setSrc]);
+};


### PR DESCRIPTION
## Summary

- add a direct Canvas Capture handoff to remotion.dev/convert while retaining WebM download as a separate stop action
- transfer large captures locally through chunked extension storage and reconstruct them as a `File` in Convert
- bundle and install the new receiver script with the unpacked extension

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run build-page` in `packages/convert`
- rebuilt and installed the unpacked Canvas Capture extension
