### PR TITLE
`@remotion/studio`: Reorganize menu toolbar actions

### DIFF
--- a/packages/claude-code-plugin/test/plugin.test.ts
+++ b/packages/claude-code-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/kimi-code-plugin/test/plugin.test.ts
+++ b/packages/kimi-code-plugin/test/plugin.test.ts
@@ -186,7 +186,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -19,7 +19,6 @@ export const getCompositionMenuItems = ({
 	setSelectedModal,
 	closeMenu,
 	readOnlyStudio,
-	includeNewCompositionItem,
 	includeCompositionManagementItems,
 }: {
 	composition: _InternalTypes['AnyComposition'] | null;
@@ -28,7 +27,6 @@ export const getCompositionMenuItems = ({
 	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
 	closeMenu: () => void;
 	readOnlyStudio: boolean;
-	includeNewCompositionItem: boolean;
 	includeCompositionManagementItems: boolean;
 }): ComboboxValue[] => {
 	const editorName = window.remotion_editorName;
@@ -96,62 +94,10 @@ export const getCompositionMenuItems = ({
 					disabled: openComponentInEditorDisabled,
 				}
 			: null,
-		{
-			id: 'copy-file-location',
-			keyHint: null,
-			label: `Copy file location`,
-			leftItem: null,
-			onClick: () => {
-				closeMenu();
-				if (!fileLocation) {
-					return;
-				}
-
-				navigator.clipboard
-					.writeText(fileLocation)
-					.then(() => {
-						showNotification('Copied file location to clipboard', 1000);
-					})
-					.catch((err) => {
-						showNotification(
-							`Could not copy to clipboard: ${(err as Error).message}`,
-							1000,
-						);
-					});
-			},
-			quickSwitcherLabel: 'Copy composition file location',
-			subMenu: null,
-			type: 'item' as const,
-			value: 'copy-file-location',
-			disabled: copyFileLocationDisabled,
-		},
-		(editorName || fileLocation) &&
-		(includeNewCompositionItem || includeCompositionManagementItems)
+		editorName && includeCompositionManagementItems
 			? {
 					type: 'divider' as const,
 					id: 'show-in-editor-divider',
-				}
-			: null,
-		includeNewCompositionItem
-			? {
-					id: 'new',
-					keyHint: null,
-					label: `New...`,
-					leftItem: null,
-					onClick: () => {
-						closeMenu();
-						setSelectedModal({
-							type: 'new-comp',
-							folderName: null,
-							parentName: null,
-							stack: null,
-						});
-					},
-					quickSwitcherLabel: 'New composition...',
-					subMenu: null,
-					type: 'item' as const,
-					value: 'new',
-					disabled: readOnlyStudio,
 				}
 			: null,
 		includeCompositionManagementItems
@@ -228,9 +174,40 @@ export const getCompositionMenuItems = ({
 					disabled: !composition || readOnlyStudio,
 				}
 			: null,
+		editorName || includeCompositionManagementItems
+			? {
+					type: 'divider' as const,
+					id: 'copy-actions-divider',
+				}
+			: null,
 		{
-			type: 'divider' as const,
-			id: 'copy-id-divider',
+			id: 'copy-file-location',
+			keyHint: null,
+			label: `Copy file location`,
+			leftItem: null,
+			onClick: () => {
+				closeMenu();
+				if (!fileLocation) {
+					return;
+				}
+
+				navigator.clipboard
+					.writeText(fileLocation)
+					.then(() => {
+						showNotification('Copied file location to clipboard', 1000);
+					})
+					.catch((err) => {
+						showNotification(
+							`Could not copy to clipboard: ${(err as Error).message}`,
+							1000,
+						);
+					});
+			},
+			quickSwitcherLabel: 'Copy composition file location',
+			subMenu: null,
+			type: 'item' as const,
+			value: 'copy-file-location',
+			disabled: copyFileLocationDisabled,
 		},
 		{
 			id: 'copy-id',
@@ -267,7 +244,7 @@ export const getCompositionMenuItems = ({
 export const getCompositionContextMenuItems = (
 	args: Omit<
 		Parameters<typeof getCompositionMenuItems>[0],
-		'includeNewCompositionItem' | 'includeCompositionManagementItems'
+		'includeCompositionManagementItems'
 	> & {
 		readonly includeCompositionManagementItems: boolean;
 	},
@@ -275,7 +252,6 @@ export const getCompositionContextMenuItems = (
 	if (args.composition === null) {
 		return getCompositionMenuItems({
 			...args,
-			includeNewCompositionItem: false,
 		});
 	}
 
@@ -287,7 +263,6 @@ export const getCompositionContextMenuItems = (
 		},
 		...getCompositionMenuItems({
 			...args,
-			includeNewCompositionItem: false,
 		}),
 	];
 };

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -79,9 +79,31 @@ const getFileMenu = ({
 		readOnlyStudio
 			? null
 			: {
+					id: 'new-composition',
+					value: 'new-composition',
+					label: 'New composition...',
+					onClick: () => {
+						closeMenu();
+						setSelectedModal({
+							type: 'new-comp',
+							folderName: null,
+							parentName: null,
+							stack: null,
+						});
+					},
+					type: 'item' as const,
+					keyHint: null,
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: 'New composition...',
+					disabled: previewServerState !== 'connected',
+				},
+		readOnlyStudio
+			? null
+			: {
 					id: 'new-folder',
 					value: 'new-folder',
-					label: 'New Folder...',
+					label: 'New folder...',
 					onClick: () => {
 						closeMenu();
 						setSelectedModal({
@@ -101,7 +123,7 @@ const getFileMenu = ({
 			? null
 			: {
 					type: 'divider' as const,
-					id: 'new-folder-divider',
+					id: 'new-project-item-divider',
 				},
 		window.remotion_isReadOnlyStudio
 			? {
@@ -121,50 +143,6 @@ const getFileMenu = ({
 					quickSwitcherLabel: 'Override input props',
 				}
 			: null,
-		readOnlyStudio
-			? null
-			: {
-					id: 'render',
-					value: 'render',
-					label: 'Render...',
-					onClick: () => {
-						closeMenu();
-						if (previewServerState !== 'connected') {
-							showNotification('Restart the studio to render', 2000);
-							return;
-						}
-
-						const renderButton = document.getElementById(
-							'render-modal-button-server',
-						) as HTMLButtonElement;
-
-						renderButton.click();
-					},
-					type: 'item' as const,
-					keyHint: 'R',
-					leftItem: null,
-					subMenu: null,
-					quickSwitcherLabel: 'Render...',
-				},
-		{
-			id: 'render-on-web',
-			value: 'render-on-web',
-			label: 'Render on web...',
-			onClick: () => {
-				closeMenu();
-
-				const renderButton = document.getElementById(
-					'render-modal-button-client',
-				) as HTMLButtonElement;
-
-				renderButton.click();
-			},
-			type: 'item' as const,
-			keyHint: null,
-			leftItem: null,
-			subMenu: null,
-			quickSwitcherLabel: 'Render on web...',
-		},
 		downloadProject
 			? {
 					id: 'download-project',
@@ -199,7 +177,7 @@ const getFileMenu = ({
 					quickSwitcherLabel: 'Download project',
 				}
 			: null,
-		!readOnlyStudio
+		!readOnlyStudio && downloadProject
 			? {
 					type: 'divider' as const,
 					id: 'open-project-divider',
@@ -284,6 +262,67 @@ const getFileMenu = ({
 		items,
 		quickSwitcherLabel: null,
 	};
+};
+
+const getRenderMenuItems = ({
+	closeMenu,
+	previewServerState,
+	readOnlyStudio,
+}: {
+	closeMenu: () => void;
+	previewServerState: 'connected' | 'init' | 'disconnected';
+	readOnlyStudio: boolean;
+}): ComboboxValue[] => {
+	return [
+		readOnlyStudio
+			? null
+			: {
+					id: 'render',
+					value: 'render',
+					label: 'Render...',
+					onClick: () => {
+						closeMenu();
+						if (previewServerState !== 'connected') {
+							showNotification('Restart the studio to render', 2000);
+							return;
+						}
+
+						const renderButton = document.getElementById(
+							'render-modal-button-server',
+						) as HTMLButtonElement;
+
+						renderButton.click();
+					},
+					type: 'item' as const,
+					keyHint: 'R',
+					leftItem: null,
+					subMenu: null,
+					quickSwitcherLabel: 'Render...',
+				},
+		{
+			id: 'render-on-web',
+			value: 'render-on-web',
+			label: 'Render on web...',
+			onClick: () => {
+				closeMenu();
+
+				const renderButton = document.getElementById(
+					'render-modal-button-client',
+				) as HTMLButtonElement;
+
+				renderButton.click();
+			},
+			type: 'item' as const,
+			keyHint: null,
+			leftItem: null,
+			subMenu: null,
+			quickSwitcherLabel: 'Render on web...',
+		},
+		{
+			type: 'divider' as const,
+			id: 'render-divider',
+		},
+	].filter(NoReactInternals.truthy);
 };
 
 export const useMenuStructure = (
@@ -848,16 +887,22 @@ export const useMenuStructure = (
 				id: 'composition' as const,
 				label: 'Composition',
 				leaveLeftPadding: false,
-				items: getCompositionMenuItems({
-					closeMenu,
-					composition: currentComposition,
-					connectionStatus: type,
-					includeCompositionManagementItems: true,
-					includeNewCompositionItem: true,
-					resolvedLocation: resolvedCompositionLocation,
-					setSelectedModal,
-					readOnlyStudio,
-				}),
+				items: [
+					...getRenderMenuItems({
+						closeMenu,
+						previewServerState: type,
+						readOnlyStudio,
+					}),
+					...getCompositionMenuItems({
+						closeMenu,
+						composition: currentComposition,
+						connectionStatus: type,
+						includeCompositionManagementItems: true,
+						resolvedLocation: resolvedCompositionLocation,
+						setSelectedModal,
+						readOnlyStudio,
+					}),
+				],
 				quickSwitcherLabel: null,
 			},
 			{

--- a/packages/studio/src/test/composition-menu-items.test.ts
+++ b/packages/studio/src/test/composition-menu-items.test.ts
@@ -62,15 +62,19 @@ const commonArgs = {
 const ids = (items: ReturnType<typeof getCompositionMenuItems>) =>
 	items.map((item) => item.id);
 
-test('composition context menus do not include New', () => {
+test('composition menus exclude creation and include management actions', () => {
 	installTestWindow();
 
+	const menuItems = getCompositionMenuItems({
+		...commonArgs,
+		includeCompositionManagementItems: true,
+	});
 	const items = getCompositionContextMenuItems({
 		...commonArgs,
 		includeCompositionManagementItems: true,
 	});
 
-	expect(ids(items)).not.toContain('new');
+	expect(ids(menuItems)).not.toContain('new');
 	expect(ids(items)).toContain('rename');
 	expect(ids(items)).toContain('duplicate');
 	expect(ids(items)).toContain('delete');
@@ -88,21 +92,23 @@ test('connected composition context menus omit management actions', () => {
 		'open-in-new-window',
 		'open-in-new-window-divider',
 		'copy-file-location',
-		'copy-id-divider',
 		'copy-id',
 	]);
 });
 
-test('the main composition menu still includes New', () => {
+test('copy actions are adjacent', () => {
 	installTestWindow();
 
 	const items = getCompositionMenuItems({
 		...commonArgs,
 		includeCompositionManagementItems: true,
-		includeNewCompositionItem: true,
 	});
+	const copyFileLocationIndex = items.findIndex(
+		(item) => item.id === 'copy-file-location',
+	);
+	const copyIdIndex = items.findIndex((item) => item.id === 'copy-id');
 
-	expect(ids(items)).toContain('new');
+	expect(copyIdIndex).toBe(copyFileLocationIndex + 1);
 });
 
 test('editor actions use Open labels and are adjacent', () => {
@@ -133,13 +139,6 @@ test('editor actions use Open labels and are adjacent', () => {
 test('read-only composition menus keep navigation and copy actions enabled', () => {
 	installTestWindowWithEditor();
 
-	const mainMenuItems = getCompositionMenuItems({
-		...commonArgs,
-		includeCompositionManagementItems: true,
-		includeNewCompositionItem: true,
-		readOnlyStudio: true,
-		resolvedLocation,
-	});
 	const items = getCompositionContextMenuItems({
 		...commonArgs,
 		includeCompositionManagementItems: true,
@@ -163,10 +162,4 @@ test('read-only composition menus keep navigation and copy actions enabled', () 
 	expect(itemById('rename').disabled).toBe(true);
 	expect(itemById('duplicate').disabled).toBe(true);
 	expect(itemById('delete').disabled).toBe(true);
-	const newItem = mainMenuItems.find((item) => item.id === 'new');
-	if (newItem?.type !== 'item') {
-		throw new Error('Expected new to be a menu item');
-	}
-
-	expect(newItem.disabled).toBe(true);
 });


### PR DESCRIPTION
## Summary

- move “New composition…” into File above “New folder…”
- group server and web rendering actions in Composition
- keep composition copy actions adjacent

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/composition-menu-items.test.ts`

Closes #9982
