### PR TITLE
Docs: Link Remotion Codex plugin

### DIFF
--- a/packages/docs/docs/ai/codex-plugin.mdx
+++ b/packages/docs/docs/ai/codex-plugin.mdx
@@ -10,7 +10,9 @@ It can help you create new Remotion projects and includes [Remotion Agent Skills
 
 ## Installation
 
-Open the ChatGPT desktop app. Visit the **Plugins** tab and search for "Remotion".
+[Open the Remotion plugin in Codex](https://chatgpt.com/plugins/plugins~Plugin_efd07789186881918253a50acfc32762?open_in_codex).
+
+Alternatively, open the ChatGPT desktop app, visit the **Plugins** tab and search for "Remotion".
 
 ## Usage
 

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -268,6 +268,11 @@ export const config: VercelConfig = {
 		}),
 		routes.redirect('/skills', '/docs/ai/skills', {permanent: false}),
 		routes.redirect(
+			'/codex',
+			'https://chatgpt.com/plugins/plugins~Plugin_efd07789186881918253a50acfc32762?open_in_codex',
+			{permanent: false},
+		),
+		routes.redirect(
 			'/repro',
 			'https://stackblitz.com/fork/github/remotion-dev/template-helloworld',
 			{permanent: false},


### PR DESCRIPTION
## Summary

- Link directly to the Remotion plugin from the Codex plugin documentation
- Add `remotion.dev/codex` as a short redirect to the plugin

Closes #10012

## Validation

- `bun run build`
- `bun run stylecheck`

## Preview

- [Codex plugin documentation](https://remotion-git-codex-link-codex-plugin-remotion.vercel.app/docs/ai/codex-plugin)
