### PR TITLE
`@remotion/studio-protocol`: Update website wording

### DIFF
--- a/packages/docs/docs/studio-protocol/index.mdx
+++ b/packages/docs/docs/studio-protocol/index.mdx
@@ -6,7 +6,7 @@ crumb: '@remotion/studio-protocol'
 
 # Remotion Studio Protocol<AvailableFrom v="4.0.502" />
 
-A versioned protocol for bringing reusable content into Remotion Studio.
+A versioned protocol for connecting websites to Remotion Studio.
 
 Protocol v1 supports [Remotion Elements](/elements) from the official Remotion Elements library. It provides one Element payload that can be delivered by dragging it into Studio or by requesting installation into the active composition.
 
@@ -45,14 +45,7 @@ import {TableOfContents} from './table-of-contents';
 
 ## Supported origins
 
-Install requests are accepted from:
-
-- `https://remotion.dev`
-- `https://www.remotion.dev`
-- HTTP `localhost`
-- HTTP `127.0.0.1`
-
-Protocol v1 is supported by the official Remotion Elements library. Other hosted websites are not currently authorized to send installation requests.
+Any HTTPS website can request an Element installation confirmation. HTTP is supported on `localhost` and `127.0.0.1` for local development.
 
 ## Compatibility
 

--- a/packages/docs/docs/studio-protocol/security.mdx
+++ b/packages/docs/docs/studio-protocol/security.mdx
@@ -18,7 +18,7 @@ Declining the confirmation does not write source files or install packages. Drag
 
 ## Allowed origins
 
-Any HTTPS website can request a Studio confirmation. HTTP is supported only for local development pages on `localhost` or `127.0.0.1`.
+Any HTTPS website can request an Element installation confirmation. HTTP is supported only for local development pages on `localhost` or `127.0.0.1`.
 
 Studio reflects only the requesting allowed origin in CORS. It does not use wildcard CORS or cross-origin credentials.
 

--- a/packages/studio-protocol/README.md
+++ b/packages/studio-protocol/README.md
@@ -1,6 +1,6 @@
 # @remotion/studio-protocol
 
-Create Element payloads and request installation into Remotion Studio
+Connect websites to Remotion Studio
 
 [![NPM Downloads](https://img.shields.io/npm/dm/@remotion/studio-protocol.svg?style=flat&color=black&label=Downloads)](https://npmcharts.com/compare/@remotion/studio-protocol?minimal=true)
 

--- a/packages/studio-protocol/package.json
+++ b/packages/studio-protocol/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@remotion/studio-protocol",
 	"version": "4.0.503",
-	"description": "Create Element payloads and request installation into Remotion Studio",
+	"description": "Connect websites to Remotion Studio",
 	"main": "dist/index.cjs",
 	"types": "dist/index.d.ts",
 	"module": "dist/esm/index.mjs",


### PR DESCRIPTION
## Summary

- Describe Studio Protocol as connecting websites to Remotion Studio rather than bringing in content
- Clarify that any HTTPS website can request an Element installation confirmation
- Update the package description consistently

This PR is stacked on #10029.

## Preview

- [Studio Protocol overview](https://remotion-git-studio-protocol-license-key-docs-remotion.vercel.app/docs/studio-protocol)
- [Studio Protocol security](https://remotion-git-studio-protocol-license-key-docs-remotion.vercel.app/docs/studio-protocol/security)

## Testing

- `cd packages/docs && bun run lint`
- `bun run build`
- `bun run stylecheck`
