### PR TITLE
Internal: Document skills eval usage

### DIFF
--- a/packages/skills-evals/README.md
+++ b/packages/skills-evals/README.md
@@ -2,4 +2,36 @@
 
 ## Usage
 
-This is an internal package and has no documentation.
+This internal package runs one-shot skill evaluations and lets you inspect the
+result, tool calls, and skill-routing behavior in a web UI.
+
+1. Install Pi:
+
+   ```sh
+   npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+   ```
+
+2. Start Pi, run `/login`, and connect a ChatGPT subscription or another model
+   provider:
+
+   ```sh
+   pi
+   ```
+
+3. From the repository root, open this package:
+
+   ```sh
+   cd packages/skills-evals
+   ```
+
+4. Add a scenario to [`scenarios.ts`](./scenarios.ts). You can also ask an agent
+   to define it.
+
+5. Start the web UI:
+
+   ```sh
+   bun run dev
+   ```
+
+6. Open [http://localhost:4321](http://localhost:4321), select the scenario,
+   and run it.


### PR DESCRIPTION
## Summary

- document how to install and authenticate Pi for skill evaluations
- explain how to add a scenario and launch the evaluation UI
- link the local UI URL

## Validation

- `bun run build`
- `bun run stylecheck`
