### PR TITLE
Experiment: Run only affected CI test groups

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -105,7 +105,7 @@ jobs:
 
   lambda-tests:
     needs: affected
-    if: needs.affected.outputs.lambda == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.lambda == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Lambda integration
@@ -134,7 +134,7 @@ jobs:
           cd packages/lambda && bunx remotion browser ensure && bun test src/test/integration --run
   nextjs-tests:
     needs: affected
-    if: needs.affected.outputs.nextjs == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.nextjs == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Next.js SSR build
@@ -156,7 +156,7 @@ jobs:
           bun run testnextjs
   browser-tests:
     needs: affected
-    if: needs.affected.outputs.browser == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.browser == 'true') }}
     runs-on: macos-latest
     timeout-minutes: 30
     name: Browser tests
@@ -184,7 +184,7 @@ jobs:
           bun run teste2e
   webrenderer-tests:
     needs: affected
-    if: needs.affected.outputs.webrenderer == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.webrenderer == 'true') }}
     runs-on: macos-latest
     timeout-minutes: 30
     name: Web renderer tests
@@ -210,7 +210,7 @@ jobs:
           bun run testbrowserstudio
   ssr-tests:
     needs: affected
-    if: needs.affected.outputs.ssr == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.ssr == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: SSR + Monorepo checks
@@ -250,7 +250,7 @@ jobs:
   template-tests:
     name: Template integration on ${{ matrix.os }}
     needs: affected
-    if: needs.affected.outputs.templates == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.templates == 'true') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -288,6 +288,7 @@ jobs:
           bun run testtemplates
   lint:
     needs: affected
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Linting + Formatting
@@ -315,12 +316,12 @@ jobs:
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
     needs: affected
-    if: needs.affected.outputs.build == 'true'
+    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix) }}
+      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}') }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
     steps:
@@ -350,6 +351,6 @@ jobs:
         run: |
           bunx turbo run make test --affected --concurrency=1 --no-update-notifier
       - name: Bundle example
