### PR TITLE
`@remotion/studio`: Fix pointer sessions outside the window

### DIFF
--- a/packages/studio/src/components/ColorPicker/AlphaSlider.tsx
+++ b/packages/studio/src/components/ColorPicker/AlphaSlider.tsx
@@ -5,6 +5,7 @@ import {
 	COLOR_PICKER_ALPHA_TRANSPARENT,
 	COLOR_PICKER_HANDLE_SHADOW,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {
 	CHECKER_BACKGROUND_COLOR,
 	CHECKER_BACKGROUND_IMAGE,
@@ -82,19 +83,24 @@ export const AlphaSlider: React.FC<{
 
 			e.preventDefault();
 			updateFromEvent(e.clientX, false);
+			let lastClientX = e.clientX;
 
-			const onMove = (ev: PointerEvent) => {
-				updateFromEvent(ev.clientX, false);
-			};
-
-			const onUp = (ev: PointerEvent) => {
-				window.removeEventListener('pointermove', onMove);
-				window.removeEventListener('pointerup', onUp);
-				updateFromEvent(ev.clientX, true);
-			};
-
-			window.addEventListener('pointermove', onMove);
-			window.addEventListener('pointerup', onUp);
+			startPointerSession({
+				event: e.nativeEvent,
+				target: e.currentTarget,
+				onMove: (ev) => {
+					lastClientX = ev.clientX;
+					updateFromEvent(ev.clientX, false);
+				},
+				onEnd: (reason, ev) => {
+					const shouldUseEndEvent =
+						reason === 'pointerup' || reason === 'buttons-released';
+					updateFromEvent(
+						shouldUseEndEvent && ev ? ev.clientX : lastClientX,
+						true,
+					);
+				},
+			});
 		},
 		[updateFromEvent],
 	);

--- a/packages/studio/src/components/ColorPicker/HueSlider.tsx
+++ b/packages/studio/src/components/ColorPicker/HueSlider.tsx
@@ -5,6 +5,7 @@ import {
 	COLOR_PICKER_HANDLE_SHADOW,
 	COLOR_PICKER_HUE_GRADIENT,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 
 const SLIDER_HEIGHT = 12;
 const HANDLE_WIDTH = 8;
@@ -53,19 +54,24 @@ export const HueSlider: React.FC<{
 
 			e.preventDefault();
 			updateFromEvent(e.clientX, false);
+			let lastClientX = e.clientX;
 
-			const onMove = (ev: PointerEvent) => {
-				updateFromEvent(ev.clientX, false);
-			};
-
-			const onUp = (ev: PointerEvent) => {
-				window.removeEventListener('pointermove', onMove);
-				window.removeEventListener('pointerup', onUp);
-				updateFromEvent(ev.clientX, true);
-			};
-
-			window.addEventListener('pointermove', onMove);
-			window.addEventListener('pointerup', onUp);
+			startPointerSession({
+				event: e.nativeEvent,
+				target: e.currentTarget,
+				onMove: (ev) => {
+					lastClientX = ev.clientX;
+					updateFromEvent(ev.clientX, false);
+				},
+				onEnd: (reason, ev) => {
+					const shouldUseEndEvent =
+						reason === 'pointerup' || reason === 'buttons-released';
+					updateFromEvent(
+						shouldUseEndEvent && ev ? ev.clientX : lastClientX,
+						true,
+					);
+				},
+			});
 		},
 		[updateFromEvent],
 	);

--- a/packages/studio/src/components/ColorPicker/SaturationValueArea.tsx
+++ b/packages/studio/src/components/ColorPicker/SaturationValueArea.tsx
@@ -6,6 +6,7 @@ import {
 	COLOR_PICKER_SATURATION_BLACK_GRADIENT,
 	COLOR_PICKER_SATURATION_VALUE_GRADIENT,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 
 const AREA_HEIGHT = 140;
 
@@ -72,21 +73,26 @@ export const SaturationValueArea: React.FC<{
 			}
 
 			e.preventDefault();
-			(e.target as HTMLElement).setPointerCapture?.(e.pointerId);
 			updateFromEvent(e.clientX, e.clientY, false);
+			let lastPosition = {clientX: e.clientX, clientY: e.clientY};
 
-			const onMove = (ev: PointerEvent) => {
-				updateFromEvent(ev.clientX, ev.clientY, false);
-			};
-
-			const onUp = (ev: PointerEvent) => {
-				window.removeEventListener('pointermove', onMove);
-				window.removeEventListener('pointerup', onUp);
-				updateFromEvent(ev.clientX, ev.clientY, true);
-			};
-
-			window.addEventListener('pointermove', onMove);
-			window.addEventListener('pointerup', onUp);
+			startPointerSession({
+				event: e.nativeEvent,
+				target: e.currentTarget,
+				onMove: (ev) => {
+					lastPosition = {clientX: ev.clientX, clientY: ev.clientY};
+					updateFromEvent(ev.clientX, ev.clientY, false);
+				},
+				onEnd: (reason, ev) => {
+					const shouldUseEndEvent =
+						reason === 'pointerup' || reason === 'buttons-released';
+					updateFromEvent(
+						shouldUseEndEvent && ev ? ev.clientX : lastPosition.clientX,
+						shouldUseEndEvent && ev ? ev.clientY : lastPosition.clientY,
+						true,
+					);
+				},
+			});
 		},
 		[updateFromEvent],
 	);

--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -5,6 +5,7 @@ import {
 	isGuidePointerUpAClick,
 	type GuidePointerDownPosition,
 } from '../../helpers/editor-guide-selection';
+import {startPointerSession} from '../../helpers/pointer-session';
 import type {Guide} from '../../state/editor-guides';
 import {
 	EditorShowGuidesContext,
@@ -37,6 +38,7 @@ const GuideComp: React.FC<{
 		setHoveredGuideId,
 		hoveredGuideId,
 		draggingGuideId,
+		moveGuidePointerRef,
 	} = useContext(EditorShowGuidesContext);
 	const {clearSelection, onSelect, selected} = useTimelineGuideSelection(
 		guide.id,
@@ -94,46 +96,6 @@ const GuideComp: React.FC<{
 		draggingGuideId,
 	]);
 
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			e.stopPropagation();
-			e.currentTarget.setPointerCapture(e.pointerId);
-			hasMovedGuideRef.current = false;
-			pointerDownPositionRef.current = {
-				guideId: guide.id,
-				clientX: e.clientX,
-				clientY: e.clientY,
-			};
-			shouldCreateGuideRef.current = false;
-			setDraggingGuideId(() => guide.id);
-		},
-		[guide.id, setDraggingGuideId, shouldCreateGuideRef],
-	);
-
-	const onMouseDown = useCallback(
-		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-			if (e.button !== 0) {
-				return;
-			}
-
-			e.preventDefault();
-			e.stopPropagation();
-			hasMovedGuideRef.current = false;
-			pointerDownPositionRef.current = {
-				guideId: guide.id,
-				clientX: e.clientX,
-				clientY: e.clientY,
-			};
-			shouldCreateGuideRef.current = false;
-			setDraggingGuideId(() => guide.id);
-		},
-		[guide.id, setDraggingGuideId, shouldCreateGuideRef],
-	);
-
 	const updateHasMovedGuide = useCallback(
 		(clientX: number, clientY: number) => {
 			const pointerDownPosition = pointerDownPositionRef.current;
@@ -153,20 +115,6 @@ const GuideComp: React.FC<{
 			}
 		},
 		[guide.id],
-	);
-
-	const onPointerMove = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			updateHasMovedGuide(e.clientX, e.clientY);
-		},
-		[updateHasMovedGuide],
-	);
-
-	const onMouseMove = useCallback(
-		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-			updateHasMovedGuide(e.clientX, e.clientY);
-		},
-		[updateHasMovedGuide],
 	);
 
 	const finishGuideInteraction = useCallback(() => {
@@ -198,56 +146,62 @@ const GuideComp: React.FC<{
 		shouldDeleteGuideRef,
 	]);
 
-	const onPointerUp = useCallback(
+	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
-			if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-				e.currentTarget.releasePointerCapture(e.pointerId);
-			}
-
-			const pointerDownPosition = pointerDownPositionRef.current;
-			pointerDownPositionRef.current = null;
-			const shouldDeleteGuide = shouldDeleteGuideRef.current;
-			finishGuideInteraction();
-			if (shouldDeleteGuide) {
+			if (e.button !== 0) {
 				return;
 			}
 
-			if (
-				isGuidePointerUpAClick({
-					pointerDownPosition,
-					guideId: guide.id,
-					clientX: e.clientX,
-					clientY: e.clientY,
-				})
-			) {
-				onSelect();
-			}
-		},
-		[finishGuideInteraction, guide.id, onSelect, shouldDeleteGuideRef],
-	);
+			e.preventDefault();
+			e.stopPropagation();
+			hasMovedGuideRef.current = false;
+			pointerDownPositionRef.current = {
+				guideId: guide.id,
+				clientX: e.clientX,
+				clientY: e.clientY,
+			};
+			shouldCreateGuideRef.current = false;
+			setDraggingGuideId(() => guide.id);
 
