### PR TITLE
remotion.dev/brand: Add responsive Studio animation

### DIFF
--- a/packages/brand/.gitignore
+++ b/packages/brand/.gitignore
@@ -8,3 +8,4 @@ public/fluid-hand-morphing-and-dissolving-animation-2026-02-18-11-59-25-utc.mov
 public/grainy-retro-hand-pinch.mov
 public/gritty-fist-punch-with-impact-animation-2026-02-18-04-46-33-utc.mov
 public/puppet-master-hand.mov
+public/design-systems-responsive/

--- a/packages/brand/src/DesignSystemsResponsive.tsx
+++ b/packages/brand/src/DesignSystemsResponsive.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	CanvasImage,
+	spring,
+	staticFile,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+const maximumScreenshotWidth = 1350;
+const minimumScreenshotWidth = 592;
+const screenshotHeight = 748;
+const screenshotCount =
+	(maximumScreenshotWidth - minimumScreenshotWidth) / 2 + 1;
+const initialRestDurationInFrames = 15;
+const motionDurationInFrames = 30;
+const contractedRestDurationInFrames = 30;
+const expandedRestDurationInFrames = 30;
+const expandStartFrame =
+	initialRestDurationInFrames +
+	motionDurationInFrames +
+	contractedRestDurationInFrames;
+
+export const designSystemsResponsiveDurationInFrames =
+	expandStartFrame + motionDurationInFrames + expandedRestDurationInFrames;
+
+export const DesignSystemsResponsive: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+	const shrinkProgress = spring({
+		frame: frame - initialRestDurationInFrames,
+		fps,
+		durationInFrames: motionDurationInFrames,
+		config: {
+			damping: 18,
+			mass: 1,
+			stiffness: 120,
+		},
+	});
+	const expandProgress = spring({
+		frame: frame - expandStartFrame,
+		fps,
+		durationInFrames: motionDurationInFrames,
+		config: {
+			damping: 18,
+			mass: 1,
+			stiffness: 120,
+		},
+	});
+	const progress =
+		frame < expandStartFrame ? shrinkProgress : 1 - expandProgress;
+	const screenshotIndex = Math.max(
+		0,
+		Math.min(screenshotCount - 1, Math.round(progress * (screenshotCount - 1))),
+	);
+	const screenshotWidth = maximumScreenshotWidth - screenshotIndex * 2;
+
+	return (
+		<AbsoluteFill
+			style={{
+				overflow: 'hidden',
+			}}
+		>
+			<CanvasImage
+				src={staticFile(
+					`design-systems-responsive/studio-${screenshotWidth}.png`,
+				)}
+				style={{
+					position: 'absolute',
+					left: '50%',
+					top: 24,
+					translate: '-50% 0',
+					width: screenshotWidth,
+					height: screenshotHeight,
+					borderRadius: 12,
+				}}
+			/>
+		</AbsoluteFill>
+	);
+};

--- a/packages/brand/src/Root.tsx
+++ b/packages/brand/src/Root.tsx
@@ -25,6 +25,10 @@ import {
 } from './Compose/WhatIsRemotion';
 import {DesignSystems, designSystemsDurationInFrames} from './DesignSystems';
 import {
+	DesignSystemsResponsive,
+	designSystemsResponsiveDurationInFrames,
+} from './DesignSystemsResponsive';
+import {
 	DocsPagesShowcase,
 	INSTAGRAM_POST_HEIGHT,
 	INSTAGRAM_POST_WIDTH,
@@ -322,6 +326,14 @@ export const RemotionRoot: React.FC = () => {
 					fps={30}
 					width={1080}
 					height={1080}
+				/>
+				<Composition
+					id="DesignSystemsResponsive"
+					component={DesignSystemsResponsive}
+					durationInFrames={designSystemsResponsiveDurationInFrames}
+					fps={30}
+					width={1350}
+					height={796}
 				/>
 				<Composition
 					id="ApplicationSimpleApp"


### PR DESCRIPTION
## Summary

- add a `DesignSystemsResponsive` brand composition driven by responsive Studio captures
- animate from wide to narrow and back with spring easing and timed holds
- keep generated screenshot assets local and ignored, and round the captured Studio surface

## Testing

- `bunx oxfmt packages/brand/.gitignore packages/brand/src/Root.tsx packages/brand/src/DesignSystemsResponsive.tsx --write`
- `bun run build`
- `bun run stylecheck`
