### PR TITLE
`@remotion/studio`: Allow precise scale input

### DIFF
--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -4,8 +4,14 @@ import {expect, test} from '@playwright/test';
 import {wave} from '@remotion/effects/wave';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {apiCall} from './api-call.mts';
-import {effectKeyframeE2eFile} from './constants.mts';
+import {
+	EXPANDED_SIDEBAR_STATE,
+	STUDIO_URL,
+	effectKeyframeE2eFile,
+} from './constants.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
 
 const getLine = (input: string, search: string) => {
 	const line = input.split('\n').findIndex((l) => l.includes(search));
@@ -90,6 +96,50 @@ test.describe('effect keyframes', () => {
 				{
 					message:
 						'Expected EffectKeyframeE2e.tsx to contain the inserted phase keyframe',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+	});
+
+	test('accepts a scale value that is more precise than its interaction step', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+
+		const scaleRow = page
+			.getByText('Scale', {exact: true})
+			.locator('..')
+			.locator('..');
+		const scaleDragger = scaleRow
+			.locator('button.__remotion_input_dragger')
+			.first();
+		await expect(scaleDragger).toBeVisible({timeout: 15_000});
+		await scaleDragger.click();
+
+		const input = scaleRow.locator('input[type="text"]');
+		await expect(input).toBeVisible();
+		await input.fill('0.525');
+		await input.press('ArrowUp');
+		await expect(input).toHaveValue('0.535');
+		await input.fill('0.525');
+		await input.press('Enter');
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('scale: 0.525');
+				},
+				{
+					message: 'Expected the precise scale value to be written to source',
 					timeout: 10_000,
 				},
 			)

--- a/packages/example/e2e/global-setup.mts
+++ b/packages/example/e2e/global-setup.mts
@@ -1,11 +1,13 @@
 import fs from 'fs';
 import {
 	ORIGINAL_CONTENT_FILE,
+	ORIGINAL_EFFECT_KEYFRAME_E2E_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
 	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	errorOverlayE2eFile,
+	effectKeyframeE2eFile,
 	hookOrderChangeE2eFile,
 	lostNodePathE2eFile,
 	rootFile,
@@ -17,6 +19,10 @@ export default async function globalSetup(): Promise<void> {
 	fs.writeFileSync(
 		ORIGINAL_VISUAL_CONTROLS_FILE,
 		fs.readFileSync(visualControlsFile, 'utf-8'),
+	);
+	fs.writeFileSync(
+		ORIGINAL_EFFECT_KEYFRAME_E2E_FILE,
+		fs.readFileSync(effectKeyframeE2eFile, 'utf-8'),
 	);
 	fs.writeFileSync(
 		ORIGINAL_LOST_NODE_PATH_E2E_FILE,

--- a/packages/example/e2e/global-teardown.mts
+++ b/packages/example/e2e/global-teardown.mts
@@ -1,11 +1,13 @@
 import fs from 'fs';
 import {
 	ORIGINAL_CONTENT_FILE,
+	ORIGINAL_EFFECT_KEYFRAME_E2E_FILE,
 	ORIGINAL_ERROR_OVERLAY_E2E_FILE,
 	ORIGINAL_HOOK_ORDER_CHANGE_E2E_FILE,
 	ORIGINAL_LOST_NODE_PATH_E2E_FILE,
 	ORIGINAL_VISUAL_CONTROLS_FILE,
 	errorOverlayE2eFile,
+	effectKeyframeE2eFile,
 	hookOrderChangeE2eFile,
 	lostNodePathE2eFile,
 	rootFile,
@@ -24,6 +26,14 @@ export default async function globalTeardown(): Promise<void> {
 			fs.readFileSync(ORIGINAL_VISUAL_CONTROLS_FILE, 'utf-8'),
 		);
 		fs.unlinkSync(ORIGINAL_VISUAL_CONTROLS_FILE);
+	}
+
+	if (fs.existsSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE)) {
+		fs.writeFileSync(
+			effectKeyframeE2eFile,
+			fs.readFileSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE, 'utf-8'),
+		);
+		fs.unlinkSync(ORIGINAL_EFFECT_KEYFRAME_E2E_FILE);
 	}
 
 	if (fs.existsSync(ORIGINAL_LOST_NODE_PATH_E2E_FILE)) {

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -5,7 +5,14 @@ import {AbsoluteFill, Solid} from 'remotion';
 export const EffectKeyframeE2e: React.FC = () => {
 	return (
 		<AbsoluteFill>
-			<Solid width={1080} height={1080} color="#1f2429" effects={[wave({})]} />
+			<Solid
+				name="Scale precision"
+				width={1080}
+				height={1080}
+				color="#1f2429"
+				style={{scale: 1}}
+				effects={[wave({})]}
+			/>
 		</AbsoluteFill>
 	);
 };

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -29,6 +29,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 	readonly buttonStyle?: React.CSSProperties;
 	readonly rightAlign: boolean;
 	readonly small?: boolean;
+	readonly allowStepMismatch?: boolean;
 	readonly snapToStep?: boolean;
 	readonly dragDecimalPlaces?: number;
 	readonly dragSensitivity?: number;
@@ -450,6 +451,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		status,
 		rightAlign,
 		small,
+		allowStepMismatch = false,
 		snapToStep = true,
 		dragDecimalPlaces,
 		dragSensitivity = 1,
@@ -469,6 +471,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			step: _step,
 		});
 	}, [_min, _step, snapToStep]);
+	const validationStep = allowStepMismatch ? 'any' : deriveStep;
 
 	const span: React.CSSProperties = useMemo(
 		() => ({
@@ -552,7 +555,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 		const validation = validateInputDraggerValue({
 			max: _max,
 			min: _min,
-			step: deriveStep,
+			step: validationStep,
 			value: newValue,
 		});
 
@@ -565,7 +568,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			fallbackRef.current.setCustomValidity(validation.message);
 			fallbackRef.current.reportValidity();
 		}
-	}, [_max, _min, deriveStep, onEscape, onValueChangeEnd]);
+	}, [_max, _min, onEscape, onValueChangeEnd, validationStep]);
 
 	const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> =
 		useCallback(
@@ -704,7 +707,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 					onChange={onInputChange}
 					min={_min}
 					max={_max}
-					step={deriveStep}
+					step={validationStep}
 					defaultValue={value}
 					status={status}
 					rightAlign={rightAlign}

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -448,6 +448,7 @@ export const TimelineScaleField: React.FC<{
 				step={step}
 				formatter={formatter}
 				rightAlign={false}
+				allowStepMismatch
 			/>
 			<div style={gapStyle} />
 			<InputDragger
@@ -464,6 +465,7 @@ export const TimelineScaleField: React.FC<{
 				step={step}
 				formatter={formatter}
 				rightAlign={false}
+				allowStepMismatch
 			/>
 			<LinkToggle linked={linked} onToggle={onToggleLink} />
 		</span>


### PR DESCRIPTION
## Summary

- allow scale fields to accept typed values that do not align with the interaction step
- keep scale dragging and arrow-key increments at the configured step
- add a Studio browser regression test that persists `scale: 0.525`

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/effect-keyframes.test.mts --project=chromium`

Closes #9765
