### PR TITLE
Elements: Clarify entry and exit animation guidance

### DIFF
--- a/.agents/skills/publish-element/SKILL.md
+++ b/.agents/skills/publish-element/SKILL.md
@@ -5,7 +5,7 @@ description: Finalize a developed Remotion Element, add it to the docs gallery, 
 
 # Publish a Remotion Element
 
-The source of truth for design and quality criteria is the [Element Guidelines](https://github.com/remotion-dev/remotion/blob/main/packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
+The source of truth for design and quality criteria is the [Element Guidelines](../../../packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
 
 This skill owns the technical publication workflow. It starts with an Element scaffold created by the [`scaffold-element` skill](../scaffold-element/SKILL.md) and does not create the initial development scaffold.
 
@@ -26,9 +26,9 @@ bun run remotion
 
 ## 2. Perform the publication review
 
-Review the finished source, MDX page, and central definition against the Element Guidelines. Resolve placeholder content and finalize the description, display name, contributors, dimensions, duration, `installationMode`, declared dependencies, preview padding, poster frame, and `preview` object. Confirm that `durationInFrames` is appropriate for both the preview and either the generated `<Sequence>` or component-owned Sequence installed into Studio. Use `installationMode: 'wrapped'` by default. Before approving `'component-owned-sequence'`, verify that the component owns the intended interactive Sequence, forwards `from`, `durationInFrames`, `name`, and `style`, defines its rendered dimensions, and remains movable and trimmable without an outer Sequence. Confirm that every external source import except `react`, `react-dom`, and `remotion` appears in `dependencies`. Remotion packages must use `version: null`; every non-Remotion package must use an exact semantic version, not a range or tag. Confirm that `posterUrl` and `videoUrl` use flat `https://remotion.media/elements/<category>-<slug>-preview.png` and `.mp4` paths. Preview assets are composited onto the standard background and use MP4 for broad browser, social-card, and embed compatibility, even when the Element itself supports transparency. These explicit URLs are the publishing source of truth.
+Review the finished source, MDX page, and central definition against the Element Guidelines and the technical requirements in the [`scaffold-element` skill](../scaffold-element/SKILL.md). Resolve placeholder content and finalize the description, display name, contributors, dimensions, duration, `installationMode`, declared dependencies, preview padding, poster frame, and `preview` object.
 
-Re-check the technical implementation requirements from the [`scaffold-element` skill](../scaffold-element/SKILL.md): The reusable implementation must remain in one self-contained TSX file, fill its configured bounds without a preview-only wrapper `<Sequence>` or source padding, and leave outer placement to either the generated wrapper or its component-owned Sequence. Animated entrances must have exits with inline, hardcoded frame ranges on useful named `Interactive.*` elements. Inner control names must not repeat the Element display name.
+Confirm that `posterUrl` and `videoUrl` use flat `https://remotion.media/elements/<category>-<slug>-preview.png` and `.mp4` paths. Preview assets are composited onto the standard background and use MP4 for broad browser, social-card, and embed compatibility, even when the Element itself supports transparency. These explicit URLs are the publishing source of truth.
 
 When the Element has Studio-editable controls, also review it using the [interactivity best practices skill](../interactivity-best-practices/SKILL.md).
 

--- a/.agents/skills/scaffold-element/SKILL.md
+++ b/.agents/skills/scaffold-element/SKILL.md
@@ -5,7 +5,7 @@ description: Scaffold a new Remotion Element with a correctly configured preview
 
 # Scaffold a Remotion Element
 
-The source of truth for design and quality criteria is the [Element Guidelines](https://github.com/remotion-dev/remotion/blob/main/packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
+The source of truth for design and quality criteria is the [Element Guidelines](../../../packages/docs/elements/guidelines.mdx). Read them completely before making changes. If this skill and the guidelines diverge on acceptance criteria, follow the guidelines.
 
 This skill owns the technical scaffolding workflow. Use the [`publish-element` skill](../publish-element/SKILL.md) when the Element is ready for the gallery.
 
@@ -14,10 +14,10 @@ This skill owns the technical scaffolding workflow. Use the [`publish-element` s
 Choose an existing category and a kebab-case slug. Before creating files, determine the initial preview metadata needed for development:
 
 - Composition width, height, fps, and preview duration
-- Installed Element duration, or `null` when it should adapt to the composition
-- Fixed Element width and height, or `null` for both so it inherits the composition dimensions
-- Whether installation uses the default generated `<Sequence>` (`installationMode: 'wrapped'`) or the component already owns the one interactive Sequence users should edit (`installationMode: 'component-owned-sequence'`)
-- Every external source dependency as `{name, version}`; use `null` for Remotion packages and an exact semantic version for every non-Remotion package
+- Installed Element duration
+- Element width and height
+- Installation mode
+- External source dependencies
 - Preview padding, which affects only the docs preview and not the Element bounds
 - A provisional poster frame
 - Explicit poster and video URLs using the flat asset convention:
@@ -41,15 +41,11 @@ mv packages/docs/elements/<category>/<slug>/element.tsx \
 
 Adapt the copied `index.mdx` to the production pattern: import `elementDefinitions`, use its `'<category>/<slug>'` entry, and set `sourceFile="./<slug>.tsx"`.
 
-Implement only enough of the component to provide a visible starting point in the intended bounds. Keep the reusable implementation in one self-contained TSX source file. Make the component fill its bounds without adding a wrapper `<Sequence>` or source padding for the preview. Do not use `left`, `right`, `top`, or `bottom` to place the Element itself; the surrounding project owns placement.
-
-Use `installationMode: 'wrapped'` by default. Use `'component-owned-sequence'` only when the component already owns the one interactive Sequence that users should edit and forwards `from`, `durationInFrames`, `name`, and `style` to that Sequence and its rendered outline. A component-owned-sequence Element must also define its own rendered dimensions.
-
-Follow the Element Guidelines for the component itself. When using Studio-editable controls, also follow the [interactivity best practices skill](../interactivity-best-practices/SKILL.md). Keep entrance and exit keyframes inline with hardcoded frame ranges on the useful named `Interactive.*` element so they can be adjusted in Studio. Do not repeat the Element display name in inner control names.
+Implement only enough of the component in the generated `<slug>.tsx` file to provide a visible starting point in the intended bounds. Follow the Element Guidelines for the component itself. When using Studio-editable controls, also follow the [interactivity best practices skill](../interactivity-best-practices/SKILL.md).
 
 ## 3. Register the development composition
 
-Import and register the component in `packages/docs/src/components/Elements/element-definitions.ts` using the planned preview metadata. Set `installationMode` explicitly. Set `durationInFrames` to the duration used by both the preview and either the generated `<Sequence>` or the component-owned Sequence installed into Studio. Declare every external source import in `dependencies` except `react`, `react-dom`, and `remotion`, which are provided by every Remotion project. Use `version: null` for Remotion packages and an exact semantic version for every non-Remotion package; version ranges and tags are not accepted. Add the explicit `preview` object next to the render metadata, including `posterUrl` and `videoUrl`. The URLs in this object are the source of truth for publishing; do not add a helper that derives production URLs from the Element slug.
+Import and register the component in `packages/docs/src/components/Elements/element-definitions.ts` using the planned preview metadata. Set `installationMode` explicitly and use the same `durationInFrames` for the preview and installed Element. Add the explicit `preview` object next to the render metadata, including `posterUrl` and `videoUrl`. The URLs in this object are the source of truth for publishing; do not add a helper that derives production URLs from the Element slug.
 
 Do not edit `packages/docs/src/remotion/Root.tsx`. It automatically creates a composition for every central definition using the same sizing and wrapper used by published Elements.
 

--- a/packages/docs/elements/guidelines.mdx
+++ b/packages/docs/elements/guidelines.mdx
@@ -37,9 +37,13 @@ An Element that already owns the one interactive Sequence users should edit may 
 
 Do not use the component-owned mode merely to remove markup: The Element needs to remain movable and trimmable through its component-owned Sequence. Do not add internal padding only to improve the gallery preview.
 
-## Make animations complete
+## Animate temporary Elements in and out
 
-Include an exit animation whenever there is an entrance animation. Animate properties within the Element, such as translation, scale, and opacity; leave placement to the generated wrapper or the component-owned Sequence.
+If an Element is intended to appear temporarily over other content—such as an overlay, lower third, label, or callout—include both an entrance and an exit animation.
+
+Backgrounds, loops, full-scene treatments, and other Elements that are not expected to enter and leave independently do not need these animations.
+
+Animate properties within the Element, such as translation, scale, and opacity; leave placement to the generated wrapper or the component-owned Sequence.
 
 ## Expose useful Studio controls
 
@@ -51,6 +55,6 @@ Follow the [interactivity best practices](/docs/studio/interactivity-best-practi
 
 ## Choose a representative preview
 
-Choose a poster frame that clearly shows the Element. The video preview should cover its full duration, including entrance and exit animations.
+Choose a poster frame that clearly shows the Element. The video preview should cover the Element's full duration and, when applicable, include its entrance and exit animations.
 
 When ready, [submit the Element](/elements/submit-an-element).


### PR DESCRIPTION
## Summary

- Recommend entrance and exit animations for temporary, overlay-like Elements rather than every Element
- Make preview guidance conditional on whether those animations apply
- Remove duplicated acceptance criteria from the Element scaffolding and publishing skills and point them to the canonical local guidelines

## Verification

- `bunx oxfmt .agents/skills/publish-element/SKILL.md .agents/skills/scaffold-element/SKILL.md packages/docs/elements/guidelines.mdx --write`
- `bun run build`
- `bun run stylecheck`


## Preview

- [Element Guidelines](https://remotion-git-elements-animation-guidelines-remotion.vercel.app/elements/guidelines)
