### PR TITLE
`@remotion/studio`: Fix submenu positioning in narrow viewports

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -24,6 +24,32 @@ test.describe('visual mode', () => {
 		});
 	});
 
+	test('should open submenus toward the side with more space', async ({
+		page,
+	}) => {
+		await page.setViewportSize({width: 500, height: 904});
+		await page.goto(STUDIO_URL);
+		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
+
+		await page.locator('.__remotion-studio-menu-initiator').first().click();
+		const compositionItem = page
+			.locator('.__remotion-studio-menu-item')
+			.filter({hasText: 'Composition'});
+		await compositionItem.hover();
+
+		const subMenuItem = page.getByRole('button', {name: 'Copy file location'});
+		await expect(subMenuItem).toBeVisible();
+
+		const [compositionBox, subMenuItemBox] = await Promise.all([
+			compositionItem.boundingBox(),
+			subMenuItem.boundingBox(),
+		]);
+
+		expect(compositionBox).not.toBeNull();
+		expect(subMenuItemBox).not.toBeNull();
+		expect(subMenuItemBox!.x).toBeGreaterThan(compositionBox!.x);
+	});
+
 	test('should navigate to schema-test composition', async ({page}) => {
 		await navigateToSchemaTest(page);
 	});

--- a/packages/studio/src/components/Menu/MenuSubItem.tsx
+++ b/packages/studio/src/components/Menu/MenuSubItem.tsx
@@ -148,8 +148,10 @@ export const MenuSubItem: React.FC<{
 		const minSpaceRequired = mobileLayout
 			? MAX_MOBILE_MENU_WIDTH
 			: MAX_MENU_WIDTH;
+		const spaceToLeft = size.left;
+		const spaceToRight = size.windowSize.width - size.left - size.width;
 		const canOpenOnRight =
-			size.windowSize.width - size.left - size.width >= minSpaceRequired;
+			spaceToRight >= minSpaceRequired || spaceToRight >= spaceToLeft;
 
 		return {
 			...menuContainerTowardsBottom,


### PR DESCRIPTION
## Summary

- prefer opening Studio submenus on the side with more available viewport space
- keep opening to the right whenever the full maximum menu width fits
- add a narrow-viewport Playwright regression test for the rendered menu geometry

## Test plan

- `bunx playwright test e2e/studio.test.mts --grep 'should open submenus toward the side with more space'`
- `bun run build`
- `bun run stylecheck`

Red/green verified: the browser test fails with the previous positioning rule and passes with this change.

Closes #9987
