### PR TITLE
Internal: Retry flaky SSR tests

### DIFF
--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -75,47 +75,51 @@ test(
 	{retry: 3},
 );
 
-test('renderFrames() should render selected frames', async () => {
-	const puppeteerInstance = await openBrowser('chrome');
-	const selectedFramesDir = await fs.promises.mkdtemp(
-		path.join(os.tmpdir(), 'remotion-selected-frames-'),
-	);
-
-	try {
-		const compositions = await getCompositions({
-			serveUrl: exampleBuild,
-			puppeteerInstance,
-			inputProps: {},
-		});
-		const tenFrameTester = compositions.find(
-			(c) => c.id === 'ten-frame-tester',
+test(
+	'renderFrames() should render selected frames',
+	async () => {
+		const puppeteerInstance = await openBrowser('chrome');
+		const selectedFramesDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'remotion-selected-frames-'),
 		);
 
-		if (!tenFrameTester) {
-			throw new Error('not found');
+		try {
+			const compositions = await getCompositions({
+				serveUrl: exampleBuild,
+				puppeteerInstance,
+				inputProps: {},
+			});
+			const tenFrameTester = compositions.find(
+				(c) => c.id === 'ten-frame-tester',
+			);
+
+			if (!tenFrameTester) {
+				throw new Error('not found');
+			}
+
+			const selectedFramesRender = await renderFrames({
+				composition: tenFrameTester,
+				frames: [5, 0, 2],
+				imageFormat: 'jpeg',
+				inputProps: {},
+				onFrameUpdate: () => undefined,
+				serveUrl: exampleBuild,
+				concurrency: null,
+				outputDir: selectedFramesDir,
+				onStart: () => undefined,
+				puppeteerInstance,
+			});
+
+			expect(selectedFramesRender.frameCount).toBe(3);
+			expect((await fs.promises.readdir(selectedFramesDir)).sort()).toEqual([
+				'element-0.jpeg',
+				'element-2.jpeg',
+				'element-5.jpeg',
+			]);
+		} finally {
+			RenderInternals.deleteDirectory(selectedFramesDir);
+			await puppeteerInstance.close({silent: false});
 		}
-
-		const selectedFramesRender = await renderFrames({
-			composition: tenFrameTester,
-			frames: [5, 0, 2],
-			imageFormat: 'jpeg',
-			inputProps: {},
-			onFrameUpdate: () => undefined,
-			serveUrl: exampleBuild,
-			concurrency: null,
-			outputDir: selectedFramesDir,
-			onStart: () => undefined,
-			puppeteerInstance,
-		});
-
-		expect(selectedFramesRender.frameCount).toBe(3);
-		expect((await fs.promises.readdir(selectedFramesDir)).sort()).toEqual([
-			'element-0.jpeg',
-			'element-2.jpeg',
-			'element-5.jpeg',
-		]);
-	} finally {
-		RenderInternals.deleteDirectory(selectedFramesDir);
-		await puppeteerInstance.close({silent: false});
-	}
-});
+	},
+	{retry: 3},
+);

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -99,5 +99,5 @@ test(
 		const sampleRate = await getSampleRateFromFile(outPath);
 		expect(sampleRate).toBe(48000);
 	},
-	{timeout: 30000},
+	{timeout: 30000, retry: 3},
 );

--- a/packages/it-tests/src/ssr/render-still.test.ts
+++ b/packages/it-tests/src/ssr/render-still.test.ts
@@ -15,33 +15,37 @@ beforeAll(async () => {
 	await ensureBrowser();
 });
 
-test('Render video with browser instance open', async () => {
-	const puppeteerInstance = await openBrowser('chrome');
-	const compositions = await getCompositions({
-		serveUrl: exampleBuild,
-		puppeteerInstance,
-		inputProps: {},
-	});
+test(
+	'Render video with browser instance open',
+	async () => {
+		const puppeteerInstance = await openBrowser('chrome');
+		const compositions = await getCompositions({
+			serveUrl: exampleBuild,
+			puppeteerInstance,
+			inputProps: {},
+		});
 
-	const reactSvg = compositions.find((c) => c.id === 'react-svg');
+		const reactSvg = compositions.find((c) => c.id === 'react-svg');
 
-	if (!reactSvg) {
-		throw new Error('not found');
-	}
+		if (!reactSvg) {
+			throw new Error('not found');
+		}
 
-	const tmpDir = os.tmpdir();
+		const tmpDir = os.tmpdir();
 
-	const outPath = path.join(tmpDir, 'out.mp4');
+		const outPath = path.join(tmpDir, 'out.mp4');
 
-	const {buffer} = await renderStill({
-		output: outPath,
-		serveUrl: exampleBuild,
-		composition: reactSvg,
-		puppeteerInstance,
-	});
-	expect(buffer).toBe(null);
-	await puppeteerInstance.close({silent: false});
-});
+		const {buffer} = await renderStill({
+			output: outPath,
+			serveUrl: exampleBuild,
+			composition: reactSvg,
+			puppeteerInstance,
+		});
+		expect(buffer).toBe(null);
+		await puppeteerInstance.close({silent: false});
+	},
+	{retry: 3},
+);
 
 test(
 	'Render still with browser instance not open and legacy webpack config',


### PR DESCRIPTION
## Summary

- Retry the SSR integration tests that depend on `remotion.media`.

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/it-tests && bun test src/ssr/render-frames.test.ts src/ssr/render-still.test.ts --timeout 40000` *(fails locally because `packages/example/build/index.html` is absent; confirms retries run through attempt 4)*
- `cd packages/it-tests && bun test src/ssr/render-media-sample-rate.test.ts --timeout 40000` *(fails locally because `packages/example/build/index.html` is absent; confirms retries run through attempt 4)*

