### PR TITLE
docs: fix static-files typo

### DIFF
--- a/packages/docs/docs/get-static-files.mdx
+++ b/packages/docs/docs/get-static-files.mdx
@@ -50,7 +50,7 @@ const videoName = files[0].name;
 // ✅ Wrap it in staticFile() instead or use `src`
 const videoSrc = files[0].src;
 
-// Find a file by it's name and import it
+// Find a file by its name and import it
 const data = files.find((f) => {
   return f.name === 'video.mp4';
 }) as StaticFile; // Use `as StaticFile` to assert the file exists

--- a/packages/docs/docs/studio/get-static-files.mdx
+++ b/packages/docs/docs/studio/get-static-files.mdx
@@ -49,7 +49,7 @@ const videoName = files[0].name;
 // ✅ Wrap it in staticFile() instead or use `src`
 const videoSrc = files[0].src;
 
-// Find a file by it's name and import it
+// Find a file by its name and import it
 const data = files.find((f) => {
   return f.name === 'video.mp4';
 }) as StaticFile; // Use `as StaticFile` to assert the file exists


### PR DESCRIPTION
Problem
- Two static-files documentation examples told readers to find a file by its name with a typo in the current upstream docs.

Triage / Root cause
- packages/docs/docs/get-static-files.mdx and packages/docs/docs/studio/get-static-files.mdx both still contained the same typo on upstream/main.

Fix
- Replace the typo with the correct possessive form in both examples so the shared docs and the Studio docs stay aligned.

Verification
- git diff --check
- python3 ../scripts/preflight_ship.py --repo remotion-dev/remotion --local /home/ubuntu/Projects/open-source/remotion --branch main --file packages/docs/docs/get-static-files.mdx --must-contain by it --must-not-contain by its name --search get-static-files typo its name
- python3 ../scripts/preflight_ship.py --repo remotion-dev/remotion --local /home/ubuntu/Projects/open-source/remotion --branch main --file packages/docs/docs/studio/get-static-files.mdx --must-contain by it --must-not-contain by its name --search studio get-static-files typo its name

Notes / Risks
- Docs-only change; no runtime behavior is affected.
