### PR TITLE
`@remotion/studio`: Reorder narrow preview controls

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -184,34 +184,28 @@ export const PreviewToolbar: React.FC<{
 				<Flex />
 				<FpsCounter playbackSpeed={playbackRate} />
 				<Spacing x={2} />
+				{isVideoComposition && isMobileLayout ? (
+					<PreviewToolbarControl>
+						<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
+					</PreviewToolbarControl>
+				) : null}
 				<PreviewToolbarControl>
-					<RenderButton
-						readOnlyStudio={readOnlyStudio}
-						size="compact"
-						hidden={isMobileLayout}
-					/>
+					<RenderButton readOnlyStudio={readOnlyStudio} size="compact" />
 				</PreviewToolbarControl>
 				{isMobileLayout ? (
-					<>
-						{isVideoComposition ? (
-							<PreviewToolbarControl>
-								<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
-							</PreviewToolbarControl>
-						) : null}
-						<PreviewToolbarControl>
-							<PreviewToolbarOverflowButton
-								readOnlyStudio={readOnlyStudio}
-								showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
-								showPlaybackRate={isVideoComposition}
-								showLoop={isVideoComposition}
-								showCompositionControls={canvasContent?.type === 'composition'}
-								playbackRate={playbackRate}
-								setPlaybackRate={setPlaybackRate}
-								loop={loop}
-								setLoop={setLoop}
-							/>
-						</PreviewToolbarControl>
-					</>
+					<PreviewToolbarControl>
+						<PreviewToolbarOverflowButton
+							readOnlyStudio={readOnlyStudio}
+							showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
+							showPlaybackRate={isVideoComposition}
+							showLoop={isVideoComposition}
+							showCompositionControls={canvasContent?.type === 'composition'}
+							playbackRate={playbackRate}
+							setPlaybackRate={setPlaybackRate}
+							loop={loop}
+							setLoop={setLoop}
+						/>
+					</PreviewToolbarControl>
 				) : null}
 				<Spacing x={1.5} />
 			</div>

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -189,9 +189,6 @@ export const PreviewToolbar: React.FC<{
 						<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
 					</PreviewToolbarControl>
 				) : null}