-	const onMouseUp = useCallback(
-		(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-			const pointerDownPosition = pointerDownPositionRef.current;
-			pointerDownPositionRef.current = null;
-			const shouldDeleteGuide = shouldDeleteGuideRef.current;
-			finishGuideInteraction();
-			if (shouldDeleteGuide) {
-				return;
-			}
+			startPointerSession({
+				event: e.nativeEvent,
+				target: e.currentTarget,
+				onMove: (moveEvent) => {
+					updateHasMovedGuide(moveEvent.clientX, moveEvent.clientY);
+					moveGuidePointerRef.current?.(moveEvent);
+				},
+				onEnd: (reason, endEvent) => {
+					const pointerDownPosition = pointerDownPositionRef.current;
+					pointerDownPositionRef.current = null;
+					const shouldDeleteGuide = shouldDeleteGuideRef.current;
+					finishGuideInteraction();
+					if (shouldDeleteGuide || reason !== 'pointerup' || !endEvent) {
+						return;
+					}
 
-			if (
-				isGuidePointerUpAClick({
-					pointerDownPosition,
-					guideId: guide.id,
-					clientX: e.clientX,
-					clientY: e.clientY,
-				})
-			) {
-				onSelect();
-			}
+					if (
+						isGuidePointerUpAClick({
+							pointerDownPosition,
+							guideId: guide.id,
+							clientX: endEvent.clientX,
+							clientY: endEvent.clientY,
+						})
+					) {
+						onSelect();
+					}
+				},
+			});
 		},
-		[finishGuideInteraction, guide.id, onSelect, shouldDeleteGuideRef],
+		[
+			finishGuideInteraction,
+			guide.id,
+			moveGuidePointerRef,
+			onSelect,
+			setDraggingGuideId,
+			shouldCreateGuideRef,
+			shouldDeleteGuideRef,
+			updateHasMovedGuide,
+		],
 	);
 
 	const onClick = useCallback(
@@ -261,11 +215,6 @@ const GuideComp: React.FC<{
 		},
 		[],
 	);
-
-	const onPointerCancel = useCallback(() => {
-		pointerDownPositionRef.current = null;
-		finishGuideInteraction();
-	}, [finishGuideInteraction]);
 
 	const isActive = selected || hoveredGuideId === guide.id;
 	const activeClassName = isActive ? '__remotion_editor_guide_selected' : null;
