### PR TITLE
`@remotion/studio`: Avoid unnecessary timeline renders

### DIFF
--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, expect, test} from 'bun:test';
-import React, {useRef} from 'react';
-import {Html5Audio, Internals} from 'remotion';
+import React, {createRef, useRef} from 'react';
+import {Html5Audio, Internals, useCurrentFrame} from 'remotion';
 import type {PlayerRef} from '../player-methods.js';
 import {Player} from '../Player.js';
 import {usePlayer} from '../use-player.js';
@@ -14,6 +14,36 @@ test('It should throw an error if not being used inside a RemotionRoot', () => {
 	expect(() => {
 		usePlayer();
 	}).toThrow();
+});
+
+test('Seeking to the current frame does not rerender the composition', () => {
+	let compositionRenders = 0;
+	const playerRef = createRef<PlayerRef>();
+	const Composition = () => {
+		compositionRenders++;
+		const frame = useCurrentFrame();
+		return React.createElement('div', null, `Frame ${frame}`);
+	};
+
+	const view = render(
+		React.createElement(Player, {
+			ref: playerRef,
+			component: Composition,
+			durationInFrames: 100,
+			compositionWidth: 1920,
+			compositionHeight: 1080,
+			fps: 30,
+		}),
+	);
+	const rendersAfterMount = compositionRenders;
+	expect(view.getByText('Frame 0')).toBeTruthy();
+
+	act(() => {
+		playerRef.current?.seekTo(0);
+	});
+
+	expect(playerRef.current?.getCurrentFrame()).toBe(0);
+	expect(compositionRenders).toBe(rendersAfterMount);
 });
 
 let createdAudioContexts = 0;

