### PR TITLE
`@remotion/studio-server`: Detect current VS Code macOS process

### DIFF
--- a/packages/claude-code-plugin/test/plugin.test.ts
+++ b/packages/claude-code-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -74,7 +74,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/kimi-code-plugin/test/plugin.test.ts
+++ b/packages/kimi-code-plugin/test/plugin.test.ts
@@ -186,7 +186,7 @@ test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);
 		expect(readFileSync(path.join(parentRoot, 'SKILL.md'), 'utf-8')).toContain(
-			'(remotion-maps/REFERENCE.md)',
+			'(./remotion-maps/REFERENCE.md)',
 		);
 		expect(
 			existsSync(path.join(parentRoot, 'remotion-maps', 'REFERENCE.md')),

--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -163,6 +163,7 @@ const COMMON_EDITORS_OSX: Record<string, Editor> = {
 		'/Applications/Sublime Text Dev.app/Contents/SharedSupport/bin/subl',
 	'/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
 		'/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
+	'/Applications/Visual Studio Code.app/Contents/MacOS/Code': 'code',
 	'/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
 	'/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron':
 		'code-insiders',
@@ -352,6 +353,24 @@ export type ProcessAndCommand = {
 	command: Editor;
 };
 
+export const findMacOsEditorsFromProcessOutput = (
+	output: string,
+): ProcessAndCommand[] => {
+	const availableEditors: ProcessAndCommand[] = [];
+	const processNames = Object.keys(COMMON_EDITORS_OSX);
+	for (let i = 0; i < processNames.length; i++) {
+		const processName = processNames[i];
+		if (output.includes(processName)) {
+			availableEditors.push({
+				process: processName,
+				command: COMMON_EDITORS_OSX[processName],
+			});
+		}
+	}
+
+	return availableEditors;
+};
+
 export async function guessEditor(): Promise<ProcessAndCommand[]> {
 	// We can find out which editor is currently running by:
 	// `ps x` on macOS and Linux
@@ -360,18 +379,7 @@ export async function guessEditor(): Promise<ProcessAndCommand[]> {
 	try {
 		if (process.platform === 'darwin') {
 			const output = (await execProm('ps x')).stdout.toString();
-			const processNames = Object.keys(COMMON_EDITORS_OSX);
-			for (let i = 0; i < processNames.length; i++) {
-				const processName = processNames[i];
-				if (output.indexOf(processName) !== -1) {
-					availableEditors.push({
-						process: processName,
-						command: COMMON_EDITORS_OSX[processName],
-					});
-				}
-			}
-
-			return availableEditors;
+			return findMacOsEditorsFromProcessOutput(output);
 		}
 
 		if (process.platform === 'win32') {

--- a/packages/studio-server/src/test/open-in-editor.test.ts
+++ b/packages/studio-server/src/test/open-in-editor.test.ts
@@ -1,5 +1,16 @@
 import {expect, test} from 'bun:test';
+import {findMacOsEditorsFromProcessOutput} from '../helpers/open-in-editor';
 import {findSearchPosition} from '../preview-server/routes/find-in-file';
+
+test('detects current VS Code macOS processes', () => {
+	const process =
+		'/Applications/Visual Studio Code.app/Contents/MacOS/Code --open-url';
+
+	expect(findMacOsEditorsFromProcessOutput(process)).toContainEqual({
+		command: 'code',
+		process: '/Applications/Visual Studio Code.app/Contents/MacOS/Code',
+	});
+});
 
 test('finds a property after the component location', () => {
 	const contents = [


### PR DESCRIPTION
## Summary

- detect the current VS Code macOS process executable
- preserve support for the previous Electron executable name
- add regression coverage for representative `ps` output

## Testing

- `bun test packages/studio-server/src/test/open-in-editor.test.ts`
- `bun run build`
- `bun run stylecheck`
- manually verified that Remotion Studio enables “Open in VS Code”
