### PR TITLE
Internal: clean up AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,47 +21,21 @@ Use `bunx` (not `npx`) to run package binaries.
 
 The current Remotion version can be found in `packages/core/src/version.ts`. The next version should increment the patch version by 1.
 
-Pull request titles should be in the format `\`[package-name]\``: [commit-message]`. For example, "`@remotion/player`: Add new feature.
+## Coding style
 
-## Before committing
+- Keep things in one function unless they are composable or reusable.
+- Do not extract single-use helpers preemptively. Inline the logic at the call site unless the helper is reused, hides a genuinely complex boundary, or has a clear independent name that improves the caller.
 
-If committing your work:
-
-1. Run `bun run build` from the root of the repo to verify all packages build successfully
-2. Run `bun run stylecheck` to ensure CI passes
-3. Include `bun.lock` when dependencies change
-
-## Contributing
-
-Read the full [contribution guide](/packages/docs/docs/contributing/index.mdx).
-
-- [General information](/packages/docs/docs/contributing/index.mdx)
-- [Implementing a new feature](/packages/docs/docs/contributing/feature.mdx)
-- [Implementing a new option](/packages/docs/docs/contributing/option.mdx)
-
-## Cloud Agents specific instructions
-
-### Runtime
-
-Bun v1.3.3 is the required package manager and test runner. It is installed at `~/.bun/bin/bun`. Ensure `~/.bun/bin` is on `PATH` (the update script handles this).
-
-### Key services
+## Key services
 
 - **Remotion Studio** (dev testbed): `cd packages/example && bun run dev` — starts at `http://localhost:3000`. This is the main dev UI for previewing video compositions.
 - **Player testbed**: `cd packages/player-example && bun run dev` — for testing `@remotion/player` changes.
 - **Docs site**: `cd packages/docs && bun run start` — Docusaurus dev server.
 
-### Rendering test videos
+## Rendering test videos
 
 From `packages/example`:
+
 - `bunx remotion compositions` — list available compositions.
 - `bunx remotion render <comp-id> --output ../../out/video.mp4` — render a video.
 - `bunx remotion still <comp-id> --output ../../out/still.png` — render a still image.
-
-### Known caveats
-
-- `@remotion/lambda-go` lint requires Go >= 1.23.0. The VM ships Go 1.22.2, so that package's lint will fail. This is optional and doesn't affect core development.
-- `@remotion/openai-whisper` tests require `OPENAI_API_KEY` env var. Without it, 1 test fails. This is expected and non-blocking.
-- The Remotion Studio (`bun run dev` in `packages/example`) sometimes reports "Already running on port 3000" if a previous instance is still bound. Check with `curl http://localhost:3000` before assuming it failed.
-- After `bun install`, always run `bun run build` before running tests or starting the Studio, as many packages depend on built artifacts from other packages.
-- The `prepare` script in root `package.json` sets git hooks path to `.githooks`. The pre-commit hook runs `bun pre-commit.ts` for formatting.


### PR DESCRIPTION
## Summary

- add coding-style guidance that keeps logic together and avoids preemptive single-use helper extraction
- remove workflow instructions already owned by dedicated skills or standard repository conventions
- remove obsolete Cloud Agent-specific setup and caveats while retaining platform-independent service and rendering commands

## Rationale

- Keeping logic in one function unless it is composable or reusable avoids unnecessary indirection. Single-use helpers should stay inline unless they hide a genuinely complex boundary or have a clear independent name that makes the caller easier to understand.
- The pre-commit build and style-check instructions duplicate the `pr` skill, so the skill should remain the authoritative workflow. The generic `bun.lock` reminder was removed with that redundant checklist to keep `AGENTS.md` focused.
- Pull request title formatting duplicates the `pr-name` skill, which already inspects and classifies each change before choosing a title.
- Agents are expected to discover contributing documentation through the repository's standard conventions. The generic Contributing section was not being consulted during feature work or PR submission, so keeping it in `AGENTS.md` did not improve behavior.
- Development no longer happens in Cloud Agents; it happens on developer Macs. Cloud-specific runtime setup and known VM caveats are therefore obsolete.
- Key local services and video-rendering commands remain useful on developer machines, so they are retained as top-level sections.

## Verification

- `bunx oxfmt AGENTS.md --write`
- `bun run build`
- `bun run stylecheck`
