### PR TITLE
`@remotion/studio`: Align effect and composition switchers

### DIFF
--- a/packages/studio/src/components/EffectPickerModal.tsx
+++ b/packages/studio/src/components/EffectPickerModal.tsx
@@ -13,10 +13,12 @@ import React, {
 } from 'react';
 import {
 	LIGHT_TEXT,
+	TRANSPARENT,
 	WHITE,
-	getBackgroundFromHoverState,
+	WHITE_ALPHA_06,
 } from '../helpers/colors';
 import {useKeybinding} from '../helpers/use-keybinding';
+import {EffectsIcon} from '../icons/effects';
 import {ModalsContext, type AddEffectModalState} from '../state/modals';
 import {ContextMenu} from './ContextMenu';
 import {addEffectToSequence} from './effect-drag-and-drop';
@@ -33,7 +35,12 @@ import {
 } from './QuickSwitcher/shared';
 
 const container: React.CSSProperties = {
-	width: 500,
+	width: 400,
+};
+
+const panelStyle: React.CSSProperties = {
+	borderRadius: 6,
+	overflow: 'hidden',
 };
 
 const content: React.CSSProperties = {
@@ -42,6 +49,7 @@ const content: React.CSSProperties = {
 
 const inputStyle: React.CSSProperties = {
 	width: '100%',
+	borderRadius: 4,
 };
 
 const resultList: React.CSSProperties = {
@@ -57,16 +65,30 @@ const noResults: React.CSSProperties = {
 };
 
 const resultContainer: React.CSSProperties = {
-	cursor: 'pointer',
+	cursor: 'default',
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
-	padding: '7px 16px',
+	paddingLeft: 16,
+	paddingRight: 16,
+	marginBottom: 1,
+	marginLeft: 4,
+	marginRight: 4,
+	borderRadius: 4,
+};
+
+const iconStyle: React.CSSProperties = {
+	width: 18,
+	height: 18,
+	flexShrink: 0,
 };
 
 const labelContainer: React.CSSProperties = {
 	flex: 1,
 	minWidth: 0,
+	overflow: 'hidden',
+	paddingTop: 5,
+	paddingBottom: 5,
 };
 
 const label: React.CSSProperties = {
@@ -95,7 +117,7 @@ const EffectPickerResult: React.FC<{
 	const style = useMemo((): React.CSSProperties => {
 		return {
 			...resultContainer,
-			backgroundColor: getBackgroundFromHoverState({hovered, selected}),
+			backgroundColor: hovered || selected ? WHITE_ALPHA_06 : TRANSPARENT,
 		};
 	}, [hovered, selected]);
 
@@ -140,6 +162,11 @@ const EffectPickerResult: React.FC<{
 				onMouseEnter={() => setHovered(true)}
 				onMouseLeave={() => setHovered(false)}
 			>
+				<EffectsIcon
+					color={selected || hovered ? WHITE : LIGHT_TEXT}
+					style={iconStyle}
+				/>
+				<Spacing x={1} />
 				<div style={labelContainer}>
 					<div style={labelStyle}>{item.label}</div>
 				</div>
@@ -278,7 +305,7 @@ export const EffectPickerModal: React.FC<{
 	readonly state: AddEffectModalState;
 }> = ({state}) => {
 	return (
-		<DismissableModal>
+		<DismissableModal panelStyle={panelStyle}>
 			<EffectPickerContent state={state} />
 		</DismissableModal>
 	);

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -67,7 +67,6 @@ const modeInactive: React.CSSProperties = {
 const modeActive: React.CSSProperties = {
 	...modeItem,
 	color: WHITE,
-	fontWeight: 'bold',
 };
 
 const content: React.CSSProperties = {
@@ -467,7 +466,7 @@ export const QuickSwitcherContent: React.FC<{
 
 	const container: React.CSSProperties = useMemo(() => {
 		return {
-			width: showKeyboardShortcuts ? 800 : 500,
+			width: showKeyboardShortcuts ? 800 : 400,
 		};
 	}, [showKeyboardShortcuts]);
 

--- a/packages/studio/src/icons/effects.tsx
+++ b/packages/studio/src/icons/effects.tsx
@@ -1,0 +1,17 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+export const EffectsIcon: React.FC<
+	SVGProps<SVGSVGElement> & {
+		readonly color: string;
+	}
+> = ({color, ...props}) => {
+	return (
+		<svg {...props} viewBox="0 0 16 16">
+			<path
+				fill={color}
+				d="M4.405 4.48C4.575 3.82 4.865 3.325 5.275 2.995C5.695 2.665 6.25 2.5 6.94 2.5H9.235V4.06H7.045C6.555 4.06 6.235 4.3 6.085 4.78L5.83 5.68H7.975V7.255H5.395L3.805 13H2.02L3.625 7.255H1.96V5.68H4.075L4.405 4.48ZM8.57102 9.085L6.87602 5.68H8.79602L9.86102 7.99L11.991 5.68H14.331L10.686 9.415L12.426 13H10.491L9.35102 10.585L7.02602 13H4.68602L8.57102 9.085Z"
+			/>
+		</svg>
+	);
+};


### PR DESCRIPTION
## Summary

- align the effects selector with the rounded, inset Quick Switcher design
- add an `fx` icon and compact composition-style rows to effect results
- reduce both selector widths to 400px and remove bold active category styling

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
