### PR TITLE
docs(contributing): fix grammar in docs-writing guide

### DIFF
--- a/packages/docs/docs/contributing/docs.mdx
+++ b/packages/docs/docs/contributing/docs.mdx
@@ -16,7 +16,7 @@ At the bottom of each page, the `Improve this page` button is the easiest way to
 
 ## Submitting a new page
 
-<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according the instructions here</a>. <br />
+<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according to the instructions here</a>. <br />
 <Step>2</Step> Create a new <code>.mdx</code> document in the <code>packages/docs/docs</code> folder. <br />
 <Step>3</Step> Add the document to <code>packages/docs/sidebars.ts</code>.<br />
 <Step>4</Step> Write what you have to say!


### PR DESCRIPTION
## Problem
The docs-writing guide currently says “according the instructions here”, which is ungrammatical in the setup step. Self-sourced.

## Triage / Root cause
`packages/docs/docs/contributing/docs.mdx` is missing the preposition “to” in the first step under “Submitting a new page”.

## Fix
Changed the phrase to “according to the instructions here”.

## Verification
- `git diff --check upstream/main...HEAD` — passed
- `python3 scripts/preflight_ship.py --repo remotion-dev/remotion --local remotion --branch main --file packages/docs/docs/contributing/docs.mdx --must-contain "according the instructions here" --must-not-contain "according to the instructions here" --search "docs-writing grammar in:title,body"` — passed
- Bun stylecheck could not run because Bun is unavailable in the environment; the repository pre-commit hook reported the same missing executable.

## Notes / Risks
Documentation-only, one-line wording correction; no runtime or API impact.