### PR TITLE
`@remotion/studio`: Align upgrade icon with toolbar buttons

### DIFF
--- a/packages/studio/src/components/UpdateCheck.tsx
+++ b/packages/studio/src/components/UpdateCheck.tsx
@@ -16,6 +16,8 @@ import {
 } from '../helpers/colors';
 import {ModalsContext} from '../state/modals';
 import {useZIndex} from '../state/z-index';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineAction} from './InlineAction';
 import {updateAvailable} from './RenderQueue/actions';
 
 export type UpdateInfo = {
@@ -37,6 +39,13 @@ const buttonStyle: React.CSSProperties = {
 	fontSize: 14,
 	display: 'inline-flex',
 	justifyContent: 'center',
+	marginLeft: 8,
+};
+
+const updateIconContainer: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flexShrink: 0,
 	marginLeft: 8,
 };
 
@@ -137,12 +146,46 @@ export const UpdateCheck = () => {
 		setHovered(false);
 	}, []);
 
+	const renderUpdateIcon: RenderInlineAction = useCallback((color) => {
+		return (
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				style={{
+					height: 16,
+					width: 16,
+					color,
+					flexShrink: 0,
+				}}
+				viewBox="0 0 512 512"
+			>
+				<path
+					fill={CURRENT_COLOR_LOWERCASE}
+					d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM135.1 217.4c-4.5 4.2-7.1 10.1-7.1 16.3c0 12.3 10 22.3 22.3 22.3H208v96c0 17.7 14.3 32 32 32h32c17.7 0 32-14.3 32-32V256h57.7c12.3 0 22.3-10 22.3-22.3c0-6.2-2.6-12.1-7.1-16.3L269.8 117.5c-3.8-3.5-8.7-5.5-13.8-5.5s-10.1 2-13.8 5.5L135.1 217.4z"
+				/>
+			</svg>
+		);
+	}, []);
+
 	if (!info) {
 		return null;
 	}
 
 	if (!info.updateAvailable && !info.skillsUpdateAvailable) {
 		return null;
+	}
+
+	if (!hasBugfixesAvailable) {
+		return (
+			<div style={updateIconContainer}>
+				<InlineAction
+					variant={null}
+					onClick={openModal}
+					renderAction={renderUpdateIcon}
+					unhoveredColor={WHITE_ALPHA_80}
+					title="Update available"
+				/>
+			</div>
+		);
 	}
 
 	return (
@@ -153,26 +196,9 @@ export const UpdateCheck = () => {
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 			type="button"
-			title={hasBugfixesAvailable ? 'Bugfixes available' : 'Update available'}
+			title="Bugfixes available"
 		>
-			{hasBugfixesAvailable ? (
-				'Bugfixes available'
-			) : (
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					style={{
-						height: 16,
-						width: 16,
-						color: 'inherit',
-					}}
-					viewBox="0 0 512 512"
-				>
-					<path
-						fill={CURRENT_COLOR_LOWERCASE}
-						d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM135.1 217.4c-4.5 4.2-7.1 10.1-7.1 16.3c0 12.3 10 22.3 22.3 22.3H208v96c0 17.7 14.3 32 32 32h32c17.7 0 32-14.3 32-32V256h57.7c12.3 0 22.3-10 22.3-22.3c0-6.2-2.6-12.1-7.1-16.3L269.8 117.5c-3.8-3.5-8.7-5.5-13.8-5.5s-10.1 2-13.8 5.5L135.1 217.4z"
-					/>
-				</svg>
-			)}
+			Bugfixes available
 		</button>
 	);
 };

