### PR TITLE
Elements: Link library from Remotion Studio

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -147,8 +147,21 @@ export const MyComponent = () => {
 	await new Promise<void>((resolve) =>
 		senderServer.listen(0, '127.0.0.1', resolve),
 	);
+	const address = senderServer.address();
+	if (address === null || typeof address === 'string') {
+		throw new Error('Expected sender server address');
+	}
 
+	const senderUrl = `http://127.0.0.1:${address.port}`;
+	const elementsLibraryRequests: string[] = [];
 	const context = await browser.newContext();
+	await context.route('https://www.remotion.dev/elements', async (route) => {
+		elementsLibraryRequests.push(route.request().url());
+		await route.fulfill({
+			status: 302,
+			headers: {Location: senderUrl},
+		});
+	});
 	try {
 		await waitForUrl(studioUrl, studioProcess);
 		const studioPage = await context.newPage();
@@ -178,13 +191,19 @@ export const MyComponent = () => {
 				],
 			});
 
-		const address = senderServer.address();
-		if (address === null || typeof address === 'string') {
-			throw new Error('Expected sender server address');
-		}
-
-		const senderPage = await context.newPage();
-		await senderPage.goto(`http://127.0.0.1:${address.port}`);
+		await studioPage.locator('[data-sidebar-toggle="right"]').click();
+		const browseElements = studioPage.getByRole('button', {
+			name: 'Browse Elements...',
+		});
+		await expect(browseElements).toBeVisible();
+		const senderPagePromise = context.waitForEvent('page', {timeout: 10_000});
+		await browseElements.click();
+		const senderPage = await senderPagePromise;
+		await senderPage.waitForLoadState('domcontentloaded');
+		expect(elementsLibraryRequests).toEqual([
+			'https://www.remotion.dev/elements',
+		]);
+		await expect(senderPage).toHaveURL(senderUrl);
 		await senderPage.getByRole('button', {name: 'Install in Studio'}).click();
 		await senderPage.waitForFunction(
 			() => document.querySelector('#status')?.textContent !== '',

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -1,6 +1,13 @@
-import React, {useContext, useEffect, useMemo, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {ExternalLinkIcon} from '../../icons/external-link';
 import {PicIcon} from '../../icons/frame';
 import {SolidIcon} from '../../icons/solid';
 import {FilmIcon} from '../../icons/video';
@@ -63,6 +70,14 @@ const CompositionActions: React.FC<{
 		insertSolid,
 	} = useCompositionActions();
 
+	const openElementsLibrary = useCallback(() => {
+		window.open(
+			'https://www.remotion.dev/elements',
+			'_blank',
+			'noopener,noreferrer',
+		);
+	}, []);
+
 	if (
 		(readOnlyStudio && !canShowInsertSolid) ||
 		(!canShowInsertAsset && !canShowInsertComposition && !canShowInsertSolid)
@@ -103,6 +118,18 @@ const CompositionActions: React.FC<{
 					)}
 				>
 					Add composition...
+				</InspectorInlineAction>
+			) : null}
+			{canShowInsertAsset ? (
+				<InspectorInlineAction
+					disabled={false}
+					onClick={openElementsLibrary}
+					renderIcon={(color) => (
+						<ExternalLinkIcon color={color} style={actionIconStyle} />
+					)}
+					title="Open the Remotion Elements library in a new tab. Install an Element there to send it to this composition."
+				>
+					Browse Elements...
 				</InspectorInlineAction>
 			) : null}
 		</InspectorActionSection>


### PR DESCRIPTION
## Summary

- add a **Browse Elements...** action alongside the composition insertion actions in Remotion Studio
- open the canonical Remotion Elements library in a new browser tab
- extend the Studio Protocol end-to-end workflow to enter through the new Studio action and install into the active composition

Closes #9776

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio'`
- `cd packages/example && bunx playwright test e2e/studio-protocol.test.mts --project=chromium`
