### PR TITLE
`@remotion/studio`: Prevent project name from wrapping

### DIFF
--- a/packages/studio/src/components/MenuBuildIndicator.tsx
+++ b/packages/studio/src/components/MenuBuildIndicator.tsx
@@ -12,6 +12,7 @@ const cwd: React.CSSProperties = {
 	alignItems: 'center',
 	justifyContent: 'center',
 	userSelect: 'none',
+	whiteSpace: 'nowrap',
 };
 
 const spinnerSize = 14;


### PR DESCRIPTION
## Summary

- prevent the Studio project name from wrapping in the menu toolbar

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test formatting --filter=@remotion/studio`

Closes #10084
