### PR TITLE
`@remotion/studio`: Remove timeline time padding for stills

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -315,9 +315,13 @@ const TimelineInner: React.FC = () => {
 					{isStudioInteractivityEnabled() ? (
 						<TimelineSelectAllKeybindings timeline={shown} />
 					) : null}
-					<TimelineHeightContainer shown={shown} hasBeenCut={hasBeenCut}>
+					<TimelineHeightContainer
+						shown={shown}
+						hasBeenCut={hasBeenCut}
+						isStill={isStill}
+					>
 						{isStill ? (
-							<TimelineList timeline={shown} />
+							<TimelineList timeline={shown} showTimePadding={false} />
 						) : (
 							<TimelineWidthProvider>
 								<TimelinePinchZoom />
@@ -336,7 +340,7 @@ const TimelineInner: React.FC = () => {
 										type="flexer"
 										sticky={<TimelineTimePlaceholders />}
 									>
-										<TimelineList timeline={shown} />
+										<TimelineList timeline={shown} showTimePadding />
 									</SplitterElement>
 									<SplitterHandle onCollapse={noop} allowToCollapse="none" />
 									<SplitterElement type="anti-flexer" sticky={null}>

--- a/packages/studio/src/components/Timeline/TimelineHeightContainer.tsx
+++ b/packages/studio/src/components/Timeline/TimelineHeightContainer.tsx
@@ -14,9 +14,10 @@ const baseStyle: React.CSSProperties = {
 const TimelineHeightContainerInner: React.FC<{
 	readonly shown: TimelineTrackData[];
 	readonly hasBeenCut: boolean;
+	readonly isStill: boolean;
 	readonly children: React.ReactNode;
-}> = ({shown, hasBeenCut, children}) => {
-	const height = useTimelineHeight({shown, hasBeenCut});
+}> = ({shown, hasBeenCut, isStill, children}) => {
+	const height = useTimelineHeight({shown, hasBeenCut, isStill});
 
 	const style = useMemo<React.CSSProperties>(
 		() => ({...baseStyle, height}),

--- a/packages/studio/src/components/Timeline/TimelineList.tsx
+++ b/packages/studio/src/components/Timeline/TimelineList.tsx
@@ -42,7 +42,8 @@ const TimelineListTrack: React.FC<{
 
 export const TimelineList: React.FC<{
 	readonly timeline: TimelineTrackData[];
-}> = ({timeline}) => {
+	readonly showTimePadding: boolean;
+}> = ({timeline, showTimePadding}) => {
 	const nestedTimeline = useMemo(
 		() => nestTimelineTracks(timeline),
 		[timeline],
@@ -50,7 +51,7 @@ export const TimelineList: React.FC<{
 
 	return (
 		<div style={container}>
-			<TimelineTimePadding />
+			{showTimePadding ? <TimelineTimePadding /> : null}
 			{nestedTimeline.map((nestedTrack) => (
 				<TimelineListTrack
 					key={nestedTrack.track.sequence.id}

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -23,9 +23,11 @@ import {TIMELINE_TIME_INDICATOR_HEIGHT} from './TimelineTimeIndicators';
 export const useTimelineHeight = ({
 	shown,
 	hasBeenCut,
+	isStill,
 }: {
 	shown: TimelineTrackData[];
 	hasBeenCut: boolean;
+	isStill: boolean;
 }): number => {
 	const {getIsExpanded} = useContext(ExpandedTracksGetterContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -103,11 +105,12 @@ export const useTimelineHeight = ({
 			tracksHeight +
 			TIMELINE_ITEM_BORDER_BOTTOM +
 			(hasBeenCut ? MAX_TIMELINE_TRACKS_NOTICE_HEIGHT : 0) +
-			TIMELINE_TIME_INDICATOR_HEIGHT
+			(isStill ? 0 : TIMELINE_TIME_INDICATOR_HEIGHT)
 		);
 	}, [
 		shown,
 		hasBeenCut,
+		isStill,
 		previewServerConnected,
 		getIsExpanded,
 		propStatuses,


### PR DESCRIPTION
## Summary

- remove the unused time-header padding above still composition tracks
- exclude the time indicator height from still timeline content sizing
- preserve the existing timeline header spacing for video compositions

## Validation

- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #9896
