### PR TITLE
Internal: Disable Twoslash in docs during local development

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
-		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && bunx turbo run prewarm-twoslash --filter=docs --no-update-notifier && docusaurus start --host 0.0.0.0",
+		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0",
 		"build-docs": "bun build-docs.ts",
 		"prewarm-twoslash": "bun prewarm-twoslash.ts",
 		"swizzle": "docusaurus swizzle",

--- a/packages/docs/prewarm-twoslash.ts
+++ b/packages/docs/prewarm-twoslash.ts
@@ -15,6 +15,7 @@ import {
 	publishLocalTwoslashCacheEntry,
 	readTwoslashCacheEntry,
 } from '../docusaurus-plugin/src/twoslash-cache';
+import {isTwoslashEnabled} from '../docusaurus-plugin/src/twoslash-enabled';
 import {expandElementSourceReferences} from './plugins/element-source-utils';
 
 const DOCS_ROOT = resolve(import.meta.dirname);
@@ -331,6 +332,11 @@ interface WorkerHandle {
 }
 
 async function main() {
+	if (!isTwoslashEnabled()) {
+		console.log('Skipping Twoslash pre-warm because Twoslash is disabled');
+		return;
+	}
+
 	const startTime = performance.now();
 
 	const glob = new Glob('**/*.{mdx,md}');

--- a/packages/docusaurus-plugin/src/shiki.ts
+++ b/packages/docusaurus-plugin/src/shiki.ts
@@ -6,6 +6,7 @@ import {visit} from 'unist-util-visit';
 import {cachedTwoslashCall} from './caching';
 import {setupNodeForTwoslashException} from './exceptionMessageDOM';
 import {addIncludes, replaceIncludesInCode} from './includes';
+import {isTwoslashEnabled} from './twoslash-enabled';
 import type {Node} from './unist-types';
 
 type OBJECT = Record<string, unknown>;
@@ -146,7 +147,7 @@ const remarkVisitor =
 			shikiHTML = twoslashSettings.wrapFragments
 				? `<div class="shiki-twoslash-fragment"></div>`
 				: '';
-		} else if (fence.meta.twoslash) {
+		} else if (fence.meta.twoslash && isTwoslashEnabled()) {
 			// Twoslash code block — use cached call
 			const importedCode = replaceIncludesInCode(includes, node.value);
 			try {
@@ -175,7 +176,7 @@ const remarkVisitor =
 				'<button class="copy-button" aria-label="Copy code to clipboard">Copy</button></pre>',
 			);
 		} else {
-			// Regular (non-twoslash) code block
+			// Regular syntax highlighting without type-checking
 			const langAliases: Record<string, string> = {
 				json5: 'json',
 				js: 'javascript',

--- a/packages/docusaurus-plugin/src/twoslash-enabled.ts
+++ b/packages/docusaurus-plugin/src/twoslash-enabled.ts
@@ -1,0 +1,7 @@
+export const isTwoslashEnabled = (): boolean => {
+	if (process.env.REMOTION_DOCS_ENABLE_TWOSLASH === '1') {
+		return true;
+	}
+
+	return process.env.REMOTION_DOCS_DISABLE_TWOSLASH !== '1';
+};

--- a/turbo.json
+++ b/turbo.json
@@ -97,6 +97,10 @@
 				"package.json"
 			],
 			"outputs": ["node_modules/.cache/twoslash/**"],
+			"env": [
+				"REMOTION_DOCS_DISABLE_TWOSLASH",
+				"REMOTION_DOCS_ENABLE_TWOSLASH"
+			],
 			"passThroughEnv": [
 				"NODE_OPTIONS",
 				"REMOTION_DOCS_LOW_MEMORY_BUILD",
@@ -121,6 +125,10 @@
 				"@remotion/example#bundle-testbed"
 			],
 			"outputs": [".docusaurus", "build"],
+			"env": [
+				"REMOTION_DOCS_DISABLE_TWOSLASH",
+				"REMOTION_DOCS_ENABLE_TWOSLASH"
+			],
 			"outputLogs": "new-only"
 		},
 		"test": {


### PR DESCRIPTION
## Summary

- disable Twoslash type-checking when starting the docs development server
- retain regular Shiki syntax highlighting for Twoslash code blocks
- allow opting back in with `REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start`
- keep Twoslash enabled for production and CI builds

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx oxfmt packages/docs/package.json packages/docs/prewarm-twoslash.ts packages/docusaurus-plugin/src/shiki.ts packages/docusaurus-plugin/src/twoslash-enabled.ts turbo.json --write`
