### PR TITLE
Skills: Fix Studio asset icon reset handling

### DIFF
--- a/.agents/skills/studio-css-reset/SKILL.md
+++ b/.agents/skills/studio-css-reset/SKILL.md
@@ -1,20 +1,61 @@
 ---
 name: studio-css-reset
-description: Guidance for Remotion Studio UI changes where the global CSS reset affects nested elements. Use when editing packages/studio UI, especially when adding wrapper spans, inline icons, labels, buttons, compact rows, or any nested text whose typography, color, sizing, or truncation must stay stable.
+description: Diagnose and fix Remotion Studio UI bugs caused by the global CSS reset. Use when nested text or SVG icons have incorrect color, typography, sizing, hover states, or truncation in packages/studio.
 ---
 
 # Studio CSS Reset
 
-Remotion Studio applies a broad CSS reset to UI elements. Treat every new nested element as reset-styled unless the local component gives it explicit visual styles.
+Remotion Studio's reset targets both the reset container and every descendant. A child does not necessarily inherit the visual styles of its parent: the reset may give that child its own computed value instead.
 
-When changing Studio UI:
+## Diagnose the affected element
 
-- Do not rely on a parent button or container for visible child text styles. Give wrapper spans or divs explicit `fontFamily`, `fontSize`, `lineHeight`, and either `color` or `color: 'inherit'`.
-- Preserve compact-row layout when introducing icon-plus-label markup. Use fixed icon dimensions, `flexShrink: 0`, and explicit label truncation styles such as `minWidth`, `overflow`, `textOverflow`, and `whiteSpace`.
-- Recheck hover and non-hover states after adding wrappers. The label should not grow, change row height, lose ellipsis, or change color unexpectedly.
-- Prefer fixing the shared Studio component once when the reset issue appears in a repeated row pattern.
+Inspect the element that actually paints the pixels, not only its parent:
 
-For Studio code changes, run at least the focused Studio checks:
+- For text, inspect the `span`, `div`, or other text wrapper.
+- For SVG icons, inspect the painted `path`, `circle`, or `rect` as well as the outer `svg`.
+- Compare computed styles in every relevant state: idle, hovered, selected, focused, and disabled.
+- Check whether the value comes from an inline style, SVG presentation attribute, inheritance, or the `.css-reset, .css-reset *` rule.
+
+## Apply explicit local styles
+
+Do not assume that styling the row, button, or outer SVG is enough.
+
+For text wrappers, explicitly set the visual properties the component depends on, such as:
+
+```tsx
+const labelStyle: React.CSSProperties = {
+	fontFamily: 'inherit',
+	fontSize: 13,
+	lineHeight: 'normal',
+	color: 'inherit',
+};
+```
+
+Use `color: 'inherit'` only when the styled element directly paints the text. It does not protect deeper descendants that receive their own reset value.
+
+For SVG icons, remember that `fill="currentColor"` resolves against the computed `color` of the painted SVG element. If the reset sets `color: white` on the inner `<path>`, setting `color: 'inherit'` only on the outer `<svg>` will not fix it. Pass the concrete state color to the component that renders the painted element:
+
+```tsx
+<AssetFileIcon color={hovered || selected ? WHITE : LIGHT_TEXT} />
+```
+
+Prefer a concrete `fill`, `stroke`, or color prop when the icon has state-dependent colors. Use `currentColor` only after confirming that the painted descendants inherit the intended color.
+
+## Preserve compact row layout
+
+When adding icon-and-label markup:
+
+- Give icons fixed dimensions and `flexShrink: 0`.
+- Give labels `minWidth: 0`, `overflow: 'hidden'`, `textOverflow: 'ellipsis'`, and `whiteSpace: 'nowrap'` when truncation is required.
+- Confirm that wrappers do not change row height, spacing, or the ellipsis behavior.
+
+Prefer fixing a shared Studio component once when the same row or icon pattern is reused.
+
+## Verify the result
+
+Do not stop after checking that the code compiles. In a running Studio, inspect the computed style of the element that paints the pixels in both idle and interactive states. Confirm that labels and icons change together and that selection does not mask a broken hover state.
+
+For Studio code changes, run at least:
 
 ```bash
 bunx turbo run make --filter='@remotion/studio'

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -695,7 +695,7 @@ const AssetSelectorItem: React.FC<{
 					<AssetFileIcon
 						fileType={previewFileType}
 						style={iconStyle}
-						color={LIGHT_TEXT}
+						color={hovered || selected ? WHITE : LIGHT_TEXT}
 					/>
 					<Spacing x={1} />
 					<div style={label}>{item.name}</div>


### PR DESCRIPTION
## Summary

- make asset file icons follow the row's hover and selection color
- avoid relying on `currentColor` through reset-styled SVG descendants
- clarify the Studio CSS reset skill with SVG-specific diagnosis and verification guidance

## Verification

- `bunx oxfmt .agents/skills/studio-css-reset/SKILL.md packages/studio/src/components/AssetSelectorItem.tsx --write`
- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'` (554 tests)
- verified the idle asset icon fill in the running Studio
