### PR TITLE
`@remotion/studio`: Reduce mobile sidebar widths

### DIFF
--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -16,12 +16,16 @@ const overlay: React.CSSProperties = {
 const panel: React.CSSProperties = {
 	position: 'fixed',
 	top: MENU_TOOLBAR_HEIGHT,
-	width: 'min(350px, calc(100% - 50px))',
 	height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
 	overflow: 'hidden',
 	background: BACKGROUND,
 	boxShadow: SHADOW_BLACK,
 };
+
+const sidebarWidth = {
+	left: 'min(210px, calc(100% - 50px))',
+	right: 'min(245px, calc(100% - 50px))',
+} satisfies Record<'left' | 'right', React.CSSProperties['width']>;
 
 export default function MobilePanel({
 	children,
@@ -55,6 +59,7 @@ export default function MobilePanel({
 				<div
 					style={{
 						...panel,
+						width: sidebarWidth[side],
 						left: side === 'left' ? 0 : undefined,
 						right: side === 'right' ? 0 : undefined,
 					}}


### PR DESCRIPTION
## Summary

- reduce the narrow-viewport left sidebar width by 40%
- reduce the narrow-viewport right sidebar width by 30%
- preserve the existing outside-click gutter on very small screens

## Testing

- `bun run build`
- `bun run stylecheck`
