### PR TITLE
`@remotion/lambda-client`: Prepare overwrite defaults for v5

### DIFF
--- a/packages/it-tests/src/monorepo/php-package.test.ts
+++ b/packages/it-tests/src/monorepo/php-package.test.ts
@@ -158,7 +158,10 @@ class Semantic
 				isProduction: null,
 				sampleRate: 48000,
 			});
-		const jsonOutput = toParse.substring(0, toParse.lastIndexOf('}') + 1);
+		const jsonOutput = toParse.substring(
+			toParse.indexOf('{'),
+			toParse.lastIndexOf('}') + 1,
+		);
 		const parsedJson = JSON.parse(jsonOutput);
 
 		expect({

--- a/packages/lambda-client/src/make-lambda-payload.ts
+++ b/packages/lambda-client/src/make-lambda-payload.ts
@@ -70,7 +70,7 @@ export type InnerRenderMediaOnLambdaInput = {
 	concurrencyPerLambda: number;
 	downloadBehavior: DownloadBehavior;
 	muted: boolean;
-	overwrite: boolean;
+	overwrite: boolean | undefined;
 	audioBitrate: string | null;
 	videoBitrate: string | null;
 	encodingMaxRate: string | null;

--- a/packages/lambda-client/src/render-media-on-lambda.ts
+++ b/packages/lambda-client/src/render-media-on-lambda.ts
@@ -192,7 +192,7 @@ export const renderMediaOnLambdaOptionalToRequired = (
 		offthreadVideoCacheSizeInBytes:
 			options.offthreadVideoCacheSizeInBytes ?? null,
 		outName: options.outName ?? null,
-		overwrite: options.overwrite ?? false,
+		overwrite: options.overwrite,
 		pixelFormat: options.pixelFormat ?? undefined,
 		privacy: options.privacy ?? 'public',
 		proResProfile: options.proResProfile ?? undefined,

--- a/packages/lambda-client/src/test/overwrite-default.test.ts
+++ b/packages/lambda-client/src/test/overwrite-default.test.ts
@@ -1,0 +1,34 @@
+import {expect, test} from 'bun:test';
+import {ENABLE_V5_BREAKING_CHANGES} from '@remotion/serverless-client';
+import {makeLambdaRenderMediaPayload} from '../make-lambda-payload';
+import {renderMediaOnLambdaOptionalToRequired} from '../render-media-on-lambda';
+
+const getOptions = () => ({
+	region: 'us-east-1' as const,
+	functionName: 'test-function',
+	serveUrl: 'https://example.com',
+	composition: 'test-composition',
+	codec: 'h264' as const,
+});
+
+test('keeps an omitted overwrite value unresolved', () => {
+	const options = renderMediaOnLambdaOptionalToRequired(getOptions());
+
+	expect(options.overwrite).toBeUndefined();
+});
+
+test('preserves an explicit overwrite value', () => {
+	const options = renderMediaOnLambdaOptionalToRequired({
+		...getOptions(),
+		overwrite: false,
+	});
+
+	expect(options.overwrite).toBe(false);
+});
+
+test('resolves an omitted overwrite value using the v5 flag', async () => {
+	const options = renderMediaOnLambdaOptionalToRequired(getOptions());
+	const payload = await makeLambdaRenderMediaPayload(options);
+
+	expect(payload.overwrite).toBe(ENABLE_V5_BREAKING_CHANGES);
+});

--- a/packages/lambda-php/src/RenderParams.php
+++ b/packages/lambda-php/src/RenderParams.php
@@ -38,7 +38,7 @@ class RenderParams
     ];
     protected $muted = false;
     protected $preferLossless = false;
-    protected $overwrite = false;
+    protected $overwrite = null;
     protected $audioBitrate = null;
     protected $videoBitrate = null;
     protected $encodingBufferSize = null;
@@ -88,7 +88,7 @@ class RenderParams
         ?int    $concurrency = null,
         ?array  $downloadBehavior = null,
         ?bool   $muted = false,
-        ?bool   $overwrite = false,
+        ?bool   $overwrite = null,
         ?int    $audioBitrate = null,
         ?int    $videoBitrate = null,
         ?string $webhook = null,
@@ -816,7 +816,7 @@ class RenderParams
 
     public function getOverwrite()
     {
-        return $this->overwrite;
+        return $this->overwrite ?? version_compare(Semantic::VERSION, '5.0.0', '>=');
     }
 
     public function getAudioBitrate()

--- a/packages/lambda-php/tests/PHPClientTest.php
+++ b/packages/lambda-php/tests/PHPClientTest.php
@@ -8,6 +8,23 @@ use Remotion\LambdaPhp\RenderParams;
 
 class PHPClientTest extends TestCase
 {
+    public function testOverwriteDefaultsToFalseInV4()
+    {
+        $params = new RenderParams();
+
+        $this->assertFalse($params->getOverwrite());
+        $this->assertFalse($params->serializeParams()['overwrite']);
+    }
+
+    public function testExplicitOverwriteValueIsPreserved()
+    {
+        $params = new RenderParams(overwrite: false);
+        $this->assertFalse($params->getOverwrite());
+
+        $params->setOverwrite(true);
+        $this->assertTrue($params->getOverwrite());
+    }
+
     public function testClient()
     {
         $client = new PHPClient(

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -309,7 +309,7 @@ class RenderMediaParams:
         default_factory=lambda: PlayInBrowser(type='play-in-browser')
     )
     muted: bool = False
-    overwrite: bool = False
+    overwrite: Optional[bool] = None
     force_path_style: Optional[bool] = None
     audio_bitrate: Optional[int] = None
     video_bitrate: Optional[int] = None
@@ -373,7 +373,11 @@ class RenderMediaParams:
             'downloadBehavior': self.download_behavior,
             'muted': self.muted,
             'version': VERSION,
-            'overwrite': self.overwrite,
+            'overwrite': (
+                self.overwrite
+                if self.overwrite is not None
+                else int(VERSION.split('.', maxsplit=1)[0]) >= 5
+            ),
             'audioBitrate': self.audio_bitrate,
             'videoBitrate': self.video_bitrate,
             'webhook': self.webhook,

--- a/packages/lambda-python/tests/test_render_client_render_media.py
+++ b/packages/lambda-python/tests/test_render_client_render_media.py
@@ -1,10 +1,29 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from remotion_lambda.models import RenderMediaParams, ShouldDownload, Webhook
 from remotion_lambda.remotionclient import RemotionClient
 from remotion_lambda.exception import RemotionInvalidArgumentException
 
+
 class TestRemotionClient(TestCase):
+    def test_overwrite_defaults_to_false_in_v4(self):
+        render_params = RenderMediaParams()
+
+        self.assertFalse(render_params.serialize_params()['overwrite'])
+
+    @patch('remotion_lambda.models.VERSION', '5.0.0')
+    def test_overwrite_defaults_to_true_in_v5(self):
+        render_params = RenderMediaParams()
+
+        self.assertTrue(render_params.serialize_params()['overwrite'])
+
+    @patch('remotion_lambda.models.VERSION', '5.0.0')
+    def test_explicit_false_overwrite_is_preserved_in_v5(self):
+        render_params = RenderMediaParams(overwrite=False)
+
+        self.assertFalse(render_params.serialize_params()['overwrite'])
+
     def test_remotion_construct_request(self):
         client = RemotionClient(
             region="us-east-1", serve_url="testbed", function_name="remotion-render"

--- a/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload.rb
+++ b/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload.rb
@@ -1,5 +1,11 @@
 require_relative 'version'
 
+def resolve_overwrite(overwrite, version)
+  return overwrite unless overwrite.nil?
+
+  version.split('.', 2).first.to_i >= 5
+end
+
 def get_render_media_on_lambda_payload(
   bucket_name: nil,
   codec:,
@@ -38,7 +44,7 @@ def get_render_media_on_lambda_payload(
   media_cache_size_in_bytes: nil,
   offthread_video_threads: nil,
   out_name: nil,
-  overwrite: false,
+  overwrite: nil,
   pixel_format: nil,
   prefer_lossless: false,
   privacy: "public",
@@ -100,7 +106,7 @@ payload = {
     mediaCacheSizeInBytes: media_cache_size_in_bytes,
     offthreadVideoThreads: offthread_video_threads,
     outName: out_name,
-    overwrite: overwrite,
+    overwrite: resolve_overwrite(overwrite, VERSION),
     pixelFormat: pixel_format,
     preferLossless: prefer_lossless,
     sampleRate: sample_rate,

--- a/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload_spec.rb
+++ b/packages/lambda-ruby/lib/remotion_lambda/render_media_on_lambda_payload_spec.rb
@@ -1,6 +1,10 @@
 require_relative 'render_media_on_lambda_payload'
 require 'json'
 
+raise "Expected overwrite to default to false in v4" unless resolve_overwrite(nil, "4.0.0") == false
+raise "Expected overwrite to default to true in v5" unless resolve_overwrite(nil, "5.0.0") == true
+raise "Expected an explicit false value to be preserved" unless resolve_overwrite(false, "5.0.0") == false
+
 # Call get_render_media_on_lambda with sample data
 payload = get_render_media_on_lambda_payload(
   codec: "h264",
@@ -24,6 +28,8 @@ payload = get_render_media_on_lambda_payload(
     hi: "there",
   }
 )
+
+raise "Expected the current SDK to default overwrite to false" unless payload[:overwrite] == false
 
 # Print as JSON
 puts JSON.generate(payload)


### PR DESCRIPTION
## Summary

- Preserve an omitted `overwrite` value in `@remotion/lambda-client` until the central v5 flag resolves the default.
- Resolve omitted PHP, Python, and Ruby values from the SDK major version, keeping the v4 default `false` and selecting `true` in v5.
- Preserve explicitly supplied `false` values in every client and add focused v4/v5 coverage.

The source-breaking Go representation change is included separately in the Remotion 5.0 PR (#3750).

## Validation

- `bun run build`
- `bun run stylecheck`
- Lambda client overwrite tests
- PHP test suite
- Python test suite and static analysis
- Ruby payload specs and syntax check

Closes #9492
