### PR TITLE
`@remotion/renderer`: destroy serve-handler read streams on aborted requests (fd leak)

### DIFF
--- a/packages/renderer/src/serve-handler/index.ts
+++ b/packages/renderer/src/serve-handler/index.ts
@@ -279,6 +279,11 @@ export const serveHandler = async (
 		readStream.destroy();
 	});
 
+	if (response.destroyed) {
+		readStream.destroy();
+		return;
+	}
+
 	response.writeHead(response.statusCode || 200, headers);
 	readStream.pipe(response);
 };

--- a/packages/renderer/src/serve-handler/index.ts
+++ b/packages/renderer/src/serve-handler/index.ts
@@ -268,6 +268,17 @@ export const serveHandler = async (
 
 	headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
 
+	const readStream = stream;
+
+	// Chrome's media demuxer aborts Range requests constantly while seeking
+	// <Video>/<Audio>. Without this, an aborted request leaves the piped stream
+	// stranded on backpressure and its file descriptor open for the life of the
+	// render process. 'close' fires on completion as well as abort, and
+	// destroy() on an already-ended stream is a no-op.
+	response.on('close', () => {
+		readStream.destroy();
+	});
+
 	response.writeHead(response.statusCode || 200, headers);
-	stream.pipe(response);
+	readStream.pipe(response);
 };

--- a/packages/renderer/src/test/serve-handler.test.ts
+++ b/packages/renderer/src/test/serve-handler.test.ts
@@ -1,43 +1,32 @@
 import {expect, test} from 'bun:test';
 import {once} from 'node:events';
-import {promises} from 'node:fs';
 import type {IncomingMessage, ServerResponse} from 'node:http';
-import os from 'node:os';
 import path from 'node:path';
 import {PassThrough} from 'node:stream';
 import {serveHandler} from '../serve-handler';
 
 test('does not serve a file after the response has closed', async () => {
-	const temporaryDirectory = await promises.mkdtemp(
-		path.join(os.tmpdir(), 'remotion-serve-handler-'),
+	const response = new PassThrough();
+	response.destroy();
+	await once(response, 'close');
+
+	let headersWritten = false;
+	const serverResponse = Object.assign(response, {
+		statusCode: 200,
+		writeHead: () => {
+			headersWritten = true;
+			return serverResponse;
+		},
+	}) as unknown as ServerResponse;
+
+	await serveHandler(
+		{
+			url: '/test/serve-handler.test.ts',
+			headers: {host: 'localhost'},
+		} as IncomingMessage,
+		serverResponse,
+		{public: path.join(__dirname, '..')},
 	);
-	await promises.writeFile(path.join(temporaryDirectory, 'video.mp4'), 'video');
 
-	try {
-		const response = new PassThrough();
-		response.destroy();
-		await once(response, 'close');
-
-		let headersWritten = false;
-		const serverResponse = Object.assign(response, {
-			statusCode: 200,
-			writeHead: () => {
-				headersWritten = true;
-				return serverResponse;
-			},
-		}) as unknown as ServerResponse;
-
-		await serveHandler(
-			{
-				url: '/video.mp4',
-				headers: {host: 'localhost'},
-			} as IncomingMessage,
-			serverResponse,
-			{public: temporaryDirectory},
-		);
-
-		expect(headersWritten).toBe(false);
-	} finally {
-		await promises.rm(temporaryDirectory, {recursive: true, force: true});
-	}
+	expect(headersWritten).toBe(false);
 });

--- a/packages/renderer/src/test/serve-handler.test.ts
+++ b/packages/renderer/src/test/serve-handler.test.ts
@@ -1,0 +1,43 @@
+import {expect, test} from 'bun:test';
+import {once} from 'node:events';
+import {promises} from 'node:fs';
+import type {IncomingMessage, ServerResponse} from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import {PassThrough} from 'node:stream';
+import {serveHandler} from '../serve-handler';
+
+test('does not serve a file after the response has closed', async () => {
+	const temporaryDirectory = await promises.mkdtemp(
+		path.join(os.tmpdir(), 'remotion-serve-handler-'),
+	);
+	await promises.writeFile(path.join(temporaryDirectory, 'video.mp4'), 'video');
+
+	try {
+		const response = new PassThrough();
+		response.destroy();
+		await once(response, 'close');
+
+		let headersWritten = false;
+		const serverResponse = Object.assign(response, {
+			statusCode: 200,
+			writeHead: () => {
+				headersWritten = true;
+				return serverResponse;
+			},
+		}) as unknown as ServerResponse;
+
+		await serveHandler(
+			{
+				url: '/video.mp4',
+				headers: {host: 'localhost'},
+			} as IncomingMessage,
+			serverResponse,
+			{public: temporaryDirectory},
+		);
+
+		expect(headersWritten).toBe(false);
+	} finally {
+		await promises.rm(temporaryDirectory, {recursive: true, force: true});
+	}
+});


### PR DESCRIPTION
Fixes #10071.

`serveHandler` pipes an `fs.createReadStream` into the response with no close/abort handler. Chrome's media demuxer aborts Range requests constantly while seeking `<Video>`/`<Audio>` (`<OffthreadVideo>` is unaffected), and every aborted request leaves the piped stream stranded on backpressure — never destroyed, its file descriptor held for the life of the render process.

`'close'` fires on normal completion as well as abort, and `destroy()` on an already-ended stream is a no-op, so only the abort path changes behaviour.

## Measured

2,000 frames of a 4K composition with 82 video clips, `--concurrency=4 --scale=0.5`, sampling `lsof -p <renderer pid> | wc -l` every 10s:

|  | start | f~570 | f~1,230 | f2,000 |
|---|---|---|---|---|
| unpatched | 62 | 483 | 819 | **1,257** |
| patched | 58 | 52 | 52 | **55** |

Same wall time in both runs (182 s). On a 16,096-frame render the unpatched curve climbed at ~0.8 fds/frame and died with `EBADF` at ~frame 15,494, three renders in a row at ~96%.

## Notes

- Equivalent to the `patch-package` patch we have run in production since June on 4.0.466; output byte-identical, no measurable cost.
- `stream` is declared as `let stream = null`, so the local `const readStream` keeps the callback's reference non-null for the type checker rather than widening the diff.
- I have not added a test — reproducing the leak needs a real render loop with an aborting client, which didn't look like it belonged in the existing suite. Happy to add one if you'd like it, in whatever shape suits you.
