### PR TITLE
`@remotion/media-utils`: Speed up the FFT behind visualizeAudio()

### DIFF
--- a/packages/media-utils/src/fft/fft-fast.ts
+++ b/packages/media-utils/src/fft/fft-fast.ts
@@ -1,95 +1,137 @@
-// https://pastebin.com/raw/D42RbPe5
-
-// Function to reverse bits in an integer
-function reverseBits(num: number, numBits: number) {
-	let result = 0;
-	for (let i = 0; i < numBits; i++) {
-		result = (result << 1) | ((num >> i) & 1);
-	}
-
-	return result;
-}
-
-// Hamming window function
-function hammingWindow(N: number) {
-	const win = new Array(N);
-	for (let i = 0; i < N; i++) {
-		win[i] = 0.8 - 0.46 * Math.cos((2 * Math.PI * i) / (N - 1));
-	}
-
-	return win;
-}
-
-// Function to calculate the bit-reversed permutation indices
-function bitReversePermutation(N: number) {
-	const bitReversed = new Array(N);
-
-	for (let i = 0; i < N; i++) {
-		bitReversed[i] = reverseBits(i, Math.log2(N));
-	}
-
-	return bitReversed;
-}
-
 export const fftFast = function (vector: Int16Array): [number, number][] {
 	const N = vector.length;
 
-	const X: [number, number][] = new Array(N);
-
 	if (N <= 1) {
+		const base: [number, number][] = new Array(N);
 		for (let i = 0; i < vector.length; i++) {
 			const value = vector[i];
-			X[i] = [value * 2, 0];
+			base[i] = [value * 2, 0];
 		}
 
-		return X;
+		return base;
 	}
 
-	// Apply a windowing function to the input data
-	const window = hammingWindow(N); // You can choose a different window function if needed
-	for (let i = 0; i < N; i++) {
-		X[i] = [vector[i] * window[i], 0];
+	// Use typed arrays for calculation to avoid tuple property access overhead.
+	const real = new Float64Array(N);
+	const imag = new Float64Array(N);
+
+	const halfN = N >> 1;
+	let rev = 0;
+	// Combined bit-reversal and the first stage (s=1) to reduce passes and allocations.
+	for (let i = 0; i < N; i += 2) {
+		const v1 = vector[rev];
+		const v2 = vector[rev + halfN];
+		real[i] = v1 + v2;
+		imag[i] = 0;
+		real[i + 1] = v1 - v2;
+		imag[i + 1] = 0;
+
+		// Efficiently advance the bit-reversal index for the next even i (i+2).
+		let bit = halfN >> 1;
+		while (rev & bit) {
+			rev ^= bit;
+			bit >>= 1;
+		}
+
+		rev ^= bit;
 	}
 
-	// Bit-Reversal Permutation
-	const bitReversed = bitReversePermutation(N);
-
-	for (let i = 0; i < N; i++) {
-		X[i] = [vector[bitReversed[i]], 0];
-	}
-
-	// Cooley-Tukey FFT
-	for (let s = 1; s <= Math.log2(N); s++) {
-		const m = 1 << s; // Number of elements in each subarray
-		const mHalf = m / 2; // Half the number of elements in each subarray
+	const logN = Math.log2(N);
+	for (let s = 2; s <= logN; s++) {
+		const m = 1 << s;
+		const mHalf = m >> 1;
 		const angleIncrement = (2 * Math.PI) / m;
+		const cosA = Math.cos(angleIncrement);
+		const sinA = Math.sin(angleIncrement);
+		const m2 = m << 1;
 
-		for (let k = 0; k < N; k += m) {
-			let omegaReal = 1.0;
-			let omegaImag = 0.0;
+		// Hoist j=0 butterfly to eliminate multiplications.
+		if (s < logN) {
+			for (let k = 0; k < N; k += m2) {
+				const r10 = real[k];
+				const r11 = imag[k];
+				const r20 = real[k + mHalf];
+				const r21 = imag[k + mHalf];
+				real[k] = r10 + r20;
+				imag[k] = r11 + r21;
+				real[k + mHalf] = r10 - r20;
+				imag[k + mHalf] = r11 - r21;
 
-			for (let j = 0; j < mHalf; j++) {
-				const tReal =
-					omegaReal * X[k + j + mHalf][0] - omegaImag * X[k + j + mHalf][1];
-				const tImag =
-					omegaReal * X[k + j + mHalf][1] + omegaImag * X[k + j + mHalf][0];
-
-				const uReal = X[k + j][0];
-				const uImag = X[k + j][1];
-
-				X[k + j] = [uReal + tReal, uImag + tImag];
-				X[k + j + mHalf] = [uReal - tReal, uImag - tImag];
-
-				// Twiddle factor update
-				const tempReal =
-					omegaReal * Math.cos(angleIncrement) -
-					omegaImag * Math.sin(angleIncrement);
-				omegaImag =
-					omegaReal * Math.sin(angleIncrement) +
-					omegaImag * Math.cos(angleIncrement);
-				omegaReal = tempReal;
+				const km = k + m;
+				const r30 = real[km];
+				const r31 = imag[km];
+				const r40 = real[km + mHalf];
+				const r41 = imag[km + mHalf];
+				real[km] = r30 + r40;
+				imag[km] = r31 + r41;
+				real[km + mHalf] = r30 - r40;
+				imag[km + mHalf] = r31 - r41;
 			}
+		} else {
+			const r10 = real[0];
+			const r11 = imag[0];
+			const r20 = real[mHalf];
+			const r21 = imag[mHalf];
+			real[0] = r10 + r20;
+			imag[0] = r11 + r21;
+			real[mHalf] = r10 - r20;
+			imag[mHalf] = r11 - r21;
 		}
+
+		// First twiddle factor update for j=0 -> j=1.
+		let omegaReal = cosA;
+		let omegaImag = sinA;
+
+		for (let j = 1; j < mHalf; j++) {
+			if (s < logN) {
+				for (let k = j; k < N; k += m2) {
+					const r10 = real[k];
+					const r11 = imag[k];
+					const r20 = real[k + mHalf];
+					const r21 = imag[k + mHalf];
+					const tR1 = omegaReal * r20 - omegaImag * r21;
+					const tI1 = omegaReal * r21 + omegaImag * r20;
+					real[k] = r10 + tR1;
+					imag[k] = r11 + tI1;
+					real[k + mHalf] = r10 - tR1;
+					imag[k + mHalf] = r11 - tI1;
+
+					const km = k + m;
+					const r30 = real[km];
+					const r31 = imag[km];
+					const r40 = real[km + mHalf];
+					const r41 = imag[km + mHalf];
+					const tR2 = omegaReal * r40 - omegaImag * r41;
+					const tI2 = omegaReal * r41 + omegaImag * r40;
+					real[km] = r30 + tR2;
+					imag[km] = r31 + tI2;
+					real[km + mHalf] = r30 - tR2;
+					imag[km + mHalf] = r31 - tI2;
+				}
+			} else {
+				const r10 = real[j];
+				const r11 = imag[j];
+				const r20 = real[j + mHalf];
+				const r21 = imag[j + mHalf];
+				const tR = omegaReal * r20 - omegaImag * r21;
+				const tI = omegaReal * r21 + omegaImag * r20;
+				real[j] = r10 + tR;
+				imag[j] = r11 + tI;
+				real[j + mHalf] = r10 - tR;
+				imag[j + mHalf] = r11 - tI;
+			}
+
+			// Bit-exact twiddle factor update.
+			const tempReal = omegaReal * cosA - omegaImag * sinA;
+			omegaImag = omegaReal * sinA + omegaImag * cosA;
+			omegaReal = tempReal;
+		}
+	}
+
+	// Final conversion to the required [number, number][] return type.
+	const X: [number, number][] = new Array(N);
+	for (let i = 0; i < N; i++) {
+		X[i] = [real[i], imag[i]];
 	}
 
 	return X;


### PR DESCRIPTION
## Problem

`fftFast()` is the radix-2 Cooley-Tukey transform used by `visualizeAudio({optimizeFor: "speed"})`. Three things in it cost time without affecting the result.

A Hamming window is built and then thrown away. The function computes `hammingWindow(N)`, which is N `Math.cos()` calls plus two N-element arrays, and applies it into `X`. The bit-reversal loop on the next statement overwrites every element of `X`, so the window never reaches the transform.

`Math.cos(angleIncrement)` and `Math.sin(angleIncrement)` are evaluated four times per butterfly, inside the innermost loop, although `angleIncrement` is constant within a stage. For a 512-point transform that is 9,216 trig calls where 18 would do.

`Math.log2(N)` is re-evaluated in the stage loop condition and once per index in `bitReversePermutation()`, and every butterfly allocates two fresh two-element arrays.

`getVisualization()` is the only caller. With `smoothing` on (the default), `visualizeAudio()` calls it three times per frame, for frames n-1, n and n+1.

## Fix

The window is removed, the per-stage cosine and sine are hoisted out of the butterfly loop, the working buffer becomes a pair of flat `Float64Array`s, and the bit-reversal index is advanced incrementally and fused with the first stage. The twiddle factor is still produced by the same repeated complex multiplication in the same order, so the arithmetic is unchanged.

## Results

Bun 1.3.14, single core, best of 7 trials.

`getVisualization()` with `optimizeFor: "speed"`:

| numberOfSamples | before | after | speedup | per frame (x3, smoothing on) |
|---|---|---|---|---|
| 16 | 0.0049 ms | 0.0029 ms | 1.69x | 0.0147 -> 0.0087 ms |
| 64 | 0.0198 ms | 0.0105 ms | 1.87x | 0.0593 -> 0.0316 ms |
| 128 | 0.0406 ms | 0.0207 ms | 1.96x | 0.1218 -> 0.0621 ms |
| 256 | 0.0859 ms | 0.0412 ms | 2.09x | 0.2576 -> 0.1235 ms |
| 512 | 0.1756 ms | 0.0812 ms | 2.16x | 0.5269 -> 0.2437 ms |

`fftFast()` on its own:

| FFT size | before | after | speedup |
|---|---|---|---|
| 128 | 0.01162 ms | 0.00197 ms | 5.89x |
| 256 | 0.02389 ms | 0.00389 ms | 6.15x |
| 512 | 0.05330 ms | 0.00804 ms | 6.63x |
| 1024 | 0.11208 ms | 0.01617 ms | 6.93x |

The audiogram template passes `optimizeFor: "speed"` at `numberOfSamples: 64 * 4`, so the 256 row is the one it hits.

## Output is bit-identical

Every double was compared with `Object.is`, not with a tolerance:

- 448,600 comparisons over `getVisualization()` output at 6 sizes and `fftFast()` output at 13 sizes from N=1 to N=4096: 0 mismatches.
- 36,846 further comparisons on adversarial vectors (all-zero, constant, all-max, all-min, alternating, impulse, symmetric, antisymmetric) at 11 sizes: 0 mismatches.

This is reachable because every change removes work rather than substituting a better formula. Computing the twiddle as `Math.cos(j * angleIncrement)` would be more accurate than the recurrence and would move the output, so I did not do it.

## Tradeoffs

- This only affects the `optimizeFor: "speed"` path. On v4 the default is `"accuracy"`, so callers reach it by opting in; on v5 it becomes the default.
- The numbers are microseconds per call. I am not claiming a measurable change in total render time.
- I removed the dead Hamming window rather than repairing it. Applying it would change every visualization output, which is a product decision rather than a performance one. Happy to file that separately.
- Not touched here, but worth knowing: the module-level `cache` in `visualize-audio.ts` is read on every call and never written to, so the three smoothing calls per frame recompute their FFTs every time.
- The `j = 0` butterfly is special-cased because the twiddle factor there is exactly `(1, 0)`. That substitution is exact for every finite value, and the adversarial zero vectors above were added to check the signed-zero case specifically.

## Verification

- `oxfmt src --check`, `eslint src` and `tsgo -d` all clean.
- `packages/media-utils` ships no test files, so the bit-exactness comparison above is the correctness evidence rather than a suite.
- The change came out of an optimization run over this one file: https://dashboard.weco.ai/share/-mR-DqMCZvYxPTaMfZHkKYXJmlXIfruA
