### PR TITLE
`@remotion/studio-protocol`: Use Element duration when installing in Studio

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -237,6 +237,12 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 								<dt>Dimensions</dt>
 								<dd>{getElementDimensionsLabel(definition)}</dd>
 							</div>
+							<div>
+								<dt>Duration</dt>
+								<dd>
+									{`${durationInFrames} frames (${durationInFrames / fps}s)`}
+								</dd>
+							</div>
 						</dl>
 					</div>
 

--- a/packages/studio-protocol/src/drag-data.ts
+++ b/packages/studio-protocol/src/drag-data.ts
@@ -271,6 +271,7 @@ export const makeDragData = ((
 					dependencies: input.dependencies,
 					dimensions: input.dimensions,
 					displayName: input.displayName,
+					durationInFrames: input.durationInFrames,
 					slug: input.slug,
 					sourceCode: input.sourceCode,
 				}),

--- a/packages/studio-protocol/src/element-drag-data.ts
+++ b/packages/studio-protocol/src/element-drag-data.ts
@@ -9,6 +9,8 @@ export type ElementDragData = {
 	version: 1;
 	element: {
 		dependencies: string[];
+		/** Absent in legacy v1 drag payloads. */
+		durationInFrames?: number;
 		slug: string;
 		displayName: string;
 		sourceCode: string;
@@ -77,6 +79,7 @@ export const makeElementDragData = ({
 	dependencies,
 	dimensions,
 	displayName,
+	durationInFrames,
 	slug,
 	sourceCode,
 }: ElementDragData['element']): ElementDragData => {
@@ -85,6 +88,7 @@ export const makeElementDragData = ({
 		version: 1,
 		element: {
 			dependencies: Array.from(new Set(dependencies)),
+			...(durationInFrames === undefined ? {} : {durationInFrames}),
 			slug,
 			displayName,
 			sourceCode,
@@ -105,6 +109,12 @@ const isDimensions = (value: unknown): value is ComponentDimensions => {
 	);
 };
 
+const isDuration = (value: unknown): value is number =>
+	typeof value === 'number' &&
+	Number.isInteger(value) &&
+	value > 0 &&
+	value <= 100_000_000;
+
 export const parseElementDragData = (value: string): ElementDragData | null => {
 	try {
 		const parsed: unknown = JSON.parse(value);
@@ -117,8 +127,14 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			return null;
 		}
 
-		const {dependencies, dimensions, displayName, slug, sourceCode} =
-			parsed.element;
+		const {
+			dependencies,
+			dimensions,
+			displayName,
+			durationInFrames,
+			slug,
+			sourceCode,
+		} = parsed.element;
 		if (
 			!isSlug(slug) ||
 			typeof displayName !== 'string' ||
@@ -129,6 +145,7 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			sourceCode.length >= 200000 ||
 			getElementComponentNameFromSourceCode(sourceCode) === null ||
 			makeElementFileNameFromSlug(slug) === null ||
+			(durationInFrames !== undefined && !isDuration(durationInFrames)) ||
 			(dependencies !== undefined &&
 				(!Array.isArray(dependencies) ||
 					dependencies.length > 100 ||
@@ -145,6 +162,7 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 
 		return makeElementDragData({
 			dependencies: dependencies ?? [],
+			durationInFrames,
 			slug,
 			displayName,
 			sourceCode,

--- a/packages/studio-protocol/src/element-payload.ts
+++ b/packages/studio-protocol/src/element-payload.ts
@@ -25,6 +25,12 @@ export type StudioElementPayload = ReturnType<typeof makeElementDragData> & {
 	readonly durationInFrames: number;
 };
 
+const isDuration = (value: unknown): value is number =>
+	typeof value === 'number' &&
+	Number.isInteger(value) &&
+	value >= 1 &&
+	value <= 100_000_000;
+
 const assertCreateElementPayloadInput = (
 	input: CreateElementPayloadInput,
 ): void => {
@@ -76,6 +82,12 @@ const assertCreateElementPayloadInput = (
 			);
 		}
 	}
+
+	if (!isDuration(input.durationInFrames)) {
+		throw new TypeError(
+			'durationInFrames must be an integer between 1 and 100000000',
+		);
+	}
 };
 
 export const createElementPayload = (
@@ -109,8 +121,7 @@ export const parseStudioElementPayload = (
 		!isRecord(value) ||
 		value.type !== 'remotion-element' ||
 		value.version !== 1 ||
-		typeof value.durationInFrames !== 'number' ||
-		!Number.isInteger(value.durationInFrames) ||
+		!isDuration(value.durationInFrames) ||
 		!isRecord(value.element)
 	) {
 		return null;
@@ -139,6 +150,10 @@ export const parseStudioElementPayload = (
 
 	const payload: StudioElementPayload = {
 		...parsed,
+		element: {
+			...parsed.element,
+			durationInFrames: value.durationInFrames,
+		},
 		durationInFrames: value.durationInFrames,
 	};
 	return JSON.stringify(payload).length <= MAX_PAYLOAD_SIZE ? payload : null;

--- a/packages/studio-protocol/src/test/element-payload.test.ts
+++ b/packages/studio-protocol/src/test/element-payload.test.ts
@@ -22,6 +22,7 @@ test('creates one canonical Element payload for HTTP and drag transports', () =>
 			dependencies: ['remotion'],
 			dimensions: {width: 800, height: 200},
 			displayName: 'Lower Third',
+			durationInFrames: 90,
 			slug: 'lower-third',
 			sourceCode: 'export const LowerThird = () => null;',
 		},

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -142,6 +142,7 @@ export const insertElementHandler: ApiHandler<
 				prettierConfigOverride: null,
 				wrapInSequence: {
 					dimensions: element.dimensions,
+					durationInFrames: element.durationInFrames ?? null,
 					from,
 					name: element.displayName,
 					position,

--- a/packages/studio-server/src/test/insert-element.test.ts
+++ b/packages/studio-server/src/test/insert-element.test.ts
@@ -51,6 +51,7 @@ const existingElementSource =
 const element = {
 	dependencies: [],
 	dimensions: {width: 900, height: 260},
+	durationInFrames: 72,
 	displayName: 'Lower Third',
 	slug: 'overlays/lower-third',
 	sourceCode: incomingElementSource,
@@ -184,8 +185,9 @@ test('creates a new Element file without an overwrite conflict', async () => {
 		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
 			incomingElementSource,
 		);
-		expect(readFileSync(fixture.compositionFile, 'utf-8')).toContain(
-			'<LowerThird',
+		const composition = readFileSync(fixture.compositionFile, 'utf-8');
+		expect(composition).toMatch(
+			/<Sequence\b(?=[^>]*\bdurationInFrames=\{72\})[^>]*>\s*<LowerThird\s*\/>\s*<\/Sequence>/,
 		);
 	} finally {
 		fixture.cleanup();

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -274,7 +274,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 				clientId: 'focused-studio-tab',
 				compositionFile: '/tmp/protocol-project/src/Composition.tsx',
 				compositionId: 'Main',
-				element: {displayName: 'Lower Third'},
+				element: {displayName: 'Lower Third', durationInFrames: 90},
 				source: {
 					type: 'studio-protocol',
 					origin: 'https://example.com',

--- a/packages/studio-shared/src/test/element-drag-data.test.ts
+++ b/packages/studio-shared/src/test/element-drag-data.test.ts
@@ -56,7 +56,7 @@ test('parses element drag data', () => {
 	).toEqual({
 		type: 'remotion-element',
 		version: 1,
-		element: validElement,
+		element: {...validElement, durationInFrames: 120},
 	});
 });
 
@@ -87,7 +87,7 @@ test('accepts element drag data with null dimensions', () => {
 	).toEqual({
 		type: 'remotion-element',
 		version: 1,
-		element: elementWithoutDimensions,
+		element: {...elementWithoutDimensions, durationInFrames: 120},
 	});
 });
 


### PR DESCRIPTION
## Summary

- Use the existing Element `durationInFrames` value for both the preview and the `<Sequence>` installed into Studio.
- Carry the duration through Element drag data and HTTP installation requests instead of dropping it before insertion.
- Generate `durationInFrames` on the installed `<Sequence>`.
- Display the duration on Element pages.
- Preserve compatibility with legacy v1 drag payloads that do not contain the duration in their serialized Element data.

## Validation

- Targeted package builds for Studio protocol, shared, server, and docs
- Focused Studio protocol, shared, server, and Elements tests
- `git diff --check`

## Stack

1. **#10021 — Use Element duration when installing in Studio**
2. #10022 — Element dependency metadata and installation
3. #10023 — Element metadata authoring cleanup

Part of #8828.
