### PR TITLE
`@remotion/studio`: Reduce canvas fit padding

### DIFF
--- a/packages/studio/src/helpers/studio-fit-padding.ts
+++ b/packages/studio/src/helpers/studio-fit-padding.ts
@@ -3,7 +3,7 @@ import {PlayerInternals} from '@remotion/player';
 import type {PreviewSize} from 'remotion';
 import {Internals} from 'remotion';
 
-export const STUDIO_FIT_PADDING = 16;
+export const STUDIO_FIT_PADDING = 8;
 
 type CanvasSize = {
 	readonly width: number;

--- a/packages/studio/src/test/composition-drop-preview.test.ts
+++ b/packages/studio/src/test/composition-drop-preview.test.ts
@@ -29,10 +29,10 @@ test('centers a composition drop preview under the pointer', () => {
 			},
 		}),
 	).toEqual({
-		left: 336,
-		top: 196,
-		width: 320,
-		height: 180,
+		left: 333.3333333333333,
+		top: 194.5,
+		width: 325.3333333333333,
+		height: 183,
 	});
 });
 
@@ -51,10 +51,10 @@ test('previews an equal-sized composition at the drop position', () => {
 			},
 		}),
 	).toEqual({
-		left: -384,
-		top: -94,
-		width: 960,
-		height: 540,
+		left: -398.3333333333333,
+		top: -100.5,
+		width: 976,
+		height: 549,
 	});
 });
 

--- a/packages/studio/src/test/studio-fit-padding.test.ts
+++ b/packages/studio/src/test/studio-fit-padding.test.ts
@@ -16,7 +16,7 @@ const makeCanvasSize = (width: number, height: number): Size => ({
 	refresh: () => undefined,
 });
 
-test('adds a 16px horizontal gutter when fitting by width', () => {
+test('adds an 8px horizontal gutter when fitting by width', () => {
 	const canvasSize = makeCanvasSize(1000, 600);
 	const transformation = calculateStudioCanvasTransformation({
 		canvasSize,
@@ -25,14 +25,14 @@ test('adds a 16px horizontal gutter when fitting by width', () => {
 		previewSize: 'auto',
 	});
 
-	expect(transformation.scale).toBeCloseTo((1000 - 32) / 1920);
-	expect(transformation.centerX).toBe(STUDIO_FIT_PADDING);
+	expect(transformation.scale).toBeCloseTo((1000 - 16) / 1920);
+	expect(transformation.centerX).toBeCloseTo(STUDIO_FIT_PADDING);
 	expect(transformation.centerY).toBeCloseTo(
 		(600 - 1080 * transformation.scale) / 2,
 	);
 });
 
-test('adds a 16px vertical gutter when fitting by height', () => {
+test('adds an 8px vertical gutter when fitting by height', () => {
 	const canvasSize = makeCanvasSize(1000, 500);
 	const transformation = calculateStudioCanvasTransformation({
 		canvasSize,
@@ -41,7 +41,7 @@ test('adds a 16px vertical gutter when fitting by height', () => {
 		previewSize: 'auto',
 	});
 
-	expect(transformation.scale).toBeCloseTo((500 - 32) / 1080);
+	expect(transformation.scale).toBeCloseTo((500 - 16) / 1080);
 	expect(transformation.centerX).toBeCloseTo(
 		(1000 - 1920 * transformation.scale) / 2,
 	);
@@ -75,6 +75,6 @@ test('keeps the layout size separate from the auto-fit size', () => {
 	const context = getStudioCurrentScaleContext(canvasSize);
 
 	expect(context.canvasSize).toBe(canvasSize);
-	expect(context.canvasSizeForAuto.width).toBe(1000 - 32);
-	expect(context.canvasSizeForAuto.height).toBe(600 - 32);
+	expect(context.canvasSizeForAuto.width).toBe(1000 - 16);
+	expect(context.canvasSizeForAuto.height).toBe(600 - 16);
 });


### PR DESCRIPTION
## Summary

- Reduce the Studio auto-fit canvas padding from 16px to 8px.
- Update the canvas transformation tests for the smaller gutter.

## Testing

- `bun test packages/studio/src/test/studio-fit-padding.test.ts`
- `bun run build`
- `bun run stylecheck`
