### PR TITLE
`@remotion/paths`: Speed up path length and point lookups

### DIFF
--- a/packages/paths/src/helpers/bezier-functions.ts
+++ b/packages/paths/src/helpers/bezier-functions.ts
@@ -1,4 +1,4 @@
-import {binomialCoefficients, cValues, tValues} from './bezier-values';
+import {cValues, tValues} from './bezier-values';
 import type {Point} from './types';
 
 export const cubicPoint = (xs: number[], ys: number[], t: number): Point => {
@@ -16,45 +16,6 @@ export const cubicPoint = (xs: number[], ys: number[], t: number): Point => {
 	return {x, y};
 };
 
-/**
- * Compute the curve derivative (hodograph) at t.
- */
-const getDerivative = (derivative: number, t: number, vs: number[]): number => {
-	// the derivative of any 't'-less function is zero.
-	const n = vs.length - 1;
-	let value;
-
-	if (n === 0) {
-		return 0;
-	}
-
-	// direct values? compute!
-	if (derivative === 0) {
-		value = 0;
-		for (let k = 0; k <= n; k++) {
-			value += binomialCoefficients[n][k] * (1 - t) ** (n - k) * t ** k * vs[k];
-		}
-
-		return value;
-	}
-
-	// Still some derivative? go down one order, then try
-	// for the lower order curve's.
-	const _vs = new Array(n);
-	for (let k = 0; k < n; k++) {
-		_vs[k] = n * (vs[k + 1] - vs[k]);
-	}
-
-	return getDerivative(derivative - 1, t, _vs);
-};
-
-function bFunc(xs: number[], ys: number[], t: number) {
-	const xbase = getDerivative(1, t, xs);
-	const ybase = getDerivative(1, t, ys);
-	const combined = xbase * xbase + ybase * ybase;
-	return Math.sqrt(combined);
-}
-
 export const getCubicArcLength = ({
 	sx,
 	sy,
@@ -64,15 +25,25 @@ export const getCubicArcLength = ({
 	sy: number[];
 	t: number;
 }) => {
+	const v0x = 3 * (sx[1] - sx[0]);
+	const v1x = 3 * (sx[2] - sx[1]);
+	const v2x = 3 * (sx[3] - sx[2]);
+	const v0y = 3 * (sy[1] - sy[0]);
+	const v1y = 3 * (sy[2] - sy[1]);
+	const v2y = 3 * (sy[3] - sy[2]);
+
 	let correctedT: number;
-
 	const n = 20;
-
 	const z = t / 2;
 	let sum = 0;
 	for (let i = 0; i < n; i++) {
 		correctedT = z * tValues[n][i] + z;
-		sum += cValues[n][i] * bFunc(sx, sy, correctedT);
+		const mt = 1 - correctedT;
+		const xbase =
+			mt * mt * v0x + 2 * mt * correctedT * v1x + correctedT * correctedT * v2x;
+		const ybase =
+			mt * mt * v0y + 2 * mt * correctedT * v1y + correctedT * correctedT * v2y;
+		sum += cValues[n][i] * Math.sqrt(xbase * xbase + ybase * ybase);
 	}
 
 	return z * sum;
@@ -89,12 +60,17 @@ export const quadraticPoint = (
 };
 
 export const cubicDerivative = (xs: number[], ys: number[], t: number) => {
-	const derivative = quadraticPoint(
-		[3 * (xs[1] - xs[0]), 3 * (xs[2] - xs[1]), 3 * (xs[3] - xs[2])],
-		[3 * (ys[1] - ys[0]), 3 * (ys[2] - ys[1]), 3 * (ys[3] - ys[2])],
-		t,
-	);
-	return derivative;
+	const v0x = 3 * (xs[1] - xs[0]);
+	const v1x = 3 * (xs[2] - xs[1]);
+	const v2x = 3 * (xs[3] - xs[2]);
+	const v0y = 3 * (ys[1] - ys[0]);
+	const v1y = 3 * (ys[2] - ys[1]);
+	const v2y = 3 * (ys[3] - ys[2]);
+	const mt = 1 - t;
+	return {
+		x: mt * mt * v0x + 2 * mt * t * v1x + t * t * v2x,
+		y: mt * mt * v0y + 2 * mt * t * v1y + t * t * v2y,
+	};
 };
 
 export const getQuadraticArcLength = (


### PR DESCRIPTION
`getCubicArcLength()` integrates a cubic Bézier with a 20-point Legendre-Gauss quadrature. Each of those 20 abscissae called `bFunc()`, which called the generic recursive `getDerivative(1, t, vs)` twice, once for x and once for y.

`getDerivative` allocated a fresh `new Array(3)` and recomputed the first-derivative control values `3 * (v[k+1] - v[k])` on every abscissa, then evaluated the polynomial with `**`. Those control values don't depend on `t`, so each cubic segment paid 40 array allocations and roughly 120 `pow` calls per length evaluation to re-derive the same six numbers.

The hodograph of a cubic Bézier is a quadratic Bézier whose control values are constant across the integral, so they're now computed once per call instead of once per abscissa. `cubicDerivative()` gets the same treatment; it was allocating two temporary arrays per call to route through `quadraticPoint()`.

`getDerivative()` and `bFunc()` are removed. Their only reachable caller was `getCubicArcLength()`, always with `derivative = 1` and a length-4 control vector, so the generic recursive form was never exercised at any other order.

## Results are bit-identical

Every value returned by `getLength()`, `getPointAtLength()`, `getTangentAtLength()` and `evolvePath()` is the same IEEE-754 double as before. Checked with `Object.is` over randomised paths covering `C`, `Q`, `S`, `L`, `A` and `H` segments: 11,200 comparisons, 0 mismatches.

Floating-point multiplication does not reassociate, so the original operation order is preserved exactly. That is the part worth reviewing closely. `((3*mt)*t)*t` and `(3*mt)*(t*t)` disagree on about 31% of random inputs, so the rewrite keeps the left-to-right grouping instead of gathering common factors. The quadrature order is unchanged, and `getQuadraticArcLength()`, `quadraticDerivative()` and `t2length()` are untouched.

## Measurements

Pure-cubic paths, Node 22.23.1, single core, best of 7 trials each:

| segments | API | before | after | speedup |
|---|---|---|---|---|
| 20 | `getLength()` | 0.0597 ms | 0.0274 ms | 2.18x |
| 20 | `getPointAtLength()` | 0.0860 ms | 0.0292 ms | 2.94x |
| 20 | `getTangentAtLength()` | 0.0838 ms | 0.0287 ms | 2.92x |
| 20 | `evolvePath()` | 0.0580 ms | 0.0264 ms | 2.19x |
| 50 | `getLength()` | 0.1429 ms | 0.0648 ms | 2.20x |
| 50 | `getPointAtLength()` | 0.1676 ms | 0.0655 ms | 2.56x |
| 50 | `getTangentAtLength()` | 0.1674 ms | 0.0655 ms | 2.56x |
| 50 | `evolvePath()` | 0.1420 ms | 0.0639 ms | 2.22x |
| 200 | `getLength()` | 0.5731 ms | 0.2588 ms | 2.21x |
| 200 | `getPointAtLength()` | 0.6050 ms | 0.2599 ms | 2.33x |
| 200 | `getTangentAtLength()` | 0.6064 ms | 0.2598 ms | 2.33x |
| 200 | `evolvePath()` | 0.5785 ms | 0.2586 ms | 2.24x |
| 1000 | `getLength()` | 2.9473 ms | 1.3310 ms | 2.21x |
| 1000 | `getPointAtLength()` | 2.9709 ms | 1.3281 ms | 2.24x |
| 1000 | `getTangentAtLength()` | 2.9661 ms | 1.3209 ms | 2.25x |
| 1000 | `evolvePath()` | 2.9377 ms | 1.3273 ms | 2.21x |

`getPointAtLength()` and `getTangentAtLength()` gain the most at 20 segments because they also pay `t2length()`, which calls the integral repeatedly while it solves for `t`.

## Why it's worth doing

`evolvePath()` calls `getLength()` once per frame. For an SVG path drawing itself across a 10-second composition at 30fps, that is 300 length evaluations of the same path, on the render thread and in the Studio.

## What this is not

These are per-call microbenchmarks of four functions in `@remotion/paths`. I am not claiming a measurable change to end-to-end render time; that depends entirely on how much of a composition is SVG path animation, and for a project that doesn't use these APIs the change does nothing at all.

`bun test src` in `packages/paths` passes unchanged: 46 tests across 21 files, the same count as on `main`.

---

The variants behind this patch came out of an automated optimisation search over `bezier-functions.ts`, scored against a bit-exactness gate. The trajectory is recorded at https://dashboard.weco.ai/share/YPTPC-6rrTQ1gQep5eIqWyCebjmS6WNb — 17 evaluations, 13 of which produced a valid score and 4 of which were rejected for changing the output. The diff here is the best-scoring of those, with the repo's formatter applied.
