### PR TITLE
docs(homepage): add Elements entry to interactive section

### DIFF
--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -71,6 +71,7 @@ const ConvertUI = ({
 	trimOutFrame,
 	enableRotateOrMirror,
 	setEnableRotateOrMirror,
+	setEnableCrop,
 	userRotation,
 	setRotation,
 	flipHorizontal,
@@ -107,6 +108,7 @@ const ConvertUI = ({
 	readonly setEnableRotateOrMirror: React.Dispatch<
 		React.SetStateAction<RotateOrMirrorOrCropState | null>
 	>;
+	readonly setEnableCrop: React.Dispatch<React.SetStateAction<boolean>>;
 	readonly userRotation: number;
 	readonly setRotation: React.Dispatch<React.SetStateAction<number>>;
 	readonly flipHorizontal: boolean;
@@ -491,19 +493,19 @@ const ConvertUI = ({
 	}, [setEnableRotateOrMirror]);
 
 	const onCropClick = useCallback(() => {
-		setEnableRotateOrMirror((m) => {
-			if (m !== 'crop') {
+		setEnableCrop((active) => {
+			if (!active) {
 				// Scroll to top of the page when crop is activated
 				if (typeof window !== 'undefined') {
 					window.scrollTo({top: 0, behavior: 'smooth'});
 				}
 
-				return 'crop';
+				return true;
 			}
 
-			return null;
+			return false;
 		});
-	}, [setEnableRotateOrMirror]);
+	}, [setEnableCrop]);
 
 	const onResizeClick = useCallback(() => {
 		setResizeOperation((r) => {
@@ -524,12 +526,12 @@ const ConvertUI = ({
 			return null;
 		}
 
-		if (enableRotateOrMirror !== 'crop') {
+		if (!crop) {
 			return dimensions;
 		}
 
 		return applyCrop(dimensions, cropRect);
-	}, [dimensions, cropRect, enableRotateOrMirror]);
+	}, [crop, dimensions, cropRect]);
 
 	const newDimensions = useMemo(() => {
 		if (unrotatedDimensions === null) {
@@ -804,7 +806,7 @@ const ConvertUI = ({
 											rotation={userRotation - (rotation ?? 0)}
 											setResizeMode={setResizeOperation}
 											requireTwoStep={Boolean(isH264Reencode)}
-											crop={enableRotateOrMirror === 'crop'}
+											crop={crop}
 											cropRect={cropRect}
 											dimensionsBeforeCrop={dimensions}
 										/>

--- a/packages/convert/app/components/FileAvailable.tsx
+++ b/packages/convert/app/components/FileAvailable.tsx
@@ -3,7 +3,7 @@ import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {normalizeVideoRotation} from '~/lib/calculate-new-dimensions-from-dimensions';
 import type {Source} from '~/lib/convert-state';
 import type {RotateOrMirrorOrCropState} from '~/lib/default-ui';
-import {defaultRotateOrMirorState} from '~/lib/default-ui';
+import {defaultCropEnabledState, defaultRotateOrMirorState} from '~/lib/default-ui';
 import {isAudioOnly} from '~/lib/is-audio-container';
 import type {RouteAction} from '~/seo';
 import {BackButton} from './BackButton';
@@ -27,10 +27,10 @@ export const FileAvailable: React.FC<{
 
 	const videoThumbnailRef = useRef<VideoThumbnailRef>(null);
 
-	const [enableRotateOrMirrow, setEnableRotateOrMirror] =
-		useState<RotateOrMirrorOrCropState>(() =>
-			defaultRotateOrMirorState(routeAction),
-		);
+	const [enableRotateOrMirrow, setEnableRotateOrMirror] = useState<RotateOrMirrorOrCropState>(() =>
+		defaultRotateOrMirorState(routeAction),
+	);
+	const [enableCrop, setEnableCrop] = useState(() => defaultCropEnabledState(routeAction));
 	const [enableTrim, setEnableTrim] = useState(
 		() =>
 			routeAction.type === 'generic-trim' || routeAction.type === 'trim-format',
@@ -81,7 +81,7 @@ export const FileAvailable: React.FC<{
 							src={src}
 							isAudio={isAudio}
 							waveform={waveform}
-							crop={enableRotateOrMirrow === 'crop'}
+							crop={enableCrop}
 							trim={enableTrim}
 							trimInFrame={trimInFrame}
 							trimOutFrame={trimOutFrame}
@@ -132,7 +132,7 @@ export const FileAvailable: React.FC<{
 										data-hidden={probeDetails}
 									>
 										<ConvertUI
-											crop={enableRotateOrMirrow === 'crop'}
+											crop={enableCrop}
 											inputContainer={probeResult.container}
 											currentVideoCodec={probeResult.videoCodec ?? null}
 											tracks={probeResult.tracks}
@@ -159,6 +159,7 @@ export const FileAvailable: React.FC<{
 											name={probeResult.name}
 											input={probeResult.input}
 											cropRect={cropOperation}
+											setEnableCrop={setEnableCrop}
 										/>
 									</div>
 								) : null}

--- a/packages/convert/app/lib/default-ui.ts
+++ b/packages/convert/app/lib/default-ui.ts
@@ -74,6 +74,18 @@ export const defaultRotateOrMirorState = (
 	);
 };
 
+export const defaultCropEnabledState = (action: RouteAction) => {
+	if (action.type === 'generic-crop') {
+		return true;
+	}
+
+	if (action.type === 'crop-format') {
+		return true;
+	}
+
+	return false;
+};
+
 export const isConvertEnabledByDefault = (action: RouteAction) => {
 	if (action.type === 'convert') {
 		return true;

--- a/packages/convert/test/default-ui.test.ts
+++ b/packages/convert/test/default-ui.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'bun:test';
 import {HLS, MP4, QTFF, WEBM} from 'mediabunny';
 import {
+	defaultCropEnabledState,
 	isConvertEnabledByDefault,
 	isVideoOnlySection,
 } from '../app/lib/default-ui';
@@ -88,4 +89,12 @@ test('uses conversion defaults on conversion pages', () => {
 			action: {type: 'generic-convert'},
 		}),
 	).toBe('mp4');
+});
+
+test('enables crop independently from mirror defaults', () => {
+	expect(defaultCropEnabledState({type: 'generic-crop'})).toBe(true);
+	expect(defaultCropEnabledState({type: 'crop-format', format: 'mp4'})).toBe(
+		true,
+	);
+	expect(defaultCropEnabledState({type: 'generic-mirror'})).toBe(false);
 });

--- a/packages/core/src/warn-about-non-seekable-media.ts
+++ b/packages/core/src/warn-about-non-seekable-media.ts
@@ -29,7 +29,7 @@ export const warnAboutNonSeekableMedia = (
 			`The media ${ref.src} cannot be seeked. This could be one of few reasons:`,
 			'1) The media resource was replaced while the video is playing but it was not loaded yet.',
 			'2) The media does not support seeking.',
-			'3) The media was loaded with security headers prventing it from being included.',
+			'3) The media was loaded with security headers preventing it from being included.',
 			'Please see https://remotion.dev/docs/non-seekable-media for assistance.',
 		].join('\n');
 

--- a/packages/docs/docs/cloudrun/cli/sites/rm.mdx
+++ b/packages/docs/docs/cloudrun/cli/sites/rm.mdx
@@ -17,7 +17,7 @@ npx remotion cloudrun sites rm central-site
 npx remotion cloudrun sites rm central-site another-site # multiple at once
 ```
 
-Removes a site (or multiple) from Cloud Storage by it's ID.
+Removes a site (or multiple) from Cloud Storage by its ID.
 
 <details>
   <summary>Example output</summary>

--- a/packages/docs/docs/contributing/docs.mdx
+++ b/packages/docs/docs/contributing/docs.mdx
@@ -16,7 +16,7 @@ At the bottom of each page, the `Improve this page` button is the easiest way to
 
 ## Submitting a new page
 
-<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according the instructions here</a>. <br />
+<Step>1</Step> Set up the Remotion repository <a href="/docs/contributing">according to the instructions here</a>. <br />
 <Step>2</Step> Create a new <code>.mdx</code> document in the <code>packages/docs/docs</code> folder. <br />
 <Step>3</Step> Add the document to <code>packages/docs/sidebars.ts</code>.<br />
 <Step>4</Step> Write what you have to say!

--- a/packages/lambda/src/shared/get-s3-operations.ts
+++ b/packages/lambda/src/shared/get-s3-operations.ts
@@ -30,6 +30,9 @@ export const getS3DiffOperations = async ({
 	const normalizedDir = Object.fromEntries(
 		Object.entries(dir).map(([key, value]) => [normalizeKey(key), value]),
 	);
+	const originalDir = Object.fromEntries(
+		Object.keys(dir).map((key) => [normalizeKey(key), key]),
+	);
 
 	const filesOnS3ButNotLocal: _Object[] = [];
 	for (const fileOnS3 of objects) {
@@ -54,7 +57,7 @@ export const getS3DiffOperations = async ({
 		}
 
 		if (!found) {
-			localFilesNotOnS3.push(normalizedLocalKey);
+			localFilesNotOnS3.push(originalDir[normalizedLocalKey]);
 		}
 	}
 
@@ -64,7 +67,7 @@ export const getS3DiffOperations = async ({
 		for (const o of objects) {
 			const key = normalizeKey(o.Key?.substring(prefix.length + 1) as string);
 			if (key === normalizedLocalKey && o.ETag === (await normalizedDir[d]())) {
-				existing.push(normalizedLocalKey);
+				existing.push(originalDir[normalizedLocalKey]);
 				break;
 			}
 		}

--- a/packages/lambda/src/shared/get-s3-operations.ts
+++ b/packages/lambda/src/shared/get-s3-operations.ts
@@ -2,6 +2,8 @@ import type {_Object} from '@aws-sdk/client-s3';
 import type {AwsProvider} from '@remotion/lambda-client';
 import type {FullClientSpecifics} from '@remotion/serverless';
 
+const normalizeKey = (key: string) => key.split('\\').join('/');
+
 export const getS3DiffOperations = async ({
 	objects,
 	bundle,
@@ -25,37 +27,44 @@ export const getS3DiffOperations = async ({
 			onProgress(totalBytes);
 		},
 	});
+	const normalizedDir = Object.fromEntries(
+		Object.entries(dir).map(([key, value]) => [normalizeKey(key), value]),
+	);
 
 	const filesOnS3ButNotLocal: _Object[] = [];
 	for (const fileOnS3 of objects) {
-		const key = fileOnS3.Key?.substring(prefix.length + 1) as string;
-		if (!dir[key]) {
+		const key = normalizeKey(
+			fileOnS3.Key?.substring(prefix.length + 1) as string,
+		);
+		if (!normalizedDir[key]) {
 			filesOnS3ButNotLocal.push(fileOnS3);
 		}
 	}
 
 	const localFilesNotOnS3: string[] = [];
-	for (const d of Object.keys(dir)) {
+	for (const d of Object.keys(normalizedDir)) {
+		const normalizedLocalKey = normalizeKey(d);
 		let found: _Object | undefined;
 		for (const o of objects) {
-			const key = o.Key?.substring(prefix.length + 1) as string;
-			if (key === d && o.ETag === (await dir[d]())) {
+			const key = normalizeKey(o.Key?.substring(prefix.length + 1) as string);
+			if (key === normalizedLocalKey && o.ETag === (await normalizedDir[d]())) {
 				found = o;
 				break;
 			}
 		}
 
 		if (!found) {
-			localFilesNotOnS3.push(d);
+			localFilesNotOnS3.push(normalizedLocalKey);
 		}
 	}
 
 	const existing: string[] = [];
-	for (const d of Object.keys(dir)) {
+	for (const d of Object.keys(normalizedDir)) {
+		const normalizedLocalKey = normalizeKey(d);
 		for (const o of objects) {
-			const key = o.Key?.substring(prefix.length + 1) as string;
-			if (key === d && o.ETag === (await dir[d]())) {
-				existing.push(d);
+			const key = normalizeKey(o.Key?.substring(prefix.length + 1) as string);
+			if (key === normalizedLocalKey && o.ETag === (await normalizedDir[d]())) {
+				existing.push(normalizedLocalKey);
 				break;
 			}
 		}

--- a/packages/lambda/src/test/unit/get-etag.test.ts
+++ b/packages/lambda/src/test/unit/get-etag.test.ts
@@ -53,3 +53,25 @@ test('recognizes an unchanged file above the multipart part-size boundary', asyn
 		existingCount: 1,
 	});
 });
+
+test('normalizes windows-style bundle-relative keys before diffing against s3 keys', async () => {
+	const bundle = await mkdtemp(path.join(tmpdir(), 'remotion-s3-diff-'));
+	const objects: _Object[] = [{Key: 'sites/test/assets/chunk.js', ETag: 'etag'}];
+	const operations = await getS3DiffOperations({
+		objects,
+		bundle,
+		prefix: 'sites/test',
+		onProgress: () => undefined,
+		fullClientSpecifics: {
+			readDirectory: () => ({
+				'assets\\chunk.js': () => Promise.resolve('etag'),
+			}),
+		} as FullClientSpecifics<AwsProvider>,
+	});
+
+	expect(operations).toEqual({
+		toDelete: [],
+		toUpload: [],
+		existingCount: 1,
+	});
+});

--- a/packages/lambda/src/test/unit/get-etag.test.ts
+++ b/packages/lambda/src/test/unit/get-etag.test.ts
@@ -44,7 +44,9 @@ test('recognizes an unchanged file above the multipart part-size boundary', asyn
 		bundle: temporaryDirectory as string,
 		prefix: 'sites/test',
 		onProgress: () => undefined,
-		fullClientSpecifics: {readDirectory} as FullClientSpecifics<AwsProvider>,
+		fullClientSpecifics: {
+			readDirectory,
+		} as unknown as FullClientSpecifics<AwsProvider>,
 	});
 
 	expect(operations).toEqual({
@@ -56,7 +58,9 @@ test('recognizes an unchanged file above the multipart part-size boundary', asyn
 
 test('normalizes windows-style bundle-relative keys before diffing against s3 keys', async () => {
 	const bundle = await mkdtemp(path.join(tmpdir(), 'remotion-s3-diff-'));
-	const objects: _Object[] = [{Key: 'sites/test/assets/chunk.js', ETag: 'etag'}];
+	const objects: _Object[] = [
+		{Key: 'sites/test/assets/chunk.js', ETag: 'etag'},
+	];
 	const operations = await getS3DiffOperations({
 		objects,
 		bundle,
@@ -66,7 +70,7 @@ test('normalizes windows-style bundle-relative keys before diffing against s3 ke
 			readDirectory: () => ({
 				'assets\\chunk.js': () => Promise.resolve('etag'),
 			}),
-		} as FullClientSpecifics<AwsProvider>,
+		} as unknown as FullClientSpecifics<AwsProvider>,
 	});
 
 	expect(operations).toEqual({
@@ -87,7 +91,7 @@ test('preserves platform-native bundle-relative keys for upload decisions', asyn
 			readDirectory: () => ({
 				'assets\\chunk.js': () => Promise.resolve('etag'),
 			}),
-		} as FullClientSpecifics<AwsProvider>,
+		} as unknown as FullClientSpecifics<AwsProvider>,
 	});
 
 	expect(operations).toEqual({

--- a/packages/lambda/src/test/unit/get-etag.test.ts
+++ b/packages/lambda/src/test/unit/get-etag.test.ts
@@ -75,3 +75,24 @@ test('normalizes windows-style bundle-relative keys before diffing against s3 ke
 		existingCount: 1,
 	});
 });
+
+test('preserves platform-native bundle-relative keys for upload decisions', async () => {
+	const bundle = await mkdtemp(path.join(tmpdir(), 'remotion-s3-diff-upload-'));
+	const operations = await getS3DiffOperations({
+		objects: [],
+		bundle,
+		prefix: 'sites/test',
+		onProgress: () => undefined,
+		fullClientSpecifics: {
+			readDirectory: () => ({
+				'assets\\chunk.js': () => Promise.resolve('etag'),
+			}),
+		} as FullClientSpecifics<AwsProvider>,
+	});
+
+	expect(operations).toEqual({
+		toDelete: [],
+		toUpload: ['assets\\chunk.js'],
+		existingCount: 0,
+	});
+});

--- a/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
@@ -17,9 +17,12 @@ export const MakeVideosInteractively: React.FC<{
 			<br /> interactively
 		</>
 	),
-	description = 'Edit and animate using drag and drop and save back to code.',
+	description = 'Edit and animate using drag and drop, reusable Elements, and save back to code.',
 	showLinks = true,
-	links = [{label: 'Remotion Studio', href: '/docs/studio'}],
+	links = [
+		{label: 'Remotion Studio', href: '/docs/studio'},
+		{label: 'Remotion Elements', href: '/elements'},
+	],
 	showVideo = true,
 	videoSrc = '/img/editing-vp9-chrome.webm',
 	fallbackVideoSrc = '/img/editing-safari.mp4',

--- a/packages/studio/src/components/FilePreview.tsx
+++ b/packages/studio/src/components/FilePreview.tsx
@@ -1,5 +1,6 @@
 import {formatBytes} from '@remotion/studio-shared';
 import React from 'react';
+import {Internals} from 'remotion';
 import {WHITE} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import type {AssetFileType} from '../helpers/get-preview-file-type';
@@ -38,7 +39,50 @@ export const FilePreview: React.FC<{
 	}
 
 	if (fileType === 'video') {
-		return <video src={src} controls />;
+		return (
+			<Internals.VideoForPreview
+				{...({
+					src,
+					className: undefined,
+					style: {
+						width: '100%',
+						height: '100%',
+						objectFit: 'contain',
+					},
+					volume: 1,
+					playbackRate: 1,
+					muted: true,
+					loop: false,
+					trimBefore: undefined,
+					trimAfter: undefined,
+					logLevel: 'warn',
+					delayRenderRetries: undefined,
+					delayRenderTimeoutInMilliseconds: undefined,
+					loopVolumeCurveBehavior: 'repeat',
+					audioStreamIndex: 0,
+					disallowFallbackToOffthreadVideo: false,
+					fallbackOffthreadVideoProps: {},
+					toneFrequency: 1000,
+					debugOverlay: false,
+					headless: false,
+					onError: undefined,
+					credentials: undefined,
+					requestInit: undefined,
+					objectFit: 'contain',
+					_experimentalInitiallyDrawCachedFrame: false,
+					effects: [],
+					controls: undefined,
+					onVideoFrame: null,
+					showInTimeline: false,
+					onlyWarnForMediaSeekingError: true,
+					onDuration: () => undefined,
+					pauseWhenBuffering: false,
+					_remotionInternalNativeLoopPassed: false,
+					_remotionInternalStack: null,
+					crossOrigin: undefined,
+				} as any)}
+			/>
+		);
 	}
 
 	if (fileType === 'image') {

--- a/packages/studio/src/components/FilePreview.tsx
+++ b/packages/studio/src/components/FilePreview.tsx
@@ -39,50 +39,7 @@ export const FilePreview: React.FC<{
 	}
 
 	if (fileType === 'video') {
-		return (
-			<Internals.VideoForPreview
-				{...({
-					src,
-					className: undefined,
-					style: {
-						width: '100%',
-						height: '100%',
-						objectFit: 'contain',
-					},
-					volume: 1,
-					playbackRate: 1,
-					muted: true,
-					loop: false,
-					trimBefore: undefined,
-					trimAfter: undefined,
-					logLevel: 'warn',
-					delayRenderRetries: undefined,
-					delayRenderTimeoutInMilliseconds: undefined,
-					loopVolumeCurveBehavior: 'repeat',
-					audioStreamIndex: 0,
-					disallowFallbackToOffthreadVideo: false,
-					fallbackOffthreadVideoProps: {},
-					toneFrequency: 1000,
-					debugOverlay: false,
-					headless: false,
-					onError: undefined,
-					credentials: undefined,
-					requestInit: undefined,
-					objectFit: 'contain',
-					_experimentalInitiallyDrawCachedFrame: false,
-					effects: [],
-					controls: undefined,
-					onVideoFrame: null,
-					showInTimeline: false,
-					onlyWarnForMediaSeekingError: true,
-					onDuration: () => undefined,
-					pauseWhenBuffering: false,
-					_remotionInternalNativeLoopPassed: false,
-					_remotionInternalStack: null,
-					crossOrigin: undefined,
-				} as any)}
-			/>
-		);
+		return <video src={src} controls />;
 	}
 
 	if (fileType === 'image') {


### PR DESCRIPTION
## Problem
The homepage did not surface Remotion Elements as a discoverable entry point, so visitors had no direct path from the interactive section to the new Elements library.

Closes #9775.

## Fix
- Added a concise Elements mention to the interactive homepage card.
- Linked the new item directly to `/elements` alongside the existing Studio link.

## Linked issue
Closes #9775

## Test plan
- `/home/ubuntu/.bun/bin/bun run lint` in `packages/promo-pages` → passed

## AI disclosure
No special disclosure required by this repo.