### PR TITLE
docs(troubleshooting): fix defaultProps typo

### DIFF
--- a/packages/docs/docs/troubleshooting/defaultprops-too-big.mdx
+++ b/packages/docs/docs/troubleshooting/defaultprops-too-big.mdx
@@ -24,7 +24,7 @@ The [`defaultProps`](/docs/composition#defaultprops) is not too big, but the lis
 
 ## Why this error occurs
 
-Remotion is trying to gather a list of compositions using [`getCompositions()`](/docs/renderer/get-compositions), and is copying them from the headless browser into Node.JS. During this operation, the JavaScript object needs to be converted into a string. The upper limit for this is 256MB, however dependending on the machine Remotion runs on, the error may also occur on smaller payloads.
+Remotion is trying to gather a list of compositions using [`getCompositions()`](/docs/renderer/get-compositions), and is copying them from the headless browser into Node.JS. During this operation, the JavaScript object needs to be converted into a string. The upper limit for this is 256MB, however depending on the machine Remotion runs on, the error may also occur on smaller payloads.
 
 ## How to fix the error
 


### PR DESCRIPTION
Problem
- The defaultProps troubleshooting page had a spelling error in the explanation of why the serialization limit can vary by machine.

Triage / Root cause
- `packages/docs/docs/troubleshooting/defaultprops-too-big.mdx` contained `dependending`, which is a visible docs typo in the current upstream file.

Fix
- Replace `dependending` with `depending` in the troubleshooting explanation.

Verification
- Confirmed the edited line in the current file.
- Ran `git diff --check` successfully.
- Tried `bun test src`, but `bun` is not installed in this environment, so the documented docs test command could not be executed here.

Notes / Risks
- Docs-only change; no runtime behavior is affected.