--- a/packages/studio/src/components/UpdateCheck.tsx
+++ b/packages/studio/src/components/UpdateCheck.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import {VERSION} from 'remotion';
 import {
-	CURRENT_COLOR_LOWERCASE,
 	TRANSPARENT,
 	WARNING_COLOR,
 	WHITE,
@@ -159,7 +158,7 @@ export const UpdateCheck = () => {
 				viewBox="0 0 512 512"
 			>
 				<path
-					fill={CURRENT_COLOR_LOWERCASE}
+					fill={color}
 					d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM135.1 217.4c-4.5 4.2-7.1 10.1-7.1 16.3c0 12.3 10 22.3 22.3 22.3H208v96c0 17.7 14.3 32 32 32h32c17.7 0 32-14.3 32-32V256h57.7c12.3 0 22.3-10 22.3-22.3c0-6.2-2.6-12.1-7.1-16.3L269.8 117.5c-3.8-3.5-8.7-5.5-13.8-5.5s-10.1 2-13.8 5.5L135.1 217.4z"
 				/>
 			</svg>

--- a/packages/studio/src/components/UpdateCheck.tsx
+++ b/packages/studio/src/components/UpdateCheck.tsx
@@ -45,7 +45,6 @@ const updateIconContainer: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
 	flexShrink: 0,
-	marginLeft: 8,
 };
 
 // Keep in sync with packages/bugs/api/[v].ts

--- a/packages/studio/src/components/UpdateModal/UpdateModal.tsx
+++ b/packages/studio/src/components/UpdateModal/UpdateModal.tsx
@@ -1,9 +1,15 @@
 import React, {useCallback, useMemo} from 'react';
-import {BLUE, LIGHT_TEXT, SELECTED_BACKGROUND} from '../../helpers/colors';
+import {
+	BLUE,
+	LIGHT_TEXT,
+	SELECTED_BACKGROUND,
+	WHITE,
+} from '../../helpers/colors';
 import {copyText} from '../../helpers/copy-text';
-import {CopyButton} from '../CopyButton';
+import {ClipboardIcon} from '../../icons/clipboard';
+import type {RenderInlineAction} from '../InlineAction';
+import {InlineAction} from '../InlineAction';
 import {KnownBugs} from '../KnownBugs';
-import {Flex, Row, Spacing} from '../layout';
 import {ModalHeader} from '../ModalHeader';
 import {DismissableModal} from '../NewComposition/DismissableModal';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -12,6 +18,11 @@ import type {Bug, UpdateInfo} from '../UpdateCheck';
 const container: React.CSSProperties = {
 	padding: 20,
 	paddingTop: 0,
+};
+
+const panelStyle: React.CSSProperties = {
+	borderRadius: 6,
+	overflow: 'hidden',
 };
 
 const text: React.CSSProperties = {
@@ -27,15 +38,34 @@ const title: React.CSSProperties = {
 	...text,
 };
 
-const code: React.CSSProperties = {
+const commandField: React.CSSProperties = {
+	alignItems: 'center',
 	background: SELECTED_BACKGROUND,
-	color: LIGHT_TEXT,
+	borderRadius: 6,
+	boxSizing: 'border-box',
+	display: 'flex',
+	marginBottom: 10,
+	marginTop: 10,
+	padding: '8px 8px 8px 10px',
+	width: '100%',
+};
+
+const code: React.CSSProperties = {
+	color: WHITE,
+	flex: 1,
 	fontFamily: 'monospace',
-	padding: '12px 10px',
 	fontSize: 14,
 	lineHeight: 1.5,
-	marginTop: 10,
-	marginBottom: 10,
+	margin: 0,
+	minWidth: 0,
+	overflowX: 'auto',
+	whiteSpace: 'pre',
+};
+
+const copyIcon: React.CSSProperties = {
+	flexShrink: 0,
+	height: 12,
+	width: 12,
 };
 
 const link: React.CSSProperties = {
@@ -79,8 +109,12 @@ export const UpdateModal: React.FC<{
 		});
 	}, [updateAction]);
 
+	const renderCopyAction: RenderInlineAction = useCallback((color) => {
+		return <ClipboardIcon color={color} style={copyIcon} />;
+	}, []);
+
 	return (
-		<DismissableModal>
+		<DismissableModal panelStyle={panelStyle}>
 			<ModalHeader title="Update available" />
 			<div style={container}>
 				{hasKnownBugs && info.updateAvailable ? (
@@ -106,19 +140,15 @@ export const UpdateModal: React.FC<{
 						{updateActionType}:
 					</div>
 				)}
-				<Row align="center">
-					<Flex>
-						<pre onClick={onClick} style={code}>
-							{updateAction}
-						</pre>
-					</Flex>
-					<Spacing x={1} />
-					<CopyButton
-						textToCopy={updateAction}
-						label="Copy"
-						labelWhenCopied="Copied!"
+				<div style={commandField}>
+					<pre style={code}>{updateAction}</pre>
+					<InlineAction
+						variant={null}
+						onClick={onClick}
+						renderAction={renderCopyAction}
+						title="Copy command"
 					/>
-				</Row>
+				</div>
 				{info.updateAvailable ? (
 					<div style={text}>
 						This will upgrade Remotion from {info.currentVersion} to{' '}

--- a/packages/studio/src/components/UpdateModal/UpdateModal.tsx
+++ b/packages/studio/src/components/UpdateModal/UpdateModal.tsx
@@ -16,8 +16,7 @@ import {showNotification} from '../Notifications/NotificationCenter';
 import type {Bug, UpdateInfo} from '../UpdateCheck';
 
 const container: React.CSSProperties = {
-	padding: 20,
-	paddingTop: 0,
+	padding: '0 16px 8px',
 };
 
 const panelStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

- render the upgrade icon with the shared toolbar action primitive
- match neighboring toolbar controls for sizing, centering, hover state, and accessibility
- preserve the existing bugfix notification label

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- visually verified the forced upgrade-icon state in Remotion Studio
