### PR TITLE
`@remotion/studio`: Fix modal stacking above floating sidebars

### DIFF
--- a/packages/studio/src/components/ModalContainer.tsx
+++ b/packages/studio/src/components/ModalContainer.tsx
@@ -62,6 +62,7 @@ export const ModalContainer: React.FC<{
 				disabled={noZIndex}
 				onOutsideClick={onOutsideClick}
 				onEscape={onEscape}
+				stackOnHighest
 			>
 				<div style={{...panel, ...panelStyle}}>{children}</div>
 			</HigherZIndex>

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -1,13 +1,16 @@
 import React, {useContext} from 'react';
+import ReactDOM from 'react-dom';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {ModalsContext} from '../state/modals';
+import {useZIndex} from '../state/z-index';
 import {AskAiModal} from './AskAiModal';
 import {ConfigureDefaultEditorModal} from './ConfigureDefaultEditorModal';
 import {ConfigureLicenseModal} from './ConfigureLicenseModal';
 import {ConfirmationDialog} from './ConfirmationDialog';
 import {EffectPickerModal} from './EffectPickerModal';
 import {InstallPackageModal} from './InstallPackage';
+import {getPortal} from './Menu/portals';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
 import {DeleteFolder} from './NewComposition/DeleteFolder';
 import {DuplicateComposition} from './NewComposition/DuplicateComposition';
@@ -28,11 +31,12 @@ export const Modals: React.FC<{
 	readonly readOnlyStudio: boolean;
 }> = ({readOnlyStudio}) => {
 	const {selectedModal: modalContextType} = useContext(ModalsContext);
+	const {currentZIndex} = useZIndex();
 	const canRender =
 		useContext(StudioServerConnectionCtx).previewServerState.type ===
 		'connected';
 
-	return (
+	return ReactDOM.createPortal(
 		<>
 			{modalContextType && modalContextType.type === 'new-comp' && (
 				<NewComposition
@@ -199,6 +203,9 @@ export const Modals: React.FC<{
 				<SvgImportDialog state={modalContextType} />
 			)}
 			{getStudioAskAIEnabled() && <AskAiModal />}
-		</>
+		</>,
+		// Modals must be above overlays opened from the editor, such as the
+		// floating sidebars used in the mobile layout.
+		getPortal(currentZIndex + 1),
 	);
 };

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -52,20 +52,30 @@ export const HigherZIndex: React.FC<{
 	readonly children: React.ReactNode;
 	readonly disabled?: boolean;
 	readonly outsideClickButton?: 'any' | 'primary';
+	readonly stackOnHighest?: boolean;
 }> = ({
 	children,
 	onEscape,
 	onOutsideClick,
 	disabled,
 	outsideClickButton = 'any',
+	stackOnHighest = false,
 }) => {
 	const context = useContext(ZIndexContext);
 	const highestContext = useContext(HighestZIndexContext);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const stackedIndex = useRef<number | null>(null);
+
+	if (disabled || !stackOnHighest) {
+		stackedIndex.current = null;
+	} else if (stackedIndex.current === null) {
+		stackedIndex.current =
+			Math.max(context.currentIndex, highestContext.highestIndex) + 1;
+	}
 
 	const currentIndex = disabled
 		? context.currentIndex
-		: context.currentIndex + 1;
+		: (stackedIndex.current ?? context.currentIndex + 1);
 
 	useEffect(() => {
 		if (disabled) {


### PR DESCRIPTION
## Summary

- render Studio modals in the managed portal layer above floating sidebars
- allow modal z-index contexts to stack above the highest active overlay
- preserve floating sidebars when dismissing a modal with Escape

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio'`
- manually verified the floating sidebar → New composition modal → Escape → Escape workflow
