### PR TITLE
Skills: Open /remotion-create preview by default

### DIFF
--- a/packages/claude-code-plugin/test/plugin.test.ts
+++ b/packages/claude-code-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/codex-plugin/build.mts
+++ b/packages/codex-plugin/build.mts
@@ -3,9 +3,11 @@ import {
 	cpSync,
 	existsSync,
 	mkdirSync,
+	readFileSync,
 	readdirSync,
 	rmSync,
 	statSync,
+	writeFileSync,
 } from 'fs';
 import {join, resolve} from 'path';
 import {fileURLToPath} from 'url';
@@ -65,6 +67,44 @@ If Studio still fails to start from Codex, ask the user to start it manually fro
 	console.log('  Added Codex-only troubleshooting instructions');
 };
 
+const makeRemotionCreateOpenPreview = () => {
+	const remotionCreateSkill = join(skillsOut, 'remotion-create', 'SKILL.md');
+	if (!existsSync(remotionCreateSkill)) {
+		return;
+	}
+
+	const currentInstructions = readFileSync(remotionCreateSkill, 'utf8');
+	const codexReplacements = [
+		[
+			'Instead of rendering the video, consider starting the preview server for faster iteration:',
+			'After creating or updating the video, start the preview server by default:',
+		],
+		[
+			'If an in-harness browser is available, open it there.',
+			'Open the exact URL in the Codex in-app browser. If no browser tool is available yet, use `tool_search` for the in-app browser control tool, then navigate to the local URL.',
+		],
+	] as const;
+
+	let codexInstructions = currentInstructions;
+	for (const [genericInstruction, codexInstruction] of codexReplacements) {
+		if (!codexInstructions.includes(genericInstruction)) {
+			throw new Error(
+				`Could not find remotion-create instruction: ${genericInstruction}`,
+			);
+		}
+
+		codexInstructions = codexInstructions.replace(
+			genericInstruction,
+			codexInstruction,
+		);
+	}
+
+	writeFileSync(remotionCreateSkill, codexInstructions);
+	console.log(
+		'  Made remotion-create open previews in the Codex in-app browser',
+	);
+};
+
 console.log('Building Codex plugin skills...\n');
 
 if (existsSync(packagesSkillsDir)) {
@@ -78,6 +118,7 @@ if (existsSync(packagesSkillsDir)) {
 	}
 	prepareEmbeddedSkills(skillsOut);
 	addCodexOnlyInstructions();
+	makeRemotionCreateOpenPreview();
 } else {
 	console.warn('Warning: packages/skills/skills/ not found');
 }

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -81,3 +81,18 @@ test('maps is available from either standalone parent skill', () => {
 		).toBe(true);
 	}
 });
+
+test('remotion-create opens the preview in the Codex in-app browser by default', () => {
+	const remotionCreateSkill = readFileSync(
+		path.join(generatedSkillsRoot, 'remotion-create', 'SKILL.md'),
+		'utf-8',
+	);
+
+	expect(remotionCreateSkill).toContain('start the preview server by default');
+	expect(remotionCreateSkill).toContain(
+		'Open the exact URL in the Codex in-app browser.',
+	);
+	expect(remotionCreateSkill).not.toContain(
+		'consider starting the preview server',
+	);
+});

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/kimi-code-plugin/test/plugin.test.ts
+++ b/packages/kimi-code-plugin/test/plugin.test.ts
@@ -186,7 +186,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -50,7 +50,7 @@ npx remotion studio --no-open
 ```
 
 This will start a long-running process and print the server URL for the preview.  
-If server is already started, it will print the URL.
+If the server is already started, it will print the URL.
 If an in-harness browser is available, open it there.
 You can visit a specific composition by navigating to `/[composition-id]`, for example `http://localhost:3000/MapAnimation`.
 


### PR DESCRIPTION
## Summary

- make the Codex build of `/remotion-create` start the Studio preview by default
- open the printed preview URL in the Codex in-app browser
- add regression coverage for the generated skill instructions

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test test/plugin.test.ts -t 'remotion-create opens'`

Closes #9980
