### PR TITLE
Elements: Improve dependency list layout

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -152,10 +152,22 @@
 	font-weight: 600;
 }
 
+.metadata > .dependenciesMetadata {
+	align-items: stretch;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 8px;
+}
+
 .dependencyList {
 	margin: 0;
 	padding-left: 18px;
 	text-align: left;
+}
+
+.dependencyList li {
+	max-width: 100%;
+	overflow-wrap: anywhere;
 }
 
 .dependencyList li + li {

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -167,7 +167,13 @@
 
 .dependencyList li {
 	max-width: 100%;
+	line-height: 1.45;
 	overflow-wrap: anywhere;
+}
+
+.dependencyList li::marker {
+	color: var(--ifm-color-primary);
+	font-size: 0.85em;
 }
 
 .dependencyList li + li {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -243,7 +243,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 								<dt>Duration</dt>
 								<dd>{durationInFrames / fps}s</dd>
 							</div>
-							<div>
+							<div className={styles.dependenciesMetadata}>
 								<dt>Dependencies</dt>
 								<dd>
 									{definition.dependencies.length === 0 ? (


### PR DESCRIPTION
## Summary

- give the Elements dependency metadata its own full-width row
- keep dependencies as a bulleted list while avoiding cramped package-name wrapping
- use compact primary-colored markers and improved line height for clearer scanning

Addresses #8828 

## Testing

- `bun run build`
- `bun run stylecheck`
