### PR TITLE
docs(elements): add page metadata to library routes

### DIFF
--- a/packages/docs/elements/backgrounds/index.mdx
+++ b/packages/docs/elements/backgrounds/index.mdx
@@ -4,7 +4,10 @@ description: Drop-in background Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+import {ElementHead} from '@site/src/components/Elements/ElementHead';
 
 # Backgrounds
+
+<ElementHead category="backgrounds" />
 
 <ElementLibrary category="backgrounds" />

--- a/packages/docs/elements/data/index.mdx
+++ b/packages/docs/elements/data/index.mdx
@@ -4,7 +4,10 @@ description: Animated data visualization Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+import {ElementHead} from '@site/src/components/Elements/ElementHead';
 
 # Data
+
+<ElementHead category="data" />
 
 <ElementLibrary category="data" />

--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -5,8 +5,11 @@ description: Drop-in, remixable video building blocks for Remotion.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+import {ElementHead} from '@site/src/components/Elements/ElementHead';
 
 # Remotion Elements
+
+<ElementHead category={null} />
 
 :::warning Work in progress
 

--- a/packages/docs/elements/overlays/index.mdx
+++ b/packages/docs/elements/overlays/index.mdx
@@ -4,7 +4,10 @@ description: Drop-in overlay Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+import {ElementHead} from '@site/src/components/Elements/ElementHead';
 
 # Overlays
+
+<ElementHead category="overlays" />
 
 <ElementLibrary category="overlays" />

--- a/packages/docs/elements/text/index.mdx
+++ b/packages/docs/elements/text/index.mdx
@@ -4,7 +4,10 @@ description: Drop-in text Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+import {ElementHead} from '@site/src/components/Elements/ElementHead';
 
 # Text
+
+<ElementHead category="text" />
 
 <ElementLibrary category="text" />

--- a/packages/docs/src/components/Elements/ElementHead.tsx
+++ b/packages/docs/src/components/Elements/ElementHead.tsx
@@ -1,0 +1,50 @@
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import React from 'react';
+import {Seo} from '../Seo';
+import {
+	getElementCategoryLabel,
+	type ElementCategory,
+} from './element-library-data';
+
+const SOCIAL_IMAGE = '/img/social-preview.png';
+
+const getTitle = (category: ElementCategory | null) => {
+	if (category === null) {
+		return 'Remotion Elements | Remotion';
+	}
+
+	return `${getElementCategoryLabel(category)} | Remotion Elements`;
+};
+
+const getDescription = (category: ElementCategory | null) => {
+	if (category === null) {
+		return 'Drop-in, remixable video building blocks for Remotion.';
+	}
+
+	return `Browse ${getElementCategoryLabel(
+		category,
+	).toLowerCase()} Elements in Remotion's library.`;
+};
+
+const getCanonicalPath = (category: ElementCategory | null) => {
+	return category === null ? '/elements/' : `/elements/${category}/`;
+};
+
+export const ElementHead: React.FC<{
+	readonly category: ElementCategory | null;
+}> = ({category}) => {
+	const context = useDocusaurusContext();
+	const canonicalPath = getCanonicalPath(category);
+	const canonicalUrl = new URL(canonicalPath, context.siteConfig.url).href;
+
+	return (
+		<Head>
+			{Seo.renderTitle(getTitle(category))}
+			{Seo.renderDescription(getDescription(category))}
+			<link rel="canonical" href={canonicalUrl} />
+			{Seo.renderImage(SOCIAL_IMAGE, context.siteConfig.url)}
+			<meta name="twitter:card" content="summary_large_image" />
+		</Head>
+	);
+};

--- a/packages/docs/src/test/element-head.test.tsx
+++ b/packages/docs/src/test/element-head.test.tsx
@@ -1,0 +1,70 @@
+import {afterAll, expect, mock, test} from 'bun:test';
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+
+mock.module('@docusaurus/Head', () => {
+	return {
+		default: ({children}: {children: React.ReactNode}) =>
+			React.createElement(React.Fragment, null, children),
+	};
+});
+
+mock.module('@docusaurus/useDocusaurusContext', () => {
+	return {
+		default: () => ({
+			siteConfig: {
+				url: 'https://remotion.dev',
+			},
+		}),
+	};
+});
+
+const {ElementHead} = await import('../components/Elements/ElementHead');
+
+afterAll(() => {
+	mock.restore();
+});
+
+test('renders overview metadata for Elements', () => {
+	const markup = renderToStaticMarkup(
+		React.createElement(ElementHead, {category: null}),
+	);
+
+	expect(markup).toContain('<title>Remotion Elements | Remotion</title>');
+	expect(markup).toContain(
+		'<meta property="og:title" content="Remotion Elements | Remotion"/>',
+	);
+	expect(markup).toContain(
+		'<meta name="description" content="Drop-in, remixable video building blocks for Remotion."/>',
+	);
+	expect(markup).toContain(
+		'<link rel="canonical" href="https://remotion.dev/elements/"/>',
+	);
+	expect(markup).toContain(
+		'<meta property="og:image" content="https://remotion.dev/img/social-preview.png"/>',
+	);
+	expect(markup).toContain(
+		'<meta name="twitter:image" content="https://remotion.dev/img/social-preview.png"/>',
+	);
+	expect(markup).toContain('<meta name="twitter:card" content="summary_large_image"/>');
+});
+
+test('renders category metadata for Elements', () => {
+	const markup = renderToStaticMarkup(
+		React.createElement(ElementHead, {category: 'backgrounds'}),
+	);
+
+	expect(markup).toContain('<title>Backgrounds | Remotion Elements</title>');
+	expect(markup).toContain(
+		'<meta property="og:title" content="Backgrounds | Remotion Elements"/>',
+	);
+	expect(markup).toContain(
+		"<meta name=\"description\" content=\"Browse backgrounds Elements in Remotion&#x27;s library.\"/>",
+	);
+	expect(markup).toContain(
+		'<link rel="canonical" href="https://remotion.dev/elements/backgrounds/"/>',
+	);
+	expect(markup).toContain(
+		'<meta property="og:image" content="https://remotion.dev/img/social-preview.png"/>',
+	);
+});


### PR DESCRIPTION
Problem
- The Remotion Elements overview and category pages had only basic frontmatter, so shared links were missing canonical URLs and richer social metadata.
- That left `/elements` and the category entry points with incomplete search and preview information.

Triage / Root cause
- The Elements MDX pages under `packages/docs/elements/` rendered the library UI, but they did not emit a shared `<Head>` block with title, description, canonical, or social preview tags.
- The existing `Seo` helper already renders title, description, and image tags, so the missing piece was a centralized wrapper for the Elements routes.

Fix
- Added `packages/docs/src/components/Elements/ElementHead.tsx` to centralize the title, description, canonical URL, and social image for the Elements overview and category pages.
- Wired the overview and all four category MDX pages to the shared head helper.
- Added a focused HTML-render test that asserts the emitted metadata for the overview and a category page.

Verification
- `/home/ubuntu/.bun/bin/bun test packages/docs/src/test/element-head.test.tsx`
- Result: pass

Notes / Risks
- The social-image fallback currently uses the existing `/img/social-preview.png` asset rather than a category-specific preview.
- The commit was created from a clean worktree based on `upstream/main`; unrelated local edits in the main checkout were left untouched.

Model Used
- GPT-5.4-mini

Checklist
- [x] I read the contribution guidance and issue context
- [x] I verified the change against current upstream
- [x] I ran the targeted test
- [x] I avoided unrelated edits
