### PR TITLE
`@remotion/studio`: Fix keyframe clipping at timeline zoom

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -15,6 +15,7 @@ import {
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 const rowClipper: React.CSSProperties = {
+	boxSizing: 'border-box',
 	marginLeft: -TIMELINE_PADDING,
 	marginRight: -TIMELINE_PADDING,
 	overflow: 'hidden',
@@ -47,7 +48,7 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 	return (
 		<>
 			{showSeparator ? <div style={rowSeparator} /> : null}
-			<div style={{...rowClipper, height}}>
+			<div style={{...rowClipper, height, width: timelineWidth ?? undefined}}>
 				<div style={{...row, height}}>
 					{rowHighlightBackground && timelineWidth !== null ? (
 						<div


### PR DESCRIPTION
## Summary

- size expanded keyframe rows to the zoom-aware timeline width
- keep timeline padding inside the clipping boundary with border-box sizing
- preserve clipping for keyframes outside the composition while keeping zoomed keyframes scrollable

## Verification

- `bun run build`
- `bun run stylecheck`
- manually verified clipping and horizontal scrolling at 2x timeline zoom

Closes #10053
