### PR TITLE
`@remotion/studio`: Fix canvas flicker when toggling sidebars

### DIFF
--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -1,5 +1,5 @@
 import {PlayerInternals} from '@remotion/player';
-import React, {useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useTimelineFlex} from '../../state/timeline';
 import type {
 	SplitterDragState,
@@ -105,8 +105,14 @@ export const SplitterContainer: React.FC<{
 		ref,
 	]);
 
-	useLayoutEffect(() => {
-		PlayerInternals.updateAllElementsSizes();
+	useEffect(() => {
+		const frame = requestAnimationFrame(() => {
+			PlayerInternals.updateAllElementsSizes();
+		});
+
+		return () => {
+			cancelAnimationFrame(frame);
+		};
 	});
 
 	return (

--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -1,5 +1,5 @@
 import {PlayerInternals} from '@remotion/player';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useTimelineFlex} from '../../state/timeline';
 import type {
 	SplitterDragState,
@@ -105,14 +105,8 @@ export const SplitterContainer: React.FC<{
 		ref,
 	]);
 
-	useEffect(() => {
-		const frame = requestAnimationFrame(() => {
-			PlayerInternals.updateAllElementsSizes();
-		});
-
-		return () => {
-			cancelAnimationFrame(frame);
-		};
+	useLayoutEffect(() => {
+		PlayerInternals.updateAllElementsSizes();
 	});
 
 	return (

--- a/packages/studio/src/components/TopPanel.tsx
+++ b/packages/studio/src/components/TopPanel.tsx
@@ -1,4 +1,12 @@
-import React, {useCallback, useContext, useEffect, useMemo} from 'react';
+import {PlayerInternals} from '@remotion/player';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from 'react';
 import {Internals} from 'remotion';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {useBreakpoint} from '../helpers/use-breakpoint';
@@ -78,6 +86,25 @@ const TopPanelInner: React.FC<{
 
 		return 'expanded';
 	}, [sidebarCollapsedStateRight]);
+	const previousSidebarState = useRef({
+		left: actualStateLeft,
+		right: actualStateRight,
+	});
+
+	useLayoutEffect(() => {
+		if (
+			previousSidebarState.current.left === actualStateLeft &&
+			previousSidebarState.current.right === actualStateRight
+		) {
+			return;
+		}
+
+		previousSidebarState.current = {
+			left: actualStateLeft,
+			right: actualStateRight,
+		};
+		PlayerInternals.updateAllElementsSizes();
+	}, [actualStateLeft, actualStateRight]);
 
 	useEffect(() => {
 		onMounted();


### PR DESCRIPTION
## Summary

- refresh element sizes during the layout phase when the resolved sidebar state changes
- preserve the existing deferred splitter refresh behavior for dragging and unrelated layout updates

## Testing

- `bun run build`
- `bun run stylecheck`
