### PR TITLE
Elements: Add homepage link

### DIFF
--- a/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
@@ -19,7 +19,10 @@ export const MakeVideosInteractively: React.FC<{
 	),
 	description = 'Edit and animate using drag and drop and save back to code.',
 	showLinks = true,
-	links = [{label: 'Remotion Studio', href: '/docs/studio'}],
+	links = [
+		{label: 'Remotion Studio', href: '/docs/studio'},
+		{label: 'Remotion Elements', href: '/elements'},
+	],
 	showVideo = true,
 	videoSrc = '/img/editing-vp9-chrome.webm',
 	fallbackVideoSrc = '/img/editing-safari.mp4',


### PR DESCRIPTION
## Summary

- add Remotion Elements below Remotion Studio in the homepage’s interactive video section
- link visitors directly to the visual Elements library

## Verification

- `bunx oxfmt packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx --write`
- `bun run build`
- `bun run stylecheck`

Closes #9775
