### PR TITLE
docs: align WebGL guides with v5 angle default

### DIFF
--- a/packages/docs/docs/html-in-canvas-guide.mdx
+++ b/packages/docs/docs/html-in-canvas-guide.mdx
@@ -109,13 +109,13 @@ From [`v4.0.455`](https://github.com/remotion-dev/remotion/releases/tag/v4.0.455
 
 We compiled a version of Chrome and made it the default, and enabled the flag for you.
 
-If your effect uses a WebGL shader, pass [`--gl=angle`](/docs/gl-options) to make the render work:
+If your effect uses a WebGL shader, Remotion 5 already defaults to [`angle`](/docs/gl-options) and falls back automatically. For older versions or explicit overrides, pass it to make the render work:
 
 ```bash
 npx remotion render --gl=angle
 ```
 
-Set it as the default in [`remotion.config.ts`](/docs/config) so Studio and CLI renders pick it up as a default:
+Set it as the default in [`remotion.config.ts`](/docs/config) if you are on Remotion 4 or want to pin the renderer explicitly so Studio and CLI renders pick it up:
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';
@@ -123,11 +123,11 @@ import {Config} from '@remotion/cli/config';
 Config.setChromiumOpenGlRenderer('angle');
 ```
 
-If your machine has no GPU, we recommend `--gl=swangle` instead (default on Lambda).
+If your machine has no GPU, `--gl=swangle` remains the fallback option (and is the default on Lambda).
 
 ## AI agents
 
-Remotion publishes [Agent Skills](/docs/ai/skills) that teach AI agents like Claude Code, Codex and Cursor how to use [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) correctly — including the [`onInit`](/docs/remotion/html-in-canvas#oninit) / [`onPaint`](/docs/remotion/html-in-canvas#onpaint) lifecycle, the [`--gl=angle` flag](#rendering) and [nesting requirements](#limitations).
+Remotion publishes [Agent Skills](/docs/ai/skills) that teach AI agents like Claude Code, Codex and Cursor how to use [`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) correctly — including the [`onInit`](/docs/remotion/html-in-canvas#oninit) / [`onPaint`](/docs/remotion/html-in-canvas#onpaint) lifecycle, renderer defaults, and [nesting requirements](#limitations).
 
 Install them with:
 

--- a/packages/docs/docs/shaders.mdx
+++ b/packages/docs/docs/shaders.mdx
@@ -84,7 +84,7 @@ export const FisheyeContent: React.FC = () => {
 
 ## Rendering
 
-When rendering a video that uses WebGL, pass [`--gl=angle`](/docs/gl-options) to ensure the headless browser can create a WebGL context:
+When rendering a video that uses WebGL, Remotion 5 already defaults to [`angle`](/docs/gl-options) and falls back automatically. On older versions or if you explicitly changed the renderer, pass `--gl=angle` to ensure the headless browser can create a WebGL context:
 
 ```bash
 bunx remotion render MyComp --gl=angle

--- a/packages/docs/docs/three.mdx
+++ b/packages/docs/docs/three.mdx
@@ -82,7 +82,7 @@ import {Config} from '@remotion/cli/config';
 Config.setChromiumOpenGlRenderer('angle');
 ```
 
-If you are on Remotion 4 or have overridden the renderer, the config file does not apply to server-side rendering, so you need to explicitly add
+If you are on Remotion 4 or have overridden the renderer, pass the renderer to server-side rendering APIs explicitly, since the config file does not apply there. Add
 
 ```json
 "chromiumOptions": {

--- a/packages/docs/docs/three.mdx
+++ b/packages/docs/docs/three.mdx
@@ -74,7 +74,7 @@ A [`<Sequence>`](/docs/sequence) by default will return a `<div>` component, whi
 
 ## Note on server-side rendering
 
-Three.JS does not render with the default OpenGL renderer - we recommend to set it to `angle`. The config file of new projects includes by default:
+For Remotion 5, Three.js rendering uses `angle` by default and falls back automatically when needed. Older projects or explicit overrides can still set it in the config file:
 
 ```ts twoslash
 import {Config} from '@remotion/cli/config';
@@ -82,7 +82,7 @@ import {Config} from '@remotion/cli/config';
 Config.setChromiumOpenGlRenderer('angle');
 ```
 
-Since the config file does not apply to server-side rendering, you need to explicitly add
+If you are on Remotion 4 or have overridden the renderer, the config file does not apply to server-side rendering, so you need to explicitly add
 
 ```json
 "chromiumOptions": {

--- a/packages/docs/docs/troubleshooting/webgl2-context.mdx
+++ b/packages/docs/docs/troubleshooting/webgl2-context.mdx
@@ -65,7 +65,7 @@ When rendering from the Studio UI, open the render modal, expand **Advanced**, a
 
 ## Machines without a GPU
 
-If you are on a machine without a GPU (for example AWS Lambda), use [`--gl=swangle`](/docs/gl-options) instead. This is the default on Lambda.
+If you are on a machine without a GPU (for example AWS Lambda), use [`--gl=swangle`](/docs/gl-options) instead. This remains the default on Lambda.
 
 ## Related
 


### PR DESCRIPTION
## Problem

Several WebGL-related docs still instruct readers to pass `--gl=angle` as if Remotion 4's `null` default were still current. In Remotion 5, `angle` is already the default renderer with automatic SwiftShader fallback (see the [v5 migration guide](/docs/5-0-migration#webgl-and-webgpu-during-rendering-are-now-enabled-by-default) and [`open-gl.mdx`](/docs/gl-options)).

Affected pages: `shaders.mdx`, `three.mdx`, `html-in-canvas-guide.mdx`, and `troubleshooting/webgl2-context.mdx`.

## Triage / Root cause

`gpu.mdx` and `webgl.mdx` were updated for v5, but these sibling guides still describe the v4 workflow only.

## Fix

- Note that Remotion 5 already defaults to `angle` with automatic fallback.
- Keep the `--gl=angle` examples and `remotion.config.ts` guidance for Remotion 4 users and explicit overrides.
- Clarify that `swangle` remains the Lambda default.

## Verification

- `python3 preflight_ship.py` against `upstream/main` — clear (bug marker present, fix marker absent, no duplicate PRs).
- `check-existing-pr.sh` — clear.
- Pre-commit docs format hook passed on commit.

## Notes / Risks

- Complements open #9963 (`gpu.mdx` v5 section) without overlapping files.
- Relates to #9524.