### PR TITLE
Skills: Use slash commands as Codex display names

### DIFF
--- a/packages/codex-plugin/build.mts
+++ b/packages/codex-plugin/build.mts
@@ -74,9 +74,17 @@ const makeRemotionCreateOpenPreview = () => {
 	}
 
 	const currentInstructions = readFileSync(remotionCreateSkill, 'utf8');
+	const previewInstruction = [
+		'Instead of rendering the video, consider starting the preview server for faster iteration:',
+		'Start the preview server after building the composition:',
+	].find((instruction) => currentInstructions.includes(instruction));
+	if (!previewInstruction) {
+		throw new Error('Could not find a remotion-create preview instruction');
+	}
+
 	const codexReplacements = [
 		[
-			'Instead of rendering the video, consider starting the preview server for faster iteration:',
+			previewInstruction,
 			'After creating or updating the video, start the preview server by default:',
 		],
 		[

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -106,3 +106,27 @@ test('Codex troubleshooting does not open the system browser', () => {
 	expect(remotionSkill).toContain('npx remotion studio --no-open');
 	expect(remotionSkill).not.toMatch(/^npx remotion studio$/m);
 });
+
+test('skill display names include Remotion', () => {
+	const expectedDisplayNames = {
+		'remotion-best-practices': 'Remotion Best Practices',
+		'remotion-captions': 'Remotion Captions',
+		'remotion-create': 'Create a Remotion Video',
+		'remotion-docs': 'Remotion Docs',
+		'remotion-interactivity': 'Remotion Interactivity',
+		'remotion-maps': 'Remotion Maps',
+		'remotion-markup': 'Remotion Markup',
+		'remotion-multimedia': 'Remotion Multimedia',
+		'remotion-render': 'Render with Remotion',
+		'remotion-saas': 'Remotion SaaS',
+		'remotion-upgrade': 'Upgrade Remotion',
+	};
+
+	for (const [skillName, displayName] of Object.entries(expectedDisplayNames)) {
+		const openAiConfig = readFileSync(
+			path.join(generatedSkillsRoot, skillName, 'agents', 'openai.yaml'),
+			'utf-8',
+		);
+		expect(openAiConfig).toContain(`display_name: '${displayName}'`);
+	}
+});

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -107,26 +107,12 @@ test('Codex troubleshooting does not open the system browser', () => {
 	expect(remotionSkill).not.toMatch(/^npx remotion studio$/m);
 });
 
-test('skill display names include Remotion', () => {
-	const expectedDisplayNames = {
-		'remotion-best-practices': 'Remotion Best Practices',
-		'remotion-captions': 'Remotion Captions',
-		'remotion-create': 'Create a Remotion Video',
-		'remotion-docs': 'Remotion Docs',
-		'remotion-interactivity': 'Remotion Interactivity',
-		'remotion-maps': 'Remotion Maps',
-		'remotion-markup': 'Remotion Markup',
-		'remotion-multimedia': 'Remotion Multimedia',
-		'remotion-render': 'Render with Remotion',
-		'remotion-saas': 'Remotion SaaS',
-		'remotion-upgrade': 'Upgrade Remotion',
-	};
-
-	for (const [skillName, displayName] of Object.entries(expectedDisplayNames)) {
+test('skill display names match their slash commands', () => {
+	for (const skillName of getDirectories(generatedSkillsRoot)) {
 		const openAiConfig = readFileSync(
 			path.join(generatedSkillsRoot, skillName, 'agents', 'openai.yaml'),
 			'utf-8',
 		);
-		expect(openAiConfig).toContain(`display_name: '${displayName}'`);
+		expect(openAiConfig).toContain(`display_name: '/${skillName}'`);
 	}
 });

--- a/packages/skills/skills/remotion-best-practices/agents/openai.yaml
+++ b/packages/skills/skills/remotion-best-practices/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Best Practices'
+  display_name: '/remotion-best-practices'
   short_description: 'Route Remotion tasks to the right workflow'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-best-practices/agents/openai.yaml
+++ b/packages/skills/skills/remotion-best-practices/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion'
+  display_name: 'Remotion Best Practices'
   short_description: 'Route Remotion tasks to the right workflow'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-captions/agents/openai.yaml
+++ b/packages/skills/skills/remotion-captions/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Captions'
+  display_name: 'Remotion Captions'
   short_description: 'Transcribe, display, and animate captions'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-captions/agents/openai.yaml
+++ b/packages/skills/skills/remotion-captions/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Captions'
+  display_name: '/remotion-captions'
   short_description: 'Transcribe, display, and animate captions'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-create/agents/openai.yaml
+++ b/packages/skills/skills/remotion-create/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Create a Remotion Video'
+  display_name: '/remotion-create'
   short_description: 'Create a new Remotion video project'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-create/agents/openai.yaml
+++ b/packages/skills/skills/remotion-create/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Create'
+  display_name: 'Create a Remotion Video'
   short_description: 'Create a new Remotion video project'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-docs/agents/openai.yaml
+++ b/packages/skills/skills/remotion-docs/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Docs'
+  display_name: 'Remotion Docs'
   short_description: 'Search current Remotion documentation'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-docs/agents/openai.yaml
+++ b/packages/skills/skills/remotion-docs/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Docs'
+  display_name: '/remotion-docs'
   short_description: 'Search current Remotion documentation'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-interactivity/agents/openai.yaml
+++ b/packages/skills/skills/remotion-interactivity/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Interactivity'
+  display_name: '/remotion-interactivity'
   short_description: 'Make compositions editable in Remotion Studio'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-interactivity/agents/openai.yaml
+++ b/packages/skills/skills/remotion-interactivity/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Interactivity'
+  display_name: 'Remotion Interactivity'
   short_description: 'Make compositions editable in Remotion Studio'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-maps/agents/openai.yaml
+++ b/packages/skills/skills/remotion-maps/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Maps'
+  display_name: 'Remotion Maps'
   short_description: 'Create animated maps in Remotion videos'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-maps/agents/openai.yaml
+++ b/packages/skills/skills/remotion-maps/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Maps'
+  display_name: '/remotion-maps'
   short_description: 'Create animated maps in Remotion videos'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-markup/agents/openai.yaml
+++ b/packages/skills/skills/remotion-markup/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Markup'
+  display_name: '/remotion-markup'
   short_description: 'Apply Remotion animation and effects practices'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-markup/agents/openai.yaml
+++ b/packages/skills/skills/remotion-markup/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Markup'
+  display_name: 'Remotion Markup'
   short_description: 'Apply Remotion animation and effects practices'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-multimedia/agents/openai.yaml
+++ b/packages/skills/skills/remotion-multimedia/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion Multimedia'
+  display_name: '/remotion-multimedia'
   short_description: 'Inspect browser-based audio and video media'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-multimedia/agents/openai.yaml
+++ b/packages/skills/skills/remotion-multimedia/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Multimedia'
+  display_name: 'Remotion Multimedia'
   short_description: 'Inspect browser-based audio and video media'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-render/agents/openai.yaml
+++ b/packages/skills/skills/remotion-render/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Render with Remotion'
+  display_name: '/remotion-render'
   short_description: 'Export Remotion videos and stills'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-render/agents/openai.yaml
+++ b/packages/skills/skills/remotion-render/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Render'
+  display_name: 'Render with Remotion'
   short_description: 'Export Remotion videos and stills'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-saas/agents/openai.yaml
+++ b/packages/skills/skills/remotion-saas/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'SaaS'
+  display_name: 'Remotion SaaS'
   short_description: 'Build apps that preview and render videos'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-saas/agents/openai.yaml
+++ b/packages/skills/skills/remotion-saas/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Remotion SaaS'
+  display_name: '/remotion-saas'
   short_description: 'Build apps that preview and render videos'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-upgrade/agents/openai.yaml
+++ b/packages/skills/skills/remotion-upgrade/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Upgrade'
+  display_name: 'Upgrade Remotion'
   short_description: 'Upgrade Remotion and related dependencies'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'

--- a/packages/skills/skills/remotion-upgrade/agents/openai.yaml
+++ b/packages/skills/skills/remotion-upgrade/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
-  display_name: 'Upgrade Remotion'
+  display_name: '/remotion-upgrade'
   short_description: 'Upgrade Remotion and related dependencies'
   icon_small: './assets/remotion-icon.png'
   icon_large: './assets/remotion-icon.png'


### PR DESCRIPTION
## Summary

- use the documented slash-command names as the Codex display names for all Remotion skills
- add a regression test that requires every generated skill label to match `/<skill-name>`

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/codex-plugin`
- `bun run checkskills`