-				<PreviewToolbarControl>
-					<RenderButton readOnlyStudio={readOnlyStudio} size="compact" />
-				</PreviewToolbarControl>
 				{isMobileLayout ? (
 					<PreviewToolbarControl>
 						<PreviewToolbarOverflowButton
@@ -207,6 +204,9 @@ export const PreviewToolbar: React.FC<{
 						/>
 					</PreviewToolbarControl>
 				) : null}
+				<PreviewToolbarControl>
+					<RenderButton readOnlyStudio={readOnlyStudio} size="compact" />
+				</PreviewToolbarControl>
 				<Spacing x={1.5} />
 			</div>
 			<PlaybackKeyboardShortcutsManager setPlaybackRate={setPlaybackRate} />

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -114,6 +114,26 @@ export const PreviewToolbar: React.FC<{
 		<div style={container} className="css-reset">
 			<div style={sideContainer}>
 				<div style={padding} />
+				{isMobileLayout ? (
+					<PreviewToolbarControl>
+						<PreviewToolbarOverflowButton
+							readOnlyStudio={readOnlyStudio}
+							showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
+							showPlaybackRate={isVideoComposition}
+							showLoop={isVideoComposition}
+							showCompositionControls={canvasContent?.type === 'composition'}
+							playbackRate={playbackRate}
+							setPlaybackRate={setPlaybackRate}
+							loop={loop}
+							setLoop={setLoop}
+						/>
+					</PreviewToolbarControl>
+				) : null}
+				{isVideoComposition && isMobileLayout ? (
+					<PreviewToolbarControl>
+						<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
+					</PreviewToolbarControl>
+				) : null}
 				<PreviewToolbarControl>
 					<TimelineZoomControls />
 				</PreviewToolbarControl>
@@ -184,26 +204,6 @@ export const PreviewToolbar: React.FC<{
 				<Flex />
 				<FpsCounter playbackSpeed={playbackRate} />
 				<Spacing x={2} />
-				{isVideoComposition && isMobileLayout ? (
-					<PreviewToolbarControl>
-						<MuteToggle muted={playerMuted} setMuted={setPlayerMuted} />
-					</PreviewToolbarControl>
-				) : null}
-				{isMobileLayout ? (
-					<PreviewToolbarControl>
-						<PreviewToolbarOverflowButton
-							readOnlyStudio={readOnlyStudio}
-							showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
-							showPlaybackRate={isVideoComposition}
-							showLoop={isVideoComposition}
-							showCompositionControls={canvasContent?.type === 'composition'}
-							playbackRate={playbackRate}
-							setPlaybackRate={setPlaybackRate}
-							loop={loop}
-							setLoop={setLoop}
-						/>
-					</PreviewToolbarControl>
-				) : null}
 				<PreviewToolbarControl>
 					<RenderButton readOnlyStudio={readOnlyStudio} size="compact" />
 				</PreviewToolbarControl>

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -160,8 +160,7 @@ const getInitialRenderType = (readOnlyStudio: boolean): RenderType => {
 export const RenderButton: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly size?: 'default' | 'compact';
-	readonly hidden: boolean;
-}> = ({readOnlyStudio, size: controlSize = 'default', hidden}) => {
+}> = ({readOnlyStudio, size: controlSize = 'default'}) => {
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();
 	const {setSelectedModal} = useContext(ModalsContext);
 	const [preferredRenderType, setPreferredRenderType] = useState<RenderType>(
@@ -559,60 +558,49 @@ export const RenderButton: React.FC<{
 				onClick={() => openServerRenderModal(true)}
 				type="button"
 			/>
-			{hidden ? (
+			<div ref={containerRef} style={containerStyle} title={tooltip}>
 				<button
-					style={{display: 'none'}}
+					type="button"
+					style={
+						controlSize === 'compact' ? compactMainButtonStyle : mainButtonStyle
+					}
 					onClick={onClick}
 					id="render-modal-button"
+				>
+					<Row
+						align="center"
+						style={
+							controlSize === 'compact'
+								? compactMainButtonContent
+								: mainButtonContent
+						}
+					>
+						<ThinRenderIcon
+							fill={CURRENT_COLOR_LOWERCASE}
+							svgProps={iconStyle}
+						/>
+						<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
+						<span style={controlSize === 'compact' ? compactLabel : label}>
+							{renderLabel}
+						</span>
+					</Row>
+				</button>
+				<div style={dividerStyle} />
+				<button
+					ref={dropdownRef}
 					type="button"
-				/>
-			) : (
-				<div ref={containerRef} style={containerStyle} title={tooltip}>
-					<button
-						type="button"
-						style={
-							controlSize === 'compact'
-								? compactMainButtonStyle
-								: mainButtonStyle
-						}
-						onClick={onClick}
-						id="render-modal-button"
-					>
-						<Row
-							align="center"
-							style={
-								controlSize === 'compact'
-									? compactMainButtonContent
-									: mainButtonContent
-							}
-						>
-							<ThinRenderIcon
-								fill={CURRENT_COLOR_LOWERCASE}
-								svgProps={iconStyle}
-							/>
-							<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
-							<span style={controlSize === 'compact' ? compactLabel : label}>
-								{renderLabel}
-							</span>
-						</Row>
-					</button>
-					<div style={dividerStyle} />
-					<button
-						ref={dropdownRef}
-						type="button"
-						style={
-							controlSize === 'compact'
-								? compactDropdownTriggerStyle
-								: dropdownTriggerStyle
-						}
-						className={MENU_INITIATOR_CLASSNAME}
-						onPointerDown={onPointerDown}
-						onClick={onClickDropdown}
-					>
-						<CaretDown />
-					</button>
-				</div>
-			)}
+					style={
+						controlSize === 'compact'
+							? compactDropdownTriggerStyle
+							: dropdownTriggerStyle
+					}
+					className={MENU_INITIATOR_CLASSNAME}
+					onPointerDown={onPointerDown}
+					onClick={onClickDropdown}
+				>
+					<CaretDown />
+				</button>
+			</div>
 			{portalStyle
 				? ReactDOM.createPortal(
 						<div style={fullScreenOverlay}>


### PR DESCRIPTION
## Summary

- move the narrow-mode overflow menu, mute control, and timeline zoom controls to the left side of the preview toolbar
- keep the render control on the right side
- preserve the existing wide toolbar layout

## Validation

- `bun run build`
- `bun run stylecheck`