-        if: matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true'
+        if: matrix.os == 'ubuntu-latest' && (needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true')
         run: |
           bunx turbo run bundle-testbed --filter=@remotion/example --no-update-notifier

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,8 @@ env:
   FORCE_COLOR: 1
   TURBO_TELEMETRY_DISABLED: 1
   TURBO_NO_UPDATE_NOTIFIER: 1
+  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+  TURBO_SCM_HEAD: ${{ github.sha }}
 jobs:
   affected:
     runs-on: ubuntu-latest
@@ -42,14 +44,25 @@ jobs:
 
           full_matrix='{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}'
           linux_matrix='{"include":[{"os":"ubuntu-latest","node_version":16}]}'
-          turbo_version=$(jq -r '.dependencies.turbo' package.json)
 
-          if ! bunx "turbo@$turbo_version" query affected > affected.json; then
-            echo "Could not determine affected tasks. Running all test groups."
+          run_all_test_groups() {
             for output in lambda nextjs browser webrenderer ssr templates build bundle_example; do
               echo "$output=true" >> "$GITHUB_OUTPUT"
             done
             echo "build_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
+          }
+
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            echo "Push to main. Running all test groups."
+            run_all_test_groups
+            echo "### Full CI after push to main" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          turbo_version=$(jq -r '.dependencies.turbo' package.json)
+          if ! bunx "turbo@$turbo_version" query affected > affected.json; then
+            echo "Could not determine affected tasks. Running all test groups."
+            run_all_test_groups
             exit 0
           fi
 
@@ -311,7 +324,7 @@ jobs:
       - name: Perform stylecheck
         timeout-minutes: 10
         run: |
-          bunx turbo run lint formatting --affected --no-update-notifier
+          bunx turbo run lint formatting ${{ github.event_name == 'pull_request' && '--affected' || '' }} --no-update-notifier
           bun run checkskills
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
@@ -349,7 +362,7 @@ jobs:
       - name: Build & Test
         timeout-minutes: 30
         run: |
-          bunx turbo run make test --affected --concurrency=1 --no-update-notifier
+          bunx turbo run make test ${{ github.event_name == 'pull_request' && '--affected' || '' }} --concurrency=1 --no-update-notifier
       - name: Bundle example
         if: matrix.os == 'ubuntu-latest' && (needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true')
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: oven-sh/setup-bun@v2.1.2
         with:
           bun-version: 1.3.3
@@ -309,6 +310,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions/setup-node@v6
         with:
           node-version: 25
@@ -341,6 +343,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,98 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
   TURBO_NO_UPDATE_NOTIFIER: 1
 jobs:
+  affected:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: Determine affected tests
+    outputs:
+      lambda: ${{ steps.query.outputs.lambda }}
+      nextjs: ${{ steps.query.outputs.nextjs }}
+      browser: ${{ steps.query.outputs.browser }}
+      webrenderer: ${{ steps.query.outputs.webrenderer }}
+      ssr: ${{ steps.query.outputs.ssr }}
+      templates: ${{ steps.query.outputs.templates }}
+      build: ${{ steps.query.outputs.build }}
+      build_matrix: ${{ steps.query.outputs.build_matrix }}
+      bundle_example: ${{ steps.query.outputs.bundle_example }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2.1.2
+        with:
+          bun-version: 1.3.3
+      - name: Query Turborepo task graph
+        id: query
+        run: |
+          set -euo pipefail
+
+          full_matrix='{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}'
+          linux_matrix='{"include":[{"os":"ubuntu-latest","node_version":16}]}'
+          turbo_version=$(jq -r '.dependencies.turbo' package.json)
+
+          if ! bunx "turbo@$turbo_version" query affected > affected.json; then
+            echo "Could not determine affected tasks. Running all test groups."
+            for output in lambda nextjs browser webrenderer ssr templates build bundle_example; do
+              echo "$output=true" >> "$GITHUB_OUTPUT"
+            done
+            echo "build_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          task_is_affected() {
+            jq -e --arg task "$1" \
+              'any(.data.affectedTasks.items[]; .name == $task)' \
+              affected.json > /dev/null
+          }
+
+          set_from_tasks() {
+            output=$1
+            shift
+            affected=false
+            for task in "$@"; do
+              if task_is_affected "$task"; then
+                affected=true
+              fi
+            done
+
+            echo "$output=$affected" >> "$GITHUB_OUTPUT"
+          }
+
+          set_from_tasks lambda testlambda
+          set_from_tasks nextjs testnextjs
+          set_from_tasks browser testwebcodecs teste2e
+          set_from_tasks webrenderer testwebrenderer testbrowserstudio
+          set_from_tasks ssr testssr
+          set_from_tasks templates testtemplates
+          set_from_tasks bundle_example bundle-testbed
+
+          build=false
+          build_matrix=$linux_matrix
+          if jq -e \
+            'any(.data.affectedTasks.items[]; .name == "make" or .name == "test")' \
+            affected.json > /dev/null; then
+            build=true
+          fi
+
+          if jq -e \
+            'any(.data.affectedTasks.items[]; (.name == "make" or .name == "test") and .package.name != "docs")' \
+            affected.json > /dev/null; then
+            build_matrix=$full_matrix
+          fi
+
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$build_matrix" >> "$GITHUB_OUTPUT"
+
+          {
+            echo '### Affected Turborepo tasks'
+            echo
+            jq -r '.data.affectedTasks.items[] | "- `\(.fullName)` (\(.reason.__typename))"' affected.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lambda-tests:
+    needs: affected
+    if: needs.affected.outputs.lambda == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Lambda integration
@@ -42,6 +133,8 @@ jobs:
         run: |
           cd packages/lambda && bunx remotion browser ensure && bun test src/test/integration --run
   nextjs-tests:
+    needs: affected
+    if: needs.affected.outputs.nextjs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Next.js SSR build
@@ -57,14 +150,13 @@ jobs:
         run: bun ci
       - name: Cache Turbo
         uses: rharkor/caching-for-turbo@v2.3.11
-      - name: Test Lambda IT
-        run: |
-          bun run build
-      - name: IT tests
+      - name: Build Next.js SSR app
         timeout-minutes: 10
         run: |
-          cd packages/player-example && bun run build-site
+          bun run testnextjs
   browser-tests:
+    needs: affected
+    if: needs.affected.outputs.browser == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
     name: Browser tests
@@ -91,6 +183,8 @@ jobs:
         run: |
           bun run teste2e
   webrenderer-tests:
+    needs: affected
+    if: needs.affected.outputs.webrenderer == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
     name: Web renderer tests
@@ -115,6 +209,8 @@ jobs:
         run: |
           bun run testbrowserstudio
   ssr-tests:
+    needs: affected
+    if: needs.affected.outputs.ssr == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: SSR + Monorepo checks
@@ -151,44 +247,10 @@ jobs:
         timeout-minutes: 10
         run: |
           cd packages/it-tests && bun test src/monorepo --run --timeout 40000
-  template-tests-check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    name: Template tests precheck
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 25
-      - uses: oven-sh/setup-bun@v2.1.2
-        with:
-          bun-version: 1.3.3
-      - name: Check if template tests are affected
-        id: check
-        run: |
-          set +e
-          bunx turbo-ignore @remotion/it-tests --task=testtemplates
-          status=$?
-          set -e
-
-          if [ "$status" -eq 0 ]; then
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "No relevant changes for testtemplates; skipping template-tests."
-          elif [ "$status" -eq 1 ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "Relevant changes detected for testtemplates; running template-tests."
-          else
-            echo "turbo-ignore failed with exit code $status"
-            exit "$status"
-          fi
   template-tests:
     name: Template integration on ${{ matrix.os }}
-    needs: template-tests-check
-    if: needs.template-tests-check.outputs.should_run == 'true'
+    needs: affected
+    if: needs.affected.outputs.templates == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -225,11 +287,14 @@ jobs:
         run: |
           bun run testtemplates
   lint:
+    needs: affected
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Linting + Formatting
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 25
@@ -245,25 +310,23 @@ jobs:
       - name: Perform stylecheck
         timeout-minutes: 10
         run: |
-          bun run stylecheck
+          bunx turbo run lint formatting --affected --no-update-notifier
+          bun run checkskills
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
+    needs: affected
+    if: needs.affected.outputs.build == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            node_version: 16
-          - os: windows-latest
-            node_version: 16
-          - os: macos-latest
-            node_version: 25
+      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix) }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
@@ -285,8 +348,8 @@ jobs:
       - name: Build & Test
         timeout-minutes: 30
         run: |
-          bun run ci
+          bunx turbo run make test --affected --concurrency=1 --no-update-notifier
       - name: Bundle example
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true'
         run: |
-          cd packages/example && bun run bundle-testbed
+          bunx turbo run bundle-testbed --filter=@remotion/example --no-update-notifier

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"testlayoututils": "turbo run testlayoututils --concurrency=1 --no-update-notifier",
 		"testeffectsvisual": "turbo run testeffectsvisual --concurrency=1 --no-update-notifier",
 		"testlambda": "turbo run testlambda --concurrency=1 --no-update-notifier",
+		"testnextjs": "turbo run testnextjs --no-update-notifier",
 		"ci": "turbo run make test --concurrency=1 --no-update-notifier",
 		"watch": "turbo watch make --concurrency=2 --experimental-write-cache",
 		"makewhisperweb": "turbo run make --filter='@remotion/whisper-web'",

--- a/packages/player-example/package.json
+++ b/packages/player-example/package.json
@@ -32,6 +32,7 @@
 		"formatting": "prettier src --check",
 		"lint": "eslint src",
 		"dev": "next dev",
-		"build-site": "next build"
+		"build-site": "next build",
+		"testnextjs": "next build"
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -16,10 +16,18 @@
 			"dependsOn": ["^make", "@remotion/example#bundle"]
 		},
 		"testtemplates": {
-			"dependsOn": ["^make", "@remotion/example#bundle"]
+			"dependsOn": ["^make", "@remotion/example#bundle"],
+			"inputs": [
+				"$TURBO_DEFAULT$",
+				"$TURBO_ROOT$/packages/template-*/**",
+				"$TURBO_ROOT$/tsconfig.json"
+			]
 		},
 		"testlambda": {
 			"dependsOn": ["^make", "@remotion/example#bundle"]
+		},
+		"@remotion/player-example#testnextjs": {
+			"dependsOn": ["^make"]
 		},
 		"testwebcodecs": {
 			"dependsOn": ["@remotion/webcodecs#make"]
@@ -193,7 +201,13 @@
 		},
 		"@remotion/brand#bundle": {
 			"dependsOn": ["^make"],
-			"inputs": ["src/**", "public/**", "remotion.config.*", "package.json", "tsconfig.json"],
+			"inputs": [
+				"src/**",
+				"public/**",
+				"remotion.config.*",
+				"package.json",
+				"tsconfig.json"
+			],
 			"outputs": ["build"],
 			"outputLogs": "new-only"
 		}


### PR DESCRIPTION
## Summary

- use `turbo query affected` as a single CI preflight to skip unrelated Lambda, SSR, browser, web-renderer, template, and Next.js jobs
- run linting, formatting, builds, and tests with `--affected` on pull requests, while limiting docs-only changes to the Ubuntu build job
- register the Next.js SSR build and template source inputs in the Turborepo task graph
- provide the pull request base and merge SHAs explicitly so Turborepo can reliably resolve the affected Git range
- run full CI on pushes to `main`, and if the affected-task preflight fails at any stage, while preserving cancellation behavior
- preserve full Git history while omitting historical file contents from the five full-history checkouts

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun run testnextjs`
- `actionlint .github/workflows/push.yml`
- `act -W .github/workflows/push.yml -l`
- `git diff --check`
- simulated docs-only and template-only changes with `turbo query affected`
- ran `turbo query affected` with explicit `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` values and confirmed the Git range resolved without a fallback warning
