### PR TITLE
`@remotion/studio`: Prefer frame 0 for Canvas drops

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1,7 +1,58 @@
-import {expect, test} from '@playwright/test';
-import {STUDIO_URL} from './constants.mts';
+import fs from 'fs';
+import {expect, test, type Page} from '@playwright/test';
+import {StudioProtocolInternals} from '@remotion/studio-protocol';
+import {STUDIO_URL, effectKeyframeE2eFile} from './constants.mts';
 import {navigateToSchemaTest} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
+
+const dropAssetOnCanvas = async ({
+	assetPath,
+	durationInSeconds,
+	page,
+}: {
+	assetPath: string;
+	durationInSeconds: number;
+	page: Page;
+}) => {
+	const dragData = StudioProtocolInternals.makeDragData({
+		type: 'asset',
+		assetPath,
+		durationInSeconds,
+		height: null,
+		width: null,
+	});
+	await page
+		.locator('.remotion-studio-composition-container')
+		.evaluate((element, data) => {
+			const rect = element.getBoundingClientRect();
+			const dataTransfer = new DataTransfer();
+			dataTransfer.setData(data.mimeType, data.payload);
+			element.dispatchEvent(
+				new DragEvent('drop', {
+					bubbles: true,
+					cancelable: true,
+					clientX: rect.left + rect.width / 2,
+					clientY: rect.top + rect.height / 2,
+					dataTransfer,
+				}),
+			);
+		}, dragData);
+};
+
+const getVideoTag = (source: string, assetPath: string) => {
+	const sourceIndex = source.indexOf(assetPath);
+	if (sourceIndex === -1) {
+		throw new Error(`Could not find ${assetPath} in source`);
+	}
+
+	const tagStart = source.lastIndexOf('<Video', sourceIndex);
+	const tagEnd = source.indexOf('/>', sourceIndex);
+	if (tagStart === -1 || tagEnd === -1) {
+		throw new Error(`Could not find <Video> tag for ${assetPath}`);
+	}
+
+	return source.slice(tagStart, tagEnd + 2);
+};
 
 test.describe('visual mode', () => {
 	test.beforeEach(async () => {
@@ -103,5 +154,47 @@ test.describe('visual mode', () => {
 		await expect(
 			page.getByRole('button', {name: '75', exact: true}),
 		).toBeVisible();
+	});
+
+	test('should place Canvas drops where they are visible at the playhead', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(
+			page.getByRole('button', {name: '0', exact: true}),
+		).toBeVisible({timeout: 15_000});
+
+		await page.locator('[data-timeline-scrubber]').click();
+		await expect(
+			page.getByRole('button', {name: '45', exact: true}),
+		).toBeVisible();
+
+		await dropAssetOnCanvas({
+			assetPath: 'quick.mov',
+			durationInSeconds: 5.866667,
+			page,
+		});
+		await expect
+			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
+			.toContain('quick.mov');
+		const longVideoTag = getVideoTag(
+			fs.readFileSync(effectKeyframeE2eFile, 'utf-8'),
+			'quick.mov',
+		);
+		expect(longVideoTag).not.toContain('from=');
+
+		await dropAssetOnCanvas({
+			assetPath: 'drums-drumsticks.mp4',
+			durationInSeconds: 0.85,
+			page,
+		});
+		await expect
+			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
+			.toContain('drums-drumsticks.mp4');
+		const shortVideoTag = getVideoTag(
+			fs.readFileSync(effectKeyframeE2eFile, 'utf-8'),
+			'drums-drumsticks.mp4',
+		);
+		expect(shortVideoTag).toContain('from={45}');
 	});
 });

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1166,6 +1166,7 @@ export const Canvas: React.FC<{
 					event,
 					fps: config.fps,
 					from: getCurrentFrame(),
+					preferCompositionStart: true,
 				});
 			} finally {
 				setIsAddingAsset(false);

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1278,6 +1278,7 @@ export const Canvas: React.FC<{
 						contentDimensions === 'none' ? null : contentDimensions,
 					dropPosition,
 					from: null,
+					preferCompositionStart: null,
 					svgImportMode,
 				});
 			} finally {

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -149,6 +149,7 @@ export const useCompositionActions = () => {
 				destinationDimensions: null,
 				dropPosition: null,
 				from: null,
+				preferCompositionStart: null,
 				svgImportMode: 'image',
 			});
 		} finally {
@@ -177,6 +178,7 @@ export const useCompositionActions = () => {
 					destinationDimensions: null,
 					dropPosition: null,
 					from: null,
+					preferCompositionStart: null,
 				});
 			} finally {
 				setIsAddingAsset(false);
@@ -241,6 +243,7 @@ export const useCompositionActions = () => {
 					compositionId: currentCompositionId,
 					dropPosition: null,
 					from: null,
+					preferCompositionStart: null,
 				});
 			} catch (error) {
 				showNotification(

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -190,6 +190,7 @@ const TimelineContextMenuArea: React.FC<{
 				destinationDimensions: null,
 				dropPosition: null,
 				from: null,
+				preferCompositionStart: null,
 				svgImportMode: 'image',
 			});
 		} finally {

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -172,6 +172,7 @@ export const useTimelineAssetDrop = () => {
 					event,
 					fps: videoConfig.fps,
 					from: frame,
+					preferCompositionStart: false,
 				});
 			} finally {
 				setIsAddingAsset(false);

--- a/packages/studio/src/components/handle-drop.ts
+++ b/packages/studio/src/components/handle-drop.ts
@@ -14,6 +14,7 @@ import {getElementDragData} from './element-drag-and-drop';
 import {enqueueElementInstallRequest} from './element-install-request';
 import {
 	getElementPositionForDrop,
+	getFromForDrop,
 	hasSvgFile,
 	importAssets,
 	importRemoteAsset,
@@ -34,6 +35,7 @@ export const handleDrop = async ({
 	event,
 	fps,
 	from,
+	preferCompositionStart,
 }: {
 	chooseSvgImportMode: () => Promise<SvgImportMode | null>;
 	compositionFile: string;
@@ -43,6 +45,7 @@ export const handleDrop = async ({
 	event: DragEvent;
 	fps: number;
 	from: number | null;
+	preferCompositionStart: boolean;
 }) => {
 	if (isFileDragEvent(event)) {
 		const files = Array.from(event.dataTransfer?.files ?? []);
@@ -65,6 +68,7 @@ export const handleDrop = async ({
 			files,
 			fps,
 			from,
+			preferCompositionStart,
 			svgImportMode,
 		});
 		return;
@@ -84,6 +88,7 @@ export const handleDrop = async ({
 			dropPosition,
 			fps,
 			from,
+			preferCompositionStart,
 		});
 		return;
 	}
@@ -99,6 +104,7 @@ export const handleDrop = async ({
 			compositionId,
 			fps,
 			from,
+			preferCompositionStart,
 			url: sfxUrl,
 		});
 		return;
@@ -116,6 +122,7 @@ export const handleDrop = async ({
 			compositionId,
 			dropPosition,
 			from,
+			preferCompositionStart,
 		});
 		return;
 	}
@@ -129,7 +136,11 @@ export const handleDrop = async ({
 			compositionFile,
 			compositionId,
 			element: element.element,
-			from,
+			from: getFromForDrop({
+				durationInFrames: element.element.durationInFrames,
+				from,
+				preferCompositionStart,
+			}),
 			position: getElementPositionForDrop({
 				dimensions: element.element.dimensions,
 				dropPosition,
@@ -147,6 +158,7 @@ export const handleDrop = async ({
 			compositionId,
 			dropPosition,
 			from,
+			preferCompositionStart,
 		});
 		return;
 	}
@@ -163,6 +175,7 @@ export const handleDrop = async ({
 		dropPosition,
 		fps,
 		from,
+		preferCompositionStart,
 		url: remoteAssetUrl,
 	});
 };

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -37,9 +37,9 @@ export const getFromForDrop = ({
 }: {
 	durationInFrames: number | null | undefined;
 	from: number | null;
-	preferCompositionStart: boolean;
+	preferCompositionStart: boolean | null;
 }): number | null => {
-	if (!preferCompositionStart) {
+	if (preferCompositionStart !== true) {
 		return from;
 	}
 
@@ -751,7 +751,7 @@ export const importAssets = async ({
 	files,
 	fps,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 	svgImportMode,
 }: {
 	compositionFile: string;
@@ -761,7 +761,7 @@ export const importAssets = async ({
 	files: File[];
 	fps: number;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 	svgImportMode: 'image' | 'inline';
 }) => {
 	if (files.length === 0) {
@@ -1017,7 +1017,7 @@ export const importRemoteAsset = async ({
 	dropPosition,
 	fps,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 	url,
 }: {
 	compositionFile: string;
@@ -1026,7 +1026,7 @@ export const importRemoteAsset = async ({
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 	url: string;
 }) => {
 	try {
@@ -1093,14 +1093,14 @@ export const insertRemoteAudio = async ({
 	compositionId,
 	fps,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 	url,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	fps: number;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 	url: string;
 }) => {
 	if (!isUrl(url)) {
@@ -1157,7 +1157,7 @@ export const insertExistingAssets = async ({
 	dropPosition,
 	fps,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 }: {
 	assetPaths: string[];
 	compositionFile: string;
@@ -1166,7 +1166,7 @@ export const insertExistingAssets = async ({
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 }) => {
 	if (assetPaths.length === 0) {
 		return;
@@ -1240,14 +1240,14 @@ export const insertComponent = async ({
 	compositionId,
 	dropPosition,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 }: {
 	component: ComponentDragData['component'];
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 }) => {
 	try {
 		const inserted = await insertCompositionElement({
@@ -1305,14 +1305,14 @@ export const insertComposition = async ({
 	compositionId,
 	dropPosition,
 	from,
-	preferCompositionStart = false,
+	preferCompositionStart,
 }: {
 	composition: CompositionDragData;
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	from: number | null;
-	preferCompositionStart?: boolean;
+	preferCompositionStart: boolean | null;
 }) => {
 	if (composition.compositionId === compositionId) {
 		showNotification('Cannot add a composition to itself', 3000);

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -30,6 +30,31 @@ export type InsertElementDropPosition = {
 	readonly centerY: number;
 };
 
+export const getFromForDrop = ({
+	durationInFrames,
+	from,
+	preferCompositionStart,
+}: {
+	durationInFrames: number | null | undefined;
+	from: number | null;
+	preferCompositionStart: boolean;
+}): number | null => {
+	if (!preferCompositionStart) {
+		return from;
+	}
+
+	if (
+		durationInFrames !== null &&
+		durationInFrames !== undefined &&
+		from !== null &&
+		from >= durationInFrames
+	) {
+		return from;
+	}
+
+	return null;
+};
+
 type InsertableAssetElement = Extract<
 	InsertableCompositionElement,
 	{type: 'asset'}
@@ -726,6 +751,7 @@ export const importAssets = async ({
 	files,
 	fps,
 	from,
+	preferCompositionStart = false,
 	svgImportMode,
 }: {
 	compositionFile: string;
@@ -735,6 +761,7 @@ export const importAssets = async ({
 	files: File[];
 	fps: number;
 	from: number | null;
+	preferCompositionStart?: boolean;
 	svgImportMode: 'image' | 'inline';
 }) => {
 	if (files.length === 0) {
@@ -787,7 +814,11 @@ export const importAssets = async ({
 				const svgInserted = await insertCompositionElement({
 					compositionFile,
 					compositionId,
-					from,
+					from: getFromForDrop({
+						durationInFrames: null,
+						from,
+						preferCompositionStart,
+					}),
 					element: {
 						type: 'svg',
 						markup: new TextDecoder().decode(contents),
@@ -834,19 +865,25 @@ export const importAssets = async ({
 
 			const resolvedDimensions = element.dimensions ?? metadata.dimensions;
 
+			const durationInFrames = assetTypeHasDuration(element.assetType)
+				? getDurationInFrames({
+						durationInSeconds: metadata.durationInSeconds,
+						fps,
+					})
+				: null;
+
 			const inserted = await insertCompositionElement({
 				compositionFile,
 				compositionId,
-				from,
+				from: getFromForDrop({
+					durationInFrames,
+					from,
+					preferCompositionStart,
+				}),
 				element: {
 					...element,
 					dimensions: resolvedDimensions,
-					durationInFrames: assetTypeHasDuration(element.assetType)
-						? getDurationInFrames({
-								durationInSeconds: metadata.durationInSeconds,
-								fps,
-							})
-						: null,
+					durationInFrames,
 					position: getAssetPositionForDrop({
 						assetDimensions: resolvedDimensions,
 						destinationDimensions,
@@ -980,6 +1017,7 @@ export const importRemoteAsset = async ({
 	dropPosition,
 	fps,
 	from,
+	preferCompositionStart = false,
 	url,
 }: {
 	compositionFile: string;
@@ -988,6 +1026,7 @@ export const importRemoteAsset = async ({
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
 	from: number | null;
+	preferCompositionStart?: boolean;
 	url: string;
 }) => {
 	try {
@@ -1008,19 +1047,24 @@ export const importRemoteAsset = async ({
 		);
 		const dimensions = element.dimensions ?? metadata.dimensions;
 
+		const durationInFrames = assetTypeHasDuration(element.assetType)
+			? getDurationInFrames({
+					durationInSeconds: metadata.durationInSeconds,
+					fps,
+				})
+			: null;
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
-			from,
+			from: getFromForDrop({
+				durationInFrames,
+				from,
+				preferCompositionStart,
+			}),
 			element: {
 				...element,
 				dimensions,
-				durationInFrames: assetTypeHasDuration(element.assetType)
-					? getDurationInFrames({
-							durationInSeconds: metadata.durationInSeconds,
-							fps,
-						})
-					: null,
+				durationInFrames,
 				position: getAssetPositionForDrop({
 					assetDimensions: dimensions,
 					destinationDimensions,
@@ -1049,12 +1093,14 @@ export const insertRemoteAudio = async ({
 	compositionId,
 	fps,
 	from,
+	preferCompositionStart = false,
 	url,
 }: {
 	compositionFile: string;
 	compositionId: string;
 	fps: number;
 	from: number | null;
+	preferCompositionStart?: boolean;
 	url: string;
 }) => {
 	if (!isUrl(url)) {
@@ -1081,7 +1127,11 @@ export const insertRemoteAudio = async ({
 			compositionFile,
 			compositionId,
 			element,
-			from,
+			from: getFromForDrop({
+				durationInFrames: element.durationInFrames,
+				from,
+				preferCompositionStart,
+			}),
 		});
 
 		if (!inserted) {
@@ -1107,6 +1157,7 @@ export const insertExistingAssets = async ({
 	dropPosition,
 	fps,
 	from,
+	preferCompositionStart = false,
 }: {
 	assetPaths: string[];
 	compositionFile: string;
@@ -1115,6 +1166,7 @@ export const insertExistingAssets = async ({
 	dropPosition: InsertElementDropPosition | null;
 	fps: number;
 	from: number | null;
+	preferCompositionStart?: boolean;
 }) => {
 	if (assetPaths.length === 0) {
 		return;
@@ -1137,19 +1189,24 @@ export const insertExistingAssets = async ({
 			);
 			const dimensions = element.dimensions ?? metadata.dimensions;
 
+			const durationInFrames = assetTypeHasDuration(element.assetType)
+				? getDurationInFrames({
+						durationInSeconds: metadata.durationInSeconds,
+						fps,
+					})
+				: null;
 			const inserted = await insertCompositionElement({
 				compositionFile,
 				compositionId,
-				from,
+				from: getFromForDrop({
+					durationInFrames,
+					from,
+					preferCompositionStart,
+				}),
 				element: {
 					...element,
 					dimensions,
-					durationInFrames: assetTypeHasDuration(element.assetType)
-						? getDurationInFrames({
-								durationInSeconds: metadata.durationInSeconds,
-								fps,
-							})
-						: null,
+					durationInFrames,
 					position: getAssetPositionForDrop({
 						assetDimensions: dimensions,
 						destinationDimensions,
@@ -1183,18 +1240,24 @@ export const insertComponent = async ({
 	compositionId,
 	dropPosition,
 	from,
+	preferCompositionStart = false,
 }: {
 	component: ComponentDragData['component'];
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	from: number | null;
+	preferCompositionStart?: boolean;
 }) => {
 	try {
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
-			from,
+			from: getFromForDrop({
+				durationInFrames: null,
+				from,
+				preferCompositionStart,
+			}),
 			element: {
 				type: 'component',
 				componentName: component.componentName,
@@ -1242,12 +1305,14 @@ export const insertComposition = async ({
 	compositionId,
 	dropPosition,
 	from,
+	preferCompositionStart = false,
 }: {
 	composition: CompositionDragData;
 	compositionFile: string;
 	compositionId: string;
 	dropPosition: InsertElementDropPosition | null;
 	from: number | null;
+	preferCompositionStart?: boolean;
 }) => {
 	if (composition.compositionId === compositionId) {
 		showNotification('Cannot add a composition to itself', 3000);
@@ -1275,7 +1340,11 @@ export const insertComposition = async ({
 		const inserted = await insertCompositionElement({
 			compositionFile,
 			compositionId,
-			from,
+			from: getFromForDrop({
+				durationInFrames: calculated.durationInFrames,
+				from,
+				preferCompositionStart,
+			}),
 			element: {
 				type: 'composition',
 				compositionId: composition.compositionId,

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -54,6 +54,13 @@ test('places timeline drops at the pointer frame', () => {
 			preferCompositionStart: false,
 		}),
 	).toBe(45);
+	expect(
+		getFromForDrop({
+			durationInFrames: 46,
+			from: 45,
+			preferCompositionStart: null,
+		}),
+	).toBe(45);
 });
 
 test('converts media duration to composition frames with two decimals', () => {

--- a/packages/studio/src/test/import-assets.test.ts
+++ b/packages/studio/src/test/import-assets.test.ts
@@ -8,8 +8,53 @@ import {
 	getCompositionPositionForDrop,
 	getDurationInFrames,
 	getElementPositionForDrop,
+	getFromForDrop,
 	hasSvgFile,
 } from '../components/import-assets';
+
+test('places Canvas drops at the composition start when they cover the playhead', () => {
+	expect(
+		getFromForDrop({
+			durationInFrames: 46,
+			from: 45,
+			preferCompositionStart: true,
+		}),
+	).toBe(null);
+	expect(
+		getFromForDrop({
+			durationInFrames: null,
+			from: 45,
+			preferCompositionStart: true,
+		}),
+	).toBe(null);
+	expect(
+		getFromForDrop({
+			durationInFrames: undefined,
+			from: 45,
+			preferCompositionStart: true,
+		}),
+	).toBe(null);
+});
+
+test('places Canvas drops at the playhead when their duration would not cover it', () => {
+	expect(
+		getFromForDrop({
+			durationInFrames: 45,
+			from: 45,
+			preferCompositionStart: true,
+		}),
+	).toBe(45);
+});
+
+test('places timeline drops at the pointer frame', () => {
+	expect(
+		getFromForDrop({
+			durationInFrames: 46,
+			from: 45,
+			preferCompositionStart: false,
+		}),
+	).toBe(45);
+});
 
 test('converts media duration to composition frames with two decimals', () => {
 	expect(getDurationInFrames({durationInSeconds: 1.2345, fps: 30})).toBe(37.03);


### PR DESCRIPTION
## Summary

- Prefer the composition start for items dropped onto the Studio Canvas
- Fall back to the current playhead when a known finite duration would make the item invisible there
- Keep timeline drops anchored to the frame underneath the pointer

## Testing

- `bun test ./packages/studio/src/test/import-assets.test.ts`
- `bunx playwright test e2e/studio.test.mts --grep "Canvas drops"`
- `bun run build`
- `bun run stylecheck`

Closes #9767
