### PR TITLE
`@remotion/browser-studio`: Disable update availability checks

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -4,9 +4,15 @@ test('loads the Browser Studio canvas and enables Visual Mode', async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
+	const updateAvailableRequests: string[] = [];
 	let rejectPageError: (error: Error) => void = () => undefined;
 	const pageError = new Promise<never>((_resolve, reject) => {
 		rejectPageError = reject;
+	});
+	page.on('request', (request) => {
+		if (new URL(request.url()).pathname === '/api/update-available') {
+			updateAvailableRequests.push(request.url());
+		}
 	});
 	page.on('pageerror', (error) => {
 		pageErrors.push(error);
@@ -37,4 +43,5 @@ test('loads the Browser Studio canvas and enables Visual Mode', async ({
 	]);
 
 	expect(pageErrors).toEqual([]);
+	expect(updateAvailableRequests).toEqual([]);
 });

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -156,7 +156,7 @@ export const MenuToolbar: React.FC<{
 						/>
 					);
 				})}
-				{readOnlyStudio ? null : <UpdateCheck />}
+				{readOnlyStudio || browserStudioOperations ? null : <UpdateCheck />}
 			</div>
 			{mobileLayout ? null : <div style={flex} />}
 			<MenuBuildIndicator mobileLayout={mobileLayout} />


### PR DESCRIPTION
## Summary

- skip mounting the Studio update check when Browser Studio operations are available
- preserve update availability checks in regular writable Remotion Studio
- cover the Browser Studio network behavior in its existing Playwright workflow

## Testing

- `bun run testbrowserstudio`
- `bun run build`
- `bun run stylecheck`

Closes #9885
