### PR TITLE
`@remotion/studio`: Left-align mobile menu labels

### DIFF
--- a/packages/studio/src/components/MenuBuildIndicator.tsx
+++ b/packages/studio/src/components/MenuBuildIndicator.tsx
@@ -55,7 +55,9 @@ const projectNameLinkHovered: React.CSSProperties = {
 	textDecoration: 'underline',
 };
 
-export const MenuBuildIndicator: React.FC = () => {
+export const MenuBuildIndicator: React.FC<{
+	readonly mobileLayout: boolean;
+}> = ({mobileLayout}) => {
 	const [isBuilding, setIsBuilding] = useState(false);
 	const [projectNameHovered, setProjectNameHovered] = useState(false);
 	const ctx = useContext(StudioServerConnectionCtx).previewServerState;
@@ -130,15 +132,15 @@ export const MenuBuildIndicator: React.FC = () => {
 
 	return (
 		<div style={cwd} title={window.remotion_cwd}>
-			{isClickable ? <Spacing x={2} /> : null}
-			{isBuilding ? (
+			{isClickable ? <Spacing x={mobileLayout ? 0.5 : 2} /> : null}
+			{mobileLayout ? null : isBuilding ? (
 				<div style={spinner}>
 					<Spinner duration={0.5} size={spinnerSize} />
 				</div>
 			) : (
 				<div style={noSpinner} />
 			)}
-			<Spacing x={0.5} />
+			{mobileLayout ? null : <Spacing x={0.5} />}
 			{isClickable ? (
 				<a
 					style={projectNameHovered ? projectNameLinkHovered : projectNameLink}
@@ -153,6 +155,14 @@ export const MenuBuildIndicator: React.FC = () => {
 				window.remotion_projectName
 			)}
 			<MenuCompositionName />
+			{mobileLayout && isBuilding ? (
+				<>
+					<Spacing x={0.5} />
+					<div style={spinner}>
+						<Spinner duration={0.5} size={spinnerSize} />
+					</div>
+				</>
+			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -158,8 +158,8 @@ export const MenuToolbar: React.FC<{
 				})}
 				{readOnlyStudio ? null : <UpdateCheck />}
 			</div>
-			<div style={flex} />
-			<MenuBuildIndicator />
+			{mobileLayout ? null : <div style={flex} />}
+			<MenuBuildIndicator mobileLayout={mobileLayout} />
 			<div style={flex} />
 			<div style={fixedWidthRight}>
 				{canUndoAndRedo ? <UndoRedoButtons /> : null}


### PR DESCRIPTION
## Summary

- left-align the project and composition labels when the Studio menu is collapsed
- reduce the gap after the Remotion menu icon in narrow layouts
- move the build spinner to the right of the label in narrow layouts
- preserve the existing desktop menu layout

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/studio` (552 tests)
