### PR TITLE
`@remotion/studio-protocol`: Add internal license key method

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -169,7 +169,13 @@ export const MyComponent = () => {
 			)
 			.toMatchObject({
 				protocol: 'remotion-studio-protocol',
-				installTarget: {compositionId: 'MyComp'},
+				capabilities: [
+					{
+						type: 'install-element',
+						target: {compositionId: 'MyComp'},
+					},
+					{type: 'set-license-key'},
+				],
 			});
 
 		const address = senderServer.address();

--- a/packages/studio-protocol/src/index.ts
+++ b/packages/studio-protocol/src/index.ts
@@ -11,6 +11,8 @@ import {
 } from './element-drag-data';
 import {parseStudioElementPayload} from './element-payload';
 import {installInStudioWithDependencies} from './install-in-studio';
+import {isValidPublicLicenseKey} from './license-key';
+import {setLicenseKeyInStudio} from './set-license-key-in-studio';
 
 export type {AssetDragData} from './asset-drag-data';
 export type {
@@ -67,8 +69,10 @@ export const StudioProtocolInternals = {
 	isComponentIdentifier,
 	isComponentImportPath,
 	installInStudioWithDependencies,
+	isValidPublicLicenseKey,
 	makeDragData,
 	makeElementFileNameFromSlug,
 	parseDragData,
 	parseStudioElementPayload,
+	setLicenseKeyInStudio,
 };

--- a/packages/studio-protocol/src/index.ts
+++ b/packages/studio-protocol/src/index.ts
@@ -45,10 +45,9 @@ export type {
 	ElementDragPreviewMetadata,
 	SfxDragPreviewMetadata,
 } from './drag-preview-metadata';
+export {setStudioDragData} from './drag-transport';
 export type {EffectDragData} from './effect-drag-data';
 export type {ElementDependency, ElementDragData} from './element-drag-data';
-export type {SfxDragData} from './sfx-drag-data';
-export {setStudioDragData} from './drag-transport';
 export {
 	createElementPayload,
 	type CreateElementPayloadInput,
@@ -58,9 +57,12 @@ export {
 	installInStudio,
 	type InstallInStudioErrorCode,
 	type InstallInStudioResult,
-	type StudioProtocolDescriptor,
-	type StudioProtocolInstallTarget,
 } from './install-in-studio';
+export type {SfxDragData} from './sfx-drag-data';
+export type {
+	StudioProtocolDescriptor,
+	StudioProtocolInstallTarget,
+} from './studio-discovery';
 
 export const StudioProtocolInternals = {
 	areComponentProps,

--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -8,6 +8,12 @@ export type StudioProtocolInstallTarget = {
 	readonly lastFocusedAt: number;
 };
 
+export type StudioProtocolLicenseKeyTarget = {
+	readonly id: string;
+	readonly expiresAt: number;
+	readonly lastFocusedAt: number;
+};
+
 export type StudioProtocolDescriptor = {
 	readonly protocol: 'remotion-studio-protocol';
 	readonly protocolVersion: 1;
@@ -17,9 +23,11 @@ export type StudioProtocolDescriptor = {
 			readonly payloadType: 'remotion-element';
 			readonly payloadVersions: readonly number[];
 		}[];
+		readonly setLicenseKey?: true;
 	};
 	readonly projectName: string | null;
 	readonly installTarget: StudioProtocolInstallTarget | null;
+	readonly licenseKeyTarget?: StudioProtocolLicenseKeyTarget | null;
 };
 
 export type InstallInStudioErrorCode =
@@ -51,20 +59,22 @@ export type InstallInStudioResult =
 			readonly message: string;
 	  };
 
-type Fetcher = (
+export type StudioProtocolFetcher = (
 	input: string | URL | Request,
 	options?: RequestInit,
 ) => Promise<Response>;
 
 export type InstallInStudioDependencies = {
-	readonly fetchFn: Fetcher;
+	readonly fetchFn: StudioProtocolFetcher;
 	readonly now: () => number;
 	readonly ports: readonly number[];
 	readonly pageOrigin: string | null;
 };
 
-const probePorts = [3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009];
-const focusedStudioMaxAge = 5 * 60 * 1000;
+export const studioProtocolProbePorts = [
+	3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009,
+];
+export const focusedStudioMaxAge = 5 * 60 * 1000;
 const requestTimeout = 2_000;
 
 const failure = (
@@ -72,12 +82,12 @@ const failure = (
 	message: string,
 ): InstallInStudioResult => ({success: false, code, message});
 
-const fetchWithTimeout = async ({
+export const fetchWithTimeout = async ({
 	fetchFn,
 	options,
 	url,
 }: {
-	readonly fetchFn: Fetcher;
+	readonly fetchFn: StudioProtocolFetcher;
 	readonly options: RequestInit | null;
 	readonly url: string;
 }) => {
@@ -112,7 +122,20 @@ const isInstallTarget = (
 	);
 };
 
-const isDescriptor = (value: unknown): value is StudioProtocolDescriptor => {
+const isLicenseKeyTarget = (
+	value: unknown,
+): value is StudioProtocolLicenseKeyTarget =>
+	isRecord(value) &&
+	typeof value.id === 'string' &&
+	value.id.length > 0 &&
+	typeof value.expiresAt === 'number' &&
+	Number.isFinite(value.expiresAt) &&
+	typeof value.lastFocusedAt === 'number' &&
+	Number.isFinite(value.lastFocusedAt);
+
+export const isStudioProtocolDescriptor = (
+	value: unknown,
+): value is StudioProtocolDescriptor => {
 	if (
 		!isRecord(value) ||
 		value.protocol !== 'remotion-studio-protocol' ||
@@ -134,7 +157,12 @@ const isDescriptor = (value: unknown): value is StudioProtocolDescriptor => {
 		capability.payloadVersions.every(
 			(version) => typeof version === 'number',
 		) &&
-		(value.installTarget === null || isInstallTarget(value.installTarget))
+		(value.installTarget === null || isInstallTarget(value.installTarget)) &&
+		(value.capabilities.setLicenseKey === undefined ||
+			value.capabilities.setLicenseKey === true) &&
+		(value.licenseKeyTarget === undefined ||
+			value.licenseKeyTarget === null ||
+			isLicenseKeyTarget(value.licenseKeyTarget))
 	);
 };
 
@@ -142,7 +170,9 @@ const hasSupportedElementCapability = (
 	descriptor: StudioProtocolDescriptor,
 ): boolean => descriptor.capabilities.install[0]!.payloadVersions.includes(1);
 
-const isAllowedOrigin = (origin: string | null): boolean => {
+export const isAllowedStudioProtocolPageOrigin = (
+	origin: string | null,
+): boolean => {
 	if (origin === null) {
 		return false;
 	}
@@ -159,13 +189,13 @@ const isAllowedOrigin = (origin: string | null): boolean => {
 	}
 };
 
-type DiscoveredStudio = {
+export type DiscoveredStudio = {
 	readonly descriptor: StudioProtocolDescriptor;
 	readonly discoveredAt: number;
 	readonly origin: string;
 };
 
-const discoverStudios = async (
+export const discoverStudios = async (
 	dependencies: InstallInStudioDependencies,
 ): Promise<{
 	readonly studios: DiscoveredStudio[];
@@ -209,7 +239,7 @@ const discoverStudios = async (
 				return null;
 			}
 
-			if (!isDescriptor(value)) {
+			if (!isStudioProtocolDescriptor(value)) {
 				foundInvalidResponse = true;
 				return null;
 			}
@@ -231,7 +261,7 @@ const discoverStudios = async (
 	};
 };
 
-const hasLegacyStudio = async (
+export const hasLegacyStudio = async (
 	dependencies: InstallInStudioDependencies,
 ): Promise<boolean> => {
 	const results = await Promise.all(
@@ -256,14 +286,14 @@ const hasLegacyStudio = async (
 	return results.some(Boolean);
 };
 
-const isAbortError = (error: unknown): boolean =>
+export const isAbortError = (error: unknown): boolean =>
 	error instanceof Error && error.name === 'AbortError';
 
 export const installInStudioWithDependencies = async (
 	payload: StudioElementPayload,
 	dependencies: InstallInStudioDependencies,
 ): Promise<InstallInStudioResult> => {
-	if (!isAllowedOrigin(dependencies.pageOrigin)) {
+	if (!isAllowedStudioProtocolPageOrigin(dependencies.pageOrigin)) {
 		return failure(
 			'unsupported-origin',
 			'Install in Studio is only supported on HTTPS websites and local development origins.',
@@ -421,6 +451,6 @@ export const installInStudio = ({
 			typeof globalThis.location === 'undefined'
 				? null
 				: globalThis.location.origin,
-		ports: probePorts,
+		ports: studioProtocolProbePorts,
 	});
 };

--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -1,34 +1,15 @@
 import type {StudioElementPayload} from './element-payload';
+import type {StudioProtocolFetcher} from './studio-discovery';
+import {
+	discoverStudios,
+	fetchWithTimeout,
+	focusedStudioMaxAge,
+	getInstallCapability,
+	hasLegacyStudio,
+	isAbortError,
+	studioProtocolProbePorts,
+} from './studio-discovery';
 import {isRecord} from './validation';
-
-export type StudioProtocolInstallTarget = {
-	readonly id: string;
-	readonly expiresAt: number;
-	readonly compositionId: string;
-	readonly lastFocusedAt: number;
-};
-
-export type StudioProtocolLicenseKeyTarget = {
-	readonly id: string;
-	readonly expiresAt: number;
-	readonly lastFocusedAt: number;
-};
-
-export type StudioProtocolDescriptor = {
-	readonly protocol: 'remotion-studio-protocol';
-	readonly protocolVersion: 1;
-	readonly studioVersion: string;
-	readonly capabilities: {
-		readonly install: readonly {
-			readonly payloadType: 'remotion-element';
-			readonly payloadVersions: readonly number[];
-		}[];
-		readonly setLicenseKey?: true;
-	};
-	readonly projectName: string | null;
-	readonly installTarget: StudioProtocolInstallTarget | null;
-	readonly licenseKeyTarget?: StudioProtocolLicenseKeyTarget | null;
-};
 
 export type InstallInStudioErrorCode =
 	| 'unsupported-origin'
@@ -59,11 +40,6 @@ export type InstallInStudioResult =
 			readonly message: string;
 	  };
 
-export type StudioProtocolFetcher = (
-	input: string | URL | Request,
-	options?: RequestInit,
-) => Promise<Response>;
-
 export type InstallInStudioDependencies = {
 	readonly fetchFn: StudioProtocolFetcher;
 	readonly now: () => number;
@@ -71,104 +47,18 @@ export type InstallInStudioDependencies = {
 	readonly pageOrigin: string | null;
 };
 
-export const studioProtocolProbePorts = [
-	3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009,
-];
-export const focusedStudioMaxAge = 5 * 60 * 1000;
-const requestTimeout = 2_000;
+export type StudioProtocolInstallRequest = {
+	readonly operation: 'install-element';
+	readonly protocol: 'remotion-studio-protocol';
+	readonly protocolVersion: 1;
+	readonly targetId: string;
+	readonly payload: StudioElementPayload;
+};
 
 const failure = (
 	code: InstallInStudioErrorCode,
 	message: string,
 ): InstallInStudioResult => ({success: false, code, message});
-
-export const fetchWithTimeout = async ({
-	fetchFn,
-	options,
-	url,
-}: {
-	readonly fetchFn: StudioProtocolFetcher;
-	readonly options: RequestInit | null;
-	readonly url: string;
-}) => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), requestTimeout);
-	try {
-		return await fetchFn(url, {
-			...(options ?? {}),
-			signal: controller.signal,
-		});
-	} finally {
-		clearTimeout(timeout);
-	}
-};
-
-const isNullableString = (value: unknown): value is string | null =>
-	value === null || typeof value === 'string';
-
-const isInstallTarget = (
-	value: unknown,
-): value is StudioProtocolInstallTarget => {
-	return (
-		isRecord(value) &&
-		typeof value.id === 'string' &&
-		value.id.length > 0 &&
-		typeof value.expiresAt === 'number' &&
-		Number.isFinite(value.expiresAt) &&
-		typeof value.compositionId === 'string' &&
-		value.compositionId.length > 0 &&
-		typeof value.lastFocusedAt === 'number' &&
-		Number.isFinite(value.lastFocusedAt)
-	);
-};
-
-const isLicenseKeyTarget = (
-	value: unknown,
-): value is StudioProtocolLicenseKeyTarget =>
-	isRecord(value) &&
-	typeof value.id === 'string' &&
-	value.id.length > 0 &&
-	typeof value.expiresAt === 'number' &&
-	Number.isFinite(value.expiresAt) &&
-	typeof value.lastFocusedAt === 'number' &&
-	Number.isFinite(value.lastFocusedAt);
-
-export const isStudioProtocolDescriptor = (
-	value: unknown,
-): value is StudioProtocolDescriptor => {
-	if (
-		!isRecord(value) ||
-		value.protocol !== 'remotion-studio-protocol' ||
-		value.protocolVersion !== 1 ||
-		typeof value.studioVersion !== 'string' ||
-		!isNullableString(value.projectName) ||
-		!isRecord(value.capabilities) ||
-		!Array.isArray(value.capabilities.install) ||
-		value.capabilities.install.length !== 1
-	) {
-		return false;
-	}
-
-	const [capability] = value.capabilities.install;
-	return (
-		isRecord(capability) &&
-		capability.payloadType === 'remotion-element' &&
-		Array.isArray(capability.payloadVersions) &&
-		capability.payloadVersions.every(
-			(version) => typeof version === 'number',
-		) &&
-		(value.installTarget === null || isInstallTarget(value.installTarget)) &&
-		(value.capabilities.setLicenseKey === undefined ||
-			value.capabilities.setLicenseKey === true) &&
-		(value.licenseKeyTarget === undefined ||
-			value.licenseKeyTarget === null ||
-			isLicenseKeyTarget(value.licenseKeyTarget))
-	);
-};
-
-const hasSupportedElementCapability = (
-	descriptor: StudioProtocolDescriptor,
-): boolean => descriptor.capabilities.install[0]!.payloadVersions.includes(1);
 
 export const isAllowedStudioProtocolPageOrigin = (
 	origin: string | null,
@@ -188,106 +78,6 @@ export const isAllowedStudioProtocolPageOrigin = (
 		return false;
 	}
 };
-
-export type DiscoveredStudio = {
-	readonly descriptor: StudioProtocolDescriptor;
-	readonly discoveredAt: number;
-	readonly origin: string;
-};
-
-export const discoverStudios = async (
-	dependencies: InstallInStudioDependencies,
-): Promise<{
-	readonly studios: DiscoveredStudio[];
-	readonly foundUnsupportedProtocol: boolean;
-	readonly foundInvalidResponse: boolean;
-}> => {
-	let foundUnsupportedProtocol = false;
-	let foundInvalidResponse = false;
-	const studios = await Promise.all(
-		dependencies.ports.map(async (port): Promise<DiscoveredStudio | null> => {
-			const origin = `http://localhost:${port}`;
-			let response: Response;
-			try {
-				response = await fetchWithTimeout({
-					fetchFn: dependencies.fetchFn,
-					options: {cache: 'no-store'},
-					url: `${origin}/api/studio-protocol`,
-				});
-			} catch {
-				return null;
-			}
-
-			if (!response.ok) {
-				return null;
-			}
-
-			let value: unknown;
-			try {
-				value = await response.json();
-			} catch {
-				foundInvalidResponse = true;
-				return null;
-			}
-
-			if (
-				isRecord(value) &&
-				value.protocol === 'remotion-studio-protocol' &&
-				value.protocolVersion !== 1
-			) {
-				foundUnsupportedProtocol = true;
-				return null;
-			}
-
-			if (!isStudioProtocolDescriptor(value)) {
-				foundInvalidResponse = true;
-				return null;
-			}
-
-			return {
-				descriptor: value,
-				discoveredAt: dependencies.now(),
-				origin,
-			};
-		}),
-	);
-
-	return {
-		studios: studios.filter(
-			(studio): studio is DiscoveredStudio => studio !== null,
-		),
-		foundUnsupportedProtocol,
-		foundInvalidResponse,
-	};
-};
-
-export const hasLegacyStudio = async (
-	dependencies: InstallInStudioDependencies,
-): Promise<boolean> => {
-	const results = await Promise.all(
-		dependencies.ports.map(async (port) => {
-			try {
-				const response = await fetchWithTimeout({
-					fetchFn: dependencies.fetchFn,
-					options: {cache: 'no-store'},
-					url: `http://localhost:${port}/api/element-install-target`,
-				});
-				if (!response.ok) {
-					return false;
-				}
-
-				const value: unknown = await response.json();
-				return isRecord(value) && value.type === 'remotion-studio';
-			} catch {
-				return false;
-			}
-		}),
-	);
-	return results.some(Boolean);
-};
-
-export const isAbortError = (error: unknown): boolean =>
-	error instanceof Error && error.name === 'AbortError';
 
 export const installInStudioWithDependencies = async (
 	payload: StudioElementPayload,
@@ -329,9 +119,12 @@ export const installInStudioWithDependencies = async (
 		);
 	}
 
-	const supportedStudios = discovery.studios.filter(({descriptor}) =>
-		hasSupportedElementCapability(descriptor),
-	);
+	const supportedStudios = discovery.studios.flatMap((studio) => {
+		const capability = getInstallCapability(studio.descriptor);
+		return capability?.payloadVersions.includes(1)
+			? [{...studio, capability}]
+			: [];
+	});
 	if (supportedStudios.length === 0) {
 		return failure(
 			'unsupported-protocol',
@@ -341,8 +134,8 @@ export const installInStudioWithDependencies = async (
 
 	const now = dependencies.now();
 	const installable = supportedStudios
-		.filter(({descriptor}) => {
-			const target = descriptor.installTarget;
+		.filter(({capability}) => {
+			const {target} = capability;
 			return (
 				target !== null &&
 				target.expiresAt > now &&
@@ -351,14 +144,14 @@ export const installInStudioWithDependencies = async (
 		})
 		.sort((a, b) => {
 			const focusDifference =
-				b.descriptor.installTarget!.lastFocusedAt -
-				a.descriptor.installTarget!.lastFocusedAt;
+				b.capability.target!.lastFocusedAt - a.capability.target!.lastFocusedAt;
 			return focusDifference === 0
 				? b.discoveredAt - a.discoveredAt
 				: focusDifference;
 		});
 	const selected = installable[0];
-	if (!selected || selected.descriptor.installTarget === null) {
+	const selectedTarget = selected?.capability.target;
+	if (!selected || selectedTarget === null || selectedTarget === undefined) {
 		return failure(
 			'no-installable-target',
 			'Focus a writable composition in Remotion Studio, then try again.',
@@ -367,18 +160,20 @@ export const installInStudioWithDependencies = async (
 
 	let response: Response;
 	try {
+		const requestBody = {
+			operation: 'install-element',
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			targetId: selectedTarget.id,
+			payload,
+		} satisfies StudioProtocolInstallRequest;
 		response = await fetchWithTimeout({
 			fetchFn: dependencies.fetchFn,
 			url: `${selected.origin}/api/studio-protocol/install`,
 			options: {
 				method: 'POST',
 				headers: {'Content-Type': 'application/json'},
-				body: JSON.stringify({
-					protocol: 'remotion-studio-protocol',
-					protocolVersion: 1,
-					targetId: selected.descriptor.installTarget.id,
-					payload,
-				}),
+				body: JSON.stringify(requestBody),
 			},
 		});
 	} catch (error) {
@@ -412,7 +207,7 @@ export const installInStudioWithDependencies = async (
 			status: 'awaiting-confirmation',
 			target: {
 				projectName: selected.descriptor.projectName,
-				compositionId: selected.descriptor.installTarget.compositionId,
+				compositionId: selectedTarget.compositionId,
 				studioOrigin: selected.origin,
 				studioVersion: selected.descriptor.studioVersion,
 			},

--- a/packages/studio-protocol/src/license-key.ts
+++ b/packages/studio-protocol/src/license-key.ts
@@ -1,0 +1,6 @@
+const publicLicenseKeyPattern = /^rm_pub_[a-zA-Z0-9]{48}$/;
+
+export const isValidPublicLicenseKey = (
+	licenseKey: unknown,
+): licenseKey is string =>
+	typeof licenseKey === 'string' && publicLicenseKeyPattern.test(licenseKey);

--- a/packages/studio-protocol/src/set-license-key-in-studio.ts
+++ b/packages/studio-protocol/src/set-license-key-in-studio.ts
@@ -1,13 +1,14 @@
+import {isValidPublicLicenseKey} from './license-key';
+import type {StudioProtocolFetcher} from './studio-discovery';
 import {
 	discoverStudios,
 	fetchWithTimeout,
 	focusedStudioMaxAge,
+	getSetLicenseKeyCapability,
 	hasLegacyStudio,
 	isAbortError,
 	studioProtocolProbePorts,
-} from './install-in-studio';
-import type {StudioProtocolFetcher} from './install-in-studio';
-import {isValidPublicLicenseKey} from './license-key';
+} from './studio-discovery';
 import {isRecord} from './validation';
 
 export type SetLicenseKeyInStudioErrorCode =
@@ -45,6 +46,14 @@ export type SetLicenseKeyInStudioDependencies = {
 	readonly now: () => number;
 	readonly ports: readonly number[];
 	readonly pageOrigin: string | null;
+};
+
+export type StudioProtocolSetLicenseKeyRequest = {
+	readonly operation: 'set-license-key';
+	readonly protocol: 'remotion-studio-protocol';
+	readonly protocolVersion: 1;
+	readonly targetId: string;
+	readonly licenseKey: string;
 };
 
 const isAllowedLicenseKeyPageOrigin = (origin: string | null): boolean => {
@@ -127,9 +136,10 @@ export const setLicenseKeyInStudioWithDependencies = async (
 		};
 	}
 
-	const supportedStudios = discovery.studios.filter(
-		({descriptor}) => descriptor.capabilities.setLicenseKey === true,
-	);
+	const supportedStudios = discovery.studios.flatMap((studio) => {
+		const capability = getSetLicenseKeyCapability(studio.descriptor);
+		return capability === null ? [] : [{...studio, capability}];
+	});
 	if (supportedStudios.length === 0) {
 		return {
 			success: false,
@@ -141,25 +151,23 @@ export const setLicenseKeyInStudioWithDependencies = async (
 
 	const now = dependencies.now();
 	const configurable = supportedStudios
-		.filter(({descriptor}) => {
-			const target = descriptor.licenseKeyTarget;
+		.filter(({capability}) => {
+			const {target} = capability;
 			return (
 				target !== null &&
-				target !== undefined &&
 				target.expiresAt > now &&
 				now - target.lastFocusedAt < focusedStudioMaxAge
 			);
 		})
 		.sort((a, b) => {
 			const focusDifference =
-				b.descriptor.licenseKeyTarget!.lastFocusedAt -
-				a.descriptor.licenseKeyTarget!.lastFocusedAt;
+				b.capability.target!.lastFocusedAt - a.capability.target!.lastFocusedAt;
 			return focusDifference === 0
 				? b.discoveredAt - a.discoveredAt
 				: focusDifference;
 		});
 	const selected = configurable[0];
-	const selectedTarget = selected?.descriptor.licenseKeyTarget;
+	const selectedTarget = selected?.capability.target;
 	if (!selected || selectedTarget === null || selectedTarget === undefined) {
 		return {
 			success: false,
@@ -170,18 +178,20 @@ export const setLicenseKeyInStudioWithDependencies = async (
 
 	let response: Response;
 	try {
+		const requestBody = {
+			operation: 'set-license-key',
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			targetId: selectedTarget.id,
+			licenseKey,
+		} satisfies StudioProtocolSetLicenseKeyRequest;
 		response = await fetchWithTimeout({
 			fetchFn: dependencies.fetchFn,
 			url: `${selected.origin}/api/studio-protocol/license-key`,
 			options: {
 				method: 'POST',
 				headers: {'Content-Type': 'application/json'},
-				body: JSON.stringify({
-					protocol: 'remotion-studio-protocol',
-					protocolVersion: 1,
-					targetId: selectedTarget.id,
-					licenseKey,
-				}),
+				body: JSON.stringify(requestBody),
 			},
 		});
 	} catch (error) {

--- a/packages/studio-protocol/src/set-license-key-in-studio.ts
+++ b/packages/studio-protocol/src/set-license-key-in-studio.ts
@@ -1,0 +1,267 @@
+import {
+	discoverStudios,
+	fetchWithTimeout,
+	focusedStudioMaxAge,
+	hasLegacyStudio,
+	isAbortError,
+	studioProtocolProbePorts,
+} from './install-in-studio';
+import type {StudioProtocolFetcher} from './install-in-studio';
+import {isValidPublicLicenseKey} from './license-key';
+import {isRecord} from './validation';
+
+export type SetLicenseKeyInStudioErrorCode =
+	| 'unsupported-origin'
+	| 'invalid-license-key'
+	| 'no-compatible-studio'
+	| 'studio-upgrade-required'
+	| 'no-configurable-target'
+	| 'unsupported-protocol'
+	| 'invalid-response'
+	| 'target-expired'
+	| 'no-config-file'
+	| 'request-rejected'
+	| 'request-timed-out'
+	| 'network-error';
+
+export type SetLicenseKeyInStudioResult =
+	| {
+			readonly success: true;
+			readonly status: 'license-key-set';
+			readonly target: {
+				readonly projectName: string | null;
+				readonly studioOrigin: string;
+				readonly studioVersion: string;
+			};
+	  }
+	| {
+			readonly success: false;
+			readonly code: SetLicenseKeyInStudioErrorCode;
+			readonly message: string;
+	  };
+
+export type SetLicenseKeyInStudioDependencies = {
+	readonly fetchFn: StudioProtocolFetcher;
+	readonly now: () => number;
+	readonly ports: readonly number[];
+	readonly pageOrigin: string | null;
+};
+
+const isAllowedLicenseKeyPageOrigin = (origin: string | null): boolean => {
+	if (origin === null) {
+		return false;
+	}
+
+	try {
+		const url = new URL(origin);
+		if (
+			url.protocol === 'http:' &&
+			(url.hostname === 'localhost' || url.hostname === '127.0.0.1')
+		) {
+			return true;
+		}
+
+		return (
+			url.origin === 'https://remotion.pro' ||
+			url.origin === 'https://www.remotion.pro'
+		);
+	} catch {
+		return false;
+	}
+};
+
+export const setLicenseKeyInStudioWithDependencies = async (
+	licenseKey: string,
+	dependencies: SetLicenseKeyInStudioDependencies,
+): Promise<SetLicenseKeyInStudioResult> => {
+	if (!isAllowedLicenseKeyPageOrigin(dependencies.pageOrigin)) {
+		return {
+			success: false,
+			code: 'unsupported-origin',
+			message:
+				'Setting a Studio license key is only supported on remotion.pro and local development origins.',
+		};
+	}
+
+	if (!isValidPublicLicenseKey(licenseKey)) {
+		return {
+			success: false,
+			code: 'invalid-license-key',
+			message: 'The license key is not a valid public Remotion license key.',
+		};
+	}
+
+	const discovery = await discoverStudios(dependencies);
+	if (discovery.studios.length === 0) {
+		if (discovery.foundUnsupportedProtocol) {
+			return {
+				success: false,
+				code: 'unsupported-protocol',
+				message:
+					'The running Remotion Studio uses an unsupported Studio Protocol version.',
+			};
+		}
+
+		if (await hasLegacyStudio(dependencies)) {
+			return {
+				success: false,
+				code: 'studio-upgrade-required',
+				message:
+					'This Remotion Studio cannot set a license key through Studio Protocol. Upgrade Remotion to 4.0.504 or newer.',
+			};
+		}
+
+		if (discovery.foundInvalidResponse) {
+			return {
+				success: false,
+				code: 'invalid-response',
+				message:
+					'Remotion Studio returned an invalid Studio Protocol response.',
+			};
+		}
+
+		return {
+			success: false,
+			code: 'no-compatible-studio',
+			message: 'Start Remotion Studio, focus it, and try again.',
+		};
+	}
+
+	const supportedStudios = discovery.studios.filter(
+		({descriptor}) => descriptor.capabilities.setLicenseKey === true,
+	);
+	if (supportedStudios.length === 0) {
+		return {
+			success: false,
+			code: 'studio-upgrade-required',
+			message:
+				'This Remotion Studio cannot set a license key through Studio Protocol. Upgrade Remotion to 4.0.504 or newer.',
+		};
+	}
+
+	const now = dependencies.now();
+	const configurable = supportedStudios
+		.filter(({descriptor}) => {
+			const target = descriptor.licenseKeyTarget;
+			return (
+				target !== null &&
+				target !== undefined &&
+				target.expiresAt > now &&
+				now - target.lastFocusedAt < focusedStudioMaxAge
+			);
+		})
+		.sort((a, b) => {
+			const focusDifference =
+				b.descriptor.licenseKeyTarget!.lastFocusedAt -
+				a.descriptor.licenseKeyTarget!.lastFocusedAt;
+			return focusDifference === 0
+				? b.discoveredAt - a.discoveredAt
+				: focusDifference;
+		});
+	const selected = configurable[0];
+	const selectedTarget = selected?.descriptor.licenseKeyTarget;
+	if (!selected || selectedTarget === null || selectedTarget === undefined) {
+		return {
+			success: false,
+			code: 'no-configurable-target',
+			message: 'Focus a writable Remotion Studio tab, then try again.',
+		};
+	}
+
+	let response: Response;
+	try {
+		response = await fetchWithTimeout({
+			fetchFn: dependencies.fetchFn,
+			url: `${selected.origin}/api/studio-protocol/license-key`,
+			options: {
+				method: 'POST',
+				headers: {'Content-Type': 'application/json'},
+				body: JSON.stringify({
+					protocol: 'remotion-studio-protocol',
+					protocolVersion: 1,
+					targetId: selectedTarget.id,
+					licenseKey,
+				}),
+			},
+		});
+	} catch (error) {
+		const timedOut = isAbortError(error);
+		return {
+			success: false,
+			code: timedOut ? 'request-timed-out' : 'network-error',
+			message: timedOut
+				? 'The request to Remotion Studio timed out.'
+				: 'Could not connect to Remotion Studio.',
+		};
+	}
+
+	let result: unknown;
+	try {
+		result = await response.json();
+	} catch {
+		return {
+			success: false,
+			code: 'invalid-response',
+			message: 'Remotion Studio returned an invalid license-key response.',
+		};
+	}
+
+	if (
+		response.ok &&
+		isRecord(result) &&
+		result.protocol === 'remotion-studio-protocol' &&
+		result.protocolVersion === 1 &&
+		result.status === 'license-key-set'
+	) {
+		return {
+			success: true,
+			status: 'license-key-set',
+			target: {
+				projectName: selected.descriptor.projectName,
+				studioOrigin: selected.origin,
+				studioVersion: selected.descriptor.studioVersion,
+			},
+		};
+	}
+
+	if (
+		isRecord(result) &&
+		result.status === 'error' &&
+		isRecord(result.error) &&
+		typeof result.error.code === 'string' &&
+		typeof result.error.message === 'string'
+	) {
+		const {code, message} = result.error;
+		return {
+			success: false,
+			code:
+				code === 'target-expired'
+					? 'target-expired'
+					: code === 'no-config-file'
+						? 'no-config-file'
+						: 'request-rejected',
+			message,
+		};
+	}
+
+	return {
+		success: false,
+		code: 'invalid-response',
+		message: 'Remotion Studio returned an invalid license-key response.',
+	};
+};
+
+export const setLicenseKeyInStudio = ({
+	licenseKey,
+}: {
+	readonly licenseKey: string;
+}): Promise<SetLicenseKeyInStudioResult> =>
+	setLicenseKeyInStudioWithDependencies(licenseKey, {
+		fetchFn: fetch,
+		now: Date.now,
+		pageOrigin:
+			typeof globalThis.location === 'undefined'
+				? null
+				: globalThis.location.origin,
+		ports: studioProtocolProbePorts,
+	});

--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -10,8 +10,6 @@ export type StudioProtocolInstallTarget = StudioProtocolTarget & {
 	readonly compositionId: string;
 };
 
-export type StudioProtocolLicenseKeyTarget = StudioProtocolTarget;
-
 export type StudioProtocolInstallCapability = {
 	readonly type: 'install-element';
 	readonly payloadType: 'remotion-element';
@@ -33,24 +31,6 @@ export type StudioProtocolDescriptor = {
 	readonly protocolVersion: 1;
 	readonly studioVersion: string;
 	readonly projectName: string | null;
-	readonly capabilities: {
-		readonly install: readonly {
-			readonly payloadType: 'remotion-element';
-			readonly payloadVersions: readonly number[];
-		}[];
-		readonly setLicenseKey?: true;
-	};
-	readonly installTarget: StudioProtocolInstallTarget | null;
-	readonly licenseKeyTarget?: StudioProtocolLicenseKeyTarget | null;
-};
-
-// Studio Protocol v1 shipped with separate capability and target fields.
-// Normalize that wire shape so operation clients can use a discriminated union
-// without breaking discovery for released Studio versions.
-type StudioProtocolClientDescriptor = Pick<
-	StudioProtocolDescriptor,
-	'projectName' | 'protocol' | 'protocolVersion' | 'studioVersion'
-> & {
 	readonly capabilities: readonly StudioProtocolCapability[];
 };
 
@@ -119,6 +99,26 @@ const isInstallTarget = (
 	);
 };
 
+const isCapability = (value: unknown): value is StudioProtocolCapability => {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	if (value.type === 'install-element') {
+		return (
+			value.payloadType === 'remotion-element' &&
+			Array.isArray(value.payloadVersions) &&
+			value.payloadVersions.every((version) => typeof version === 'number') &&
+			(value.target === null || isInstallTarget(value.target))
+		);
+	}
+
+	return (
+		value.type === 'set-license-key' &&
+		(value.target === null || isTarget(value.target))
+	);
+};
+
 export const isStudioProtocolDescriptor = (
 	value: unknown,
 ): value is StudioProtocolDescriptor => {
@@ -128,60 +128,20 @@ export const isStudioProtocolDescriptor = (
 		value.protocolVersion !== 1 ||
 		typeof value.studioVersion !== 'string' ||
 		!isNullableString(value.projectName) ||
-		!isRecord(value.capabilities) ||
-		!Array.isArray(value.capabilities.install) ||
-		value.capabilities.install.length !== 1
+		!Array.isArray(value.capabilities) ||
+		!value.capabilities.every(isCapability)
 	) {
 		return false;
 	}
 
-	const [installCapability] = value.capabilities.install;
-	return (
-		isRecord(installCapability) &&
-		installCapability.payloadType === 'remotion-element' &&
-		Array.isArray(installCapability.payloadVersions) &&
-		installCapability.payloadVersions.every(
-			(version) => typeof version === 'number',
-		) &&
-		(value.installTarget === null || isInstallTarget(value.installTarget)) &&
-		(value.capabilities.setLicenseKey === undefined ||
-			value.capabilities.setLicenseKey === true) &&
-		(value.licenseKeyTarget === undefined ||
-			value.licenseKeyTarget === null ||
-			isTarget(value.licenseKeyTarget))
+	const capabilityTypes = value.capabilities.map(
+		(capability) => capability.type,
 	);
-};
-
-const normalizeDescriptor = (
-	descriptor: StudioProtocolDescriptor,
-): StudioProtocolClientDescriptor => {
-	const [installCapability] = descriptor.capabilities.install;
-	return {
-		protocol: descriptor.protocol,
-		protocolVersion: descriptor.protocolVersion,
-		studioVersion: descriptor.studioVersion,
-		projectName: descriptor.projectName,
-		capabilities: [
-			{
-				type: 'install-element',
-				payloadType: installCapability!.payloadType,
-				payloadVersions: installCapability!.payloadVersions,
-				target: descriptor.installTarget,
-			},
-			...(descriptor.capabilities.setLicenseKey === true
-				? [
-						{
-							type: 'set-license-key' as const,
-							target: descriptor.licenseKeyTarget ?? null,
-						},
-					]
-				: []),
-		],
-	};
+	return new Set(capabilityTypes).size === capabilityTypes.length;
 };
 
 export const getInstallCapability = (
-	descriptor: StudioProtocolClientDescriptor,
+	descriptor: StudioProtocolDescriptor,
 ): StudioProtocolInstallCapability | null =>
 	descriptor.capabilities.find(
 		(capability): capability is StudioProtocolInstallCapability =>
@@ -189,7 +149,7 @@ export const getInstallCapability = (
 	) ?? null;
 
 export const getSetLicenseKeyCapability = (
-	descriptor: StudioProtocolClientDescriptor,
+	descriptor: StudioProtocolDescriptor,
 ): StudioProtocolSetLicenseKeyCapability | null =>
 	descriptor.capabilities.find(
 		(capability): capability is StudioProtocolSetLicenseKeyCapability =>
@@ -197,7 +157,7 @@ export const getSetLicenseKeyCapability = (
 	) ?? null;
 
 export type DiscoveredStudio = {
-	readonly descriptor: StudioProtocolClientDescriptor;
+	readonly descriptor: StudioProtocolDescriptor;
 	readonly discoveredAt: number;
 	readonly origin: string;
 };
@@ -252,7 +212,7 @@ export const discoverStudios = async (
 			}
 
 			return {
-				descriptor: normalizeDescriptor(value),
+				descriptor: value,
 				discoveredAt: dependencies.now(),
 				origin,
 			};

--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -1,0 +1,297 @@
+import {isRecord} from './validation';
+
+export type StudioProtocolTarget = {
+	readonly id: string;
+	readonly expiresAt: number;
+	readonly lastFocusedAt: number;
+};
+
+export type StudioProtocolInstallTarget = StudioProtocolTarget & {
+	readonly compositionId: string;
+};
+
+export type StudioProtocolLicenseKeyTarget = StudioProtocolTarget;
+
+export type StudioProtocolInstallCapability = {
+	readonly type: 'install-element';
+	readonly payloadType: 'remotion-element';
+	readonly payloadVersions: readonly number[];
+	readonly target: StudioProtocolInstallTarget | null;
+};
+
+export type StudioProtocolSetLicenseKeyCapability = {
+	readonly type: 'set-license-key';
+	readonly target: StudioProtocolTarget | null;
+};
+
+export type StudioProtocolCapability =
+	| StudioProtocolInstallCapability
+	| StudioProtocolSetLicenseKeyCapability;
+
+export type StudioProtocolDescriptor = {
+	readonly protocol: 'remotion-studio-protocol';
+	readonly protocolVersion: 1;
+	readonly studioVersion: string;
+	readonly projectName: string | null;
+	readonly capabilities: {
+		readonly install: readonly {
+			readonly payloadType: 'remotion-element';
+			readonly payloadVersions: readonly number[];
+		}[];
+		readonly setLicenseKey?: true;
+	};
+	readonly installTarget: StudioProtocolInstallTarget | null;
+	readonly licenseKeyTarget?: StudioProtocolLicenseKeyTarget | null;
+};
+
+// Studio Protocol v1 shipped with separate capability and target fields.
+// Normalize that wire shape so operation clients can use a discriminated union
+// without breaking discovery for released Studio versions.
+type StudioProtocolClientDescriptor = Pick<
+	StudioProtocolDescriptor,
+	'projectName' | 'protocol' | 'protocolVersion' | 'studioVersion'
+> & {
+	readonly capabilities: readonly StudioProtocolCapability[];
+};
+
+export type StudioProtocolFetcher = (
+	input: string | URL | Request,
+	options?: RequestInit,
+) => Promise<Response>;
+
+export type StudioProtocolDiscoveryDependencies = {
+	readonly fetchFn: StudioProtocolFetcher;
+	readonly now: () => number;
+	readonly ports: readonly number[];
+};
+
+export const studioProtocolProbePorts = [
+	3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009,
+];
+export const focusedStudioMaxAge = 5 * 60 * 1000;
+const requestTimeout = 2_000;
+
+export const fetchWithTimeout = async ({
+	fetchFn,
+	options,
+	url,
+}: {
+	readonly fetchFn: StudioProtocolFetcher;
+	readonly options: RequestInit | null;
+	readonly url: string;
+}) => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), requestTimeout);
+	try {
+		return await fetchFn(url, {
+			...(options ?? {}),
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const isNullableString = (value: unknown): value is string | null =>
+	value === null || typeof value === 'string';
+
+const isTarget = (value: unknown): value is StudioProtocolTarget =>
+	isRecord(value) &&
+	typeof value.id === 'string' &&
+	value.id.length > 0 &&
+	typeof value.expiresAt === 'number' &&
+	Number.isFinite(value.expiresAt) &&
+	typeof value.lastFocusedAt === 'number' &&
+	Number.isFinite(value.lastFocusedAt);
+
+const isInstallTarget = (
+	value: unknown,
+): value is StudioProtocolInstallTarget => {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	const {compositionId} = value;
+	return (
+		isTarget(value) &&
+		typeof compositionId === 'string' &&
+		compositionId.length > 0
+	);
+};
+
+export const isStudioProtocolDescriptor = (
+	value: unknown,
+): value is StudioProtocolDescriptor => {
+	if (
+		!isRecord(value) ||
+		value.protocol !== 'remotion-studio-protocol' ||
+		value.protocolVersion !== 1 ||
+		typeof value.studioVersion !== 'string' ||
+		!isNullableString(value.projectName) ||
+		!isRecord(value.capabilities) ||
+		!Array.isArray(value.capabilities.install) ||
+		value.capabilities.install.length !== 1
+	) {
+		return false;
+	}
+
+	const [installCapability] = value.capabilities.install;
+	return (
+		isRecord(installCapability) &&
+		installCapability.payloadType === 'remotion-element' &&
+		Array.isArray(installCapability.payloadVersions) &&
+		installCapability.payloadVersions.every(
+			(version) => typeof version === 'number',
+		) &&
+		(value.installTarget === null || isInstallTarget(value.installTarget)) &&
+		(value.capabilities.setLicenseKey === undefined ||
+			value.capabilities.setLicenseKey === true) &&
+		(value.licenseKeyTarget === undefined ||
+			value.licenseKeyTarget === null ||
+			isTarget(value.licenseKeyTarget))
+	);
+};
+
+const normalizeDescriptor = (
+	descriptor: StudioProtocolDescriptor,
+): StudioProtocolClientDescriptor => {
+	const [installCapability] = descriptor.capabilities.install;
+	return {
+		protocol: descriptor.protocol,
+		protocolVersion: descriptor.protocolVersion,
+		studioVersion: descriptor.studioVersion,
+		projectName: descriptor.projectName,
+		capabilities: [
+			{
+				type: 'install-element',
+				payloadType: installCapability!.payloadType,
+				payloadVersions: installCapability!.payloadVersions,
+				target: descriptor.installTarget,
+			},
+			...(descriptor.capabilities.setLicenseKey === true
+				? [
+						{
+							type: 'set-license-key' as const,
+							target: descriptor.licenseKeyTarget ?? null,
+						},
+					]
+				: []),
+		],
+	};
+};
+
+export const getInstallCapability = (
+	descriptor: StudioProtocolClientDescriptor,
+): StudioProtocolInstallCapability | null =>
+	descriptor.capabilities.find(
+		(capability): capability is StudioProtocolInstallCapability =>
+			capability.type === 'install-element',
+	) ?? null;
+
+export const getSetLicenseKeyCapability = (
+	descriptor: StudioProtocolClientDescriptor,
+): StudioProtocolSetLicenseKeyCapability | null =>
+	descriptor.capabilities.find(
+		(capability): capability is StudioProtocolSetLicenseKeyCapability =>
+			capability.type === 'set-license-key',
+	) ?? null;
+
+export type DiscoveredStudio = {
+	readonly descriptor: StudioProtocolClientDescriptor;
+	readonly discoveredAt: number;
+	readonly origin: string;
+};
+
+export const discoverStudios = async (
+	dependencies: StudioProtocolDiscoveryDependencies,
+): Promise<{
+	readonly studios: DiscoveredStudio[];
+	readonly foundUnsupportedProtocol: boolean;
+	readonly foundInvalidResponse: boolean;
+}> => {
+	let foundUnsupportedProtocol = false;
+	let foundInvalidResponse = false;
+	const studios = await Promise.all(
+		dependencies.ports.map(async (port): Promise<DiscoveredStudio | null> => {
+			const origin = `http://localhost:${port}`;
+			let response: Response;
+			try {
+				response = await fetchWithTimeout({
+					fetchFn: dependencies.fetchFn,
+					options: {cache: 'no-store'},
+					url: `${origin}/api/studio-protocol`,
+				});
+			} catch {
+				return null;
+			}
+
+			if (!response.ok) {
+				return null;
+			}
+
+			let value: unknown;
+			try {
+				value = await response.json();
+			} catch {
+				foundInvalidResponse = true;
+				return null;
+			}
+
+			if (
+				isRecord(value) &&
+				value.protocol === 'remotion-studio-protocol' &&
+				value.protocolVersion !== 1
+			) {
+				foundUnsupportedProtocol = true;
+				return null;
+			}
+
+			if (!isStudioProtocolDescriptor(value)) {
+				foundInvalidResponse = true;
+				return null;
+			}
+
+			return {
+				descriptor: normalizeDescriptor(value),
+				discoveredAt: dependencies.now(),
+				origin,
+			};
+		}),
+	);
+
+	return {
+		studios: studios.filter(
+			(studio): studio is DiscoveredStudio => studio !== null,
+		),
+		foundUnsupportedProtocol,
+		foundInvalidResponse,
+	};
+};
+
+export const hasLegacyStudio = async (
+	dependencies: StudioProtocolDiscoveryDependencies,
+): Promise<boolean> => {
+	const results = await Promise.all(
+		dependencies.ports.map(async (port) => {
+			try {
+				const response = await fetchWithTimeout({
+					fetchFn: dependencies.fetchFn,
+					options: {cache: 'no-store'},
+					url: `http://localhost:${port}/api/element-install-target`,
+				});
+				if (!response.ok) {
+					return false;
+				}
+
+				const value: unknown = await response.json();
+				return isRecord(value) && value.type === 'remotion-studio';
+			} catch {
+				return false;
+			}
+		}),
+	);
+	return results.some(Boolean);
+};
+
+export const isAbortError = (error: unknown): boolean =>
+	error instanceof Error && error.name === 'AbortError';

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -113,6 +113,7 @@ test('delivers the payload to the exact most recently focused Studio target', as
 		'http://localhost:3001/api/studio-protocol/install',
 	);
 	expect(JSON.parse(String(installRequest?.options?.body))).toEqual({
+		operation: 'install-element',
 		protocol: 'remotion-studio-protocol',
 		protocolVersion: 1,
 		targetId: 'newest-target',

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -25,16 +25,20 @@ const descriptor = ({
 	protocol: 'remotion-studio-protocol',
 	protocolVersion: 1,
 	studioVersion: '4.0.502',
-	capabilities: {
-		install: [{payloadType: 'remotion-element', payloadVersions: [1]}],
-	},
 	projectName,
-	installTarget: {
-		id: targetId,
-		expiresAt: 1_010_000,
-		compositionId,
-		lastFocusedAt,
-	},
+	capabilities: [
+		{
+			type: 'install-element',
+			payloadType: 'remotion-element',
+			payloadVersions: [1],
+			target: {
+				id: targetId,
+				expiresAt: 1_010_000,
+				compositionId,
+				lastFocusedAt,
+			},
+		},
+	],
 });
 
 const jsonResponse = (value: unknown, status = 200) =>
@@ -133,7 +137,17 @@ test('distinguishes a compatible Studio without an installable target', async ()
 						projectName: 'Project',
 						targetId: 'target',
 					}),
-					installTarget: null,
+					capabilities: [
+						{
+							...descriptor({
+								compositionId: 'Main',
+								lastFocusedAt: 950_000,
+								projectName: 'Project',
+								targetId: 'target',
+							}).capabilities[0],
+							target: null,
+						},
+					],
 				}),
 			);
 		}

--- a/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
@@ -18,21 +18,27 @@ const descriptor = ({
 	protocol: 'remotion-studio-protocol',
 	protocolVersion: 1,
 	studioVersion: '4.0.504',
-	capabilities: {
-		install: [{payloadType: 'remotion-element', payloadVersions: [1]}],
-		...(setLicenseKey ? {setLicenseKey: true} : {}),
-	},
 	projectName,
-	installTarget: null,
-	...(setLicenseKey
-		? {
-				licenseKeyTarget: {
-					id: targetId,
-					expiresAt: now + 10_000,
-					lastFocusedAt,
-				},
-			}
-		: {}),
+	capabilities: [
+		{
+			type: 'install-element',
+			payloadType: 'remotion-element',
+			payloadVersions: [1],
+			target: null,
+		},
+		...(setLicenseKey
+			? [
+					{
+						type: 'set-license-key',
+						target: {
+							id: targetId,
+							expiresAt: now + 10_000,
+							lastFocusedAt,
+						},
+					},
+				]
+			: []),
+	],
 });
 
 const jsonResponse = (value: unknown, status = 200) =>
@@ -171,7 +177,15 @@ test('distinguishes old Studios from a Studio without a focused target', async (
 						projectName: 'Project',
 						targetId: 'unused',
 					}),
-					licenseKeyTarget: null,
+					capabilities: descriptor({
+						lastFocusedAt: now,
+						projectName: 'Project',
+						targetId: 'unused',
+					}).capabilities.map((capability) =>
+						capability.type === 'set-license-key'
+							? {...capability, target: null}
+							: capability,
+					),
 				}),
 			),
 	});

--- a/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
@@ -1,0 +1,217 @@
+import {expect, test} from 'bun:test';
+import {setLicenseKeyInStudioWithDependencies} from '../set-license-key-in-studio';
+
+const licenseKey = `rm_pub_${'a'.repeat(48)}`;
+const now = 1_000_000;
+
+const descriptor = ({
+	lastFocusedAt,
+	projectName,
+	setLicenseKey = true,
+	targetId,
+}: {
+	readonly lastFocusedAt: number;
+	readonly projectName: string;
+	readonly setLicenseKey?: boolean;
+	readonly targetId: string;
+}) => ({
+	protocol: 'remotion-studio-protocol',
+	protocolVersion: 1,
+	studioVersion: '4.0.504',
+	capabilities: {
+		install: [{payloadType: 'remotion-element', payloadVersions: [1]}],
+		...(setLicenseKey ? {setLicenseKey: true} : {}),
+	},
+	projectName,
+	installTarget: null,
+	...(setLicenseKey
+		? {
+				licenseKeyTarget: {
+					id: targetId,
+					expiresAt: now + 10_000,
+					lastFocusedAt,
+				},
+			}
+		: {}),
+});
+
+const jsonResponse = (value: unknown, status = 200) =>
+	new Response(JSON.stringify(value), {
+		headers: {'Content-Type': 'application/json'},
+		status,
+	});
+
+const dependencies = {
+	now: () => now,
+	pageOrigin: 'https://www.remotion.pro',
+	ports: [3000, 3001],
+};
+
+test('sets the key in the most recently focused Studio project', async () => {
+	const requests: Array<{
+		readonly options?: RequestInit;
+		readonly url: string;
+	}> = [];
+	const fetchFn = (input: string | URL | Request, options?: RequestInit) => {
+		const url = String(input);
+		requests.push({options, url});
+		if (url === 'http://localhost:3000/api/studio-protocol') {
+			return Promise.resolve(
+				jsonResponse(
+					descriptor({
+						lastFocusedAt: now - 200,
+						projectName: 'Older',
+						targetId: 'older-target',
+					}),
+				),
+			);
+		}
+
+		if (url === 'http://localhost:3001/api/studio-protocol') {
+			return Promise.resolve(
+				jsonResponse(
+					descriptor({
+						lastFocusedAt: now - 100,
+						projectName: 'Focused project',
+						targetId: 'focused-target',
+					}),
+				),
+			);
+		}
+
+		return Promise.resolve(
+			jsonResponse({
+				protocol: 'remotion-studio-protocol',
+				protocolVersion: 1,
+				status: 'license-key-set',
+			}),
+		);
+	};
+
+	expect(
+		await setLicenseKeyInStudioWithDependencies(licenseKey, {
+			...dependencies,
+			fetchFn,
+		}),
+	).toEqual({
+		success: true,
+		status: 'license-key-set',
+		target: {
+			projectName: 'Focused project',
+			studioOrigin: 'http://localhost:3001',
+			studioVersion: '4.0.504',
+		},
+	});
+	const request = requests.at(-1);
+	expect(request?.url).toBe(
+		'http://localhost:3001/api/studio-protocol/license-key',
+	);
+	expect(request?.options?.method).toBe('POST');
+	expect(JSON.parse(String(request?.options?.body))).toEqual({
+		protocol: 'remotion-studio-protocol',
+		protocolVersion: 1,
+		targetId: 'focused-target',
+		licenseKey,
+	});
+});
+
+test('rejects unauthorized origins and malformed keys before discovery', async () => {
+	let requests = 0;
+	const fetchFn = () => {
+		requests++;
+		return Promise.resolve(new Response(null, {status: 404}));
+	};
+
+	expect(
+		await setLicenseKeyInStudioWithDependencies(licenseKey, {
+			...dependencies,
+			fetchFn,
+			pageOrigin: 'https://example.com',
+		}),
+	).toMatchObject({success: false, code: 'unsupported-origin'});
+	expect(
+		await setLicenseKeyInStudioWithDependencies('rm_sec_private', {
+			...dependencies,
+			fetchFn,
+		}),
+	).toMatchObject({success: false, code: 'invalid-license-key'});
+	expect(requests).toBe(0);
+});
+
+test('distinguishes old Studios from a Studio without a focused target', async () => {
+	const oldStudio = await setLicenseKeyInStudioWithDependencies(licenseKey, {
+		...dependencies,
+		ports: [3000],
+		fetchFn: () =>
+			Promise.resolve(
+				jsonResponse(
+					descriptor({
+						lastFocusedAt: now,
+						projectName: 'Old project',
+						setLicenseKey: false,
+						targetId: 'unused',
+					}),
+				),
+			),
+	});
+	expect(oldStudio).toMatchObject({
+		success: false,
+		code: 'studio-upgrade-required',
+	});
+
+	const noTarget = await setLicenseKeyInStudioWithDependencies(licenseKey, {
+		...dependencies,
+		ports: [3000],
+		fetchFn: () =>
+			Promise.resolve(
+				jsonResponse({
+					...descriptor({
+						lastFocusedAt: now,
+						projectName: 'Project',
+						targetId: 'unused',
+					}),
+					licenseKeyTarget: null,
+				}),
+			),
+	});
+	expect(noTarget).toMatchObject({
+		success: false,
+		code: 'no-configurable-target',
+	});
+});
+
+test('maps structured server errors and malformed responses', async () => {
+	const run = (response: Response) =>
+		setLicenseKeyInStudioWithDependencies(licenseKey, {
+			...dependencies,
+			ports: [3000],
+			fetchFn: (input) =>
+				String(input).endsWith('/api/studio-protocol')
+					? Promise.resolve(
+							jsonResponse(
+								descriptor({
+									lastFocusedAt: now,
+									projectName: 'Project',
+									targetId: 'target',
+								}),
+							),
+						)
+					: Promise.resolve(response),
+		});
+
+	expect(
+		await run(
+			jsonResponse(
+				{
+					status: 'error',
+					error: {code: 'no-config-file', message: 'No config'},
+				},
+				409,
+			),
+		),
+	).toEqual({success: false, code: 'no-config-file', message: 'No config'});
+	expect(await run(new Response('not json'))).toMatchObject({
+		success: false,
+		code: 'invalid-response',
+	});
+});

--- a/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
@@ -108,6 +108,7 @@ test('sets the key in the most recently focused Studio project', async () => {
 	);
 	expect(request?.options?.method).toBe('POST');
 	expect(JSON.parse(String(request?.options?.body))).toEqual({
+		operation: 'set-license-key',
 		protocol: 'remotion-studio-protocol',
 		protocolVersion: 1,
 		targetId: 'focused-target',

--- a/packages/studio-server/src/preview-server/element-install-state.ts
+++ b/packages/studio-server/src/preview-server/element-install-state.ts
@@ -15,11 +15,14 @@ export type ElementInstallTarget = {
 	updatedAt: number;
 };
 
+export type StudioProtocolTargetPurpose = 'install-element' | 'set-license-key';
+
 const targetsByClientId = new Map<string, ElementInstallTarget>();
 
 type StudioProtocolTarget = {
 	readonly id: string;
 	readonly origin: string;
+	readonly purpose: StudioProtocolTargetPurpose;
 	readonly target: ElementInstallTarget;
 	readonly expiresAt: number;
 };
@@ -75,10 +78,12 @@ export const getElementInstallTarget = (requestId: string | null) => {
 export const issueStudioProtocolTarget = ({
 	now,
 	origin,
+	purpose,
 	target,
 }: {
 	readonly now: number;
 	readonly origin: string;
+	readonly purpose: StudioProtocolTargetPurpose;
 	readonly target: ElementInstallTarget;
 }) => {
 	for (const [id, existing] of studioProtocolTargets) {
@@ -90,6 +95,7 @@ export const issueStudioProtocolTarget = ({
 	const issued: StudioProtocolTarget = {
 		id: randomUUID(),
 		origin,
+		purpose,
 		target: {...target},
 		expiresAt: now + STUDIO_PROTOCOL_TARGET_MAX_AGE,
 	};
@@ -100,10 +106,12 @@ export const issueStudioProtocolTarget = ({
 export const consumeStudioProtocolTarget = ({
 	now,
 	origin,
+	purpose,
 	targetId,
 }: {
 	readonly now: number;
 	readonly origin: string;
+	readonly purpose: StudioProtocolTargetPurpose;
 	readonly targetId: string;
 }): ElementInstallTarget | null => {
 	const issued = studioProtocolTargets.get(targetId);
@@ -111,7 +119,8 @@ export const consumeStudioProtocolTarget = ({
 	if (
 		issued === undefined ||
 		issued.expiresAt <= now ||
-		issued.origin !== origin
+		issued.origin !== origin ||
+		issued.purpose !== purpose
 	) {
 		return null;
 	}
@@ -120,8 +129,17 @@ export const consumeStudioProtocolTarget = ({
 	if (
 		current === null ||
 		now - current.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE ||
+		current.readOnly
+	) {
+		return null;
+	}
+
+	if (purpose === 'set-license-key') {
+		return issued.target;
+	}
+
+	if (
 		!current.canInstall ||
-		current.readOnly ||
 		current.compositionFile !== issued.target.compositionFile ||
 		current.compositionId !== issued.target.compositionId
 	) {

--- a/packages/studio-server/src/preview-server/routes/update-public-license.ts
+++ b/packages/studio-server/src/preview-server/routes/update-public-license.ts
@@ -50,6 +50,21 @@ export const updatePublicLicenseInConfig = ({
 	return `${configWithoutExistingCalls}${separator}Config.setPublicLicenseKey('${escapedPublicLicenseKey}');\n`;
 };
 
+export const setPublicLicenseKeyInConfigFile = ({
+	configFile,
+	publicLicenseKey,
+}: {
+	readonly configFile: string;
+	readonly publicLicenseKey: string;
+}) => {
+	const configContents = readFileSync(configFile, 'utf8');
+	writeFileAndNotifyFileWatchers(
+		configFile,
+		updatePublicLicenseInConfig({configContents, publicLicenseKey}),
+		undefined,
+	);
+};
+
 export const updatePublicLicenseHandler: ApiHandler<
 	UpdatePublicLicenseRequest,
 	UpdatePublicLicenseResponse
@@ -68,15 +83,10 @@ export const updatePublicLicenseHandler: ApiHandler<
 		});
 	}
 
-	const configContents = readFileSync(configFile, 'utf8');
-	writeFileAndNotifyFileWatchers(
+	setPublicLicenseKeyInConfigFile({
 		configFile,
-		updatePublicLicenseInConfig({
-			configContents,
-			publicLicenseKey: input.publicLicenseKey,
-		}),
-		undefined,
-	);
+		publicLicenseKey: input.publicLicenseKey,
+	});
 
 	return Promise.resolve({success: true});
 };

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -8,14 +8,16 @@ import {
 	getElementInstallTarget,
 	issueStudioProtocolTarget,
 } from '../element-install-state';
+import type {ElementInstallTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {
+	getAllowedLicenseKeyOrigin,
 	getAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
 } from './origin-policy';
 import {writeStudioProtocolError} from './protocol-response';
 
-const ELEMENT_INSTALL_FOCUS_MAX_AGE = 5 * 60 * 1000;
+const STUDIO_PROTOCOL_FOCUS_MAX_AGE = 5 * 60 * 1000;
 export const ELEMENT_INSTALL_TARGET_RESPONSE_WAIT = 250;
 
 const requestInstallTarget = ({
@@ -31,24 +33,34 @@ const requestInstallTarget = ({
 	return requestId;
 };
 
-const getLiveInstallableTarget = (requestId: string) => {
+const getLiveStudioTarget = (requestId: string) => {
 	const target = getElementInstallTarget(requestId);
 	const now = Date.now();
 	if (
 		target === null ||
 		now - target.updatedAt >= ELEMENT_INSTALL_TARGET_MAX_AGE ||
 		target.lastFocusedAt === null ||
-		now - target.lastFocusedAt >= ELEMENT_INSTALL_FOCUS_MAX_AGE ||
-		!target.canInstall ||
-		target.readOnly ||
-		target.compositionFile === null ||
-		target.compositionId === null
+		now - target.lastFocusedAt >= STUDIO_PROTOCOL_FOCUS_MAX_AGE ||
+		target.readOnly
 	) {
 		return null;
 	}
 
 	return target;
 };
+
+const isInstallableTarget = (
+	target: ElementInstallTarget | null,
+): target is ElementInstallTarget & {
+	readonly compositionFile: string;
+	readonly compositionId: string;
+	readonly lastFocusedAt: number;
+} =>
+	target !== null &&
+	target.canInstall &&
+	target.compositionFile !== null &&
+	target.compositionId !== null &&
+	target.lastFocusedAt !== null;
 
 const getProject = ({
 	gitSource,
@@ -76,7 +88,7 @@ export const handleStudioProtocolDiscovery = ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({request, response});
+	setStudioProtocolCorsHeaders({licenseKey: false, request, response});
 	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
@@ -102,13 +114,27 @@ export const handleStudioProtocolDiscovery = ({
 	return new Promise<void>((resolve) => {
 		setTimeout(() => {
 			const now = Date.now();
-			const target = getLiveInstallableTarget(requestId);
-			const issued =
-				target === null
+			const target = getLiveStudioTarget(requestId);
+			const installTarget = isInstallableTarget(target) ? target : null;
+			const issuedInstallTarget =
+				installTarget === null
 					? null
 					: issueStudioProtocolTarget({
 							now,
 							origin: requestOrigin,
+							purpose: 'install-element',
+							target: installTarget,
+						});
+			const licenseKeyOrigin = getAllowedLicenseKeyOrigin(
+				request.headers.origin,
+			);
+			const issuedLicenseKeyTarget =
+				target === null || licenseKeyOrigin === null
+					? null
+					: issueStudioProtocolTarget({
+							now,
+							origin: licenseKeyOrigin,
+							purpose: 'set-license-key',
 							target,
 						});
 			response.writeHead(200, {
@@ -127,15 +153,26 @@ export const handleStudioProtocolDiscovery = ({
 								payloadVersions: [1],
 							},
 						],
+						setLicenseKey: true,
 					},
 					projectName: getProject({gitSource, remotionRoot}),
 					installTarget:
-						issued === null || target === null
+						issuedInstallTarget === null || installTarget === null
 							? null
 							: {
-									id: issued.id,
-									expiresAt: issued.expiresAt,
-									compositionId: target.compositionId,
+									id: issuedInstallTarget.id,
+									expiresAt: issuedInstallTarget.expiresAt,
+									compositionId: installTarget.compositionId,
+									lastFocusedAt: installTarget.lastFocusedAt,
+								},
+					licenseKeyTarget:
+						issuedLicenseKeyTarget === null ||
+						target === null ||
+						target.lastFocusedAt === null
+							? null
+							: {
+									id: issuedLicenseKeyTarget.id,
+									expiresAt: issuedLicenseKeyTarget.expiresAt,
 									lastFocusedAt: target.lastFocusedAt,
 								},
 				}),

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -147,34 +147,35 @@ export const handleStudioProtocolDiscovery = ({
 					protocolVersion: 1,
 					studioVersion: VERSION,
 					projectName: getProject({gitSource, remotionRoot}),
-					capabilities: {
-						install: [
-							{
-								payloadType: 'remotion-element',
-								payloadVersions: [1],
-							},
-						],
-						setLicenseKey: true,
-					},
-					installTarget:
-						issuedInstallTarget === null || installTarget === null
-							? null
-							: {
-									id: issuedInstallTarget.id,
-									expiresAt: issuedInstallTarget.expiresAt,
-									compositionId: installTarget.compositionId,
-									lastFocusedAt: installTarget.lastFocusedAt,
-								},
-					licenseKeyTarget:
-						issuedLicenseKeyTarget === null ||
-						target === null ||
-						target.lastFocusedAt === null
-							? null
-							: {
-									id: issuedLicenseKeyTarget.id,
-									expiresAt: issuedLicenseKeyTarget.expiresAt,
-									lastFocusedAt: target.lastFocusedAt,
-								},
+					capabilities: [
+						{
+							type: 'install-element',
+							payloadType: 'remotion-element',
+							payloadVersions: [1],
+							target:
+								issuedInstallTarget === null || installTarget === null
+									? null
+									: {
+											id: issuedInstallTarget.id,
+											expiresAt: issuedInstallTarget.expiresAt,
+											compositionId: installTarget.compositionId,
+											lastFocusedAt: installTarget.lastFocusedAt,
+										},
+						},
+						{
+							type: 'set-license-key',
+							target:
+								issuedLicenseKeyTarget === null ||
+								target === null ||
+								target.lastFocusedAt === null
+									? null
+									: {
+											id: issuedLicenseKeyTarget.id,
+											expiresAt: issuedLicenseKeyTarget.expiresAt,
+											lastFocusedAt: target.lastFocusedAt,
+										},
+						},
+					],
 				}),
 			);
 			resolve();

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -3,12 +3,12 @@ import path from 'node:path';
 import type {GitSource} from '@remotion/studio-shared';
 import {getProjectName} from '@remotion/studio-shared';
 import {VERSION} from 'remotion/version';
+import type {ElementInstallTarget} from '../element-install-state';
 import {
 	ELEMENT_INSTALL_TARGET_MAX_AGE,
 	getElementInstallTarget,
 	issueStudioProtocolTarget,
 } from '../element-install-state';
-import type {ElementInstallTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {
 	getAllowedLicenseKeyOrigin,
@@ -146,6 +146,7 @@ export const handleStudioProtocolDiscovery = ({
 					protocol: 'remotion-studio-protocol',
 					protocolVersion: 1,
 					studioVersion: VERSION,
+					projectName: getProject({gitSource, remotionRoot}),
 					capabilities: {
 						install: [
 							{
@@ -155,7 +156,6 @@ export const handleStudioProtocolDiscovery = ({
 						],
 						setLicenseKey: true,
 					},
-					projectName: getProject({gitSource, remotionRoot}),
 					installTarget:
 						issuedInstallTarget === null || installTarget === null
 							? null

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -15,7 +15,7 @@ import {writeStudioProtocolError} from './protocol-response';
 type FocusStudioTab = (studioUrl: string) => void;
 
 const studioProtocolInstallRequestSchema = z.object({
-	operation: z.literal('install-element').optional(),
+	operation: z.literal('install-element'),
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.literal(1),
 	targetId: z.string(),

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -2,8 +2,8 @@ import type {IncomingMessage, ServerResponse} from 'node:http';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import type {ElementInstallRequest} from '@remotion/studio-shared';
 import {z} from 'zod';
-import {consumeStudioProtocolTarget} from '../element-install-state';
 import type {getElementInstallTarget} from '../element-install-state';
+import {consumeStudioProtocolTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {parseRequestBody, RequestBodyTooLargeError} from '../parse-body';
 import {
@@ -15,6 +15,7 @@ import {writeStudioProtocolError} from './protocol-response';
 type FocusStudioTab = (studioUrl: string) => void;
 
 const studioProtocolInstallRequestSchema = z.object({
+	operation: z.literal('install-element').optional(),
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.literal(1),
 	targetId: z.string(),

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -79,7 +79,7 @@ export const handleStudioProtocolInstall = async ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({request, response});
+	setStudioProtocolCorsHeaders({licenseKey: false, request, response});
 	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
@@ -153,6 +153,7 @@ export const handleStudioProtocolInstall = async ({
 	const target = consumeStudioProtocolTarget({
 		now: Date.now(),
 		origin: requestOrigin,
+		purpose: 'install-element',
 		targetId: parsedRequest.data.targetId,
 	});
 	if (target === null) {

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
@@ -11,7 +11,7 @@ import {
 import {writeStudioProtocolError} from './protocol-response';
 
 const studioProtocolLicenseKeyRequestSchema = z.object({
-	operation: z.literal('set-license-key').optional(),
+	operation: z.literal('set-license-key'),
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.literal(1),
 	targetId: z.string().min(1),

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
@@ -11,6 +11,7 @@ import {
 import {writeStudioProtocolError} from './protocol-response';
 
 const studioProtocolLicenseKeyRequestSchema = z.object({
+	operation: z.literal('set-license-key').optional(),
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.literal(1),
 	targetId: z.string().min(1),

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
@@ -1,0 +1,152 @@
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import {StudioProtocolInternals} from '@remotion/studio-protocol';
+import {z} from 'zod';
+import {consumeStudioProtocolTarget} from '../element-install-state';
+import {parseRequestBody, RequestBodyTooLargeError} from '../parse-body';
+import {setPublicLicenseKeyInConfigFile} from '../routes/update-public-license';
+import {
+	getAllowedLicenseKeyOrigin,
+	setStudioProtocolCorsHeaders,
+} from './origin-policy';
+import {writeStudioProtocolError} from './protocol-response';
+
+const studioProtocolLicenseKeyRequestSchema = z.object({
+	protocol: z.literal('remotion-studio-protocol'),
+	protocolVersion: z.literal(1),
+	targetId: z.string().min(1),
+	licenseKey: z.string(),
+});
+
+const MAX_STUDIO_PROTOCOL_LICENSE_KEY_BODY_SIZE = 4096;
+
+export const handleStudioProtocolLicenseKey = async ({
+	configFile,
+	request,
+	response,
+}: {
+	readonly configFile: string | null;
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+}): Promise<void> => {
+	setStudioProtocolCorsHeaders({licenseKey: true, request, response});
+	const requestOrigin = getAllowedLicenseKeyOrigin(request.headers.origin);
+	if (requestOrigin === null) {
+		writeStudioProtocolError({
+			code: 'unsupported-origin',
+			message: 'Origin not allowed',
+			response,
+			status: 403,
+		});
+		return;
+	}
+
+	if (request.method !== 'POST') {
+		writeStudioProtocolError({
+			code: 'method-not-allowed',
+			message: 'Use POST to set a public license key.',
+			response,
+			status: 405,
+		});
+		return;
+	}
+
+	let body: unknown;
+	try {
+		body = await parseRequestBody(request, {
+			maxBytes: MAX_STUDIO_PROTOCOL_LICENSE_KEY_BODY_SIZE,
+		});
+	} catch (error) {
+		if (error instanceof RequestBodyTooLargeError) {
+			writeStudioProtocolError({
+				code: 'request-too-large',
+				message: 'The request body is too large.',
+				response,
+				status: 413,
+			});
+			return;
+		}
+
+		writeStudioProtocolError({
+			code: 'invalid-request',
+			message: 'The request body is not valid JSON.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	const parsedRequest = studioProtocolLicenseKeyRequestSchema.safeParse(body);
+	if (!parsedRequest.success) {
+		writeStudioProtocolError({
+			code: 'unsupported-protocol',
+			message: 'Invalid Remotion Studio Protocol request.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	if (
+		!StudioProtocolInternals.isValidPublicLicenseKey(
+			parsedRequest.data.licenseKey,
+		)
+	) {
+		writeStudioProtocolError({
+			code: 'invalid-license-key',
+			message: 'The license key is not a valid public Remotion license key.',
+			response,
+			status: 400,
+		});
+		return;
+	}
+
+	const target = consumeStudioProtocolTarget({
+		now: Date.now(),
+		origin: requestOrigin,
+		purpose: 'set-license-key',
+		targetId: parsedRequest.data.targetId,
+	});
+	if (target === null) {
+		writeStudioProtocolError({
+			code: 'target-expired',
+			message: 'The selected Studio target is no longer available.',
+			response,
+			status: 409,
+		});
+		return;
+	}
+
+	if (configFile === null) {
+		writeStudioProtocolError({
+			code: 'no-config-file',
+			message: 'The selected Studio did not load a Remotion config file.',
+			response,
+			status: 409,
+		});
+		return;
+	}
+
+	try {
+		setPublicLicenseKeyInConfigFile({
+			configFile,
+			publicLicenseKey: parsedRequest.data.licenseKey,
+		});
+	} catch {
+		writeStudioProtocolError({
+			code: 'config-write-failed',
+			message: 'Could not update the Remotion config file.',
+			response,
+			status: 500,
+		});
+		return;
+	}
+
+	response.writeHead(200, {'Content-Type': 'application/json'});
+	response.end(
+		JSON.stringify({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'license-key-set',
+		}),
+	);
+};

--- a/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
@@ -1,5 +1,9 @@
 import type {IncomingMessage, ServerResponse} from 'node:http';
 
+const isLoopbackHttp = (url: URL) =>
+	url.protocol === 'http:' &&
+	(url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+
 export const getAllowedStudioProtocolOrigin = (
 	origin: string | undefined,
 ): string | null => {
@@ -9,10 +13,7 @@ export const getAllowedStudioProtocolOrigin = (
 
 	try {
 		const url = new URL(origin);
-		const isLoopbackHttp =
-			url.protocol === 'http:' &&
-			(url.hostname === 'localhost' || url.hostname === '127.0.0.1');
-		if (url.protocol !== 'https:' && !isLoopbackHttp) {
+		if (url.protocol !== 'https:' && !isLoopbackHttp(url)) {
 			return null;
 		}
 
@@ -22,18 +23,44 @@ export const getAllowedStudioProtocolOrigin = (
 	}
 };
 
-export const isAllowedStudioProtocolOrigin = (
+export const getAllowedLicenseKeyOrigin = (
 	origin: string | undefined,
-): boolean => getAllowedStudioProtocolOrigin(origin) !== null;
+): string | null => {
+	if (!origin) {
+		return null;
+	}
+
+	try {
+		const url = new URL(origin);
+		if (isLoopbackHttp(url)) {
+			return url.origin;
+		}
+
+		if (
+			url.origin === 'https://remotion.pro' ||
+			url.origin === 'https://www.remotion.pro'
+		) {
+			return url.origin;
+		}
+
+		return null;
+	} catch {
+		return null;
+	}
+};
 
 export const setStudioProtocolCorsHeaders = ({
+	licenseKey,
 	request,
 	response,
 }: {
+	readonly licenseKey: boolean;
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): void => {
-	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const origin = licenseKey
+		? getAllowedLicenseKeyOrigin(request.headers.origin)
+		: getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (origin === null) {
 		return;
 	}
@@ -50,16 +77,19 @@ export const setStudioProtocolCorsHeaders = ({
 };
 
 export const handleStudioProtocolOptions = ({
+	licenseKey,
 	request,
 	response,
 }: {
+	readonly licenseKey: boolean;
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({request, response});
-	response.writeHead(
-		getAllowedStudioProtocolOrigin(request.headers.origin) === null ? 403 : 204,
-	);
+	setStudioProtocolCorsHeaders({licenseKey, request, response});
+	const origin = licenseKey
+		? getAllowedLicenseKeyOrigin(request.headers.origin)
+		: getAllowedStudioProtocolOrigin(request.headers.origin);
+	response.writeHead(origin === null ? 403 : 204);
 	response.end();
 	return Promise.resolve();
 };

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -30,6 +30,7 @@ import {getEditorName} from './preview-server/routes/open-in-editor';
 import {serveStatic} from './preview-server/serve-static';
 import {handleStudioProtocolDiscovery} from './preview-server/studio-protocol/handle-discovery';
 import {handleStudioProtocolInstall} from './preview-server/studio-protocol/handle-install';
+import {handleStudioProtocolLicenseKey} from './preview-server/studio-protocol/handle-license-key';
 import {handleStudioProtocolOptions} from './preview-server/studio-protocol/origin-policy';
 import {validateSameOrigin} from './preview-server/validate-same-origin';
 import {reloadPreviouslySuppressedFiles} from './preview-server/watch-ignore-next-change';
@@ -439,10 +440,15 @@ export const handleRoutes = ({
 
 	if (
 		url.pathname === '/api/studio-protocol' ||
-		url.pathname === '/api/studio-protocol/install'
+		url.pathname === '/api/studio-protocol/install' ||
+		url.pathname === '/api/studio-protocol/license-key'
 	) {
 		if (request.method === 'OPTIONS') {
-			return handleStudioProtocolOptions({request, response});
+			return handleStudioProtocolOptions({
+				licenseKey: url.pathname === '/api/studio-protocol/license-key',
+				request,
+				response,
+			});
 		}
 
 		if (url.pathname === '/api/studio-protocol') {
@@ -453,6 +459,10 @@ export const handleRoutes = ({
 				request,
 				response,
 			});
+		}
+
+		if (url.pathname === '/api/studio-protocol/license-key') {
+			return handleStudioProtocolLicenseKey({configFile, request, response});
 		}
 
 		return handleStudioProtocolInstall({

--- a/packages/studio-server/src/test/element-install-state.test.ts
+++ b/packages/studio-server/src/test/element-install-state.test.ts
@@ -7,212 +7,148 @@ import {
 	updateElementInstallTarget,
 } from '../preview-server/element-install-state';
 
+const updateTarget = ({
+	canInstall = true,
+	clientId = 'focused-tab',
+	compositionId = 'Main',
+	lastFocusedAt = Date.now(),
+	readOnly = false,
+	requestId = 'protocol-request',
+}: {
+	readonly canInstall?: boolean;
+	readonly clientId?: string;
+	readonly compositionId?: string | null;
+	readonly lastFocusedAt?: number;
+	readonly readOnly?: boolean;
+	readonly requestId?: string | null;
+}) => {
+	updateElementInstallTarget({
+		requestId,
+		clientId,
+		compositionFile:
+			compositionId === null ? null : `/project/src/${compositionId}.tsx`,
+		compositionId,
+		canInstall,
+		lastFocusedAt,
+		readOnly,
+		studioUrl: `http://localhost:3000/${compositionId ?? ''}`,
+	});
+};
+
 test('uses the most recently focused Studio target even when older tabs keep updating', () => {
 	clearElementInstallStateForTests();
-
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'older-tab',
-		compositionFile: '/project/src/older.tsx',
-		compositionId: 'older-composition',
-		canInstall: true,
-		lastFocusedAt: 1000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/older-composition',
-	});
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'focused-tab',
-		compositionFile: '/project/src/focused.tsx',
-		compositionId: 'focused-composition',
-		canInstall: true,
-		lastFocusedAt: 2000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/focused-composition',
-	});
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'older-tab',
-		compositionFile: '/project/src/older.tsx',
-		compositionId: 'older-composition',
-		canInstall: true,
-		lastFocusedAt: 1000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/older-composition',
-	});
+	updateTarget({clientId: 'older-tab', lastFocusedAt: 1000, requestId: null});
+	updateTarget({clientId: 'focused-tab', lastFocusedAt: 2000, requestId: null});
+	updateTarget({clientId: 'older-tab', lastFocusedAt: 1000, requestId: null});
 
 	expect(getElementInstallTarget(null)?.clientId).toBe('focused-tab');
-	expect(getElementInstallTarget(null)?.studioUrl).toBe(
-		'http://localhost:3000/focused-composition',
-	);
 });
 
-test('falls back to update recency when focus timestamps match', async () => {
+test('binds install tokens to one origin, purpose and composition', () => {
 	clearElementInstallStateForTests();
-
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'first-tab',
-		compositionFile: '/project/src/first.tsx',
-		compositionId: 'first-composition',
-		canInstall: true,
-		lastFocusedAt: 1000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/first-composition',
-	});
-
-	await new Promise((resolve) => setTimeout(resolve, 2));
-
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'second-tab',
-		compositionFile: '/project/src/second.tsx',
-		compositionId: 'second-composition',
-		canInstall: true,
-		lastFocusedAt: 1000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/second-composition',
-	});
-
-	expect(getElementInstallTarget(null)?.clientId).toBe('second-tab');
-});
-
-test('binds a single-use Studio Protocol token to the selected composition', () => {
-	clearElementInstallStateForTests();
-	updateElementInstallTarget({
-		requestId: 'protocol-request',
-		clientId: 'focused-tab',
-		compositionFile: '/project/src/main.tsx',
-		compositionId: 'Main',
-		canInstall: true,
-		lastFocusedAt: Date.now(),
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/Main',
-	});
+	updateTarget({});
 	const selected = getElementInstallTarget('protocol-request');
 	if (selected === null) {
 		throw new Error('Expected an install target');
 	}
 
-	const issued = issueStudioProtocolTarget({
+	const wrongPurpose = issueStudioProtocolTarget({
 		now: Date.now(),
 		origin: 'https://example.com',
+		purpose: 'install-element',
 		target: selected,
 	});
 	expect(
 		consumeStudioProtocolTarget({
 			now: Date.now(),
 			origin: 'https://example.com',
-			targetId: issued.id,
-		})?.compositionId,
-	).toBe('Main');
-	expect(
-		consumeStudioProtocolTarget({
-			now: Date.now(),
-			origin: 'https://example.com',
-			targetId: issued.id,
+			purpose: 'set-license-key',
+			targetId: wrongPurpose.id,
 		}),
 	).toBe(null);
-});
 
-test('rejects a token from another origin', () => {
-	clearElementInstallStateForTests();
-	updateElementInstallTarget({
-		requestId: 'protocol-request',
-		clientId: 'focused-tab',
-		compositionFile: '/project/src/main.tsx',
-		compositionId: 'Main',
-		canInstall: true,
-		lastFocusedAt: Date.now(),
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/Main',
+	const changedComposition = issueStudioProtocolTarget({
+		now: Date.now(),
+		origin: 'https://example.com',
+		purpose: 'install-element',
+		target: selected,
 	});
-	const selected = getElementInstallTarget('protocol-request');
-	if (selected === null) {
+	updateTarget({compositionId: 'Other', requestId: null});
+	expect(
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://example.com',
+			purpose: 'install-element',
+			targetId: changedComposition.id,
+		}),
+	).toBe(null);
+
+	updateTarget({});
+	const current = getElementInstallTarget('protocol-request');
+	if (current === null) {
 		throw new Error('Expected an install target');
 	}
 
-	const issued = issueStudioProtocolTarget({
+	const wrongOrigin = issueStudioProtocolTarget({
 		now: Date.now(),
 		origin: 'https://example.com',
-		target: selected,
+		purpose: 'install-element',
+		target: current,
 	});
 	expect(
 		consumeStudioProtocolTarget({
 			now: Date.now(),
 			origin: 'https://other.example',
-			targetId: issued.id,
+			purpose: 'install-element',
+			targetId: wrongOrigin.id,
 		}),
 	).toBe(null);
 });
 
-test('invalidates a token if the selected tab changes compositions', () => {
+test('license-key targets are project-level, single-use and invalidated by read-only mode', () => {
 	clearElementInstallStateForTests();
-	updateElementInstallTarget({
-		requestId: 'protocol-request',
-		clientId: 'focused-tab',
-		compositionFile: '/project/src/main.tsx',
-		compositionId: 'Main',
-		canInstall: true,
-		lastFocusedAt: Date.now(),
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/Main',
-	});
+	updateTarget({canInstall: false, compositionId: null});
 	const selected = getElementInstallTarget('protocol-request');
 	if (selected === null) {
-		throw new Error('Expected an install target');
+		throw new Error('Expected a Studio target');
 	}
 
 	const issued = issueStudioProtocolTarget({
 		now: Date.now(),
-		origin: 'https://example.com',
+		origin: 'https://remotion.pro',
+		purpose: 'set-license-key',
 		target: selected,
-	});
-	updateElementInstallTarget({
-		requestId: null,
-		clientId: 'focused-tab',
-		compositionFile: '/project/src/other.tsx',
-		compositionId: 'Other',
-		canInstall: true,
-		lastFocusedAt: Date.now(),
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/Other',
 	});
 	expect(
 		consumeStudioProtocolTarget({
 			now: Date.now(),
-			origin: 'https://example.com',
+			origin: 'https://remotion.pro',
+			purpose: 'set-license-key',
+			targetId: issued.id,
+		})?.clientId,
+	).toBe('focused-tab');
+	expect(
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://remotion.pro',
+			purpose: 'set-license-key',
 			targetId: issued.id,
 		}),
 	).toBe(null);
-});
 
-test('can select a target for a specific request', () => {
-	clearElementInstallStateForTests();
-
-	updateElementInstallTarget({
-		requestId: 'first-request',
-		clientId: 'first-tab',
-		compositionFile: '/project/src/first.tsx',
-		compositionId: 'first-composition',
-		canInstall: true,
-		lastFocusedAt: 1000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/first-composition',
+	const readOnlyToken = issueStudioProtocolTarget({
+		now: Date.now(),
+		origin: 'https://remotion.pro',
+		purpose: 'set-license-key',
+		target: selected,
 	});
-	updateElementInstallTarget({
-		requestId: 'second-request',
-		clientId: 'second-tab',
-		compositionFile: '/project/src/second.tsx',
-		compositionId: 'second-composition',
-		canInstall: true,
-		lastFocusedAt: 2000,
-		readOnly: false,
-		studioUrl: 'http://localhost:3000/second-composition',
-	});
-
-	expect(getElementInstallTarget('first-request')?.clientId).toBe('first-tab');
-	expect(getElementInstallTarget('second-request')?.clientId).toBe(
-		'second-tab',
-	);
+	updateTarget({canInstall: false, compositionId: null, readOnly: true});
+	expect(
+		consumeStudioProtocolTarget({
+			now: Date.now(),
+			origin: 'https://remotion.pro',
+			purpose: 'set-license-key',
+			targetId: readOnlyToken.id,
+		}),
+	).toBe(null);
 });

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -1,8 +1,15 @@
 import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {createServer} from 'node:http';
 import {connect} from 'node:net';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 import {createElementPayload} from '@remotion/studio-protocol';
 import type {EventSourceEvent} from '@remotion/studio-shared';
+import {
+	createFileWatcherRegistry,
+	setFileWatcherRegistry,
+} from '../file-watcher';
 import {
 	clearElementInstallStateForTests,
 	updateElementInstallTarget,
@@ -10,6 +17,7 @@ import {
 import type {LiveEventsServer} from '../preview-server/live-events';
 import {handleStudioProtocolDiscovery} from '../preview-server/studio-protocol/handle-discovery';
 import {handleStudioProtocolInstall} from '../preview-server/studio-protocol/handle-install';
+import {handleStudioProtocolLicenseKey} from '../preview-server/studio-protocol/handle-license-key';
 import {handleStudioProtocolOptions} from '../preview-server/studio-protocol/origin-policy';
 
 const payload = createElementPayload({
@@ -134,9 +142,11 @@ test('discovers an exact Studio target and delivers one install request over HTT
 	const server = createServer((request, response) => {
 		const {pathname} = new URL(request.url ?? '/', 'http://localhost');
 		if (request.method === 'OPTIONS') {
-			handleStudioProtocolOptions({request, response}).catch((error) =>
-				response.destroy(error),
-			);
+			handleStudioProtocolOptions({
+				licenseKey: false,
+				request,
+				response,
+			}).catch((error) => response.destroy(error));
 			return;
 		}
 
@@ -274,7 +284,7 @@ test('discovers an exact Studio target and delivers one install request over HTT
 				clientId: 'focused-studio-tab',
 				compositionFile: '/tmp/protocol-project/src/Composition.tsx',
 				compositionId: 'Main',
-				element: {displayName: 'Lower Third', durationInFrames: 90},
+				element: {displayName: 'Lower Third'},
 				source: {
 					type: 'studio-protocol',
 					origin: 'https://example.com',
@@ -303,6 +313,207 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		await new Promise<void>((resolve, reject) => {
 			server.close((error) => (error ? reject(error) : resolve()));
 		});
+		clearElementInstallStateForTests();
+	}
+});
+
+test('sets a public license key in the focused Studio project over HTTP', async () => {
+	clearElementInstallStateForTests();
+	const directory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-license-protocol-'),
+	);
+	const configFile = path.join(directory, 'remotion.config.ts');
+	let loadedConfigFile: string | null = configFile;
+	writeFileSync(
+		configFile,
+		[
+			"import {Config} from '@remotion/cli/config';",
+			"Config.setPublicLicenseKey('rm_pub_old');",
+			'',
+		].join('\n'),
+	);
+	const unsetRegistry = setFileWatcherRegistry(createFileWatcherRegistry());
+	const liveEventsServer: LiveEventsServer = {
+		addNewClientListener: () => () => undefined,
+		closeConnections: () => Promise.resolve(),
+		router: () => Promise.resolve(),
+		sendEventToClient: (event) => {
+			if (event.type !== 'request-element-install-target') {
+				return;
+			}
+
+			updateElementInstallTarget({
+				requestId: event.requestId,
+				clientId: 'focused-studio-tab',
+				compositionFile: null,
+				compositionId: null,
+				canInstall: false,
+				lastFocusedAt: Date.now(),
+				readOnly: false,
+				studioUrl: 'http://localhost:3000',
+			});
+		},
+		sendEventToClientId: () => false,
+	};
+	const server = createServer((request, response) => {
+		const {pathname} = new URL(request.url ?? '/', 'http://localhost');
+		if (request.method === 'OPTIONS') {
+			handleStudioProtocolOptions({
+				licenseKey: pathname === '/api/studio-protocol/license-key',
+				request,
+				response,
+			}).catch((error) => response.destroy(error));
+			return;
+		}
+
+		if (pathname === '/api/studio-protocol') {
+			handleStudioProtocolDiscovery({
+				gitSource: null,
+				liveEventsServer,
+				remotionRoot: directory,
+				request,
+				response,
+			}).catch((error) => response.destroy(error));
+			return;
+		}
+
+		handleStudioProtocolLicenseKey({
+			configFile: loadedConfigFile,
+			request,
+			response,
+		}).catch((error) => response.destroy(error));
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+	try {
+		const address = server.address();
+		if (address === null || typeof address === 'string') {
+			throw new Error('Expected an HTTP server address');
+		}
+
+		const origin = `http://127.0.0.1:${address.port}`;
+		const deniedPreflight = await fetch(
+			`${origin}/api/studio-protocol/license-key`,
+			{
+				method: 'OPTIONS',
+				headers: {Origin: 'https://example.com'},
+			},
+		);
+		expect(deniedPreflight.status).toBe(403);
+		expect(
+			deniedPreflight.headers.get('access-control-allow-origin'),
+		).toBeNull();
+
+		const untrustedDiscovery = await fetch(`${origin}/api/studio-protocol`, {
+			headers: {Origin: 'https://example.com'},
+		});
+		expect(untrustedDiscovery.status).toBe(200);
+		expect(await untrustedDiscovery.json()).toMatchObject({
+			capabilities: {setLicenseKey: true},
+			installTarget: null,
+			licenseKeyTarget: null,
+		});
+
+		const discovery = await fetch(`${origin}/api/studio-protocol`, {
+			headers: {Origin: 'https://www.remotion.pro'},
+		});
+		const descriptor = (await discovery.json()) as {
+			licenseKeyTarget: {id: string};
+		};
+		expect(descriptor.licenseKeyTarget.id).toBeString();
+
+		const validLicenseKey = `rm_pub_${'a'.repeat(48)}`;
+		const body = {
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			targetId: descriptor.licenseKeyTarget.id,
+			licenseKey: validLicenseKey,
+		};
+		const invalidKeyResponse = await fetch(
+			`${origin}/api/studio-protocol/license-key`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'https://www.remotion.pro',
+				},
+				body: JSON.stringify({...body, licenseKey: 'rm_sec_private'}),
+			},
+		);
+		expect(invalidKeyResponse.status).toBe(400);
+		expect(await invalidKeyResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'invalid-license-key'},
+		});
+		expect(readFileSync(configFile, 'utf8')).toContain('rm_pub_old');
+
+		const response = await fetch(`${origin}/api/studio-protocol/license-key`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Origin: 'https://www.remotion.pro',
+			},
+			body: JSON.stringify(body),
+		});
+		expect(await response.json()).toEqual({
+			protocol: 'remotion-studio-protocol',
+			protocolVersion: 1,
+			status: 'license-key-set',
+		});
+		expect(readFileSync(configFile, 'utf8')).toBe(
+			[
+				"import {Config} from '@remotion/cli/config';",
+				`Config.setPublicLicenseKey('${validLicenseKey}');`,
+				'',
+			].join('\n'),
+		);
+
+		const replay = await fetch(`${origin}/api/studio-protocol/license-key`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Origin: 'https://www.remotion.pro',
+			},
+			body: JSON.stringify(body),
+		});
+		expect(replay.status).toBe(409);
+		expect(await replay.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'target-expired'},
+		});
+
+		const noConfigDiscovery = await fetch(`${origin}/api/studio-protocol`, {
+			headers: {Origin: 'https://www.remotion.pro'},
+		});
+		const noConfigDescriptor = (await noConfigDiscovery.json()) as {
+			licenseKeyTarget: {id: string};
+		};
+		loadedConfigFile = null;
+		const noConfigResponse = await fetch(
+			`${origin}/api/studio-protocol/license-key`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Origin: 'https://www.remotion.pro',
+				},
+				body: JSON.stringify({
+					...body,
+					targetId: noConfigDescriptor.licenseKeyTarget.id,
+				}),
+			},
+		);
+		expect(noConfigResponse.status).toBe(409);
+		expect(await noConfigResponse.json()).toMatchObject({
+			status: 'error',
+			error: {code: 'no-config-file'},
+		});
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+		unsetRegistry();
+		rmSync(directory, {recursive: true, force: true});
 		clearElementInstallStateForTests();
 	}
 });

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -205,12 +205,13 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		const descriptor = (await discoveryResponse.json()) as {
 			installTarget: {id: string; compositionId: string};
 		};
-		expect(descriptor.installTarget.compositionId).toBe('Main');
+		const {installTarget} = descriptor;
+		expect(installTarget.compositionId).toBe('Main');
 
 		const installBody = {
 			protocol: 'remotion-studio-protocol',
 			protocolVersion: 1,
-			targetId: descriptor.installTarget.id,
+			targetId: installTarget.id,
 			payload,
 		};
 		const invalidEnvelopeResponse = await fetch(
@@ -420,13 +421,15 @@ test('sets a public license key in the focused Studio project over HTTP', async 
 		const descriptor = (await discovery.json()) as {
 			licenseKeyTarget: {id: string};
 		};
-		expect(descriptor.licenseKeyTarget.id).toBeString();
+		const {licenseKeyTarget} = descriptor;
+		expect(licenseKeyTarget.id).toBeString();
 
 		const validLicenseKey = `rm_pub_${'a'.repeat(48)}`;
 		const body = {
+			operation: 'set-license-key',
 			protocol: 'remotion-studio-protocol',
 			protocolVersion: 1,
-			targetId: descriptor.licenseKeyTarget.id,
+			targetId: licenseKeyTarget.id,
 			licenseKey: validLicenseKey,
 		};
 		const invalidKeyResponse = await fetch(

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -203,12 +203,18 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		expect(discoveryResponse.status).toBe(200);
 		expect(discoveryResponse.headers.get('cache-control')).toBe('no-store');
 		const descriptor = (await discoveryResponse.json()) as {
-			installTarget: {id: string; compositionId: string};
+			capabilities: [
+				{
+					type: 'install-element';
+					target: {id: string; compositionId: string};
+				},
+			];
 		};
-		const {installTarget} = descriptor;
+		const installTarget = descriptor.capabilities[0].target;
 		expect(installTarget.compositionId).toBe('Main');
 
 		const installBody = {
+			operation: 'install-element',
 			protocol: 'remotion-studio-protocol',
 			protocolVersion: 1,
 			targetId: installTarget.id,
@@ -410,18 +416,22 @@ test('sets a public license key in the focused Studio project over HTTP', async 
 		});
 		expect(untrustedDiscovery.status).toBe(200);
 		expect(await untrustedDiscovery.json()).toMatchObject({
-			capabilities: {setLicenseKey: true},
-			installTarget: null,
-			licenseKeyTarget: null,
+			capabilities: [
+				{type: 'install-element', target: null},
+				{type: 'set-license-key', target: null},
+			],
 		});
 
 		const discovery = await fetch(`${origin}/api/studio-protocol`, {
 			headers: {Origin: 'https://www.remotion.pro'},
 		});
 		const descriptor = (await discovery.json()) as {
-			licenseKeyTarget: {id: string};
+			capabilities: [
+				{type: 'install-element'},
+				{type: 'set-license-key'; target: {id: string}},
+			];
 		};
-		const {licenseKeyTarget} = descriptor;
+		const licenseKeyTarget = descriptor.capabilities[1].target;
 		expect(licenseKeyTarget.id).toBeString();
 
 		const validLicenseKey = `rm_pub_${'a'.repeat(48)}`;
@@ -489,7 +499,10 @@ test('sets a public license key in the focused Studio project over HTTP', async 
 			headers: {Origin: 'https://www.remotion.pro'},
 		});
 		const noConfigDescriptor = (await noConfigDiscovery.json()) as {
-			licenseKeyTarget: {id: string};
+			capabilities: [
+				{type: 'install-element'},
+				{type: 'set-license-key'; target: {id: string}},
+			];
 		};
 		loadedConfigFile = null;
 		const noConfigResponse = await fetch(
@@ -502,7 +515,7 @@ test('sets a public license key in the focused Studio project over HTTP', async 
 				},
 				body: JSON.stringify({
 					...body,
-					targetId: noConfigDescriptor.licenseKeyTarget.id,
+					targetId: noConfigDescriptor.capabilities[1].target.id,
 				}),
 			},
 		);


### PR DESCRIPTION
## Summary

- Add an internal `setLicenseKeyInStudio()` capability to `StudioProtocolInternals`
- Discover the most recently focused writable Studio project without requiring an active composition
- Add a trusted-origin, purpose-bound protocol endpoint that updates the loaded Remotion config
- Reuse the existing AST-safe config transformation and file-watcher-aware write path
- Add client, target-state, and route/filesystem integration coverage

The capability is intentionally not part of the public top-level API because only Remotion-controlled origins may invoke it.

Wording updates are in the stacked follow-up PR #10030.

## Security

The mutation is restricted to `remotion.pro`, `www.remotion.pro`, and loopback HTTP origins. It accepts only public `rm_pub_` keys. Targets are short-lived, single-use, origin-bound, and purpose-bound.

## Testing

- `bun test packages/studio-protocol/src/test`
- `bun test packages/studio-server/src/test/studio-protocol-routes.test.ts`
- `bun test packages/studio-server/src/test/element-install-state.test.ts packages/studio-server/src/test/update-public-license.test.ts`
- `bun run build`
- `bun run stylecheck`
