### PR TITLE
`@remotion/studio`: Open remote asset sources from inspector

### DIFF
--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -424,7 +424,7 @@ export const InspectorSequenceSection: React.FC<{
 						</span>
 					),
 					disabled: false,
-					onClick: null,
+					onClick: () => openTimelineAssetLink(linkInfo, selectAsset),
 					title: linkInfo.href,
 				};
 			}


### PR DESCRIPTION
## Summary

- Make remote asset sources in the sequence inspector clickable
- Open the source URL in a new tab using the existing asset-link behavior

## Testing

- `bun test packages/studio/src/test/timeline-video-info.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9782