--- a/packages/player/src/use-player.ts
+++ b/packages/player/src/use-player.ts
@@ -68,7 +68,9 @@ export const usePlayer = (): UsePlayerMethods => {
 				: Math.max(0, newFrame);
 
 			if (video?.id) {
-				setTimelinePosition((c) => ({...c, [video.id]: frameToSeekTo}));
+				setTimelinePosition((c) =>
+					c[video.id] === frameToSeekTo ? c : {...c, [video.id]: frameToSeekTo},
+				);
 			}
 
 			frameRef.current = frameToSeekTo;

--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -118,7 +118,7 @@ const drawLoopedWaveform = ({
 	ctx.fillRect(0, 0, w, h);
 };
 
-export const AudioWaveform: React.FC<{
+const AudioWaveformInner: React.FC<{
 	readonly src: string;
 	readonly height: number;
 	readonly visualizationWidth: number;
@@ -407,3 +407,5 @@ export const AudioWaveform: React.FC<{
 		</div>
 	);
 };
+
+export const AudioWaveform = React.memo(AudioWaveformInner);

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -293,6 +293,10 @@ const TimelineDragHandlerInner: React.FC = () => {
 			});
 
 			setFrame((c) => {
+				if (c[videoConfig.id] === frame) {
+					return c;
+				}
+
 				const newObj = {...c, [videoConfig.id]: frame};
 				Internals.persistCurrentFrame(newObj);
 				return newObj;

--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -1,3 +1,4 @@
+import {stringifySequenceSubscriptionKey} from '@remotion/studio-shared';
 import React, {useContext} from 'react';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
@@ -31,13 +32,17 @@ const rowSeparator: React.CSSProperties = {
 	height: TIMELINE_ITEM_BORDER_BOTTOM,
 };
 
-const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
+type TimelineExpandedKeyframeRowProps = {
 	readonly height: number;
 	readonly keyframes: ReturnType<typeof getTimelineKeyframes>;
 	readonly canEditEasing: boolean;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly showSeparator: boolean;
-}> = ({height, keyframes, canEditEasing, nodePathInfo, showSeparator}) => {
+};
+
+const TimelineExpandedKeyframeRowUnmemoized: React.FC<
+	TimelineExpandedKeyframeRowProps
+> = ({height, keyframes, canEditEasing, nodePathInfo, showSeparator}) => {
 	const timelineWidth = useContext(TimelineWidthContext);
 	const rowHighlightBackground =
 		useTimelineRowHighlightBackground(nodePathInfo);
@@ -82,6 +87,59 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<{
 	);
 };
 
+const areTimelineExpandedKeyframeRowPropsEqual = (
+	prevProps: TimelineExpandedKeyframeRowProps,
+	nextProps: TimelineExpandedKeyframeRowProps,
+) => {
+	if (
+		prevProps.height !== nextProps.height ||
+		prevProps.canEditEasing !== nextProps.canEditEasing ||
+		prevProps.showSeparator !== nextProps.showSeparator ||
+		prevProps.keyframes.length !== nextProps.keyframes.length ||
+		prevProps.nodePathInfo.index !== nextProps.nodePathInfo.index ||
+		prevProps.nodePathInfo.numberOfSequencesWithThisNodePath !==
+			nextProps.nodePathInfo.numberOfSequencesWithThisNodePath ||
+		prevProps.nodePathInfo.supportsEffects !==
+			nextProps.nodePathInfo.supportsEffects ||
+		stringifySequenceSubscriptionKey(
+			prevProps.nodePathInfo.sequenceSubscriptionKey,
+		) !==
+			stringifySequenceSubscriptionKey(
+				nextProps.nodePathInfo.sequenceSubscriptionKey,
+			) ||
+		prevProps.nodePathInfo.auxiliaryKeys.length !==
+			nextProps.nodePathInfo.auxiliaryKeys.length
+	) {
+		return false;
+	}
+
+	const prevVideoConfig =
+		prevProps.nodePathInfo.sequenceSubscriptionKey.videoConfigValues;
+	const nextVideoConfig =
+		nextProps.nodePathInfo.sequenceSubscriptionKey.videoConfigValues;
+	if (
+		prevVideoConfig !== nextVideoConfig &&
+		(prevVideoConfig === null ||
+			nextVideoConfig === null ||
+			prevVideoConfig.durationInFrames !== nextVideoConfig.durationInFrames ||
+			prevVideoConfig.fps !== nextVideoConfig.fps ||
+			prevVideoConfig.height !== nextVideoConfig.height ||
+			prevVideoConfig.width !== nextVideoConfig.width)
+	) {
+		return false;
+	}
+
+	return (
+		prevProps.keyframes.every(
+			(keyframe, index) => keyframe.frame === nextProps.keyframes[index].frame,
+		) &&
+		prevProps.nodePathInfo.auxiliaryKeys.every(
+			(key, index) => key === nextProps.nodePathInfo.auxiliaryKeys[index],
+		)
+	);
+};
+
 export const TimelineExpandedKeyframeRow = React.memo(
 	TimelineExpandedKeyframeRowUnmemoized,
+	areTimelineExpandedKeyframeRowPropsEqual,
 );

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -70,16 +70,20 @@ export const TimelineKeyframeEasingLineVisual = React.memo(
 	TimelineKeyframeEasingLineVisualUnmemoized,
 );
 
-const TimelineKeyframeEasingLineUnmemoized: React.FC<{
+type TimelineKeyframeEasingLineProps = {
 	readonly fromFrame: number;
 	readonly toFrame: number;
 	readonly rowHeight: number;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly segmentIndex: number;
-}> = ({fromFrame, toFrame, rowHeight, nodePathInfo, segmentIndex}) => {
+};
+
+const TimelineKeyframeEasingLineInteraction: React.FC<
+	TimelineKeyframeEasingLineProps & {
+		readonly style: React.CSSProperties;
+	}
+> = ({fromFrame, toFrame, nodePathInfo, segmentIndex, style}) => {
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const videoConfig = useVideoConfig();
-	const timelineWidth = useContext(TimelineWidthContext);
 	const {selected, onSelect, selectable, selectionItem} =
 		useTimelineEasingSelection({
 			nodePathInfo,
@@ -88,6 +92,13 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 			segmentIndex,
 		});
 	useTimelineMarqueeSelectableItem(selectionItem, buttonRef);
+	const interactiveStyle = useMemo(
+		() => ({
+			...style,
+			pointerEvents: selectable ? ('auto' as const) : ('none' as const),
+		}),
+		[selectable, style],
+	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const sequencesRef = useContext(Internals.SequenceManagerRefContext);
 	const propStatusesRef = useContext(
@@ -180,6 +191,41 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 		[contextMenuValues, onSelect, selectable, selected],
 	);
 
+	const onPointerDown = useTimelineEasingKeyframeDrag({
+		onSelect,
+		selectable,
+		selected,
+		selectionItem,
+	});
+
+	return (
+		<>
+			<button
+				ref={buttonRef}
+				{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
+				type="button"
+				style={interactiveStyle}
+				title={`Easing from frame ${fromFrame} to ${toFrame}`}
+				aria-label={`Select easing from frame ${fromFrame} to ${toFrame}`}
+				onPointerDown={selectable ? onPointerDown : undefined}
+			>
+				<TimelineKeyframeEasingLineVisual selected={selected} />
+			</button>
+			<ContextMenuForTarget
+				triggerRef={buttonRef}
+				values={contextMenuValues}
+				onOpen={onOpenContextMenu}
+			/>
+		</>
+	);
+};
+
+const TimelineKeyframeEasingLineUnmemoized: React.FC<
+	TimelineKeyframeEasingLineProps
+> = ({fromFrame, toFrame, rowHeight, nodePathInfo, segmentIndex}) => {
+	const videoConfig = useVideoConfig();
+	const timelineWidth = useContext(TimelineWidthContext);
+
 	const style = useMemo((): React.CSSProperties | null => {
 		if (timelineWidth === null) {
 			return null;
@@ -206,49 +252,30 @@ const TimelineKeyframeEasingLineUnmemoized: React.FC<{
 		return {
 			...easingLineButton,
 			left,
-			pointerEvents: selectable ? 'auto' : 'none',
 			top: rowHeight / 2,
 			width,
 		};
 	}, [
 		fromFrame,
 		rowHeight,
-		selectable,
 		timelineWidth,
 		toFrame,
 		videoConfig.durationInFrames,
 	]);
-
-	const onPointerDown = useTimelineEasingKeyframeDrag({
-		onSelect,
-		selectable,
-		selected,
-		selectionItem,
-	});
 
 	if (style === null) {
 		return null;
 	}
 
 	return (
-		<>
-			<button
-				ref={buttonRef}
-				{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
-				type="button"
-				style={style}
-				title={`Easing from frame ${fromFrame} to ${toFrame}`}
-				aria-label={`Select easing from frame ${fromFrame} to ${toFrame}`}
-				onPointerDown={selectable ? onPointerDown : undefined}
-			>
-				<TimelineKeyframeEasingLineVisual selected={selected} />
-			</button>
-			<ContextMenuForTarget
-				triggerRef={buttonRef}
-				values={contextMenuValues}
-				onOpen={onOpenContextMenu}
-			/>
-		</>
+		<TimelineKeyframeEasingLineInteraction
+			fromFrame={fromFrame}
+			toFrame={toFrame}
+			rowHeight={rowHeight}
+			nodePathInfo={nodePathInfo}
+			segmentIndex={segmentIndex}
+			style={style}
+		/>
 	);
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -47,6 +47,7 @@ import {
 } from '../ExpandedTracksProvider';
 import {useSelectComposition} from '../InitialCompositionLoader';
 import {Spacing} from '../layout';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {
 	canEditSelectedOutlineCrop,
@@ -56,6 +57,7 @@ import {useSelectAsset} from '../use-select-asset';
 import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {getSequenceContextMenuItems} from './get-sequence-context-menu-items';
+import {getCurrentFrame} from './imperative-state';
 import {saveSequenceProps} from './save-sequence-prop';
 import {getTimelineAssetLinkInfo} from './timeline-asset-link';
 import {
@@ -241,7 +243,54 @@ type SequenceDropTarget =
 			readonly reason: string;
 	  };
 
-export const TimelineSequenceItem: React.FC<{
+const TimelineSequenceItemContextMenu: React.FC<{
+	readonly children: React.ReactNode;
+	readonly contextMenuValues: ComboboxValue[];
+	readonly includeFreezeFrameMenuItem: boolean;
+	readonly onOpen: (() => void) | null;
+	readonly freezeFrameMenuItemProps: Omit<
+		Parameters<typeof useSequenceFreezeFrameMenuItem>[0],
+		'timelinePosition'
+	>;
+}> = ({
+	children,
+	contextMenuValues,
+	freezeFrameMenuItemProps,
+	includeFreezeFrameMenuItem,
+	onOpen,
+}) => {
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
+		...freezeFrameMenuItemProps,
+		timelinePosition,
+	});
+	const values = useMemo(() => {
+		if (!includeFreezeFrameMenuItem || freezeFrameMenuItem === null) {
+			return contextMenuValues;
+		}
+
+		const renameIndex = contextMenuValues.findIndex(
+			(item) => item.id === 'rename-sequence',
+		);
+		if (renameIndex === -1) {
+			return contextMenuValues;
+		}
+
+		return [
+			...contextMenuValues.slice(0, renameIndex + 1),
+			freezeFrameMenuItem,
+			...contextMenuValues.slice(renameIndex + 1),
+		];
+	}, [contextMenuValues, freezeFrameMenuItem, includeFreezeFrameMenuItem]);
+
+	return (
+		<ContextMenu values={values} onOpen={onOpen}>
+			{children}
+		</ContextMenu>
+	);
+};
+
+const TimelineSequenceItemInner: React.FC<{
 	readonly children: React.ReactNode;
 	readonly sequence: TSequence;
 	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
@@ -284,7 +333,6 @@ export const TimelineSequenceItem: React.FC<{
 	const [sequenceDropRejection, setSequenceDropRejection] = useState<
 		string | null
 	>(null);
-	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const {canOpenInEditor, editorInfo, openInEditor, originalLocation} =
 		useOpenSequenceInEditor(sequence);
 	const fileLocation = useMemo(
@@ -789,7 +837,7 @@ export const TimelineSequenceItem: React.FC<{
 					connectedCompositions[0],
 					true,
 					getConnectedCompositionFrame({
-						timelinePosition,
+						timelinePosition: getCurrentFrame(),
 						sequence,
 						sequenceFrameOffset,
 					}),
@@ -806,7 +854,6 @@ export const TimelineSequenceItem: React.FC<{
 			selectComposition,
 			sequence,
 			sequenceFrameOffset,
-			timelinePosition,
 		],
 	);
 	const canHandleSequenceDoubleClick =
@@ -876,19 +923,30 @@ export const TimelineSequenceItem: React.FC<{
 		setIsRenaming(true);
 	}, [canRenameThisSequence]);
 
-	const freezeFrameMenuItem = useSequenceFreezeFrameMenuItem({
-		clientId:
-			previewInteractive && previewServerState.type === 'connected'
-				? previewServerState.clientId
-				: null,
-		nodePath,
-		propStatusesForOverride,
-		sequence,
-		sequenceFrameOffset,
-		setPropStatuses,
-		timelinePosition,
-		validatedSource: validatedLocation?.source ?? null,
-	});
+	const freezeFrameMenuItemProps = useMemo(
+		() => ({
+			clientId:
+				previewInteractive && previewServerState.type === 'connected'
+					? previewServerState.clientId
+					: null,
+			nodePath,
+			propStatusesForOverride,
+			sequence,
+			sequenceFrameOffset,
+			setPropStatuses,
+			validatedSource: validatedLocation?.source ?? null,
+		}),
+		[
+			nodePath,
+			previewInteractive,
+			previewServerState,
+			propStatusesForOverride,
+			sequence,
+			sequenceFrameOffset,
+			setPropStatuses,
+			validatedLocation?.source,
+		],
+	);
 
 	const canAddEffect =
 		nodePathInfo?.supportsEffects === true &&
@@ -1034,7 +1092,6 @@ export const TimelineSequenceItem: React.FC<{
 							subMenu: null,
 							value: 'rename-sequence',
 						},
-						...(freezeFrameMenuItem ? [freezeFrameMenuItem] : []),
 					]
 				: [],
 		});
@@ -1049,7 +1106,6 @@ export const TimelineSequenceItem: React.FC<{
 		duplicateDisabled,
 		editorInfo,
 		fileLocation,
-		freezeFrameMenuItem,
 		nodePathInfo?.supportsEffects,
 		onAddEffect,
 		onCrop,
@@ -1245,12 +1301,14 @@ export const TimelineSequenceItem: React.FC<{
 	return (
 		<>
 			{previewConnected || window.remotion_isReadOnlyStudio ? (
-				<ContextMenu
-					values={contextMenuValues}
+				<TimelineSequenceItemContextMenu
+					contextMenuValues={contextMenuValues}
+					freezeFrameMenuItemProps={freezeFrameMenuItemProps}
+					includeFreezeFrameMenuItem={isStudioInteractivityEnabled()}
 					onOpen={selectable ? onSelect : null}
 				>
 					{draggableTrackRow}
-				</ContextMenu>
+				</TimelineSequenceItemContextMenu>
 			) : (
 				draggableTrackRow
 			)}
@@ -1277,3 +1335,5 @@ export const TimelineSequenceItem: React.FC<{
 		</>
 	);
 };
+
+export const TimelineSequenceItem = React.memo(TimelineSequenceItemInner);

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -212,14 +212,93 @@ const Value: React.FC<{
 	);
 };
 
-export const TimelineSequenceKeyframedValue: React.FC<{
+type TimelineSequenceKeyframedValueBaseProps = {
 	readonly field: SchemaFieldInfo;
 	readonly fileName: string;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: InteractivitySchema;
 	readonly propStatus: CanUpdateSequencePropStatusKeyframed;
+};
+
+type TimelineSequenceKeyframedValueProps =
+	TimelineSequenceKeyframedValueBaseProps &
+		(
+			| {
+					readonly sourceFrame: number;
+					readonly keyframeDisplayOffset?: never;
+			  }
+			| {
+					readonly sourceFrame?: never;
+					readonly keyframeDisplayOffset: number;
+			  }
+		);
+
+type TimelineSequenceKeyframedValueAtSourceFrameProps = Pick<
+	TimelineSequenceKeyframedValueBaseProps,
+	'field' | 'nodePath' | 'propStatus'
+> & {
 	readonly sourceFrame: number;
-}> = ({field, fileName, nodePath, schema, propStatus, sourceFrame}) => {
+	readonly dragOverrideValue:
+		| ReturnType<typeof Internals.makeKeyframedDragOverride>
+		| undefined;
+	readonly onSave: (value: unknown, frame: number) => Promise<void>;
+	readonly onDragValueChangeAtFrame: (
+		value: unknown,
+		sourceFrame: number,
+	) => void;
+	readonly onDragEnd: () => void;
+};
+
+const TimelineSequenceKeyframedValueAtSourceFrame: React.FC<
+	TimelineSequenceKeyframedValueAtSourceFrameProps
+> = ({
+	field,
+	nodePath,
+	propStatus,
+	sourceFrame,
+	dragOverrideValue,
+	onSave,
+	onDragValueChangeAtFrame,
+	onDragEnd,
+}) => {
+	const onDragValueChange = useCallback<TimelineFieldOnDragValueChange>(
+		(value) => onDragValueChangeAtFrame(value, sourceFrame),
+		[onDragValueChangeAtFrame, sourceFrame],
+	);
+
+	return (
+		<TimelineKeyframedValue
+			field={field}
+			propStatus={propStatus}
+			sourceFrame={sourceFrame}
+			dragOverrideValue={dragOverrideValue}
+			onSave={onSave}
+			onDragValueChange={onDragValueChange}
+			onDragEnd={onDragEnd}
+			scaleLockNodePath={nodePath}
+		/>
+	);
+};
+
+const TimelineSequenceKeyframedValueAtCurrentFrame: React.FC<
+	Omit<TimelineSequenceKeyframedValueAtSourceFrameProps, 'sourceFrame'> & {
+		readonly keyframeDisplayOffset: number;
+	}
+> = ({keyframeDisplayOffset, ...props}) => {
+	const timelinePosition = Internals.Timeline.useTimelinePosition();
+
+	return (
+		<TimelineSequenceKeyframedValueAtSourceFrame
+			{...props}
+			sourceFrame={timelinePosition - keyframeDisplayOffset}
+		/>
+	);
+};
+
+const TimelineSequenceKeyframedValueUnmemoized: React.FC<
+	TimelineSequenceKeyframedValueProps
+> = (props) => {
+	const {field, fileName, nodePath, schema, propStatus} = props;
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
 	);
@@ -256,39 +335,51 @@ export const TimelineSequenceKeyframedValue: React.FC<{
 		[clientId, field.key, fileName, nodePath, schema, setPropStatuses],
 	);
 
-	const onKeyframedDragValueChange =
-		useCallback<TimelineFieldOnDragValueChange>(
-			(value) => {
-				setDragOverrides(
-					nodePath,
-					field.key,
-					Internals.makeKeyframedDragOverride({
-						status: propStatus,
-						frame: sourceFrame,
-						value,
-					}),
-				);
-			},
-			[propStatus, field.key, nodePath, setDragOverrides, sourceFrame],
-		);
+	const onKeyframedDragValueChangeAtFrame = useCallback(
+		(value: unknown, sourceFrame: number) => {
+			setDragOverrides(
+				nodePath,
+				field.key,
+				Internals.makeKeyframedDragOverride({
+					status: propStatus,
+					frame: sourceFrame,
+					value,
+				}),
+			);
+		},
+		[propStatus, field.key, nodePath, setDragOverrides],
+	);
 
 	const onKeyframedDragEnd = useCallback(() => {
 		clearDragOverrides(nodePath);
 	}, [clearDragOverrides, nodePath]);
 
-	return (
-		<TimelineKeyframedValue
-			field={field}
-			propStatus={propStatus}
-			sourceFrame={sourceFrame}
-			dragOverrideValue={dragOverrideValue}
-			onSave={onSaveKeyframed}
-			onDragValueChange={onKeyframedDragValueChange}
-			onDragEnd={onKeyframedDragEnd}
-			scaleLockNodePath={nodePath}
+	const valueProps = {
+		field,
+		nodePath,
+		propStatus,
+		dragOverrideValue,
+		onSave: onSaveKeyframed,
+		onDragValueChangeAtFrame: onKeyframedDragValueChangeAtFrame,
+		onDragEnd: onKeyframedDragEnd,
+	};
+
+	return props.sourceFrame !== undefined ? (
+		<TimelineSequenceKeyframedValueAtSourceFrame
+			{...valueProps}
+			sourceFrame={props.sourceFrame}
+		/>
+	) : (
+		<TimelineSequenceKeyframedValueAtCurrentFrame
+			{...valueProps}
+			keyframeDisplayOffset={props.keyframeDisplayOffset}
 		/>
 	);
 };
+
+export const TimelineSequenceKeyframedValue = React.memo(
+	TimelineSequenceKeyframedValueUnmemoized,
+);
 
 export const TimelineSequencePropItem: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -318,9 +409,6 @@ export const TimelineSequencePropItem: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const selection = useTimelineRowSelection(nodePathInfo);
-	const timelinePosition = Internals.Timeline.useTimelinePosition();
-	const sourceFrame = timelinePosition - keyframeDisplayOffset;
-
 	const propStatusesForOverride = Internals.getPropStatusesCtx(
 		visualModePropStatuses,
 		nodePath,
@@ -477,7 +565,7 @@ export const TimelineSequencePropItem: React.FC<{
 			nodePath={nodePath}
 			schema={schema}
 			propStatus={propStatus}
-			sourceFrame={sourceFrame}
+			keyframeDisplayOffset={keyframeDisplayOffset}
 		/>
 	) : propStatus.status === 'static' ? (
 		<Value

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -946,7 +946,7 @@ const clearFromDragOverrides = ({
 	}
 };
 
-export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
+const TimelineSequenceLeftEdgeDragHandleInner: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
@@ -1217,6 +1217,10 @@ export const TimelineSequenceLeftEdgeDragHandle: React.FC<{
 		/>
 	);
 };
+
+export const TimelineSequenceLeftEdgeDragHandle = React.memo(
+	TimelineSequenceLeftEdgeDragHandleInner,
+);
 
 export const useTimelineSequenceFromDrag = ({
 	nodePathInfo,
@@ -1523,7 +1527,7 @@ export const useTimelineSequenceFromDrag = ({
 	};
 };
 
-export const TimelineSequenceRightEdgeDragHandle: React.FC<{
+const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
@@ -1781,3 +1785,7 @@ export const TimelineSequenceRightEdgeDragHandle: React.FC<{
 		/>
 	);
 };
+
+export const TimelineSequenceRightEdgeDragHandle = React.memo(
+	TimelineSequenceRightEdgeDragHandleInner,
+);

--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -261,11 +261,11 @@ export const TimelineTimeIndicators: React.FC = () => {
 	);
 };
 
-const TimelineTimeIndicatorsInner: React.FC<{
+const TimelineTimeIndicatorsInner = React.memo<{
 	readonly windowWidth: number;
 	readonly fps: number;
 	readonly durationInFrames: number;
-}> = ({windowWidth, durationInFrames, fps}) => {
+}>(({windowWidth, durationInFrames, fps}) => {
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -407,4 +407,4 @@ const TimelineTimeIndicatorsInner: React.FC<{
 			})}
 		</div>
 	);
-};
+});

--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -46,7 +46,7 @@ const filmstripContainerStyle: React.CSSProperties = {
 
 const MAX_FROZEN_FRAME_CACHE_DEVIATION = WEBCODECS_TIMESCALE * 0.05;
 
-export const TimelineVideoInfo: React.FC<{
+const TimelineVideoInfoInner: React.FC<{
 	readonly src: string;
 	readonly visualizationWidth: number;
 	readonly naturalWidth: number;
@@ -483,3 +483,5 @@ export const TimelineVideoInfo: React.FC<{
 		</div>
 	);
 };
+
+export const TimelineVideoInfo = React.memo(TimelineVideoInfoInner);

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -77,7 +77,7 @@ const TimelineZoomSlider: React.FC<{
 	);
 };
 
-export const TimelineZoomControls: React.FC<{
+const TimelineZoomControlsInner: React.FC<{
 	readonly sliderMaxWidth?: number;
 }> = ({sliderMaxWidth}) => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
@@ -147,3 +147,5 @@ export const TimelineZoomControls: React.FC<{
 		</div>
 	);
 };
+
+export const TimelineZoomControls = React.memo(TimelineZoomControlsInner);


### PR DESCRIPTION
## Summary

- memoize `AudioWaveform` so timeline frame updates do not rerender the waveform when its inputs are unchanged
- memoize `TimelineVideoInfo` so frame updates do not rerender the filmstrip and nested waveform when their inputs are unchanged
- memoize the timeline sequence left and right edge drag handles so frame updates do not recreate their interaction state
- memoize `TimelineZoomControls` so unrelated parent updates do not rerender the zoom controls
- preserve timeline frame state identity for same-frame seeks, preventing `TimelineSequenceCurrentFrame` and other frame consumers from rerendering during no-op pointer moves
- keep `TimelineSequenceItem` off the frame update path by reading the frame imperatively for double-clicks and isolating the freeze-frame menu state in a small child boundary
- memoize `TimelineTimeIndicatorsInner` so sequence refreshes do not rebuild unchanged timeline ticks
- compare expanded keyframe row props semantically so recreated keyframe arrays and node paths do not bypass the existing memo boundary
- isolate easing-line interaction contexts from its geometry component so live selection and drag state do not recalculate unchanged line positions
- isolate current-frame interpolation from `TimelineSequenceKeyframedValue` so only the displayed value updates with the playhead

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio'`
- `bun test src/test/index.test.ts` (from `packages/player`)
- `bunx turbo run lint --filter=@remotion/player --filter=@remotion/studio`
- `bunx turbo run make --filter=@remotion/studio`
