### PR TITLE
`remotion`: Add crop props to Interactive elements

### DIFF
--- a/packages/core/src/Interactive.tsx
+++ b/packages/core/src/Interactive.tsx
@@ -22,6 +22,7 @@ import {
 } from './interactivity-schema.js';
 import type {AbsoluteFillLayout, SequenceProps} from './Sequence.js';
 import {Sequence} from './Sequence.js';
+import {useCropStyle} from './use-crop-style.js';
 import {
 	withInteractivitySchema,
 	type WithInteractivitySchemaOptions,
@@ -101,13 +102,13 @@ export type InteractivePremountProps = Pick<
 	| 'styleWhilePostmounted'
 >;
 
-type InteractiveSequenceProps = InteractiveBaseProps;
+type InteractiveManagedProps = InteractiveBaseProps & InteractiveCropProps;
 
 type InteractiveElementProps<Tag extends InteractiveTag> = Omit<
 	React.ComponentPropsWithoutRef<Tag>,
-	keyof InteractiveSequenceProps
+	keyof InteractiveManagedProps
 > &
-	InteractiveSequenceProps;
+	InteractiveManagedProps;
 
 type InteractiveElementComponent<Tag extends InteractiveTag> =
 	React.ComponentType<
@@ -146,6 +147,7 @@ const makeRemotionComponentIdentity = ({
 const interactiveElementSchema = {
 	...baseSchema,
 	...transformSchema,
+	...cropSchema,
 } as const satisfies InteractivitySchema;
 
 const interactiveBackgroundElementSchema = {
@@ -230,10 +232,23 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 			name,
 			showInTimeline,
 			controls,
+			cropLeft,
+			cropRight,
+			cropTop,
+			cropBottom,
+			style,
 			...props
 		} = propsWithControls as Props & {
 			readonly controls: SequenceControls | undefined;
 		};
+		const croppedStyle = useCropStyle({
+			cropLeft,
+			cropRight,
+			cropTop,
+			cropBottom,
+			style: style ?? null,
+			componentName: displayName,
+		});
 		const refForOutline = useRef<ElementType | null>(null);
 		const callbackRef = useCallback(
 			(element: ElementType | null) => {
@@ -259,6 +274,7 @@ const makeInteractiveElement = <Tag extends InteractiveTag>(
 			>
 				{React.createElement(tag, {
 					...props,
+					style: croppedStyle ?? undefined,
 					ref: callbackRef,
 				})}
 			</Sequence>

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1154,6 +1154,7 @@ test('Img registers a refForOutline pointing to the rendered image element', () 
 test('Interactive elements register their rendered element for Studio outlines', () => {
 	const registeredSequences: TSequence[] = [];
 	const divRef = React.createRef<HTMLDivElement>();
+	const rectRef = React.createRef<SVGRectElement>();
 	const documentationLink = 'https://www.remotion.dev/docs/interactive';
 
 	render(
@@ -1162,7 +1163,15 @@ test('Interactive elements register their rendered element for Studio outlines',
 				registeredSequences.push(sequence);
 			}}
 		>
-			<Interactive.Div ref={divRef}>Hello</Interactive.Div>
+			<Interactive.Div
+				ref={divRef}
+				cropBottom={0.4}
+				cropLeft={0.1}
+				cropRight={0.2}
+				cropTop={0.3}
+			>
+				Hello
+			</Interactive.Div>
 			<Interactive.Span>World</Interactive.Span>
 			<Interactive.Svg viewBox="0 0 100 100">
 				<Interactive.Circle />
@@ -1170,7 +1179,12 @@ test('Interactive elements register their rendered element for Studio outlines',
 				<Interactive.G />
 				<Interactive.Line />
 				<Interactive.Path />
-				<Interactive.Rect width={100} height={100} />
+				<Interactive.Rect
+					ref={rectRef}
+					cropLeft={0.25}
+					height={100}
+					width={100}
+				/>
 				<Interactive.Text x={50} y={50}>
 					Label
 				</Interactive.Text>
@@ -1223,6 +1237,20 @@ test('Interactive elements register their rendered element for Studio outlines',
 		divRef.current,
 	);
 	expect(getByName('<Interactive.Div>')?.controls).not.toBe(null);
+	expect(divRef.current?.style.clipPath).toBe('inset(30% 20% 40% 10%)');
+	expect(divRef.current?.getAttributeNames()).not.toContain('cropleft');
+	expect(rectRef.current?.style.clipPath).toBe('inset(0% 0% 0% 25%)');
+
+	for (const sequence of registeredSequences) {
+		for (const cropField of [
+			'cropLeft',
+			'cropRight',
+			'cropTop',
+			'cropBottom',
+		]) {
+			expect(sequence.controls?.schema).toHaveProperty(cropField);
+		}
+	}
 
 	for (const displayName of [
 		'<Interactive.Div>',

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -201,6 +201,8 @@ The prop type matching `Interactive.premountSchema`.
 
 Every `Interactive` component inherits [`durationInFrames`](/docs/sequence#durationinframes), [`from`](/docs/sequence#from), [`trimBefore`](/docs/sequence#trimbefore), [`freeze`](/docs/sequence#freeze), [`hidden`](/docs/sequence#hidden), [`name`](/docs/sequence#name) and [`showInTimeline`](/docs/sequence#showintimeline) from [`<Sequence>`](/docs/sequence).
 
+Every `Interactive` component also supports [`cropLeft`](/docs/sequence#cropleft), [`cropRight`](/docs/sequence#cropright), [`cropTop`](/docs/sequence#croptop) and [`cropBottom`](/docs/sequence#cropbottom) from <AvailableFrom v="4.0.506" inline />.
+
 ```tsx twoslash title="Timed element"
 import {Interactive} from 'remotion';
 
@@ -208,6 +210,18 @@ export const MyComp: React.FC = () => {
   return (
     <Interactive.Div from={30} durationInFrames={90}>
       Visible from frame 30 to 119
+    </Interactive.Div>
+  );
+};
+```
+
+```tsx twoslash title="Cropped element"
+import {Interactive} from 'remotion';
+
+export const MyComp: React.FC = () => {
+  return (
+    <Interactive.Div cropLeft={0.1} cropRight={0.2}>
+      Cropped content
     </Interactive.Div>
   );
 };


### PR DESCRIPTION
## Summary

- add crop props to all built-in `Interactive.*` HTML and SVG elements
- apply crop clipping to the rendered element without forwarding crop props to the DOM
- document the new props and cover rendering plus Studio schema registration

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test` from `packages/core`

## Preview

- [Interactive documentation](https://remotion-git-codex-interactive-crop-props-remotion.vercel.app/docs/interactive)
