### PR TITLE
Experiment: Preserve required CI checks for skipped suites

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          full_matrix='{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}'
-          linux_matrix='{"include":[{"os":"ubuntu-latest","node_version":16}]}'
+          full_matrix='{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":true},{"os":"macos-latest","node_version":25,"run_build":true}]}'
+          required_matrix='{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":false}]}'
 
           run_all_test_groups() {
             for output in lambda nextjs browser webrenderer ssr templates build bundle_example; do
@@ -95,7 +95,7 @@ jobs:
           set_from_tasks bundle_example bundle-testbed
 
           build=false
-          build_matrix=$linux_matrix
+          build_matrix=$required_matrix
           if jq -e \
             'any(.data.affectedTasks.items[]; .name == "make" or .name == "test")' \
             affected.json > /dev/null; then
@@ -366,12 +366,12 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}') }}
+      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":true},{"os":"macos-latest","node_version":25,"run_build":true}]}') }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
-      RUN_BUILD: ${{ needs.affected.result != 'success' || needs.affected.outputs.build == 'true' }}
+      RUN_BUILD: ${{ matrix.run_build && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true') }}
       RUN_BUNDLE: ${{ needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true' }}
-      RUN_BUILD_JOB: ${{ needs.affected.result != 'success' || needs.affected.outputs.build == 'true' || needs.affected.outputs.bundle_example == 'true' }}
+      RUN_BUILD_JOB: ${{ (matrix.run_build && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true')) || (matrix.os == 'ubuntu-latest' && (needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true')) }}
     steps:
       - name: No affected build tasks
         if: env.RUN_BUILD_JOB != 'true'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -122,7 +122,7 @@ jobs:
     if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.lambda == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    name: Lambda integration
+    name: Lambda integration tests
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -146,6 +146,21 @@ jobs:
         timeout-minutes: 10
         run: |
           cd packages/lambda && bunx remotion browser ensure && bun test src/test/integration --run
+  lambda-tests-required:
+    needs: [affected, lambda-tests]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    name: Lambda integration
+    steps:
+      - name: Verify Lambda integration result
+        env:
+          RESULT: ${{ needs.lambda-tests.result }}
+        run: |
+          if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
+            echo "Lambda integration tests concluded with $RESULT."
+            exit 1
+          fi
+          echo "Lambda integration tests concluded with $RESULT."
   nextjs-tests:
     needs: affected
     if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.nextjs == 'true') }}
@@ -227,7 +242,7 @@ jobs:
     if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.ssr == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: SSR + Monorepo checks
+    name: SSR + Monorepo tests
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -261,6 +276,21 @@ jobs:
         timeout-minutes: 10
         run: |
           cd packages/it-tests && bun test src/monorepo --run --timeout 40000
+  ssr-tests-required:
+    needs: [affected, ssr-tests]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    name: SSR + Monorepo checks
+    steps:
+      - name: Verify SSR and monorepo result
+        env:
+          RESULT: ${{ needs.ssr-tests.result }}
+        run: |
+          if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
+            echo "SSR and monorepo tests concluded with $RESULT."
+            exit 1
+          fi
+          echo "SSR and monorepo tests concluded with $RESULT."
   template-tests:
     name: Template integration on ${{ matrix.os }}
     needs: affected
@@ -331,7 +361,7 @@ jobs:
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true') }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
@@ -339,19 +369,28 @@ jobs:
       matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16},{"os":"windows-latest","node_version":16},{"os":"macos-latest","node_version":25}]}') }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
+      RUN_BUILD: ${{ needs.affected.result != 'success' || needs.affected.outputs.build == 'true' }}
+      RUN_BUNDLE: ${{ needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true' }}
+      RUN_BUILD_JOB: ${{ needs.affected.result != 'success' || needs.affected.outputs.build == 'true' || needs.affected.outputs.bundle_example == 'true' }}
     steps:
-      - uses: actions/checkout@v6
+      - name: No affected build tasks
+        if: env.RUN_BUILD_JOB != 'true'
+        run: echo "No build tasks are affected."
+      - if: env.RUN_BUILD_JOB == 'true'
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: blob:none
-      - uses: actions/setup-node@v6
+      - if: env.RUN_BUILD_JOB == 'true'
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
-      - uses: oven-sh/setup-bun@v2.1.2
+      - if: env.RUN_BUILD_JOB == 'true'
+        uses: oven-sh/setup-bun@v2.1.2
         with:
           bun-version: 1.3.3
       - name: Cache Bun dependencies (Windows)
-        if: matrix.os == 'windows-latest'
+        if: env.RUN_BUILD_JOB == 'true' && matrix.os == 'windows-latest'
         uses: actions/cache@v5
         with:
           path: D:\.bun\install\cache
@@ -359,14 +398,17 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
+        if: env.RUN_BUILD_JOB == 'true'
         run: bun ci
       - name: Cache Turbo
+        if: env.RUN_BUILD_JOB == 'true'
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Build & Test
+        if: env.RUN_BUILD == 'true'
         timeout-minutes: 30
         run: |
           bunx turbo run make test ${{ github.event_name == 'pull_request' && '--affected' || '' }} --concurrency=1 --no-update-notifier
       - name: Bundle example
-        if: matrix.os == 'ubuntu-latest' && (needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true')
+        if: matrix.os == 'ubuntu-latest' && env.RUN_BUNDLE == 'true'
         run: |
           bunx turbo run bundle-testbed --filter=@remotion/example --no-update-notifier


### PR DESCRIPTION
## Summary

- preserve the required Lambda and SSR check names when their expensive suites are intentionally skipped
- propagate failures from affected Lambda and SSR suites through the required checks
- keep the required Ubuntu build check successful as a lightweight no-op when no build task is affected

## Verification

- `bun run build`
- `bun run stylecheck`
- `actionlint -verbose .github/workflows/push.yml`
- `git diff --check`
