### PR TITLE
`@remotion/studio`: Prevent preview toolbar controls from shrinking

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -62,7 +62,8 @@ const padding: React.CSSProperties = {
 };
 
 const toolbarControl: React.CSSProperties = {
-	display: 'contents',
+	display: 'flex',
+	flexShrink: 0,
 };
 
 const PreviewToolbarControl: React.FC<{


### PR DESCRIPTION
## Summary

- keep preview toolbar controls at their intended size while resizing the viewport
- preserve the spacing between toolbar icons by making each control group non-shrinking

## Testing

- `bun run build`
- `bun run stylecheck`