@@ -308,12 +257,6 @@ const GuideComp: React.FC<{
 			<div
 				style={guideStyle}
 				onPointerDown={onPointerDown}
-				onPointerMove={onPointerMove}
-				onPointerUp={onPointerUp}
-				onPointerCancel={onPointerCancel}
-				onMouseDown={onMouseDown}
-				onMouseMove={onMouseMove}
-				onMouseUp={onMouseUp}
 				onClick={onClick}
 				className="__remotion_editor_guide"
 				{...{[PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR]: 'true'}}

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -29,6 +29,10 @@ interface RulerProps {
 	readonly markingGaps: number;
 	readonly orientation: 'horizontal' | 'vertical';
 	readonly size: Size;
+	readonly onPointerSessionStart: (
+		event: React.PointerEvent<HTMLCanvasElement>,
+		guideId: string,
+	) => void;
 }
 
 const makeGuideId = (): string => {
@@ -43,6 +47,7 @@ const Ruler: React.FC<RulerProps> = ({
 	size,
 	markingGaps,
 	orientation,
+	onPointerSessionStart,
 }) => {
 	const rulerCanvasRef = useRef<HTMLCanvasElement | null>(null);
 	const isVerticalRuler = orientation === 'vertical';
@@ -148,6 +153,7 @@ const Ruler: React.FC<RulerProps> = ({
 						},
 					];
 				});
+				onPointerSessionStart(e, guideId);
 			},
 			[
 				shouldCreateGuideRef,
@@ -158,6 +164,7 @@ const Ruler: React.FC<RulerProps> = ({
 				originOffset,
 				unsafeVideoConfig.id,
 				cursor,
+				onPointerSessionStart,
 			],
 		);
 

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -10,6 +10,7 @@ import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
 import {getRulerPoints, getRulerScaleRange} from '../../helpers/editor-ruler';
 import type {AssetMetadata} from '../../helpers/get-asset-metadata';
 import type {Dimensions} from '../../helpers/is-current-selected-still';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {useStudioCanvasDimensions} from '../../helpers/use-studio-canvas-dimensions';
 import {
 	EditorShowGuidesContext,
@@ -56,6 +57,7 @@ export const EditorRulers: React.FC<{
 		shouldDeleteGuideRef,
 		setGuidesList,
 		draggingGuideId,
+		moveGuidePointerRef,
 		setDraggingGuideId,
 	} = useContext(EditorShowGuidesContext);
 	const {clearSelection, selectedItems} = useTimelineSelection();
@@ -116,7 +118,7 @@ export const EditorRulers: React.FC<{
 	const requestAnimationFrameRef = useRef<number | null>(null);
 
 	const onMouseMove = useCallback(
-		(e: PointerEvent) => {
+		(e: PointerEvent, guideId: string | null) => {
 			if (requestAnimationFrameRef.current) {
 				cancelAnimationFrame(requestAnimationFrameRef.current);
 			}
@@ -141,7 +143,7 @@ export const EditorRulers: React.FC<{
 
 					setGuidesList((prevState) => {
 						const newGuides = prevState.map((guide) => {
-							if (guide.id !== draggingGuideId) {
+							if (guide.id !== guideId) {
 								return guide;
 							}
 
@@ -165,7 +167,7 @@ export const EditorRulers: React.FC<{
 					setGuidesList((prevState) => {
 						// Intentionally no persist, only persist on mouse up
 						return prevState.map((guide) => {
-							if (guide.id !== draggingGuideId) {
+							if (guide.id !== guideId) {
 								return guide;
 							}
 
@@ -194,69 +196,79 @@ export const EditorRulers: React.FC<{
 			containerRef,
 			shouldDeleteGuideRef,
 			setGuidesList,
-			draggingGuideId,
 			scale,
 			canvasPosition.left,
 			canvasPosition.top,
 		],
 	);
 
-	const onMouseUp = useCallback(() => {
-		const shouldDeleteGuide = shouldDeleteGuideRef.current;
+	const finishGuideInteraction = useCallback(
+		(guideId: string) => {
+			if (requestAnimationFrameRef.current) {
+				cancelAnimationFrame(requestAnimationFrameRef.current);
+				requestAnimationFrameRef.current = null;
+			}
 
-		setGuidesList((prevState) => {
-			const newGuides = prevState.filter((selected) => {
-				if (!shouldDeleteGuide) {
-					return true;
-				}
+			const shouldDeleteGuide = shouldDeleteGuideRef.current;
 
-				return selected.id !== draggingGuideId;
+			setGuidesList((prevState) => {
+				const newGuides = prevState.filter((selected) => {
+					if (!shouldDeleteGuide) {
+						return true;
+					}
+
+					return selected.id !== guideId;
+				});
+				persistGuidesList(newGuides);
+				return newGuides;
 			});
-			persistGuidesList(newGuides);
-			return newGuides;
-		});
 
-		const deletedGuideWasSelected = selectedItems.some(
-			(item) => item.type === 'guide' && item.guideId === draggingGuideId,
-		);
-		if (shouldDeleteGuide && deletedGuideWasSelected) {
-			clearSelection();
-		}
+			const deletedGuideWasSelected = selectedItems.some(
+				(item) => item.type === 'guide' && item.guideId === guideId,
+			);
+			if (shouldDeleteGuide && deletedGuideWasSelected) {
+				clearSelection();
+			}
 
-		shouldDeleteGuideRef.current = false;
-		stopForcingSpecificCursor();
-		shouldCreateGuideRef.current = false;
-		setDraggingGuideId(() => null);
-		document.removeEventListener('pointerup', onMouseUp);
-		document.removeEventListener('pointercancel', onMouseUp);
-		document.removeEventListener('pointermove', onMouseMove);
-	}, [
-		clearSelection,
-		draggingGuideId,
-		shouldCreateGuideRef,
-		shouldDeleteGuideRef,
-		setDraggingGuideId,
-		setGuidesList,
-		onMouseMove,
-		selectedItems,
-	]);
+			shouldDeleteGuideRef.current = false;
+			stopForcingSpecificCursor();
+			shouldCreateGuideRef.current = false;
+			setDraggingGuideId(() => null);
+		},
+		[
+			clearSelection,
+			shouldCreateGuideRef,
+			shouldDeleteGuideRef,
+			setDraggingGuideId,
+			setGuidesList,
+			selectedItems,
+		],
+	);
 
 	useLayoutEffect(() => {
-		if (draggingGuideId !== null) {
-			document.addEventListener('pointermove', onMouseMove);
-			document.addEventListener('pointerup', onMouseUp);
-			document.addEventListener('pointercancel', onMouseUp);
-		}
+		moveGuidePointerRef.current = (event) => {
+			onMouseMove(event, draggingGuideId);
+		};
 
 		return () => {
-			document.removeEventListener('pointermove', onMouseMove);
-			document.removeEventListener('pointerup', onMouseUp);
-			document.removeEventListener('pointercancel', onMouseUp);
+			moveGuidePointerRef.current = null;
 			if (requestAnimationFrameRef.current) {
 				cancelAnimationFrame(requestAnimationFrameRef.current);
 			}
 		};
-	}, [draggingGuideId, onMouseMove, onMouseUp]);
+	}, [draggingGuideId, moveGuidePointerRef, onMouseMove]);
+
+	const onPointerSessionStart = useCallback(
+		(event: React.PointerEvent<HTMLCanvasElement>, guideId: string) => {
+			startPointerSession({
+				event: event.nativeEvent,
+				target: event.currentTarget,
+				onMove: (moveEvent) => onMouseMove(moveEvent, guideId),
+				onEnd: () => finishGuideInteraction(guideId),
+			});
+		},
+		[finishGuideInteraction, onMouseMove],
+	);
 
 	return (
 		<>
@@ -269,6 +281,7 @@ export const EditorRulers: React.FC<{
 				markingGaps={rulerMarkingGaps}
 				originOffset={canvasPosition.left}
 				size={canvasSize}
+				onPointerSessionStart={onPointerSessionStart}
 			/>
 			<Ruler
 				orientation="vertical"
@@ -278,6 +291,7 @@ export const EditorRulers: React.FC<{
 				markingGaps={rulerMarkingGaps}
 				originOffset={canvasPosition.top}
 				size={canvasSize}
+				onPointerSessionStart={onPointerSessionStart}
 			/>
 		</>
 	);

--- a/packages/studio/src/components/ForceSpecificCursor.tsx
+++ b/packages/studio/src/components/ForceSpecificCursor.tsx
@@ -5,7 +5,21 @@ const ref = React.createRef<HTMLDivElement>();
 const removeAutomaticCleanupListeners = () => {
 	window.removeEventListener('pointerup', stopForcingSpecificCursor, true);
 	window.removeEventListener('pointercancel', stopForcingSpecificCursor, true);
+	window.removeEventListener('pointermove', stopIfNoButtonsArePressed, true);
 	window.removeEventListener('blur', stopForcingSpecificCursor, true);
+	document.removeEventListener('visibilitychange', stopIfDocumentIsHidden);
+};
+
+const stopIfNoButtonsArePressed = (event: PointerEvent) => {
+	if (event.buttons === 0) {
+		stopForcingSpecificCursor();
+	}
+};
+
+const stopIfDocumentIsHidden = () => {
+	if (document.visibilityState === 'hidden') {
+		stopForcingSpecificCursor();
+	}
 };
 
 export const forceSpecificCursor = (cursor: string): void => {
@@ -21,7 +35,9 @@ export const forceSpecificCursor = (cursor: string): void => {
 	// initiator so the cursor overlay can never remain stuck.
 	window.addEventListener('pointerup', stopForcingSpecificCursor, true);
 	window.addEventListener('pointercancel', stopForcingSpecificCursor, true);
+	window.addEventListener('pointermove', stopIfNoButtonsArePressed, true);
 	window.addEventListener('blur', stopForcingSpecificCursor, true);
+	document.addEventListener('visibilitychange', stopIfDocumentIsHidden);
 };
 
 export const stopForcingSpecificCursor = () => {

--- a/packages/studio/src/components/Menu/MenuItem.tsx
+++ b/packages/studio/src/components/Menu/MenuItem.tsx
@@ -7,6 +7,7 @@ import {
 	WHITE_ALPHA_80,
 	getBackgroundFromHoverState,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {MenuContent} from '../NewComposition/MenuContent';
@@ -115,17 +116,24 @@ export const MenuItem: React.FC<{
 
 				onItemSelected(id);
 
-				window.addEventListener(
-					'pointerup',
-					(evt) => {
-						if (!isMenuItem(evt.target as HTMLElement)) {
-							onItemQuit();
+				startPointerSession({
+					event: e.nativeEvent,
+					target: e.currentTarget,
+					onEnd: (reason, evt) => {
+						if (
+							(reason === 'pointerup' || reason === 'buttons-released') &&
+							evt
+						) {
+							const target = document.elementFromPoint(
+								evt.clientX,
+								evt.clientY,
+							);
+							if (!target || !isMenuItem(target as HTMLElement)) {
+								onItemQuit();
+							}
 						}
 					},
-					{
-						once: true,
-					},
-				);
+				});
 			},
 			[id, onItemQuit, onItemSelected],
 		);

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -7,6 +7,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {interpolate} from 'remotion';
 import {BLUE, TRANSPARENT} from '../../helpers/colors';
 import {noop} from '../../helpers/noop';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {getClickLock, setClickLock} from '../../state/input-dragger-click-lock';
 import {HigherZIndex} from '../../state/z-index';
 import {
@@ -600,16 +601,16 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	const onPointerDown: PointerEventHandler<HTMLButtonElement> = useCallback(
 		(e) => {
 			e.stopPropagation();
-			pointerDownRef.current = true;
 			const target = e.currentTarget as HTMLButtonElement;
 			const {pageX, pageY, button} = e;
 			if (button !== 0) {
 				return;
 			}
 
+			pointerDownRef.current = true;
 			let lastDragValue: number | null = null;
 
-			const moveListener = (ev: MouseEvent) => {
+			const moveListener = (ev: PointerEvent) => {
 				const xDistance = ev.pageX - pageX;
 				const distanceFromStart = Math.sqrt(
 					xDistance ** 2 + (ev.pageY - pageY) ** 2,
@@ -644,39 +645,25 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				onValueChange(nextValue);
 			};
 
-			window.addEventListener('mousemove', moveListener);
-			const endDrag = (commit: boolean) => {
-				window.removeEventListener('mousemove', moveListener);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerCancel);
-				window.removeEventListener('blur', onWindowBlur);
-				pointerDownRef.current = false;
-				setDragging(false);
-				stopForcingSpecificCursor();
-				if (commit && lastDragValue !== null && onValueChangeEnd) {
-					onValueChangeEnd(lastDragValue);
-				}
+			startPointerSession({
+				event: e.nativeEvent,
+				target,
+				onMove: moveListener,
+				onEnd: (reason) => {
+					pointerDownRef.current = false;
+					setDragging(false);
+					stopForcingSpecificCursor();
+					const commit =
+						reason === 'pointerup' || reason === 'buttons-released';
+					if (commit && lastDragValue !== null && onValueChangeEnd) {
+						onValueChangeEnd(lastDragValue);
+					}
 
-				setTimeout(() => {
-					setClickLock(false);
-				}, 2);
-			};
-
-			const onPointerUp = () => {
-				endDrag(true);
-			};
-
-			const onPointerCancel = () => {
-				endDrag(false);
-			};
-
-			const onWindowBlur = () => {
-				endDrag(false);
-			};
-
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerCancel);
-			window.addEventListener('blur', onWindowBlur);
+					setTimeout(() => {
+						setClickLock(false);
+					}, 2);
+				},
+			});
 		},
 		[
 			_step,

--- a/packages/studio/src/components/SelectedOutlineCropControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineCropControls.tsx
@@ -5,6 +5,7 @@ import {
 	SELECTED_OUTLINE_DROP_SHADOW,
 	TRANSPARENT,
 } from '../helpers/colors';
+import {startPointerSession} from '../helpers/pointer-session';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -290,9 +291,6 @@ const CropHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragStarted) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -344,9 +342,12 @@ const CropHandle: React.FC<{
 					});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 		},
 		[
 			clearDragOverrides,

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -14,6 +14,7 @@ import {getConnectedCompositions} from '../helpers/get-connected-compositions';
 import {getSequenceDoubleClickAction} from '../helpers/get-sequence-double-click-action';
 import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
 import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
+import {startPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ModalsContext} from '../state/modals';
 import {callApi} from './call-api';
@@ -333,9 +334,6 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
 				stopForcingSpecificCursor();
@@ -390,9 +388,12 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 					});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 			window.addEventListener('keydown', onKeyChange);
 			window.addEventListener('keyup', onKeyChange);
 		},
@@ -671,9 +672,6 @@ const SelectedOutlinePolygon: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
 				if (dragStarted) {
@@ -738,9 +736,12 @@ const SelectedOutlinePolygon: React.FC<{
 					});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 			window.addEventListener('keydown', onKeyChange);
 			window.addEventListener('keyup', onKeyChange);
 		},
@@ -1010,9 +1011,6 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragStarted) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -1081,9 +1079,12 @@ const SelectedOutlineScaleEdgeLine: React.FC<{
 					});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 		},
 		[
 			allScaleDragTargets,
@@ -1337,9 +1338,6 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
 				if (dragStarted) {
@@ -1410,9 +1408,12 @@ const SelectedOutlineRotationCornerHandle: React.FC<{
 					});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 			window.addEventListener('keydown', onKeyChange);
 			window.addEventListener('keyup', onKeyChange);
 		},

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {BLUE, SELECTED_OUTLINE_UV_DROP_SHADOW, WHITE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {startPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {
 	forceSpecificCursor,
@@ -372,9 +373,6 @@ const SelectedUvEllipseStartHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragging) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -393,9 +391,12 @@ const SelectedUvEllipseStartHandle: React.FC<{
 				});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 		},
 		[
 			clearEffectDragOverrides,
@@ -518,9 +519,6 @@ const SelectedUvEllipseResizeHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragging) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -539,9 +537,12 @@ const SelectedUvEllipseResizeHandle: React.FC<{
 				});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 		},
 		[
 			axis,
@@ -735,9 +736,6 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				window.removeEventListener('keydown', onKeyChange);
 				window.removeEventListener('keyup', onKeyChange);
 				if (dragging) {
@@ -758,9 +756,12 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 				});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 			window.addEventListener('keydown', onKeyChange);
 			window.addEventListener('keyup', onKeyChange);
 		},
@@ -935,9 +936,6 @@ const SelectedUvHandleCircle: React.FC<{
 			};
 
 			const onPointerUp = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerUp);
 				if (dragging) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);
@@ -997,9 +995,12 @@ const SelectedUvHandleCircle: React.FC<{
 				});
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerUp);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
 		},
 		[
 			clearEffectDragOverrides,

--- a/packages/studio/src/components/ShowGuidesProvider.tsx
+++ b/packages/studio/src/components/ShowGuidesProvider.tsx
@@ -12,6 +12,9 @@ export const ShowGuidesProvider: React.FC<{
 }> = ({children}) => {
 	const [guidesList, setGuidesList] = useState<Guide[]>(() => loadGuidesList());
 	const [draggingGuideId, setDraggingGuideId] = useState<string | null>(null);
+	const moveGuidePointerRef = useRef<((event: PointerEvent) => void) | null>(
+		null,
+	);
 	const [hoveredGuideId, setHoveredGuideId] = useState<string | null>(null);
 	const [editorShowGuides, setEditorShowGuidesState] = useState(() =>
 		loadEditorShowGuidesOption(),
@@ -37,6 +40,7 @@ export const ShowGuidesProvider: React.FC<{
 			guidesList,
 			setGuidesList,
 			draggingGuideId,
+			moveGuidePointerRef,
 			setDraggingGuideId,
 			shouldCreateGuideRef,
 			shouldDeleteGuideRef,

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -1,5 +1,6 @@
 import {PlayerInternals} from '@remotion/player';
 import React, {useContext, useEffect, useRef} from 'react';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -38,7 +39,6 @@ export const SplitterHandle: React.FC<{
 			return;
 		}
 
-		// Cleanup for the listeners that only exist for the duration of a drag.
 		let endDrag: (() => void) | null = null;
 
 		const onPointerDown = (e: PointerEvent) => {
@@ -99,17 +99,6 @@ export const SplitterHandle: React.FC<{
 				return newFlex;
 			};
 
-			endDrag = () => {
-				dragContext.isDragging.current = false;
-				stopForcingSpecificCursor();
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerCancel);
-				window.removeEventListener('blur', onWindowBlur);
-				endDrag = null;
-				PlayerInternals.updateAllElementsSizes();
-			};
-
 			const onPointerMove = (ev: PointerEvent) => {
 				if (!dragContext.isDragging.current) {
 					return;
@@ -133,27 +122,25 @@ export const SplitterHandle: React.FC<{
 				}
 			};
 
-			const onPointerUp = (ev: PointerEvent) => {
-				if (!dragContext.isDragging.current) {
-					return;
-				}
+			endDrag = startPointerSession({
+				event: e,
+				target: current,
+				onMove: onPointerMove,
+				onEnd: (reason, endEvent) => {
+					if (
+						(reason === 'pointerup' || reason === 'buttons-released') &&
+						endEvent &&
+						dragContext.isDragging.current
+					) {
+						dragContext.persistFlex(getNewValue(endEvent, true));
+					}
 
-				dragContext.persistFlex(getNewValue(ev, true));
-				endDrag?.();
-			};
-
-			const onPointerCancel = () => {
-				endDrag?.();
-			};
-
-			const onWindowBlur = () => {
-				endDrag?.();
-			};
-
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerCancel);
-			window.addEventListener('blur', onWindowBlur);
+					dragContext.isDragging.current = false;
+					stopForcingSpecificCursor();
+					endDrag = null;
+					PlayerInternals.updateAllElementsSizes();
+				},
+			});
 		};
 
 		current.addEventListener('pointerdown', onPointerDown);

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -18,13 +18,14 @@ import {
 	BLUE,
 	EASING_SELECTED_BACKGROUND,
 	INPUT_BACKGROUND,
-	WHITE_ALPHA_05,
 	LIGHT_TEXT,
 	WHITE,
+	WHITE_ALPHA_05,
 	WHITE_ALPHA_12,
 	WHITE_ALPHA_35,
 	WHITE_ALPHA_72,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {Checkbox} from '../Checkbox';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {InputDragger} from '../NewComposition/InputDragger';
@@ -1041,32 +1042,6 @@ export const EasingEditor: React.FC<{
 		[getValueFromPointer, setBezierAndPreview],
 	);
 
-	useEffect(() => {
-		if (activeHandle === null) {
-			return;
-		}
-
-		const onPointerMove = (event: PointerEvent) => {
-			updateHandleFromPointer(activeHandle, event);
-		};
-
-		const onPointerUp = () => {
-			commitEasing(
-				serializeBezier(bezierRef.current),
-				liveOverrideVersionRef.current,
-			);
-			setActiveHandle(null);
-		};
-
-		window.addEventListener('pointermove', onPointerMove);
-		window.addEventListener('pointerup', onPointerUp, {once: true});
-
-		return () => {
-			window.removeEventListener('pointermove', onPointerMove);
-			window.removeEventListener('pointerup', onPointerUp);
-		};
-	}, [activeHandle, commitEasing, updateHandleFromPointer]);
-
 	const onHandlePointerDown = useCallback(
 		(handle: HandleIndex, event: React.PointerEvent<SVGCircleElement>) => {
 			if (previewServerState.type !== 'connected') {
@@ -1075,10 +1050,38 @@ export const EasingEditor: React.FC<{
 
 			event.preventDefault();
 			event.stopPropagation();
+			const bezierBeforeDrag = [...bezierRef.current] as CubicBezierTuple;
 			setActiveHandle(handle);
 			updateHandleFromPointer(handle, event);
+			startPointerSession({
+				event,
+				target: event.currentTarget,
+				onMove: (moveEvent) => {
+					updateHandleFromPointer(handle, moveEvent);
+				},
+				onEnd: (reason) => {
+					if (reason === 'pointerup' || reason === 'buttons-released') {
+						commitEasing(
+							serializeBezier(bezierRef.current),
+							liveOverrideVersionRef.current,
+						);
+					} else {
+						clearEasingDragOverrides(pendingOverrideTargetsRef.current);
+						pendingOverrideTargetsRef.current = [];
+						bezierRef.current = bezierBeforeDrag;
+						setBezier(bezierBeforeDrag);
+					}
+
+					setActiveHandle(null);
+				},
+			});
 		},
-		[previewServerState.type, updateHandleFromPointer],
+		[
+			clearEasingDragOverrides,
+			commitEasing,
+			previewServerState.type,
+			updateHandleFromPointer,
+		],
 	);
 
 	useEffect(() => {

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
 import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
@@ -111,6 +112,9 @@ const TimelineDragHandlerInner: React.FC = () => {
 		| {
 				dragging: true;
 				wasPlaying: boolean;
+				button: number;
+				pointerId: number;
+				target: HTMLDivElement;
 		  }
 	>({
 		dragging: false,
@@ -156,7 +160,11 @@ const TimelineDragHandlerInner: React.FC = () => {
 			setDragging({
 				dragging: true,
 				wasPlaying: playing,
+				button: e.button,
+				pointerId: e.pointerId,
+				target: e.currentTarget,
 			});
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 			pause();
 		},
 		[isHighestContext, videoConfig, left, width, seek, playing, pause],
@@ -297,18 +305,46 @@ const TimelineDragHandlerInner: React.FC = () => {
 		[dragging, left, play, videoConfig, setFrame, width],
 	);
 
+	const onPointerCancelScrubbing = useCallback(() => {
+		stopInterval();
+		document.body.style.userSelect = '';
+		document.body.style.webkitUserSelect = '';
+		if (!dragging.dragging) {
+			return;
+		}
+
+		setDragging({dragging: false});
+		if (dragging.wasPlaying) {
+			play();
+		}
+	}, [dragging, play]);
+
 	useEffect(() => {
 		if (!dragging.dragging) {
 			return;
 		}
 
-		window.addEventListener('pointermove', onPointerMoveScrubbing);
-		window.addEventListener('pointerup', onPointerUpScrubbing);
-		return () => {
-			window.removeEventListener('pointermove', onPointerMoveScrubbing);
-			window.removeEventListener('pointerup', onPointerUpScrubbing);
-		};
-	}, [dragging.dragging, onPointerMoveScrubbing, onPointerUpScrubbing]);
+		return startPointerSession({
+			event: dragging,
+			target: dragging.target,
+			onMove: onPointerMoveScrubbing,
+			onEnd: (reason, endEvent) => {
+				if (
+					(reason === 'pointerup' || reason === 'buttons-released') &&
+					endEvent
+				) {
+					onPointerUpScrubbing(endEvent);
+				} else {
+					onPointerCancelScrubbing();
+				}
+			},
+		});
+	}, [
+		dragging,
+		onPointerCancelScrubbing,
+		onPointerMoveScrubbing,
+		onPointerUpScrubbing,
+	]);
 
 	const ref = useRef<HTMLDivElement>(null);
 

--- a/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {
 	useTimelineInOutFramePosition,
 	useTimelineSetInOutFramePosition,
@@ -61,6 +62,9 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 				dragging: 'in' | 'out';
 				initialOffset: number;
 				boundaries: [number, number];
+				button: number;
+				pointerId: number;
+				target: HTMLDivElement;
 		  }
 	>({
 		dragging: false,
@@ -120,7 +124,11 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 				dragging: 'in',
 				initialOffset: getClientXWithScroll(e.clientX),
 				boundaries: [-Infinity, outMarker - inMarker],
+				button: e.button,
+				pointerId: e.pointerId,
+				target: e.currentTarget,
 			});
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 		},
 		[isHighestContext, videoConfig, inFrame, get, outFrame],
 	);
@@ -155,7 +163,11 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 				dragging: 'out',
 				initialOffset: getClientXWithScroll(e.clientX),
 				boundaries: [inMarker - outMarker, Infinity],
+				button: e.button,
+				pointerId: e.pointerId,
+				target: e.currentTarget,
 			});
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 		},
 		[isHighestContext, videoConfig, inFrame, get, outFrame],
 	);
@@ -311,18 +323,23 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 			return;
 		}
 
-		window.addEventListener('pointermove', onPointerMoveInOut);
-		window.addEventListener('pointerup', onPointerUpInOut);
-		window.addEventListener('pointercancel', onPointerCancelInOut);
-		window.addEventListener('blur', onPointerCancelInOut);
-		return () => {
-			window.removeEventListener('pointermove', onPointerMoveInOut);
-			window.removeEventListener('pointerup', onPointerUpInOut);
-			window.removeEventListener('pointercancel', onPointerCancelInOut);
-			window.removeEventListener('blur', onPointerCancelInOut);
-		};
+		return startPointerSession({
+			event: inOutDragging,
+			target: inOutDragging.target,
+			onMove: onPointerMoveInOut,
+			onEnd: (reason, endEvent) => {
+				if (
+					(reason === 'pointerup' || reason === 'buttons-released') &&
+					endEvent
+				) {
+					onPointerUpInOut(endEvent);
+				} else {
+					onPointerCancelInOut();
+				}
+			},
+		});
 	}, [
-		inOutDragging.dragging,
+		inOutDragging,
 		onPointerCancelInOut,
 		onPointerMoveInOut,
 		onPointerUpInOut,

--- a/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
@@ -5,6 +5,7 @@ import {
 	LIGHT_COLOR,
 	WHITE,
 } from '../../helpers/colors';
+import {startPointerSession} from '../../helpers/pointer-session';
 import type {RenderInlineAction} from '../InlineAction';
 
 const eyeIcon: React.CSSProperties = {
@@ -37,6 +38,10 @@ export const timelineLayerIconContainer: React.CSSProperties = {
 };
 
 let layerPointedDown: null | 'enable' | 'disable' = null;
+let stopLayerPointerSession: (() => void) | null = null;
+let lastPaintedLayerEye: Element | null = null;
+const layerEyeActions = new WeakMap<Element, () => void>();
+const TIMELINE_LAYER_EYE_ATTR = 'data-timeline-layer-eye';
 
 export const TimelineLayerEye: React.FC<{
 	readonly onInvoked: (type: 'enable' | 'disable') => void;
@@ -91,15 +96,30 @@ export const TimelineLayerEye: React.FC<{
 
 			e.preventDefault();
 			e.stopPropagation();
+			stopLayerPointerSession?.();
 			layerPointedDown = hidden ? 'enable' : 'disable';
 			onInvoked(layerPointedDown);
-			window.addEventListener(
-				'pointerup',
-				() => {
-					layerPointedDown = null;
+			lastPaintedLayerEye = e.currentTarget;
+			stopLayerPointerSession = startPointerSession({
+				event: e,
+				target: e.currentTarget,
+				onMove: (moveEvent) => {
+					const pointedElement = document
+						.elementFromPoint(moveEvent.clientX, moveEvent.clientY)
+						?.closest(`[${TIMELINE_LAYER_EYE_ATTR}]`);
+					if (!pointedElement || pointedElement === lastPaintedLayerEye) {
+						return;
+					}
+
+					lastPaintedLayerEye = pointedElement;
+					layerEyeActions.get(pointedElement)?.();
 				},
-				{once: true},
-			);
+				onEnd: () => {
+					layerPointedDown = null;
+					lastPaintedLayerEye = null;
+					stopLayerPointerSession = null;
+				},
+			});
 		},
 		[hidden, onInvoked],
 	);
@@ -118,6 +138,19 @@ export const TimelineLayerEye: React.FC<{
 		}
 	}, [onInvoked]);
 
+	const registerLayerEye = useCallback(
+		(element: HTMLDivElement | null) => {
+			if (element) {
+				layerEyeActions.set(element, () => {
+					if (layerPointedDown) {
+						onInvoked(layerPointedDown);
+					}
+				});
+			}
+		},
+		[onInvoked],
+	);
+
 	const onDoubleClick: React.MouseEventHandler<HTMLDivElement> = useCallback(
 		(e) => {
 			e.stopPropagation();
@@ -127,6 +160,8 @@ export const TimelineLayerEye: React.FC<{
 
 	return (
 		<div
+			ref={registerLayerEye}
+			{...{[TIMELINE_LAYER_EYE_ATTR]: true}}
 			style={timelineLayerIconContainer}
 			draggable={false}
 			onDragStart={onDragStart}

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -37,6 +37,7 @@ import {
 	isStudioInteractivityEnabled,
 	isStudioSelectionEnabled,
 } from '../../helpers/interactivity-enabled';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
@@ -1573,10 +1574,7 @@ export const useTimelineMarqueeSelection = () => {
 				return;
 			}
 
-			const {currentTarget: target, pointerId} = event;
-			if (target.setPointerCapture) {
-				target.setPointerCapture(pointerId);
-			}
+			const {currentTarget: target} = event;
 
 			const initialBounds = target.getBoundingClientRect();
 			const marqueeBounds: TimelineMarqueeRect = {
@@ -1603,13 +1601,6 @@ export const useTimelineMarqueeSelection = () => {
 			const selectionBeforeMarquee = selectedItems;
 
 			const cleanup = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerCancel);
-				if (target.hasPointerCapture?.(pointerId)) {
-					target.releasePointerCapture(pointerId);
-				}
-
 				document.body.style.userSelect = previousUserSelect;
 				document.body.style.webkitUserSelect = previousWebkitUserSelect;
 				setMarqueeRect(null);
@@ -1653,18 +1644,21 @@ export const useTimelineMarqueeSelection = () => {
 				updateSelection(moveEvent.clientX, moveEvent.clientY);
 			};
 
-			const onPointerUp = (upEvent: PointerEvent) => {
-				updateSelection(upEvent.clientX, upEvent.clientY);
-				cleanup();
-			};
+			startPointerSession({
+				event,
+				target,
+				onMove: onPointerMove,
+				onEnd: (reason, endEvent) => {
+					if (
+						(reason === 'pointerup' || reason === 'buttons-released') &&
+						endEvent
+					) {
+						updateSelection(endEvent.clientX, endEvent.clientY);
+					}
 
-			const onPointerCancel = () => {
-				cleanup();
-			};
-
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerCancel);
+					cleanup();
+				},
+			});
 		},
 		[
 			canSelect,

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -12,11 +12,11 @@ import React, {
 import type {
 	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
+	InteractivitySchema,
 	OverrideIdToNodePaths,
 	PropStatuses,
 	SequencePropsSubscriptionKey,
 	TSequence,
-	InteractivitySchema,
 } from 'remotion';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -24,6 +24,7 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {TRANSPARENT} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {EditorSnappingContext} from '../../state/editor-snapping';
@@ -969,6 +970,8 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 		latestDeltaFrames: number;
 		pxPerFrame: number;
 		pointerId: number;
+		button: number;
+		target: HTMLDivElement;
 		targets: readonly TimelineSequenceLeftEdgeDragTarget[];
 	} | null>(null);
 
@@ -1093,8 +1096,11 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 				latestDeltaFrames: 0,
 				pxPerFrame,
 				pointerId: e.pointerId,
+				button: e.button,
+				target: e.currentTarget,
 				targets,
 			};
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 			document.body.style.userSelect = 'none';
 			document.body.style.webkitUserSelect = 'none';
 			forceSpecificCursor('ew-resize');
@@ -1171,22 +1177,28 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 			finishDrag(false);
 		};
 
-		const onWindowBlur = () => {
-			finishDrag(false);
-		};
+		const activeDragState = dragStateRef.current;
+		if (!activeDragState) {
+			return;
+		}
 
-		window.addEventListener('pointermove', onMove);
-		window.addEventListener('pointerup', onUp);
-		window.addEventListener('pointercancel', onCancel);
-		window.addEventListener('blur', onWindowBlur);
-
-		return () => {
-			window.removeEventListener('pointermove', onMove);
-			window.removeEventListener('pointerup', onUp);
-			window.removeEventListener('pointercancel', onCancel);
-			window.removeEventListener('blur', onWindowBlur);
-			finishDrag(false);
-		};
+		return startPointerSession({
+			event: activeDragState,
+			target: activeDragState.target,
+			onMove,
+			onEnd: (reason, endEvent) => {
+				if (
+					(reason === 'pointerup' || reason === 'buttons-released') &&
+					endEvent
+				) {
+					onUp(endEvent);
+				} else if (endEvent) {
+					onCancel(endEvent);
+				} else {
+					finishDrag(false);
+				}
+			},
+		});
 	}, [dragging, finishDrag]);
 
 	const style: React.CSSProperties = {
@@ -1239,6 +1251,8 @@ export const useTimelineSequenceFromDrag = ({
 		latestDeltaFrames: number;
 		pxPerFrame: number;
 		pointerId: number;
+		button: number;
+		target: HTMLDivElement;
 		targets: readonly TimelineSequenceFromDragTarget[];
 	} | null>(null);
 
@@ -1383,8 +1397,11 @@ export const useTimelineSequenceFromDrag = ({
 				latestDeltaFrames: 0,
 				pxPerFrame,
 				pointerId: e.pointerId,
+				button: e.button,
+				target: e.currentTarget,
 				targets,
 			};
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 			document.body.style.userSelect = 'none';
 			document.body.style.webkitUserSelect = 'none';
 			setDragging(true);
@@ -1476,22 +1493,28 @@ export const useTimelineSequenceFromDrag = ({
 			finishDrag(false);
 		};
 
-		const onWindowBlur = () => {
-			finishDrag(false);
-		};
+		const activeDragState = dragStateRef.current;
+		if (!activeDragState) {
+			return;
+		}
 
-		window.addEventListener('pointermove', onMove);
-		window.addEventListener('pointerup', onUp);
-		window.addEventListener('pointercancel', onCancel);
-		window.addEventListener('blur', onWindowBlur);
-
-		return () => {
-			window.removeEventListener('pointermove', onMove);
-			window.removeEventListener('pointerup', onUp);
-			window.removeEventListener('pointercancel', onCancel);
-			window.removeEventListener('blur', onWindowBlur);
-			finishDrag(false);
-		};
+		return startPointerSession({
+			event: activeDragState,
+			target: activeDragState.target,
+			onMove,
+			onEnd: (reason, endEvent) => {
+				if (
+					(reason === 'pointerup' || reason === 'buttons-released') &&
+					endEvent
+				) {
+					onUp(endEvent);
+				} else if (endEvent) {
+					onCancel(endEvent);
+				} else {
+					finishDrag(false);
+				}
+			},
+		});
 	}, [dragging, finishDrag]);
 
 	return {
@@ -1524,6 +1547,8 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 		latestDeltaFrames: number;
 		pxPerFrame: number;
 		pointerId: number;
+		button: number;
+		target: HTMLDivElement;
 		targets: readonly TimelineSequenceDurationDragTarget[];
 	} | null>(null);
 
@@ -1647,8 +1672,11 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 				latestDeltaFrames: 0,
 				pxPerFrame,
 				pointerId: e.pointerId,
+				button: e.button,
+				target: e.currentTarget,
 				targets,
 			};
+			e.currentTarget.setPointerCapture?.(e.pointerId);
 			document.body.style.userSelect = 'none';
 			document.body.style.webkitUserSelect = 'none';
 			forceSpecificCursor('ew-resize');
@@ -1713,23 +1741,28 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 			finishDrag(false);
 		};
 
-		// Bail if the page loses focus mid-drag.
-		const onWindowBlur = () => {
-			finishDrag(false);
-		};
+		const activeDragState = dragStateRef.current;
+		if (!activeDragState) {
+			return;
+		}
 
-		window.addEventListener('pointermove', onMove);
-		window.addEventListener('pointerup', onUp);
-		window.addEventListener('pointercancel', onCancel);
-		window.addEventListener('blur', onWindowBlur);
-
-		return () => {
-			window.removeEventListener('pointermove', onMove);
-			window.removeEventListener('pointerup', onUp);
-			window.removeEventListener('pointercancel', onCancel);
-			window.removeEventListener('blur', onWindowBlur);
-			finishDrag(false);
-		};
+		return startPointerSession({
+			event: activeDragState,
+			target: activeDragState.target,
+			onMove,
+			onEnd: (reason, endEvent) => {
+				if (
+					(reason === 'pointerup' || reason === 'buttons-released') &&
+					endEvent
+				) {
+					onUp(endEvent);
+				} else if (endEvent) {
+					onCancel(endEvent);
+				} else {
+					finishDrag(false);
+				}
+			},
+		});
 	}, [dragging, finishDrag]);
 
 	const style: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -7,15 +7,16 @@ import {useCallback, useContext} from 'react';
 import type {
 	CanUpdateSequencePropStatusKeyframed,
 	DragOverrideValue,
+	InteractivitySchema,
 	OverrideIdToNodePaths,
 	PropStatuses,
 	SequencePropsSubscriptionKey,
-	InteractivitySchema,
 	TSequence,
 } from 'remotion';
 import {Internals, useVideoConfig} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {startPointerSession} from '../../helpers/pointer-session';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {callMoveKeyframes} from './call-move-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
@@ -573,11 +574,8 @@ export const useTimelineKeyframeDrag = ({
 				return dragTargets;
 			};
 
-			const cleanup = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerCancel);
-			};
+			let stopPointerSession: (() => void) | null = null;
+			const cleanup = () => stopPointerSession?.();
 
 			const clearActiveOverrides = () => {
 				const targets = dragTargets;
@@ -727,9 +725,18 @@ export const useTimelineKeyframeDrag = ({
 				clearDraggedKeyframes();
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerCancel);
+			stopPointerSession = startPointerSession({
+				event: e,
+				target: e.currentTarget,
+				onMove: onPointerMove,
+				onEnd: (reason) => {
+					if (reason === 'pointerup' || reason === 'buttons-released') {
+						onPointerUp();
+					} else {
+						onPointerCancel();
+					}
+				},
+			});
 		},
 		[
 			clearDragOverrides,
@@ -846,11 +853,8 @@ export const useTimelineEasingKeyframeDrag = ({
 				return dragTargets;
 			};
 
-			const cleanup = () => {
-				window.removeEventListener('pointermove', onPointerMove);
-				window.removeEventListener('pointerup', onPointerUp);
-				window.removeEventListener('pointercancel', onPointerCancel);
-			};
+			let stopPointerSession: (() => void) | null = null;
+			const cleanup = () => stopPointerSession?.();
 
 			const clearActiveOverrides = () => {
 				const targets = dragTargets;
@@ -999,9 +1003,18 @@ export const useTimelineEasingKeyframeDrag = ({
 				clearDraggedKeyframes();
 			};
 
-			window.addEventListener('pointermove', onPointerMove);
-			window.addEventListener('pointerup', onPointerUp);
-			window.addEventListener('pointercancel', onPointerCancel);
+			stopPointerSession = startPointerSession({
+				event: e,
+				target: e.currentTarget,
+				onMove: onPointerMove,
+				onEnd: (reason) => {
+					if (reason === 'pointerup' || reason === 'buttons-released') {
+						onPointerUp();
+					} else {
+						onPointerCancel();
+					}
+				},
+			});
 		},
 		[
 			clearDragOverrides,

--- a/packages/studio/src/helpers/pointer-session.ts
+++ b/packages/studio/src/helpers/pointer-session.ts
@@ -1,0 +1,129 @@
+export type PointerSessionEndReason =
+	| 'pointerup'
+	| 'pointercancel'
+	| 'lostpointercapture'
+	| 'blur'
+	| 'visibilitychange'
+	| 'buttons-released'
+	| 'manual';
+
+type PointerSessionEvent = Pick<PointerEvent, 'button' | 'pointerId'>;
+
+const getButtonMask = (button: number) => {
+	if (button === 0) {
+		return 1;
+	}
+
+	if (button === 1) {
+		return 4;
+	}
+
+	if (button === 2) {
+		return 2;
+	}
+
+	return 1 << button;
+};
+
+export const startPointerSession = ({
+	event,
+	target,
+	onMove,
+	onEnd,
+}: {
+	event: PointerSessionEvent;
+	target: Element;
+	onMove?: (event: PointerEvent) => void;
+	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
+}): (() => void) => {
+	const {pointerId} = event;
+	const buttonMask = getButtonMask(event.button);
+	let ended = false;
+
+	const cleanup = () => {
+		window.removeEventListener('pointermove', handleMove);
+		window.removeEventListener('pointerup', handleUp);
+		window.removeEventListener('pointercancel', handleCancel);
+		window.removeEventListener('blur', handleBlur);
+		document.removeEventListener('visibilitychange', handleVisibilityChange);
+		target.removeEventListener('lostpointercapture', handleLostPointerCapture);
+
+		if (target.hasPointerCapture?.(pointerId)) {
+			try {
+				target.releasePointerCapture(pointerId);
+			} catch {
+				// The browser may already have released capture.
+			}
+		}
+	};
+
+	const end = (
+		reason: PointerSessionEndReason,
+		pointerEvent: PointerEvent | null,
+	) => {
+		if (ended) {
+			return;
+		}
+
+		ended = true;
+		cleanup();
+		onEnd(reason, pointerEvent);
+	};
+
+	function handleMove(moveEvent: PointerEvent) {
+		if (moveEvent.pointerId !== pointerId) {
+			return;
+		}
+
+		if ((moveEvent.buttons & buttonMask) === 0) {
+			end('buttons-released', moveEvent);
+			return;
+		}
+
+		onMove?.(moveEvent);
+	}
+
+	function handleUp(upEvent: PointerEvent) {
+		if (upEvent.pointerId === pointerId) {
+			end('pointerup', upEvent);
+		}
+	}
+
+	function handleCancel(cancelEvent: PointerEvent) {
+		if (cancelEvent.pointerId === pointerId) {
+			end('pointercancel', cancelEvent);
+		}
+	}
+
+	function handleLostPointerCapture(lostEvent: Event) {
+		const pointerEvent = lostEvent as PointerEvent;
+		if (pointerEvent.pointerId === pointerId) {
+			end('lostpointercapture', pointerEvent);
+		}
+	}
+
+	function handleBlur() {
+		end('blur', null);
+	}
+
+	function handleVisibilityChange() {
+		if (document.visibilityState === 'hidden') {
+			end('visibilitychange', null);
+		}
+	}
+
+	try {
+		target.setPointerCapture?.(pointerId);
+	} catch {
+		// Capture is best-effort for detached or browser-owned targets.
+	}
+
+	window.addEventListener('pointermove', handleMove);
+	window.addEventListener('pointerup', handleUp);
+	window.addEventListener('pointercancel', handleCancel);
+	window.addEventListener('blur', handleBlur);
+	document.addEventListener('visibilitychange', handleVisibilityChange);
+	target.addEventListener('lostpointercapture', handleLostPointerCapture);
+
+	return () => end('manual', null);
+};

--- a/packages/studio/src/state/editor-guides.ts
+++ b/packages/studio/src/state/editor-guides.ts
@@ -14,6 +14,7 @@ export type GuideState = {
 	guidesList: Guide[];
 	setGuidesList: (cb: (prevState: Guide[]) => Guide[]) => void;
 	draggingGuideId: string | null;
+	moveGuidePointerRef: React.RefObject<((event: PointerEvent) => void) | null>;
 	setDraggingGuideId: (cb: (prevState: string | null) => string | null) => void;
 	setHoveredGuideId: (cb: (prevState: string | null) => string | null) => void;
 	hoveredGuideId: string | null;
@@ -45,6 +46,7 @@ export const EditorShowGuidesContext = createContext<GuideState>({
 	guidesList: [],
 	setGuidesList: () => undefined,
 	draggingGuideId: null,
+	moveGuidePointerRef: {current: null},
 	setDraggingGuideId: () => undefined,
 	shouldCreateGuideRef: {current: false},
 	shouldDeleteGuideRef: {current: false},

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -5,6 +5,7 @@ import React, {
 	useMemo,
 	useRef,
 } from 'react';
+import {startPointerSession} from '../helpers/pointer-session';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {HighestZIndexContext} from './highest-z-index';
 import {getClickLock} from './input-dragger-click-lock';
@@ -81,9 +82,9 @@ export const HigherZIndex: React.FC<{
 			return;
 		}
 
-		let onUp: ((upEvent: MouseEvent) => void) | null = null;
+		let endPointerSession: (() => void) | null = null;
 
-		const listener = (downEvent: MouseEvent) => {
+		const listener = (downEvent: PointerEvent) => {
 			if (outsideClickButton === 'primary' && downEvent.button !== 0) {
 				return;
 			}
@@ -95,19 +96,28 @@ export const HigherZIndex: React.FC<{
 				return;
 			}
 
-			onUp = (upEvent: MouseEvent) => {
-				if (
-					highestContext.highestIndex === currentIndex &&
-					!getClickLock() &&
-					// Don't trigger if that click removed that node
-					document.contains(upEvent.target as Node)
-				) {
-					upEvent.stopPropagation();
-					onOutsideClick(upEvent.target as Node);
-				}
-			};
-
-			window.addEventListener('pointerup', onUp, {once: true});
+			endPointerSession?.();
+			endPointerSession = startPointerSession({
+				event: downEvent,
+				target: downEvent.target as Element,
+				onEnd: (reason, upEvent) => {
+					endPointerSession = null;
+					if (
+						(reason === 'pointerup' || reason === 'buttons-released') &&
+						upEvent &&
+						highestContext.highestIndex === currentIndex &&
+						!getClickLock()
+					) {
+						const target =
+							document.elementFromPoint(upEvent.clientX, upEvent.clientY) ??
+							(upEvent.target as Element);
+						if (document.contains(target)) {
+							upEvent.stopPropagation();
+							onOutsideClick(target);
+						}
+					}
+				},
+			});
 		};
 
 		// If a menu is opened, then this component will also still receive the pointerdown event.
@@ -119,12 +129,8 @@ export const HigherZIndex: React.FC<{
 			window.addEventListener('pointerdown', listener, true);
 		});
 		return () => {
-			if (onUp) {
-				// @ts-expect-error
-				window.removeEventListener('pointerup', onUp, {once: true});
-			}
-
-			onUp = null;
+			endPointerSession?.();
+			endPointerSession = null;
 
 			return window.removeEventListener('pointerdown', listener, true);
 		};

--- a/packages/studio/src/test/pointer-session.test.ts
+++ b/packages/studio/src/test/pointer-session.test.ts
@@ -1,0 +1,160 @@
+import {expect, test} from 'bun:test';
+import {
+	type PointerSessionEndReason,
+	startPointerSession,
+} from '../helpers/pointer-session';
+
+class CaptureTarget extends EventTarget {
+	private readonly capturedPointers = new Set<number>();
+	public releasedPointers: number[] = [];
+
+	setPointerCapture(pointerId: number) {
+		this.capturedPointers.add(pointerId);
+	}
+
+	hasPointerCapture(pointerId: number) {
+		return this.capturedPointers.has(pointerId);
+	}
+
+	releasePointerCapture(pointerId: number) {
+		this.capturedPointers.delete(pointerId);
+		this.releasedPointers.push(pointerId);
+	}
+}
+
+class FakeDocument extends EventTarget {
+	public visibilityState: DocumentVisibilityState = 'visible';
+}
+
+const makePointerEvent = (
+	type: string,
+	{
+		pointerId,
+		button = 0,
+		buttons = 1,
+	}: {
+		pointerId: number;
+		button?: number;
+		buttons?: number;
+	},
+) => {
+	return Object.assign(new Event(type), {
+		pointerId,
+		button,
+		buttons,
+	}) as PointerEvent;
+};
+
+test('pointer sessions filter their pointer and clean up every termination path', () => {
+	const originalWindow = globalThis.window;
+	const originalDocument = globalThis.document;
+	const fakeWindow = new EventTarget() as Window & typeof globalThis;
+	const fakeDocument = new FakeDocument();
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: fakeWindow,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		configurable: true,
+		value: fakeDocument,
+	});
+
+	try {
+		const target = new CaptureTarget();
+		const moves: number[] = [];
+		const endings: PointerSessionEndReason[] = [];
+		startPointerSession({
+			event: {button: 0, pointerId: 4},
+			target: target as unknown as Element,
+			onMove: (event) => moves.push(event.pointerId),
+			onEnd: (reason) => endings.push(reason),
+		});
+
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointermove', {pointerId: 8, buttons: 1}),
+		);
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointerup', {pointerId: 8, buttons: 0}),
+		);
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointermove', {pointerId: 4, buttons: 1}),
+		);
+		expect(moves).toEqual([4]);
+		expect(endings).toEqual([]);
+
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointermove', {pointerId: 4, buttons: 0}),
+		);
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointercancel', {pointerId: 4, buttons: 0}),
+		);
+		expect(endings).toEqual(['buttons-released']);
+		expect(target.releasedPointers).toEqual([4]);
+
+		const terminationCases: {
+			reason: PointerSessionEndReason;
+			trigger: (sessionTarget: CaptureTarget, pointerId: number) => void;
+		}[] = [
+			{
+				reason: 'pointerup',
+				trigger: (_sessionTarget, pointerId) =>
+					fakeWindow.dispatchEvent(
+						makePointerEvent('pointerup', {pointerId, buttons: 0}),
+					),
+			},
+			{
+				reason: 'pointercancel',
+				trigger: (_sessionTarget, pointerId) =>
+					fakeWindow.dispatchEvent(
+						makePointerEvent('pointercancel', {pointerId, buttons: 0}),
+					),
+			},
+			{
+				reason: 'lostpointercapture',
+				trigger: (sessionTarget, pointerId) =>
+					sessionTarget.dispatchEvent(
+						makePointerEvent('lostpointercapture', {
+							pointerId,
+							buttons: 0,
+						}),
+					),
+			},
+			{
+				reason: 'blur',
+				trigger: () => fakeWindow.dispatchEvent(new Event('blur')),
+			},
+			{
+				reason: 'visibilitychange',
+				trigger: () => {
+					fakeDocument.visibilityState = 'hidden';
+					fakeDocument.dispatchEvent(new Event('visibilitychange'));
+					fakeDocument.visibilityState = 'visible';
+				},
+			},
+		];
+
+		for (const [index, terminationCase] of terminationCases.entries()) {
+			const sessionTarget = new CaptureTarget();
+			const reasons: PointerSessionEndReason[] = [];
+			const pointerId = index + 10;
+			startPointerSession({
+				event: {button: 0, pointerId},
+				target: sessionTarget as unknown as Element,
+				onEnd: (reason) => reasons.push(reason),
+			});
+			terminationCase.trigger(sessionTarget, pointerId);
+			terminationCase.trigger(sessionTarget, pointerId);
+			expect(reasons).toEqual([terminationCase.reason]);
+			expect(sessionTarget.releasedPointers).toEqual([pointerId]);
+		}
+	} finally {
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: originalWindow,
+		});
+		Object.defineProperty(globalThis, 'document', {
+			configurable: true,
+			value: originalDocument,
+		});
+	}
+});


### PR DESCRIPTION
## Summary

- add a shared captured pointer-session primitive with pointer ID filtering and idempotent cleanup
- migrate Studio layout, guides, value controls, Visual Mode gestures, and timeline interactions
- recover safely from pointer cancellation, lost capture, window blur, hidden documents, and re-entry without pressed buttons
- preserve interaction-specific commit and rollback behavior
- add focused lifecycle coverage for the shared pointer session

## Testing

- `bun test packages/studio/src` (553 tests)
- `bun run build`
- `bun run stylecheck`

Closes #9966
