### PR TITLE
`create-video`: Use bundler override for Tailwind

### DIFF
--- a/packages/create-video/src/add-tailwind.ts
+++ b/packages/create-video/src/add-tailwind.ts
@@ -50,7 +50,7 @@ export const addTailwindToConfig = (projectRoot: string) => {
 		...headerLines,
 		`import { enableTailwind } from '@remotion/tailwind-v4';`,
 		...tailLines,
-		'Config.overrideWebpackConfig(enableTailwind);',
+		'Config.overrideBundlerConfig(enableTailwind);',
 	];
 
 	fs.writeFileSync(configFile, newLines.join('\n') + '\n');

--- a/packages/create-video/src/test/add-tailwind.test.ts
+++ b/packages/create-video/src/test/add-tailwind.test.ts
@@ -1,0 +1,32 @@
+import {expect, test} from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {addTailwindToConfig} from '../add-tailwind';
+
+for (const extension of ['ts', 'js']) {
+	test(`Adds a bundler-compatible Tailwind override to a ${extension} config`, () => {
+		const projectRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'create-video-tailwind-'),
+		);
+		const configFile = path.join(projectRoot, `remotion.config.${extension}`);
+
+		try {
+			fs.writeFileSync(
+				configFile,
+				`import { Config } from '@remotion/cli/config';\n\nConfig.setRspack(true);\n`,
+			);
+
+			addTailwindToConfig(projectRoot);
+
+			const config = fs.readFileSync(configFile, 'utf-8');
+			expect(config).toContain(
+				`import { enableTailwind } from '@remotion/tailwind-v4';`,
+			);
+			expect(config).toContain('Config.overrideBundlerConfig(enableTailwind);');
+			expect(config).not.toContain('Config.overrideWebpackConfig');
+		} finally {
+			fs.rmSync(projectRoot, {recursive: true, force: true});
+		}
+	});
+}


### PR DESCRIPTION
## Summary

- use the shared bundler config override when `create-video` adds Tailwind v4
- cover generated TypeScript and JavaScript configs with a regression test

## Validation

- `bun run build`
- `bun run stylecheck`
- `bun test packages/create-video/src`
- red/green regression verification

Closes #10113
