### PR TITLE
`@remotion/studio`: Improve narrow viewport sidebars

### DIFF
--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -24,7 +24,6 @@ import {copyText} from '../helpers/copy-text';
 import type {AssetFolder, AssetStructure} from '../helpers/create-folder-tree';
 import {getFileManagerName} from '../helpers/get-file-manager-name';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
-import {useMobileLayout} from '../helpers/mobile-layout';
 import {
 	markAssetSidebarScrollFromRowClick,
 	maybeScrollAssetSidebarRowIntoView,
@@ -38,7 +37,6 @@ import {getCachedMediaMetadata} from '../helpers/use-media-metadata';
 import {ClipboardIcon} from '../icons/clipboard';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {ModalsContext} from '../state/modals';
-import {SidebarContext} from '../state/sidebar';
 import {AssetFileIcon} from './AssetFileIcon';
 import {useConfirmationDialog} from './ConfirmationDialog';
 import {ContextMenu} from './ContextMenu';
@@ -412,10 +410,8 @@ const AssetSelectorItem: React.FC<{
 	const fileManagerName = getFileManagerName(
 		window.remotion_fileSystemPlatform,
 	);
-	const isMobileLayout = useMobileLayout();
 	const [hovered, setHovered] = useState(false);
 	const [isDragging, setIsDragging] = useState(false);
-	const {setSidebarCollapsedState} = useContext(SidebarContext);
 	const {setSelectedModal} = useContext(ModalsContext);
 	const confirm = useConfirmationDialog();
 	const connectionStatus = useContext(StudioServerConnectionCtx)
@@ -463,15 +459,7 @@ const AssetSelectorItem: React.FC<{
 		markAssetSidebarScrollFromRowClick(relativePath);
 		setCanvasContent({type: 'asset', asset: relativePath});
 		pushUrl(`/assets/${relativePath}`);
-		if (isMobileLayout) {
-			setSidebarCollapsedState({left: 'collapsed', right: 'collapsed'});
-		}
-	}, [
-		isMobileLayout,
-		relativePath,
-		setCanvasContent,
-		setSidebarCollapsedState,
-	]);
+	}, [relativePath, setCanvasContent]);
 
 	const onDragStart: React.DragEventHandler<HTMLDivElement> = useCallback(
 		(e) => {

--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -66,6 +66,7 @@ export const EditorContent: React.FC<{
 			maxFlexerSize={null}
 			minFlexerSize={null}
 			maxAntiFlexerSize={null}
+			minAntiFlexerSize={null}
 		>
 			<SplitterElement sticky={null} type="flexer">
 				{children}

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -3,12 +3,10 @@ import {useCallback, useContext, useEffect} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {getKeysToExpand} from '../helpers/create-folder-tree';
-import {useMobileLayout} from '../helpers/mobile-layout';
 import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
 import {getRoute, pushUrl} from '../helpers/url-state';
 import {FolderContext} from '../state/folders';
-import {SidebarContext} from '../state/sidebar';
 import {explorerSidebarTabs} from './ExplorerPanelRef';
 import {deriveCanvasContentFromUrl} from './load-canvas-content-from-url';
 import {useSelectAsset} from './use-select-asset';
@@ -18,8 +16,6 @@ export const useSelectComposition = () => {
 	const {setCompositionFoldersExpanded} = useContext(FolderContext);
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
 	const setFrame = Internals.useTimelineSetFrame();
-	const isMobileLayout = useMobileLayout();
-	const {setSidebarCollapsedState} = useContext(SidebarContext);
 
 	return useCallback(
 		(
@@ -57,18 +53,9 @@ export const useSelectComposition = () => {
 
 					return newState;
 				});
-				if (isMobileLayout) {
-					setSidebarCollapsedState({left: 'collapsed', right: 'collapsed'});
-				}
 			}
 		},
-		[
-			isMobileLayout,
-			setCanvasContent,
-			setCompositionFoldersExpanded,
-			setFrame,
-			setSidebarCollapsedState,
-		],
+		[setCanvasContent, setCompositionFoldersExpanded, setFrame],
 	);
 };
 

--- a/packages/studio/src/components/MobilePanel.tsx
+++ b/packages/studio/src/components/MobilePanel.tsx
@@ -22,25 +22,20 @@ const panel: React.CSSProperties = {
 	boxShadow: SHADOW_BLACK,
 };
 
-const sidebarWidth = {
-	left: 'min(210px, calc(100% - 50px))',
-	right: 'min(245px, calc(100% - 50px))',
-} satisfies Record<'left' | 'right', React.CSSProperties['width']>;
+const sidebarWidth = 'min(290px, calc(100% - 50px))';
 
 export default function MobilePanel({
 	children,
 	onClose,
-	side,
 }: {
 	children: React.ReactNode;
 	onClose: () => void;
-	side: 'left' | 'right';
 }) {
 	const {currentZIndex} = useZIndex();
 	const onOutsideClick = React.useCallback(
 		(target: Node) => {
 			const element = target instanceof Element ? target : null;
-			const toggleSelector = `[data-sidebar-toggle="${side}"]`;
+			const toggleSelector = '[data-sidebar-toggle="left"]';
 			if (
 				element?.closest(toggleSelector) ||
 				element?.closest('button')?.querySelector(toggleSelector)
@@ -50,7 +45,7 @@ export default function MobilePanel({
 
 			onClose();
 		},
-		[onClose, side],
+		[onClose],
 	);
 
 	return ReactDOM.createPortal(
@@ -59,9 +54,8 @@ export default function MobilePanel({
 				<div
 					style={{
 						...panel,
-						width: sidebarWidth[side],
-						left: side === 'left' ? 0 : undefined,
-						right: side === 'right' ? 0 : undefined,
+						width: sidebarWidth,
+						left: 0,
 					}}
 				>
 					{children}

--- a/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
@@ -1,13 +1,11 @@
 import type {RenderJob} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo} from 'react';
 import {CURRENT_COLOR} from '../../helpers/colors';
-import {useMobileLayout} from '../../helpers/mobile-layout';
 import {
 	makeClientRetryPayload,
 	makeRetryPayload,
 } from '../../helpers/retry-payload';
 import {ModalsContext} from '../../state/modals';
-import {SidebarContext} from '../../state/sidebar';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import type {
@@ -21,8 +19,6 @@ export const RenderQueueRepeatItem: React.FC<{
 	readonly job: AnyRenderJob;
 }> = ({job}) => {
 	const {setSelectedModal} = useContext(ModalsContext);
-	const isMobileLayout = useMobileLayout();
-	const {setSidebarCollapsedState} = useContext(SidebarContext);
 
 	const isClientJob = isClientRenderJob(job);
 
@@ -39,18 +35,8 @@ export const RenderQueueRepeatItem: React.FC<{
 				const retryPayload = makeRetryPayload(job as RenderJob);
 				setSelectedModal(retryPayload);
 			}
-
-			if (isMobileLayout) {
-				setSidebarCollapsedState({left: 'collapsed', right: 'collapsed'});
-			}
 		},
-		[
-			isMobileLayout,
-			job,
-			isClientJob,
-			setSelectedModal,
-			setSidebarCollapsedState,
-		],
+		[job, isClientJob, setSelectedModal],
 	);
 
 	const icon: React.CSSProperties = useMemo(() => {

--- a/packages/studio/src/components/SidebarRenderButton.tsx
+++ b/packages/studio/src/components/SidebarRenderButton.tsx
@@ -11,10 +11,8 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {useMobileLayout} from '../helpers/mobile-layout';
 import {ThinRenderIcon} from '../icons/render';
 import {ModalsContext} from '../state/modals';
-import {SidebarContext} from '../state/sidebar';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 
@@ -23,8 +21,6 @@ export const SidebarRenderButton: React.FC<{
 	readonly visible: boolean;
 }> = ({composition, visible}) => {
 	const {setSelectedModal} = useContext(ModalsContext);
-	const {setSidebarCollapsedState} = useContext(SidebarContext);
-	const isMobileLayout = useMobileLayout();
 
 	const iconStyle: SVGProps<SVGSVGElement> = useMemo(() => {
 		return {
@@ -102,19 +98,8 @@ export const SidebarRenderButton: React.FC<{
 				initialDarkMode: defaults.darkMode,
 				readOnlyStudio: false,
 			});
-
-			if (isMobileLayout) {
-				setSidebarCollapsedState({left: 'collapsed', right: 'collapsed'});
-			}
 		},
-		[
-			composition.defaultProps,
-			composition.id,
-			isMobileLayout,
-			props,
-			setSelectedModal,
-			setSidebarCollapsedState,
-		],
+		[composition.defaultProps, composition.id, props, setSelectedModal],
 	);
 
 	const renderAction: RenderInlineAction = useCallback(

--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -31,6 +31,7 @@ export const SplitterContainer: React.FC<{
 	readonly maxFlexerSize: number | null;
 	readonly minFlexerSize: number | null;
 	readonly maxAntiFlexerSize: number | null;
+	readonly minAntiFlexerSize: number | null;
 	readonly id: string;
 	readonly defaultFlex: number;
 	readonly children: React.ReactNode;
@@ -43,6 +44,7 @@ export const SplitterContainer: React.FC<{
 	maxFlexerSize,
 	minFlexerSize,
 	maxAntiFlexerSize,
+	minAntiFlexerSize,
 	id,
 }) => {
 	const [initialTimelineFlex, persistFlex] = useTimelineFlex(id);
@@ -66,6 +68,7 @@ export const SplitterContainer: React.FC<{
 		maxAntiFlexerSize,
 		maxFlex,
 		maxFlexerSize,
+		minAntiFlexerSize,
 		minFlex,
 		minFlexerSize,
 	});
@@ -83,6 +86,7 @@ export const SplitterContainer: React.FC<{
 			maxFlexerSize,
 			minFlexerSize,
 			maxAntiFlexerSize,
+			minAntiFlexerSize,
 			defaultFlex,
 			persistFlex,
 		};
@@ -94,6 +98,7 @@ export const SplitterContainer: React.FC<{
 		maxFlexerSize,
 		minFlexerSize,
 		maxAntiFlexerSize,
+		minAntiFlexerSize,
 		minFlex,
 		orientation,
 		persistFlex,

--- a/packages/studio/src/components/Splitter/SplitterContext.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContext.tsx
@@ -14,6 +14,7 @@ export type TSplitterContext = {
 	maxFlexerSize: number | null;
 	minFlexerSize: number | null;
 	maxAntiFlexerSize: number | null;
+	minAntiFlexerSize: number | null;
 	defaultFlex: number;
 	id: string;
 	persistFlex: (value: number) => void;
@@ -31,6 +32,7 @@ type SplitterFlexBounds = Pick<
 	| 'maxAntiFlexerSize'
 	| 'maxFlex'
 	| 'maxFlexerSize'
+	| 'minAntiFlexerSize'
 	| 'minFlex'
 	| 'minFlexerSize'
 > & {
@@ -42,6 +44,7 @@ export const getSplitterFlexBounds = ({
 	maxAntiFlexerSize,
 	maxFlex,
 	maxFlexerSize,
+	minAntiFlexerSize,
 	minFlex,
 	minFlexerSize,
 }: SplitterFlexBounds) => {
@@ -62,6 +65,7 @@ export const getSplitterFlexBounds = ({
 		Math.min(
 			maxFlex,
 			maxFlexerSize === null ? 1 : maxFlexerSize / availableSize,
+			minAntiFlexerSize === null ? 1 : 1 - minAntiFlexerSize / availableSize,
 		),
 	);
 
@@ -87,6 +91,7 @@ export const SplitterContext = React.createContext<TSplitterContext>({
 	maxFlexerSize: null,
 	minFlexerSize: null,
 	maxAntiFlexerSize: null,
+	minAntiFlexerSize: null,
 	defaultFlex: 1,
 	id: '--',
 	persistFlex: () => undefined,

--- a/packages/studio/src/components/Splitter/SplitterElement.tsx
+++ b/packages/studio/src/components/Splitter/SplitterElement.tsx
@@ -11,6 +11,8 @@ export const SplitterElement: React.FC<{
 	const context = useContext(SplitterContext);
 	const maxSize =
 		type === 'flexer' ? context.maxFlexerSize : context.maxAntiFlexerSize;
+	const minSize =
+		type === 'flexer' ? context.minFlexerSize : context.minAntiFlexerSize;
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -27,8 +29,14 @@ export const SplitterElement: React.FC<{
 				context.orientation === 'horizontal'
 					? (maxSize ?? undefined)
 					: undefined,
+			minWidth:
+				context.orientation === 'vertical' ? (minSize ?? undefined) : undefined,
+			minHeight:
+				context.orientation === 'horizontal'
+					? (minSize ?? undefined)
+					: undefined,
 		};
-	}, [context.flexValue, context.orientation, maxSize, type]);
+	}, [context.flexValue, context.orientation, maxSize, minSize, type]);
 
 	const stickStyle: React.CSSProperties = useMemo(() => {
 		return {

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -67,6 +67,7 @@ export const SplitterHandle: React.FC<{
 				maxAntiFlexerSize: dragContext.maxAntiFlexerSize,
 				maxFlex: dragContext.maxFlex,
 				maxFlexerSize: dragContext.maxFlexerSize,
+				minAntiFlexerSize: dragContext.minAntiFlexerSize,
 				minFlex: dragContext.minFlex,
 				minFlexerSize: dragContext.minFlexerSize,
 			});

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -330,6 +330,7 @@ const TimelineInner: React.FC = () => {
 									maxFlexerSize={null}
 									minFlexerSize={MIN_TIMELINE_LABELS_WIDTH}
 									maxAntiFlexerSize={null}
+									minAntiFlexerSize={null}
 								>
 									<SplitterElement
 										type="flexer"

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -32,6 +32,7 @@ const row: React.CSSProperties = {
 };
 
 const MAX_SIDEBAR_WIDTH = 350;
+const MIN_SIDEBAR_WIDTH = 250;
 
 export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 	const {sidebarCollapsedStateLeft} = useContext(SidebarContext);
@@ -116,12 +117,13 @@ const TopPanelInner: React.FC<{
 						maxFlexerSize={MAX_SIDEBAR_WIDTH}
 						minFlexerSize={null}
 						maxAntiFlexerSize={null}
+						minAntiFlexerSize={null}
 						id="sidebar-to-preview"
 						orientation="vertical"
 					>
 						{actualStateLeft === 'expanded' ? (
 							isMobileLayout ? (
-								<MobilePanel onClose={onCollapseLeft} side="left">
+								<MobilePanel onClose={onCollapseLeft}>
 									<ExplorerPanel readOnlyStudio={readOnlyStudio} />
 								</MobilePanel>
 							) : (
@@ -144,6 +146,7 @@ const TopPanelInner: React.FC<{
 								maxFlexerSize={null}
 								minFlexerSize={null}
 								maxAntiFlexerSize={MAX_SIDEBAR_WIDTH}
+								minAntiFlexerSize={MIN_SIDEBAR_WIDTH}
 								id="canvas-to-right-sidebar"
 								orientation="vertical"
 							>
@@ -152,22 +155,16 @@ const TopPanelInner: React.FC<{
 										<CanvasIfSizeIsAvailable />
 									</div>
 								</SplitterElement>
-								{actualStateRight === 'expanded' && !isMobileLayout ? (
+								{actualStateRight === 'expanded' ? (
 									<SplitterHandle
 										allowToCollapse="right"
 										onCollapse={onCollapseRight}
 									/>
 								) : null}
 								{actualStateRight === 'expanded' ? (
-									isMobileLayout ? (
-										<MobilePanel onClose={onCollapseRight} side="right">
-											<OptionsPanel readOnlyStudio={readOnlyStudio} />
-										</MobilePanel>
-									) : (
-										<SplitterElement sticky={null} type="anti-flexer">
-											<OptionsPanel readOnlyStudio={readOnlyStudio} />
-										</SplitterElement>
-									)
+									<SplitterElement sticky={null} type="anti-flexer">
+										<OptionsPanel readOnlyStudio={readOnlyStudio} />
+									</SplitterElement>
 								) : null}
 							</SplitterContainer>
 						</SplitterElement>

--- a/packages/studio/src/test/splitter-flex-bounds.test.ts
+++ b/packages/studio/src/test/splitter-flex-bounds.test.ts
@@ -9,6 +9,7 @@ const getTimelineLabelsWidth = (availableSize: number, flexValue: number) => {
 			maxAntiFlexerSize: null,
 			maxFlex: 0.5,
 			maxFlexerSize: null,
+			minAntiFlexerSize: null,
 			minFlex: 0.15,
 			minFlexerSize: 240,
 		}) * availableSize
@@ -21,4 +22,27 @@ test('keeps the timeline labels pane at least 240px wide while resizing', () => 
 	expect(getTimelineLabelsWidth(800, 0.2)).toBe(240);
 	expect(getTimelineLabelsWidth(400, 0.2)).toBe(240);
 	expect(getTimelineLabelsWidth(1000, 0.8)).toBe(500);
+});
+
+const getRightSidebarWidth = (availableSize: number, flexValue: number) => {
+	return (
+		(1 -
+			getClampedSplitterFlex({
+				availableSize,
+				flexValue,
+				maxAntiFlexerSize: 350,
+				maxFlex: 0.8,
+				maxFlexerSize: null,
+				minAntiFlexerSize: 250,
+				minFlex: 0.5,
+				minFlexerSize: null,
+			})) *
+		availableSize
+	);
+};
+
+test('keeps the right sidebar between 250px and 350px wide', () => {
+	expect(getRightSidebarWidth(1000, 0.9)).toBeCloseTo(250);
+	expect(getRightSidebarWidth(1000, 0.75)).toBeCloseTo(250);
+	expect(getRightSidebarWidth(1000, 0.5)).toBeCloseTo(350);
 });


### PR DESCRIPTION
## Summary

- keep the right sidebar docked in narrow viewports
- add 250px minimum sizing for the right sidebar and widen the floating left sidebar
- preserve sidebar visibility when switching compositions, selecting assets, or opening render flows

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/splitter-flex-bounds.test.ts`
