### PR TITLE
`@remotion/studio`: Replace narrow sidebar with quick switcher

### DIFF
--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -1,10 +1,16 @@
 import type {SetStateAction} from 'react';
 import React, {useCallback, useContext, useMemo, useState} from 'react';
+import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {useMenuStructure} from '../helpers/use-menu-structure';
+import {SearchIcon} from '../icons/search';
+import {ModalsContext} from '../state/modals';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineAction} from './InlineAction';
 import {Row} from './layout';
 import {MENU_TOOLBAR_HEIGHT} from './menu-toolbar-height';
 import type {MenuId} from './Menu/MenuItem';
@@ -37,6 +43,7 @@ export const MenuToolbar: React.FC<{
 }> = ({readOnlyStudio}) => {
 	const [selected, setSelected] = useState<string | null>(null);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {setSelectedModal} = useContext(ModalsContext);
 	const browserStudioOperations = getBrowserStudioOperations();
 	const canUndoAndRedo =
 		!readOnlyStudio ||
@@ -130,6 +137,24 @@ export const MenuToolbar: React.FC<{
 		e.stopPropagation();
 	}, []);
 
+	const openQuickSwitcher = useCallback(() => {
+		setSelectedModal({
+			type: 'quick-switcher',
+			mode: 'compositions',
+			invocationTimestamp: Date.now(),
+			assetSelection: null,
+			compositionSelection: null,
+		});
+	}, [setSelectedModal]);
+
+	const renderSearchIcon: RenderInlineAction = useCallback((color) => {
+		return <SearchIcon color={color} width={18} height={18} />;
+	}, []);
+
+	const searchTooltip = areKeyboardShortcutsDisabled()
+		? 'Quick Switcher'
+		: `Quick Switcher (${cmdOrCtrlCharacter}+K)`;
+
 	return (
 		<Row
 			align="center"
@@ -138,7 +163,16 @@ export const MenuToolbar: React.FC<{
 			onPointerDown={onPointerDown}
 		>
 			<div style={fixedWidthLeft}>
-				<SidebarCollapserControl side="left" />
+				{mobileLayout ? (
+					<InlineAction
+						variant={null}
+						onClick={openQuickSwitcher}
+						renderAction={renderSearchIcon}
+						title={searchTooltip}
+					/>
+				) : (
+					<SidebarCollapserControl side="left" />
+				)}
 				{structure.map((s) => {
 					return (
 						<MenuItem

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -8,7 +8,6 @@ import {CanvasIfSizeIsAvailable} from './CanvasIfSizeIsAvailable';
 import {TitleUpdater} from './CurrentCompositionSideEffects';
 import {useIsRulerVisible} from './EditorRuler/use-is-ruler-visible';
 import {ExplorerPanel} from './ExplorerPanel';
-import MobilePanel from './MobilePanel';
 import {ObserveDefaultProps} from './ObserveDefaultPropsContext';
 import {OptionsPanel} from './OptionsPanel';
 import {PreviewToolbar} from './PreviewToolbar';
@@ -36,9 +35,14 @@ const MIN_SIDEBAR_WIDTH = 250;
 
 export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 	const {sidebarCollapsedStateLeft} = useContext(SidebarContext);
+	const isMobileLayout = useMobileLayout();
 	const responsiveLeftStatus = useBreakpoint(1200) ? 'collapsed' : 'expanded';
 
 	const actualStateLeft = useMemo((): 'expanded' | 'collapsed' => {
+		if (isMobileLayout) {
+			return 'collapsed';
+		}
+
 		if (sidebarCollapsedStateLeft === 'collapsed') {
 			return 'collapsed';
 		}
@@ -48,7 +52,7 @@ export const useResponsiveSidebarStatus = (): 'collapsed' | 'expanded' => {
 		}
 
 		return responsiveLeftStatus;
-	}, [sidebarCollapsedStateLeft, responsiveLeftStatus]);
+	}, [isMobileLayout, sidebarCollapsedStateLeft, responsiveLeftStatus]);
 
 	return actualStateLeft;
 };
@@ -97,8 +101,6 @@ const TopPanelInner: React.FC<{
 		setSidebarCollapsedState({left: null, right: 'collapsed'});
 	}, [setSidebarCollapsedState]);
 
-	const isMobileLayout = useMobileLayout();
-
 	return (
 		<ObserveDefaultProps
 			compositionId={
@@ -122,17 +124,11 @@ const TopPanelInner: React.FC<{
 						orientation="vertical"
 					>
 						{actualStateLeft === 'expanded' ? (
-							isMobileLayout ? (
-								<MobilePanel onClose={onCollapseLeft}>
-									<ExplorerPanel readOnlyStudio={readOnlyStudio} />
-								</MobilePanel>
-							) : (
-								<SplitterElement sticky={null} type="flexer">
-									<ExplorerPanel readOnlyStudio={readOnlyStudio} />
-								</SplitterElement>
-							)
+							<SplitterElement sticky={null} type="flexer">
+								<ExplorerPanel readOnlyStudio={readOnlyStudio} />
+							</SplitterElement>
 						) : null}
-						{actualStateLeft === 'expanded' && !isMobileLayout ? (
+						{actualStateLeft === 'expanded' ? (
 							<SplitterHandle
 								allowToCollapse="left"
 								onCollapse={onCollapseLeft}

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -57,7 +57,7 @@ const iconContainer: React.CSSProperties = {
 const iconPath: React.CSSProperties = {
 	color: 'inherit',
 };
-const ICON_SIZE = 16;
+const ICON_SIZE = 17;
 
 const getFileMenu = ({
 	readOnlyStudio,

--- a/packages/studio/src/icons/search.tsx
+++ b/packages/studio/src/icons/search.tsx
@@ -1,0 +1,19 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+// Font Awesome Pro v7.3.1, Copyright 2026 Fonticons, Inc.
+// https://fontawesome.com/license (Commercial License)
+export const SearchIcon: React.FC<
+	SVGProps<SVGSVGElement> & {
+		readonly color: string;
+	}
+> = ({color, ...props}) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" {...props}>
+			<path
+				fill={color}
+				d="M432 272C432 183.6 360.4 112 272 112C183.6 112 112 183.6 112 272C112 360.4 183.6 432 272 432C360.4 432 432 360.4 432 272zM401.1 435.1C365.7 463.2 320.8 480 272 480C157.1 480 64 386.9 64 272C64 157.1 157.1 64 272 64C386.9 64 480 157.1 480 272C480 320.8 463.2 365.7 435.1 401.1L569 535C578.4 544.4 578.4 559.6 569 568.9C559.6 578.2 544.4 578.3 535.1 568.9L401.1 435.1z"
+			/>
+		</svg>
+	);
+};


### PR DESCRIPTION
## Summary

- keep the left sidebar hidden in narrow Studio layouts
- replace the narrow-layout sidebar toggle with a quick switcher search button
- add the supplied search icon and refine the compact toolbar icon sizing

## Testing

- `bun run build`
- `bun run stylecheck`
- manually verified the 800px and 1000px responsive states in Remotion Studio
