### PR TITLE
`remotion`: Make `<Series>` timeline-trimmable

### DIFF
--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -11,11 +11,7 @@ import {
 	sequenceSchemaDefaultLayoutNone,
 	type InteractivitySchema,
 } from '../interactivity-schema.js';
-import type {
-	LayoutAndStyle,
-	SequenceProps,
-	SequencePropsWithoutDuration,
-} from '../Sequence.js';
+import type {LayoutAndStyle, SequenceProps} from '../Sequence.js';
 import {Sequence, SequenceWithoutSchema} from '../Sequence.js';
 import {validateDurationInFrames} from '../validation/validate-duration-in-frames.js';
 import {withInteractivitySchema} from '../with-interactivity-schema.js';
@@ -99,14 +95,11 @@ const SeriesSequence = Interactive.withSchema({
 	SeriesSequenceProps & React.RefAttributes<HTMLDivElement>
 >;
 
-type SeriesProps = SequencePropsWithoutDuration;
+type SeriesProps = SequenceProps;
 const SequenceWithoutSchemaWithRef =
 	SequenceWithoutSchema as React.ComponentType<
 		SequenceProps & {readonly ref?: React.Ref<HTMLDivElement>}
 	>;
-
-const {durationInFrames: _seriesDurationInFramesSchema, ...seriesSchema} =
-	sequenceSchemaDefaultLayoutNone;
 
 const validateSeriesSequenceProps = ({
 	durationInFrames,
@@ -267,7 +260,7 @@ const Series: React.ComponentType<SeriesProps> & {
 		Component: SeriesInner,
 		componentName: '<Series>',
 		componentIdentity: 'dev.remotion.remotion.Series',
-		schema: seriesSchema,
+		schema: sequenceSchemaDefaultLayoutNone,
 		supportsEffects: false,
 	}),
 	{

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -236,16 +236,14 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 	}, [props.children]);
 
 	return (
-		<IsInsideSeriesContainer>
-			<Sequence
-				layout="none"
-				name="<Series>"
-				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/series"
-				{...props}
-			>
-				{childrenValue}
-			</Sequence>
-		</IsInsideSeriesContainer>
+		<Sequence
+			layout="none"
+			name="<Series>"
+			_remotionInternalDocumentationLink="https://www.remotion.dev/docs/series"
+			{...props}
+		>
+			<IsInsideSeriesContainer>{childrenValue}</IsInsideSeriesContainer>
+		</Sequence>
 	);
 };
 

--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -11,7 +11,11 @@ import {
 	sequenceSchemaDefaultLayoutNone,
 	type InteractivitySchema,
 } from '../interactivity-schema.js';
-import type {LayoutAndStyle, SequenceProps} from '../Sequence.js';
+import type {
+	LayoutAndStyle,
+	SequenceProps,
+	SequencePropsWithoutDuration,
+} from '../Sequence.js';
 import {Sequence, SequenceWithoutSchema} from '../Sequence.js';
 import {validateDurationInFrames} from '../validation/validate-duration-in-frames.js';
 import {withInteractivitySchema} from '../with-interactivity-schema.js';
@@ -95,11 +99,14 @@ const SeriesSequence = Interactive.withSchema({
 	SeriesSequenceProps & React.RefAttributes<HTMLDivElement>
 >;
 
-type SeriesProps = SequenceProps;
+type SeriesProps = SequencePropsWithoutDuration;
 const SequenceWithoutSchemaWithRef =
 	SequenceWithoutSchema as React.ComponentType<
 		SequenceProps & {readonly ref?: React.Ref<HTMLDivElement>}
 	>;
+
+const {durationInFrames: _seriesDurationInFramesSchema, ...seriesSchema} =
+	sequenceSchemaDefaultLayoutNone;
 
 const validateSeriesSequenceProps = ({
 	durationInFrames,
@@ -260,7 +267,7 @@ const Series: React.ComponentType<SeriesProps> & {
 		Component: SeriesInner,
 		componentName: '<Series>',
 		componentIdentity: 'dev.remotion.remotion.Series',
-		schema: sequenceSchemaDefaultLayoutNone,
+		schema: seriesSchema,
 		supportsEffects: false,
 	}),
 	{

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -314,7 +314,7 @@ test('Sequence layout="none" uses outlineRef for Studio outlines', () => {
 	expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe('DIV');
 });
 
-test('Series inherits Sequence controls except durationInFrames', () => {
+test('Series inherits Sequence controls', () => {
 	const registeredSequences: TSequence[] = [];
 
 	render(
@@ -336,7 +336,7 @@ test('Series inherits Sequence controls except durationInFrames', () => {
 
 	expect(series?.controls?.schema).toHaveProperty('from');
 	expect(series?.controls?.schema).toHaveProperty('freeze');
-	expect(series?.controls?.schema).not.toHaveProperty('durationInFrames');
+	expect(series?.controls?.schema).toHaveProperty('durationInFrames');
 });
 
 test('Series.Sequence registers with its own visual controls', () => {

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -314,6 +314,31 @@ test('Sequence layout="none" uses outlineRef for Studio outlines', () => {
 	expect(registeredSequences[0]?.refForOutline?.current?.tagName).toBe('DIV');
 });
 
+test('Series inherits Sequence controls except durationInFrames', () => {
+	const registeredSequences: TSequence[] = [];
+
+	render(
+		<SequenceTestWrapper
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Series from={5} freeze={2}>
+				<Series.Sequence durationInFrames={10}>First</Series.Sequence>
+			</Series>
+		</SequenceTestWrapper>,
+	);
+
+	const series = registeredSequences.find(
+		(sequence) =>
+			sequence.controls?.componentIdentity === 'dev.remotion.remotion.Series',
+	);
+
+	expect(series?.controls?.schema).toHaveProperty('from');
+	expect(series?.controls?.schema).toHaveProperty('freeze');
+	expect(series?.controls?.schema).not.toHaveProperty('durationInFrames');
+});
+
 test('Series.Sequence registers with its own visual controls', () => {
 	const registeredSequences: TSequence[] = [];
 	const firstStack = 'Error\n    at FirstSeriesSequence';

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -337,6 +337,7 @@ test('Series inherits Sequence controls', () => {
 	expect(series?.controls?.schema).toHaveProperty('from');
 	expect(series?.controls?.schema).toHaveProperty('freeze');
 	expect(series?.controls?.schema).toHaveProperty('durationInFrames');
+	expect(series?.isInsideSeries).toBe(false);
 });
 
 test('Series.Sequence registers with its own visual controls', () => {

--- a/packages/docs/docs/series.mdx
+++ b/packages/docs/docs/series.mdx
@@ -48,9 +48,9 @@ export const Example: React.FC = () => {
 
 ## `<Series>` props
 
-Since <AvailableFrom v="4.0.443" inline />, `<Series>` is a [`<Sequence>`](/docs/sequence) under the hood and accepts all of its props, with `layout` defaulting to `"none"`.
+Since <AvailableFrom v="4.0.443" inline />, `<Series>` is a [`<Sequence>`](/docs/sequence) under the hood and accepts its props, except for [`durationInFrames`](/docs/sequence#durationinframes). The duration of a `<Series>` is determined by its `<Series.Sequence>` children.
 
-Apart from the props listed below, all props from [`<Sequence>`](/docs/sequence) are accepted.
+The `layout` prop defaults to `"none"`.
 
 ### `layout?`
 

--- a/packages/docs/docs/series.mdx
+++ b/packages/docs/docs/series.mdx
@@ -48,9 +48,9 @@ export const Example: React.FC = () => {
 
 ## `<Series>` props
 
-Since <AvailableFrom v="4.0.443" inline />, `<Series>` is a [`<Sequence>`](/docs/sequence) under the hood and accepts its props, except for [`durationInFrames`](/docs/sequence#durationinframes). The duration of a `<Series>` is determined by its `<Series.Sequence>` children.
+Since <AvailableFrom v="4.0.443" inline />, `<Series>` is a [`<Sequence>`](/docs/sequence) under the hood and accepts all of its props, with `layout` defaulting to `"none"`.
 
-The `layout` prop defaults to `"none"`.
+Apart from the props listed below, all props from [`<Sequence>`](/docs/sequence) are accepted.
 
 ### `layout?`
 


### PR DESCRIPTION
## Summary

- keep the complete inherited `<Sequence>` schema on `<Series>`, including `durationInFrames`
- register the parent `<Series>` outside its child cascading context so Studio exposes its trim handles
- keep each `<Series.Sequence>` registered as an inside-Series cascading sequence
- add integration coverage for the inherited controls and parent timeline registration

## Tests

- `bun test src/test/sequence-register-once.test.tsx`
- `bun run build`
- `bun run stylecheck`

Closes #9997
