### PR TITLE
`@remotion/promo-pages`: Shorten homepage link labels

### DIFF
--- a/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
+++ b/packages/promo-pages/src/components/homepage/MakeVideosInteractively.tsx
@@ -20,8 +20,8 @@ export const MakeVideosInteractively: React.FC<{
 	description = 'Edit and animate using drag and drop and save back to code.',
 	showLinks = true,
 	links = [
-		{label: 'Remotion Studio', href: '/docs/studio'},
-		{label: 'Remotion Elements', href: '/elements'},
+		{label: 'Studio', href: '/docs/studio'},
+		{label: 'Elements', href: '/elements'},
 	],
 	showVideo = true,
 	videoSrc = '/img/editing-vp9-chrome.webm',


### PR DESCRIPTION
## Summary

- shorten the homepage link labels from “Remotion Studio” and “Remotion Elements” to “Studio” and “Elements”
- keep the existing Studio and Elements destinations unchanged

## Testing

- `bun run build`
- `bun run stylecheck`
