### PR TITLE
`@remotion/studio`: Fix read-only metadata layout

### DIFF
--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -49,17 +49,18 @@ const computedValueStyle: React.CSSProperties = {
 	fontFamily: 'sans-serif',
 	fontSize: 12,
 	fontStyle: 'italic',
-	lineHeight: 1.5,
+	lineHeight: '20px',
 };
 
 const dimensionsControls: React.CSSProperties = {
 	alignItems: 'center',
+	color: 'inherit',
 	display: 'flex',
 	fontFamily: 'sans-serif',
-	fontSize: 12,
+	fontSize: 13,
 	gap: 4,
 	justifyContent: 'flex-end',
-	lineHeight: '16px',
+	lineHeight: '20px',
 	minWidth: 0,
 };
 
@@ -85,7 +86,7 @@ const metadataLabelControls: React.CSSProperties = {
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	gap: 2,
-	lineHeight: '18px',
+	lineHeight: '20px',
 	minWidth: 0,
 };
 
@@ -93,7 +94,7 @@ const metadataLabelText: React.CSSProperties = {
 	color: 'inherit',
 	fontFamily: 'sans-serif',
 	fontSize: 13,
-	lineHeight: '18px',
+	lineHeight: '20px',
 	minWidth: 0,
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
@@ -464,6 +465,7 @@ export const CompositionMetadata: React.FC<{
 						pendingValue={pendingValues.width ?? null}
 						value={video.width}
 					/>
+					{disabled ? '\u00A0' : null}
 					<CompositionMetadataValue
 						computed={heightIsComputed}
 						disabled={disabled}

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -192,7 +192,9 @@ export const detailRow: React.CSSProperties = {
 
 export const detailLabel: React.CSSProperties = {
 	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
 	fontSize: 13,
+	lineHeight: '20px',
 	minWidth: 0,
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
@@ -201,8 +203,10 @@ export const detailLabel: React.CSSProperties = {
 
 export const detailValue: React.CSSProperties = {
 	color: WHITE,
+	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontVariantNumeric: 'tabular-nums',
+	lineHeight: '20px',
 	minWidth: 0,
 	textAlign: 'right',
 	wordBreak: 'break-word',


### PR DESCRIPTION
## Summary

- separate width and height with whitespace in read-only Studio
- normalize Inspector detail-row typography against the Studio CSS reset
- use a consistent 13px font size and 20px line height for composition metadata

## Testing

- `bun run build`
- `bun run stylecheck`
- verified computed styles in a static read-only Studio bundle

Closes https://github.com/remotion-dev/remotion/issues/9721
