### PR TITLE
Skills: Open Studio after creating a video

### DIFF
--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -4,6 +4,10 @@ description: Router for all Remotion skills
 version: 4.0.503
 ---
 
+## Creating a video
+
+If the user asks to make, create, or build a new video or composition, load [Create a new Remotion video](./remotion-create/SKILL.md), whether or not a Remotion project already exists. Creation requests should end by opening the composition in Remotion Studio. Do not infer a render request from the word “video”; only render or export when the user explicitly asks for a video file or finished render.
+
 ## New project setup
 
 If no Remotion project currently exists, load [Create a new Remotion project](./remotion-create/SKILL.md)

--- a/packages/skills/skills/remotion-best-practices/SKILL.md
+++ b/packages/skills/skills/remotion-best-practices/SKILL.md
@@ -6,7 +6,7 @@ version: 4.0.503
 
 ## Creating a video
 
-If the user asks to make, create, or build a new video or composition, load [Create a new Remotion video](./remotion-create/SKILL.md), whether or not a Remotion project already exists. Creation requests should end by opening the composition in Remotion Studio. Do not infer a render request from the word “video”; only render or export when the user explicitly asks for a video file or finished render.
+If the user asks to make, create, or build a new video or composition, load [Create a new Remotion video](./remotion-create/SKILL.md), whether or not a Remotion project already exists.
 
 ## New project setup
 

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remotion-create
-description: Create a new Remotion video or composition and preview it
+description: Create a new Remotion video
 version: 4.0.503
 ---
 

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -1,11 +1,25 @@
 ---
 name: remotion-create
-description: Create a new Remotion video
+description: Create a new Remotion video or composition and preview it in Remotion Studio
 version: 4.0.503
 ---
 
 These are instructions for making a new Remotion project and composition.  
 If this is not the next task, see [Remotion Best Practices](../remotion-best-practices/SKILL.md)
+
+## Default workflow: create, then open Studio
+
+Treat requests to **make**, **create**, or **build** a video as requests for an editable composition, not as requests for a rendered video file.
+
+After implementing the composition:
+
+1. Start Remotion Studio and keep the process running.
+2. Open the composition in an available in-app browser, or give the user the direct Studio URL if no browser is available.
+3. Tell the user that the composition is ready to preview and edit.
+
+Do not render the full video unless the user explicitly asks to **render**, **export**, or deliver a video file such as an MP4. A duration, aspect ratio, or phrase such as “promo video” does not by itself imply that a rendered file is required.
+
+For example, “Make a 20-second promo video about Remotion” means build it and open it in Studio. “Export the promo video as an MP4” means render a file.
 
 ## Scaffold a project
 
@@ -39,9 +53,9 @@ By structuring the React Markup following [Remotion Interactivity Best Practices
 
 If Tailwind is requested, see [tailwind.md](tailwind.md) for using TailwindCSS in Remotion.
 
-## Starting preview
+## Open the preview
 
-Instead of rendering the video, consider starting the preview server for faster iteration:
+For a video creation request, start the preview server after building the composition:
 
 ```bash
 npx remotion studio --no-open
@@ -51,6 +65,8 @@ This will start a long-running process and print the server URL for the preview.
 If the server is already started, it will print the URL.
 If an in-harness browser is available, open it there.
 You can visit a specific composition by navigating to `/[composition-id]`, for example `http://localhost:3000/MapAnimation`.
+
+Rendering is a separate follow-up step. Only proceed to a full render when the user explicitly requests an exported file. A one-frame render for implementation QA is allowed when useful, but it does not replace opening Studio for the user.
 
 ## Follow-up
 

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -1,25 +1,11 @@
 ---
 name: remotion-create
-description: Create a new Remotion video or composition and preview it in Remotion Studio
+description: Create a new Remotion video or composition and preview it
 version: 4.0.503
 ---
 
 These are instructions for making a new Remotion project and composition.  
 If this is not the next task, see [Remotion Best Practices](../remotion-best-practices/SKILL.md)
-
-## Default workflow: create, then open Studio
-
-Treat requests to **make**, **create**, or **build** a video as requests for an editable composition, not as requests for a rendered video file.
-
-After implementing the composition:
-
-1. Start Remotion Studio and keep the process running.
-2. Open the composition in an available in-app browser, or give the user the direct Studio URL if no browser is available.
-3. Tell the user that the composition is ready to preview and edit.
-
-Do not render the full video unless the user explicitly asks to **render**, **export**, or deliver a video file such as an MP4. A duration, aspect ratio, or phrase such as “promo video” does not by itself imply that a rendered file is required.
-
-For example, “Make a 20-second promo video about Remotion” means build it and open it in Studio. “Export the promo video as an MP4” means render a file.
 
 ## Scaffold a project
 
@@ -55,7 +41,7 @@ If Tailwind is requested, see [tailwind.md](tailwind.md) for using TailwindCSS i
 
 ## Open the preview
 
-For a video creation request, start the preview server after building the composition:
+Start the preview server after building the composition:
 
 ```bash
 npx remotion studio --no-open
@@ -66,7 +52,15 @@ If the server is already started, it will print the URL.
 If an in-harness browser is available, open it there.
 You can visit a specific composition by navigating to `/[composition-id]`, for example `http://localhost:3000/MapAnimation`.
 
-Rendering is a separate follow-up step. Only proceed to a full render when the user explicitly requests an exported file. A one-frame render for implementation QA is allowed when useful, but it does not replace opening Studio for the user.
+## Render the video
+
+Only render if the user explicitly asks for it.
+
+```
+npx remotion render
+```
+
+For more options, see [Rendering](../remotion-render/SKILL.md).
 
 ## Follow-up
 


### PR DESCRIPTION
## Summary

- make video creation requests open the composition in Remotion Studio by default
- require explicit render or export intent before producing a full video file
- route new composition requests through `remotion-create` even in existing projects

## Testing

- `bun run build`
- `bun run stylecheck`
