### PR TITLE
Elements: Link dependencies to npm

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -252,9 +252,15 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 										<ul className={styles.dependencyList}>
 											{definition.dependencies.map((dependency) => (
 												<li key={dependency.name}>
-													{dependency.version === null
-														? dependency.name
-														: `${dependency.name}@${dependency.version}`}
+													<a
+														href={`https://www.npmjs.com/package/${dependency.name}`}
+														rel="noopener noreferrer"
+														target="_blank"
+													>
+														{dependency.version === null
+															? dependency.name
+															: `${dependency.name}@${dependency.version}`}
+													</a>
 												</li>
 											))}
 										</ul>


### PR DESCRIPTION
## Summary

- Link each Remotion Element dependency to its npm package page
- Open dependency links in a new tab

## Verification

- `bun run build`
- `bun run stylecheck`
