### PR TITLE
Elements: Add spacing before contribution links

### DIFF
--- a/packages/docs/elements/index.mdx
+++ b/packages/docs/elements/index.mdx
@@ -12,4 +12,6 @@ Remotion Elements are drop-in, HTML-first video building blocks. Send one from t
 
 <ElementLibrary category={null} />
 
+<div style={{height: 24}} />
+
 To contribute, follow the [Element Guidelines](/elements/guidelines) and [submission instructions](/elements/submit-an-element).


### PR DESCRIPTION
## Summary

Adds vertical spacing between the Remotion Elements gallery and the contribution links.

## Verification

- `bunx oxfmt packages/docs/elements/index.mdx --write`
- `bun run build`
- `bun run stylecheck`

## Preview

- [Remotion Elements](https://remotion-git-elements-contribution-spacing-remotion.vercel.app/elements)
