### PR TITLE
`@remotion/studio`: Add editor button to menu bar

### DIFF
--- a/packages/studio/src/components/MenuBuildIndicator.tsx
+++ b/packages/studio/src/components/MenuBuildIndicator.tsx
@@ -1,21 +1,8 @@
-import type {GitSource} from '@remotion/studio-shared';
-import React, {
-	useCallback,
-	useContext,
-	useEffect,
-	useMemo,
-	useState,
-} from 'react';
-import {StudioServerConnectionCtx} from '../helpers/client-id';
+import React, {useEffect, useMemo, useState} from 'react';
 import {WHITE_ALPHA_80} from '../helpers/colors';
-import {
-	getGitSourceBranchUrl,
-	getGitSourceName,
-} from '../helpers/get-git-menu-item';
-import {openInEditor} from '../helpers/open-in-editor';
+import {InspectorOpenInEditor} from './InspectorOpenInEditor';
 import {Spacing} from './layout';
 import {MenuCompositionName} from './MenuCompositionName';
-import {showNotification} from './Notifications/NotificationCenter';
 import {Spinner} from './Spinner';
 
 const cwd: React.CSSProperties = {
@@ -39,82 +26,17 @@ const noSpinner: React.CSSProperties = {
 	width: spinnerSize,
 };
 
-const projectNameLinkBase: React.CSSProperties = {
-	color: 'inherit',
-	textDecoration: 'none',
-	cursor: 'pointer',
-	fontSize: 'inherit',
-	textUnderlineOffset: 2,
-};
-
-const projectNameLink: React.CSSProperties = {
-	...projectNameLinkBase,
-};
-
-const projectNameLinkHovered: React.CSSProperties = {
-	...projectNameLinkBase,
-	textDecoration: 'underline',
-};
-
 export const MenuBuildIndicator: React.FC<{
 	readonly mobileLayout: boolean;
 }> = ({mobileLayout}) => {
 	const [isBuilding, setIsBuilding] = useState(false);
-	const [projectNameHovered, setProjectNameHovered] = useState(false);
-	const ctx = useContext(StudioServerConnectionCtx).previewServerState;
-
-	const showEditorLink = window.remotion_editorName && ctx.type === 'connected';
-	const showGitLink = !showEditorLink && Boolean(window.remotion_gitSource);
-
-	const handleProjectNameClick = useCallback(async () => {
-		if (showEditorLink) {
-			await openInEditor(
-				{
-					originalFileName: `${window.remotion_cwd}`,
-					originalLineNumber: 1,
-					originalColumnNumber: 1,
-					originalFunctionName: null,
-					originalScriptCode: null,
-				},
-				null,
-			)
-				.then(({success}) => {
-					if (!success) {
-						showNotification(
-							`Could not open ${window.remotion_editorName}`,
-							2000,
-						);
-					}
-				})
-				.catch((err) => {
-					// eslint-disable-next-line no-console
-					console.error(err);
-					showNotification(
-						`Could not open ${window.remotion_editorName}`,
-						2000,
-					);
-				});
-		} else if (showGitLink) {
-			window.open(
-				getGitSourceBranchUrl(window.remotion_gitSource as GitSource),
-				'_blank',
-			);
-		}
-	}, [showEditorLink, showGitLink]);
-
-	const projectNameTitle = useMemo(() => {
-		if (showEditorLink) {
-			return `Open in ${window.remotion_editorName}`;
-		}
-
-		if (showGitLink) {
-			return `Open ${getGitSourceName(window.remotion_gitSource as GitSource)} Repo`;
-		}
-
-		return undefined;
-	}, [showEditorLink, showGitLink]);
-
-	const isClickable = showEditorLink || showGitLink;
+	const folderLocation = useMemo(() => {
+		return {
+			source: window.remotion_cwd,
+			line: 1,
+			column: 1,
+		};
+	}, []);
 
 	useEffect(() => {
 		window.remotion_isBuilding = () => {
@@ -133,37 +55,31 @@ export const MenuBuildIndicator: React.FC<{
 
 	return (
 		<div style={cwd} title={window.remotion_cwd}>
-			{isClickable ? <Spacing x={mobileLayout ? 0.5 : 2} /> : null}
-			{mobileLayout ? null : isBuilding ? (
+			<Spacing x={mobileLayout ? 0.5 : 2} />
+			{window.remotion_projectName}
+			<MenuCompositionName />
+			<InspectorOpenInEditor location={folderLocation} />
+			{mobileLayout ? null : <Spacing x={0.5} />}
+			{mobileLayout ? (
+				isBuilding ? (
+					<>
+						<Spacing x={0.5} />
+						<div style={spinner}>
+							<Spinner
+								duration={0.5}
+								size={spinnerSize}
+								color={WHITE_ALPHA_80}
+							/>
+						</div>
+					</>
+				) : null
+			) : isBuilding ? (
 				<div style={spinner}>
 					<Spinner duration={0.5} size={spinnerSize} color={WHITE_ALPHA_80} />
 				</div>
 			) : (
 				<div style={noSpinner} />
 			)}
-			{mobileLayout ? null : <Spacing x={0.5} />}
-			{isClickable ? (
-				<a
-					style={projectNameHovered ? projectNameLinkHovered : projectNameLink}
-					title={projectNameTitle}
-					onClick={handleProjectNameClick}
-					onPointerEnter={() => setProjectNameHovered(true)}
-					onPointerLeave={() => setProjectNameHovered(false)}
-				>
-					{window.remotion_projectName}
-				</a>
-			) : (
-				window.remotion_projectName
-			)}
-			<MenuCompositionName />
-			{mobileLayout && isBuilding ? (
-				<>
-					<Spacing x={0.5} />
-					<div style={spinner}>
-						<Spinner duration={0.5} size={spinnerSize} color={WHITE_ALPHA_80} />
-					</div>
-				</>
-			) : null}
 		</div>
 	);
 };

--- a/packages/studio/src/components/MenuCompositionName.tsx
+++ b/packages/studio/src/components/MenuCompositionName.tsx
@@ -1,12 +1,6 @@
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
-import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT} from '../helpers/colors';
-import {getFileManagerName} from '../helpers/get-file-manager-name';
-import {openOriginalPositionInEditor} from '../helpers/open-in-editor';
-import {showNotification} from './Notifications/NotificationCenter';
-import {openInFileExplorer} from './RenderQueue/actions';
-import {useResolvedStack} from './Timeline/use-resolved-stack';
 
 const baseStyle: React.CSSProperties = {
 	color: 'inherit',
@@ -21,16 +15,6 @@ const compositionNameStyle: React.CSSProperties = {
 	cursor: 'default',
 };
 
-const clickableStyle: React.CSSProperties = {
-	...baseStyle,
-	cursor: 'pointer',
-};
-
-const clickableHoveredStyle: React.CSSProperties = {
-	...clickableStyle,
-	textDecoration: 'underline',
-};
-
 const slashStyle: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	marginInline: 4,
@@ -42,11 +26,6 @@ export const MenuCompositionName: React.FC = () => {
 	const {canvasContent, compositions} = useContext(
 		Internals.CompositionManager,
 	);
-	const connectionStatus = useContext(StudioServerConnectionCtx)
-		.previewServerState.type;
-	const [opening, setOpening] = useState(false);
-	const [hovered, setHovered] = useState(false);
-
 	const composition = useMemo(() => {
 		if (canvasContent === null || canvasContent.type !== 'composition') {
 			return null;
@@ -58,73 +37,16 @@ export const MenuCompositionName: React.FC = () => {
 	}, [canvasContent, compositions]);
 	const asset = canvasContent?.type === 'asset' ? canvasContent.asset : null;
 
-	const resolvedLocation = useResolvedStack(composition?.stack ?? null);
-	const fileManagerName = getFileManagerName(
-		window.remotion_fileSystemPlatform,
-	);
-
-	const canOpenComposition =
-		resolvedLocation &&
-		window.remotion_editorName &&
-		connectionStatus === 'connected';
-	const canOpenAsset =
-		asset !== null &&
-		window.remotion_publicFolderExists !== null &&
-		connectionStatus === 'connected';
-	const canOpen = canOpenComposition || canOpenAsset;
-
-	const handleClick = useCallback(async () => {
-		if (!canOpen || opening) {
-			return;
-		}
-
-		setOpening(true);
-		try {
-			if (asset !== null && window.remotion_publicFolderExists !== null) {
-				await openInFileExplorer({
-					directory: `${window.remotion_publicFolderExists}/${asset}`,
-				});
-			} else if (resolvedLocation) {
-				await openOriginalPositionInEditor(resolvedLocation, null);
-			}
-		} catch (err) {
-			showNotification((err as Error).message, 2000);
-		} finally {
-			setOpening(false);
-		}
-	}, [asset, canOpen, opening, resolvedLocation]);
-
 	if (!composition && asset === null) {
 		return null;
 	}
 
 	const name = composition?.id ?? asset;
-	const title = composition
-		? canOpenComposition
-			? `Open in ${window.remotion_editorName}`
-			: composition.id
-		: canOpenAsset
-			? `Show in ${fileManagerName}`
-			: (asset ?? undefined);
 
 	return (
 		<>
 			<span style={slashStyle}>/</span>
-			<a
-				style={
-					canOpen && !opening
-						? hovered
-							? clickableHoveredStyle
-							: clickableStyle
-						: compositionNameStyle
-				}
-				title={title}
-				onClick={handleClick}
-				onPointerEnter={() => setHovered(true)}
-				onPointerLeave={() => setHovered(false)}
-			>
-				{name}
-			</a>
+			<span style={compositionNameStyle}>{name}</span>
 		</>
 	);
 };


### PR DESCRIPTION
## Summary

- add the existing editor picker control to the Studio menu bar
- open the project folder from the new control
- keep project and composition names non-interactive

## Testing

- `bun run build`
- `bun run stylecheck`
