### PR TITLE
`@remotion/studio`: Add default coding agent setting

### DIFF
--- a/packages/cli/src/config-file-change.ts
+++ b/packages/cli/src/config-file-change.ts
@@ -46,6 +46,7 @@ const configMethodLifecycles = {
 	setColorSpace: 'runtime',
 	setConcurrency: 'runtime',
 	setCrf: 'runtime',
+	setDefaultCodingAgent: 'runtime',
 	setDefaultEditor: 'runtime',
 	setDelayRenderTimeoutInMilliseconds: 'runtime',
 	setDeleteAfter: 'runtime',

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -11,8 +11,9 @@ import type {
 	CodecOrUndefined,
 	ColorSpace,
 	Crf,
-	DeleteAfter,
+	DefaultCodingAgent,
 	DefaultEditor,
+	DeleteAfter,
 	FrameRange,
 	NumberOfGifLoops,
 	StillImageFormat,
@@ -121,6 +122,7 @@ const {
 	enableCrossSiteIsolationOption,
 	imageSequencePatternOption,
 	darkModeOption,
+	defaultCodingAgentOption,
 	defaultEditorOption,
 	askAIOption,
 	publicLicenseKeyOption,
@@ -620,6 +622,10 @@ type FlatConfig = RemotionConfigObject &
 		 * Set the editor used when opening files from Remotion Studio.
 		 */
 		setDefaultEditor: (editor: DefaultEditor) => void;
+		/**
+		 * Set the coding agent used by Remotion Studio.
+		 */
+		setDefaultCodingAgent: (codingAgent: DefaultCodingAgent) => void;
 
 		setDeleteAfter: (day: DeleteAfter | null) => void;
 		/**
@@ -837,6 +843,7 @@ export const Config: FlatConfig = {
 	setEnableCrossSiteIsolation: enableCrossSiteIsolationOption.setConfig,
 	setAskAIEnabled: askAIOption.setConfig,
 	setPublicLicenseKey: publicLicenseKeyOption.setConfig,
+	setDefaultCodingAgent: defaultCodingAgentOption.setConfig,
 	setDefaultEditor: defaultEditorOption.setConfig,
 	setForceNewStudioEnabled: forceNewStudioOption.setConfig,
 	setIPv4: ipv4Option.setConfig,

--- a/packages/cli/src/parsed-cli.ts
+++ b/packages/cli/src/parsed-cli.ts
@@ -29,6 +29,7 @@ const {
 	publicPathOption,
 	audioLatencyHintOption,
 	darkModeOption,
+	defaultCodingAgentOption,
 	defaultEditorOption,
 	publicLicenseKeyOption,
 	forceNewStudioOption,
@@ -97,6 +98,9 @@ export type CommandLineOptions = {
 		typeof ignoreCertificateErrorsOption
 	> | null;
 	[darkModeOption.cliFlag]: TypeOfOption<typeof darkModeOption> | null;
+	[defaultCodingAgentOption.cliFlag]: TypeOfOption<
+		typeof defaultCodingAgentOption
+	>;
 	[defaultEditorOption.cliFlag]: TypeOfOption<typeof defaultEditorOption>;
 	[disableWebSecurityOption.cliFlag]: TypeOfOption<
 		typeof disableWebSecurityOption

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -47,6 +47,7 @@ const {
 	portOption,
 	browserOption,
 	previewSampleRateOption,
+	defaultCodingAgentOption,
 	defaultEditorOption,
 } = BrowserSafeApis.options;
 
@@ -167,6 +168,8 @@ export const studioCommand = async (
 		audioLatencyHintOption.getValue({commandLine: parsedCli}).value;
 	const getPreviewSampleRate = () =>
 		previewSampleRateOption.getValue({commandLine: parsedCli}).value;
+	const getDefaultCodingAgent = () =>
+		defaultCodingAgentOption.getValue({commandLine: parsedCli}).value;
 	const getDefaultEditor = () =>
 		defaultEditorOption.getValue({commandLine: parsedCli}).value;
 
@@ -289,6 +292,7 @@ export const studioCommand = async (
 		forceIPv4: ipv4Option.getValue({commandLine: parsedCli}).value,
 		getAudioLatencyHint,
 		getPreviewSampleRate,
+		getDefaultCodingAgent,
 		getDefaultEditor,
 		enableCrossSiteIsolation,
 		forceNew: forceNewStudioOption.getValue({commandLine: parsedCli}).value,

--- a/packages/cli/src/test/config-reload.test.ts
+++ b/packages/cli/src/test/config-reload.test.ts
@@ -40,7 +40,7 @@ test('an invalid config reload keeps the previous configuration', async () => {
 	});
 	temporaryDirectory = mkdtempSync(path.join(tmpdir(), 'remotion-config-'));
 	writeConfig(
-		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(4321); Config.setDefaultEditor('cursor');`,
+		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(4321); Config.setDefaultEditor('cursor'); Config.setDefaultCodingAgent('codex');`,
 	);
 
 	await loadConfig(temporaryDirectory);
@@ -49,9 +49,14 @@ test('an invalid config reload keeps the previous configuration', async () => {
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
 	).toBe('cursor');
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBe('codex');
 
 	writeConfig(
-		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(5678); Config.setDefaultEditor('windsurf'); throw new Error('Invalid config');`,
+		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(5678); Config.setDefaultEditor('windsurf'); Config.setDefaultCodingAgent('cursor'); throw new Error('Invalid config');`,
 	);
 	expect((await reloadTestConfig()).type).toBe('error');
 	expect(ConfigInternals.getStudioPort()).toBe(4321);
@@ -59,9 +64,14 @@ test('an invalid config reload keeps the previous configuration', async () => {
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
 	).toBe('cursor');
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBe('codex');
 
 	writeConfig(
-		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(5678); Config.setDefaultEditor('windsurf');`,
+		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(5678); Config.setDefaultEditor('windsurf'); Config.setDefaultCodingAgent('cursor');`,
 	);
 	const snapshotErrorMessage = 'The derived config snapshot was rejected';
 	expect(
@@ -77,13 +87,18 @@ test('an invalid config reload keeps the previous configuration', async () => {
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
 	).toBe('cursor');
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBe('codex');
 
 	writeConfig('this is not valid JavaScript }');
 	expect((await reloadTestConfig()).type).toBe('error');
 	expect(ConfigInternals.getStudioPort()).toBe(4321);
 
 	writeConfig(
-		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(6789); Config.setDefaultEditor({type: 'custom', name: 'Acme Editor', executable: '/opt/acme/editor', arguments: ['--goto', '%TARGET_PATH%:%LINE_NUMBER%:%COLUMN_NUMBER%']});`,
+		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(6789); Config.setDefaultEditor({type: 'custom', name: 'Acme Editor', executable: '/opt/acme/editor', arguments: ['--goto', '%TARGET_PATH%:%LINE_NUMBER%:%COLUMN_NUMBER%']}); Config.setDefaultCodingAgent('claude-code');`,
 	);
 	expect((await reloadTestConfig()).type).toBe('success');
 	expect(ConfigInternals.getStudioPort()).toBe(6789);
@@ -96,6 +111,11 @@ test('an invalid config reload keeps the previous configuration', async () => {
 		executable: '/opt/acme/editor',
 		arguments: ['--goto', '%TARGET_PATH%:%LINE_NUMBER%:%COLUMN_NUMBER%'],
 	});
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBe('claude-code');
 
 	writeConfig(
 		`const {Config} = require('@remotion/cli/config'); Config.setStudioPort(7890);`,
@@ -104,6 +124,11 @@ test('an invalid config reload keeps the previous configuration', async () => {
 	expect(
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
+	).toBeNull();
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
 	).toBeNull();
 });
 

--- a/packages/cli/src/test/config-reset.test.ts
+++ b/packages/cli/src/test/config-reset.test.ts
@@ -37,6 +37,7 @@ test('reset config options restores defaults before reloading config', async () 
 	Config.setStudioPort(4321);
 	Config.setMaxTimelineTracks(123);
 	Config.setChromiumOpenGlRenderer('angle');
+	Config.setDefaultCodingAgent('codex');
 	Config.setDefaultEditor('cursor');
 	Config.setBufferStateDelayInMilliseconds(200);
 	Config.overrideBundlerConfig((config, {bundler}) => ({
@@ -61,6 +62,11 @@ test('reset config options restores defaults before reloading config', async () 
 	expect(
 		BrowserSafeApis.options.glOption.getValue({commandLine: {}}).value,
 	).toBe('angle');
+	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBe('codex');
 	expect(
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
@@ -102,6 +108,11 @@ test('reset config options restores defaults before reloading config', async () 
 		BrowserSafeApis.options.glOption.getValue({commandLine: {}}).value,
 	).toBeNull();
 	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {},
+		}).value,
+	).toBeNull();
+	expect(
 		BrowserSafeApis.options.defaultEditorOption.getValue({commandLine: {}})
 			.value,
 	).toBeNull();
@@ -133,8 +144,9 @@ test('reset config options restores defaults before reloading config', async () 
 	).toBe(true);
 });
 
-test('the CLI editor flag takes precedence over Config.setDefaultEditor()', () => {
+test('CLI app flags take precedence over the configured defaults', () => {
 	ConfigInternals.resetConfigOptions();
+	Config.setDefaultCodingAgent('codex');
 	Config.setDefaultEditor({
 		type: 'custom',
 		name: 'Acme Editor',
@@ -143,10 +155,18 @@ test('the CLI editor flag takes precedence over Config.setDefaultEditor()', () =
 	});
 
 	expect(
+		BrowserSafeApis.options.defaultCodingAgentOption.getValue({
+			commandLine: {'coding-agent': 'cursor'},
+		}),
+	).toEqual({source: 'cli', value: 'cursor'});
+	expect(
 		BrowserSafeApis.options.defaultEditorOption.getValue({
 			commandLine: {editor: 'zed'},
 		}),
 	).toEqual({source: 'cli', value: 'zed'});
+	expect(() => Config.setDefaultCodingAgent('invalid' as 'codex')).toThrow(
+		'Config.setDefaultCodingAgent() must be one of',
+	);
 	expect(() => Config.setDefaultEditor('invalid' as 'cursor')).toThrow(
 		'Config.setDefaultEditor() must be one of',
 	);

--- a/packages/docs/docs/cli/studio.mdx
+++ b/packages/docs/docs/cli/studio.mdx
@@ -65,6 +65,14 @@ Inline JSON string isn't supported on Windows shells because it removes the `"` 
 npx remotion studio --editor=cursor
 ```
 
+### `--coding-agent`<AvailableFrom v="4.0.506" />
+
+<Options id="coding-agent" cli />
+
+```sh title="Terminal"
+npx remotion studio --coding-agent=codex
+```
+
 ### `--rspack`<AvailableFrom v="4.0.502" />
 
 <Options id="rspack" />

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -233,6 +233,20 @@ The [command line flag](/docs/cli/studio#--disable-interactivity) `--disable-int
 
 See [Opening files in a code editor](/docs/studio/open-in-editor) for built-in editor IDs, custom editor configuration, and platform support.
 
+## `setDefaultCodingAgent()`<AvailableFrom v="4.0.506" />
+
+<Options id="coding-agent" />
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setDefaultCodingAgent('codex');
+```
+
+Available coding agents: `codex`, `cursor`, `github-copilot`, and `claude-code`.
+
+The [`--coding-agent`](/docs/cli/studio#--coding-agent) command line flag takes precedence over this option.
+
 ## ~~`setAllowHtmlInCanvasEnabled()`~~<AvailableFrom v="4.0.447" />
 
 :::info Deprecated

--- a/packages/renderer/src/client.ts
+++ b/packages/renderer/src/client.ts
@@ -35,6 +35,8 @@ import {
 } from './pixel-format';
 import {validateOutputFilename} from './validate-output-filename';
 export {AvailableOptions, TypeOfOption} from './options';
+export {defaultCodingAgentIds} from './options/default-coding-agent';
+export type {DefaultCodingAgent} from './options/default-coding-agent';
 export {
 	customEditorColumnNumberPlaceholder,
 	customEditorLineNumberPlaceholder,

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -100,8 +100,8 @@ export {
 } from './frame-range';
 export {
 	GetCompositionsOptions,
-	getCompositions,
 	LegacyGetCompositionsOptions,
+	getCompositions,
 } from './get-compositions';
 export {SilentPart, getSilentParts} from './get-silent-parts';
 export {VideoMetadata, getVideoMetadata} from './get-video-metadata';
@@ -119,6 +119,8 @@ export type {ChromiumOptions} from './open-browser';
 export {ChromeMode} from './options/chrome-mode';
 export {ColorSpace} from './options/color-space';
 export type {Concurrency} from './options/concurrency';
+export {defaultCodingAgentIds} from './options/default-coding-agent';
+export type {DefaultCodingAgent} from './options/default-coding-agent';
 export {
 	customEditorColumnNumberPlaceholder,
 	customEditorLineNumberPlaceholder,

--- a/packages/renderer/src/options/default-coding-agent.tsx
+++ b/packages/renderer/src/options/default-coding-agent.tsx
@@ -1,0 +1,68 @@
+import type {AnyRemotionOption} from './option';
+
+export const defaultCodingAgentIds = [
+	'codex',
+	'cursor',
+	'github-copilot',
+	'claude-code',
+] as const;
+
+export type DefaultCodingAgent = (typeof defaultCodingAgentIds)[number];
+
+const cliFlag = 'coding-agent' as const;
+let defaultCodingAgent: DefaultCodingAgent | null = null;
+
+const validateDefaultCodingAgent = (
+	value: unknown,
+	source: string,
+): DefaultCodingAgent | null => {
+	if (value === null) {
+		return null;
+	}
+
+	if (
+		typeof value !== 'string' ||
+		!defaultCodingAgentIds.includes(value as DefaultCodingAgent)
+	) {
+		throw new TypeError(
+			`${source} must be one of: ${defaultCodingAgentIds.join(', ')}. Received: ${JSON.stringify(value)}`,
+		);
+	}
+
+	return value as DefaultCodingAgent;
+};
+
+export const defaultCodingAgentOption = {
+	name: 'Default coding agent',
+	cliFlag,
+	description: () => (
+		<>
+			Set the default coding agent for Remotion Studio. Available coding agents:{' '}
+			<code>{defaultCodingAgentIds.join(', ')}</code>.
+		</>
+	),
+	ssrName: null,
+	docLink: 'https://www.remotion.dev/docs/config#setdefaultcodingagent',
+	type: null as DefaultCodingAgent | null,
+	getValue: ({commandLine}) => {
+		const cliValue = commandLine[cliFlag];
+		if (cliValue !== undefined && cliValue !== null) {
+			return {
+				value: validateDefaultCodingAgent(cliValue, `--${cliFlag}`),
+				source: 'cli',
+			};
+		}
+
+		return {
+			value: defaultCodingAgent,
+			source: 'config',
+		};
+	},
+	setConfig(value) {
+		defaultCodingAgent = validateDefaultCodingAgent(
+			value,
+			'Config.setDefaultCodingAgent()',
+		);
+	},
+	id: cliFlag,
+} satisfies AnyRemotionOption<DefaultCodingAgent | null>;

--- a/packages/renderer/src/options/index.tsx
+++ b/packages/renderer/src/options/index.tsx
@@ -15,6 +15,7 @@ import {configOption} from './config';
 import {crfOption} from './crf';
 import {enableCrossSiteIsolationOption} from './cross-site-isolation';
 import {darkModeOption} from './dark-mode';
+import {defaultCodingAgentOption} from './default-coding-agent';
 import {defaultEditorOption} from './default-editor';
 import {deleteAfterOption} from './delete-after';
 import {disableGitSourceOption} from './disable-git-source';
@@ -153,6 +154,7 @@ export const allOptions = {
 	imageSequencePatternOption,
 	mediaCacheSizeInBytesOption,
 	darkModeOption,
+	defaultCodingAgentOption,
 	defaultEditorOption,
 	publicLicenseKeyOption,
 	isProductionOption,

--- a/packages/studio-server/src/helpers/coding-agent-registry.ts
+++ b/packages/studio-server/src/helpers/coding-agent-registry.ts
@@ -1,0 +1,124 @@
+import {execFile} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {homedir} from 'node:os';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import type {DefaultCodingAgent} from '@remotion/renderer';
+import {defaultCodingAgentIds} from '@remotion/renderer';
+
+const execFilePromise = promisify(execFile);
+
+export type InstalledCodingAgent = {
+	id: DefaultCodingAgent;
+	name: string;
+	applicationPath: string;
+};
+
+type CodingAgentDefinition = {
+	name: string;
+	bundleIdentifiers: readonly string[];
+	applicationNames: readonly string[];
+};
+
+const codingAgentDefinitions = {
+	codex: {
+		name: 'Codex',
+		bundleIdentifiers: ['com.openai.codex'],
+		applicationNames: ['ChatGPT.app'],
+	},
+	cursor: {
+		name: 'Cursor',
+		bundleIdentifiers: ['com.todesktop.230313mzl4w4u92'],
+		applicationNames: ['Cursor.app'],
+	},
+	'github-copilot': {
+		name: 'GitHub Copilot',
+		bundleIdentifiers: ['com.github.githubapp'],
+		applicationNames: ['GitHub Copilot.app'],
+	},
+	'claude-code': {
+		name: 'Claude Code',
+		bundleIdentifiers: ['com.anthropic.claudefordesktop'],
+		applicationNames: ['Claude.app'],
+	},
+} satisfies Record<DefaultCodingAgent, CodingAgentDefinition>;
+
+export type CodingAgentDiscoveryContext = {
+	platform: NodeJS.Platform;
+	homeDirectory: string;
+	pathExists: (filePath: string) => boolean;
+	findMacApplications: (bundleIdentifier: string) => Promise<readonly string[]>;
+};
+
+const findMacApplications = async (
+	bundleIdentifier: string,
+): Promise<readonly string[]> => {
+	try {
+		const {stdout} = await execFilePromise('mdfind', [
+			`kMDItemCFBundleIdentifier == '${bundleIdentifier}'`,
+		]);
+		return stdout
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean);
+	} catch {
+		return [];
+	}
+};
+
+const defaultDiscoveryContext: CodingAgentDiscoveryContext = {
+	platform: process.platform,
+	homeDirectory: homedir(),
+	pathExists: existsSync,
+	findMacApplications,
+};
+
+export const discoverAvailableCodingAgents = async (
+	context: CodingAgentDiscoveryContext,
+): Promise<readonly InstalledCodingAgent[]> => {
+	if (context.platform !== 'darwin') {
+		return [];
+	}
+
+	const installedCodingAgents: InstalledCodingAgent[] = [];
+	for (const id of defaultCodingAgentIds) {
+		const definition = codingAgentDefinitions[id];
+		const discoveredApplications = (
+			await Promise.all(
+				definition.bundleIdentifiers.map((bundleIdentifier) =>
+					context.findMacApplications(bundleIdentifier),
+				),
+			)
+		).flat();
+		const knownApplications = definition.applicationNames.flatMap((name) => [
+			path.join('/Applications', name),
+			path.join(context.homeDirectory, 'Applications', name),
+		]);
+
+		for (const applicationPath of new Set([
+			...discoveredApplications,
+			...knownApplications,
+		])) {
+			if (context.pathExists(applicationPath)) {
+				installedCodingAgents.push({
+					applicationPath,
+					id,
+					name: definition.name,
+				});
+				break;
+			}
+		}
+	}
+
+	return installedCodingAgents;
+};
+
+let availableCodingAgents: Promise<readonly InstalledCodingAgent[]> | null =
+	null;
+
+export const getAvailableCodingAgents = () => {
+	availableCodingAgents ??= discoverAvailableCodingAgents(
+		defaultDiscoveryContext,
+	);
+	return availableCodingAgents;
+};

--- a/packages/studio-server/src/helpers/coding-agent-registry.ts
+++ b/packages/studio-server/src/helpers/coding-agent-registry.ts
@@ -91,8 +91,8 @@ export const discoverAvailableCodingAgents = async (
 			)
 		).flat();
 		const knownApplications = definition.applicationNames.flatMap((name) => [
-			path.join('/Applications', name),
-			path.join(context.homeDirectory, 'Applications', name),
+			path.posix.join('/Applications', name),
+			path.posix.join(context.homeDirectory, 'Applications', name),
 		]);
 
 		for (const applicationPath of new Set([

--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -12,6 +12,10 @@ import {handleCancelRender} from './routes/cancel-render';
 import {compositionComponentInfoHandler} from './routes/composition-component-info';
 import {convertFigmaClipboardToSvgHandler} from './routes/convert-figma-clipboard-to-svg';
 import {
+	getDefaultCodingAgentInfoHandler,
+	updateDefaultCodingAgentHandler,
+} from './routes/default-coding-agent';
+import {
 	getDefaultEditorInfoHandler,
 	updateDefaultEditorHandler,
 } from './routes/default-editor';
@@ -111,6 +115,8 @@ export const allApiRoutes: {
 	'/api/rename-static-file': renameStaticFileHandler,
 	'/api/restart-studio': handleRestartStudio,
 	'/api/update-public-license': updatePublicLicenseHandler,
+	'/api/default-coding-agent-info': getDefaultCodingAgentInfoHandler,
+	'/api/update-default-coding-agent': updateDefaultCodingAgentHandler,
 	'/api/default-editor-info': getDefaultEditorInfoHandler,
 	'/api/update-default-editor': updateDefaultEditorHandler,
 	'/api/install-package': handleInstallPackage,

--- a/packages/studio-server/src/preview-server/api-types.ts
+++ b/packages/studio-server/src/preview-server/api-types.ts
@@ -1,5 +1,9 @@
 import type {IncomingMessage, ServerResponse} from 'node:http';
-import type {DefaultEditor, LogLevel} from '@remotion/renderer';
+import type {
+	DefaultCodingAgent,
+	DefaultEditor,
+	LogLevel,
+} from '@remotion/renderer';
 import type {RenderJobWithCleanup} from '@remotion/studio-shared';
 
 export type QueueMethods = {
@@ -29,5 +33,6 @@ export type ApiHandler<ReqData, ResData> = (params: {
 	publicDir: string;
 	binariesDirectory: string | null;
 	configFile: string | null;
+	getDefaultCodingAgent: () => DefaultCodingAgent | null;
 	getDefaultEditor: () => DefaultEditor | null;
 }) => Promise<ResData>;

--- a/packages/studio-server/src/preview-server/handler.ts
+++ b/packages/studio-server/src/preview-server/handler.ts
@@ -1,5 +1,9 @@
 import type {IncomingMessage, ServerResponse} from 'node:http';
-import type {DefaultEditor, LogLevel} from '@remotion/renderer';
+import type {
+	DefaultCodingAgent,
+	DefaultEditor,
+	LogLevel,
+} from '@remotion/renderer';
 import type {ApiHandler, QueueMethods} from './api-types';
 import {parseRequestBody} from './parse-body';
 import {validateSameOrigin} from './validate-same-origin';
@@ -15,6 +19,7 @@ export const handleRequest = async <Req, Res>({
 	binariesDirectory,
 	publicDir,
 	configFile,
+	getDefaultCodingAgent,
 	getDefaultEditor,
 }: {
 	remotionRoot: string;
@@ -24,6 +29,7 @@ export const handleRequest = async <Req, Res>({
 	entryPoint: string;
 	binariesDirectory: string | null;
 	configFile: string | null;
+	getDefaultCodingAgent: () => DefaultCodingAgent | null;
 	getDefaultEditor: () => DefaultEditor | null;
 	handler: ApiHandler<Req, Res>;
 	logLevel: LogLevel;
@@ -54,6 +60,7 @@ export const handleRequest = async <Req, Res>({
 			binariesDirectory,
 			publicDir,
 			configFile,
+			getDefaultCodingAgent,
 			getDefaultEditor,
 		});
 

--- a/packages/studio-server/src/preview-server/routes/default-coding-agent.ts
+++ b/packages/studio-server/src/preview-server/routes/default-coding-agent.ts
@@ -1,0 +1,101 @@
+import {readFileSync} from 'node:fs';
+import type {DefaultCodingAgent} from '@remotion/renderer';
+import {defaultCodingAgentIds} from '@remotion/renderer';
+import type {
+	GetDefaultCodingAgentInfoRequest,
+	GetDefaultCodingAgentInfoResponse,
+	UpdateDefaultCodingAgentRequest,
+	UpdateDefaultCodingAgentResponse,
+} from '@remotion/studio-shared';
+import * as recast from 'recast';
+import {parseAst} from '../../codemods/parse-ast';
+import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
+import {getAvailableCodingAgents} from '../../helpers/coding-agent-registry';
+import type {ApiHandler} from '../api-types';
+
+export const updateDefaultCodingAgentInConfig = ({
+	configContents,
+	defaultCodingAgent,
+}: {
+	configContents: string;
+	defaultCodingAgent: DefaultCodingAgent | null;
+}) => {
+	const ast = parseAst(configContents);
+	recast.types.visit(ast.program, {
+		visitExpressionStatement(path) {
+			const {expression} = path.node;
+			if (
+				expression.type === 'CallExpression' &&
+				expression.callee.type === 'MemberExpression' &&
+				!expression.callee.computed &&
+				expression.callee.object.type === 'Identifier' &&
+				expression.callee.object.name === 'Config' &&
+				expression.callee.property.type === 'Identifier' &&
+				expression.callee.property.name === 'setDefaultCodingAgent'
+			) {
+				path.prune();
+				return false;
+			}
+
+			this.traverse(path);
+		},
+	});
+
+	const configWithoutExistingCalls = recast.print(ast, {
+		lineTerminator: '\n',
+	}).code;
+	if (defaultCodingAgent === null) {
+		return configWithoutExistingCalls;
+	}
+
+	const separator = configWithoutExistingCalls.endsWith('\n') ? '' : '\n';
+	return `${configWithoutExistingCalls}${separator}Config.setDefaultCodingAgent('${defaultCodingAgent}');\n`;
+};
+
+export const getDefaultCodingAgentInfoHandler: ApiHandler<
+	GetDefaultCodingAgentInfoRequest,
+	GetDefaultCodingAgentInfoResponse
+> = async ({getDefaultCodingAgent}) => {
+	const installedCodingAgents = await getAvailableCodingAgents();
+	return {
+		defaultCodingAgent: getDefaultCodingAgent(),
+		installedCodingAgents: installedCodingAgents.map(({id, name}) => ({
+			id,
+			name,
+		})),
+	};
+};
+
+export const updateDefaultCodingAgentHandler: ApiHandler<
+	UpdateDefaultCodingAgentRequest,
+	UpdateDefaultCodingAgentResponse
+> = ({input, configFile}) => {
+	if (configFile === null || configFile === undefined) {
+		return Promise.resolve({
+			success: false,
+			reason: 'No Remotion config file was loaded.',
+		});
+	}
+
+	if (
+		input.defaultCodingAgent !== null &&
+		!defaultCodingAgentIds.includes(input.defaultCodingAgent)
+	) {
+		return Promise.resolve({
+			success: false,
+			reason: `Unknown coding agent: ${input.defaultCodingAgent}`,
+		});
+	}
+
+	const configContents = readFileSync(configFile, 'utf8');
+	writeFileAndNotifyFileWatchers(
+		configFile,
+		updateDefaultCodingAgentInConfig({
+			configContents,
+			defaultCodingAgent: input.defaultCodingAgent,
+		}),
+		undefined,
+	);
+
+	return Promise.resolve({success: true});
+};

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -10,7 +10,11 @@ import {
 	WatchIgnoreNextChangePlugin,
 	webpack,
 } from '@remotion/bundler';
-import type {DefaultEditor, LogLevel} from '@remotion/renderer';
+import type {
+	DefaultCodingAgent,
+	DefaultEditor,
+	LogLevel,
+} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	GitSource,
@@ -71,6 +75,7 @@ export const startServer = async (options: {
 	forceNew: boolean;
 	rspack: boolean;
 	getStudioRuntimeConfig: () => StudioRuntimeConfig;
+	getDefaultCodingAgent: () => DefaultCodingAgent | null;
 	getDefaultEditor: () => DefaultEditor | null;
 	configFile: string | null;
 }): Promise<StartServerResult> => {
@@ -177,6 +182,7 @@ export const startServer = async (options: {
 					getPreviewSampleRate: options.getPreviewSampleRate,
 					enableCrossSiteIsolation: options.enableCrossSiteIsolation,
 					getStudioRuntimeConfig: options.getStudioRuntimeConfig,
+					getDefaultCodingAgent: options.getDefaultCodingAgent,
 					getDefaultEditor: options.getDefaultEditor,
 					configFile: options.configFile,
 				});

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -4,7 +4,11 @@ import type {IncomingMessage, ServerResponse} from 'node:http';
 import path, {join} from 'node:path';
 import {URLSearchParams} from 'node:url';
 import {BundlerInternals} from '@remotion/bundler';
-import type {DefaultEditor, LogLevel} from '@remotion/renderer';
+import type {
+	DefaultCodingAgent,
+	DefaultEditor,
+	LogLevel,
+} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	ApiRoutes,
@@ -379,6 +383,7 @@ export const handleRoutes = ({
 	getPreviewSampleRate,
 	enableCrossSiteIsolation,
 	getStudioRuntimeConfig,
+	getDefaultCodingAgent,
 	getDefaultEditor,
 	configFile,
 }: {
@@ -405,6 +410,7 @@ export const handleRoutes = ({
 	getPreviewSampleRate: () => number | null;
 	enableCrossSiteIsolation: boolean;
 	getStudioRuntimeConfig: () => StudioRuntimeConfig;
+	getDefaultCodingAgent: () => DefaultCodingAgent | null;
 	getDefaultEditor: () => DefaultEditor | null;
 	configFile: string | null;
 }): Promise<void> => {
@@ -499,6 +505,7 @@ export const handleRoutes = ({
 				binariesDirectory,
 				publicDir,
 				configFile,
+				getDefaultCodingAgent,
 				getDefaultEditor,
 			});
 		}

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -6,7 +6,11 @@ import type {
 	RspackOverrideFn,
 	WebpackOverrideFn,
 } from '@remotion/bundler';
-import type {DefaultEditor, LogLevel} from '@remotion/renderer';
+import type {
+	DefaultCodingAgent,
+	DefaultEditor,
+	LogLevel,
+} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	GitSource,
@@ -61,6 +65,7 @@ export const startStudio = async ({
 	forceNew,
 	rspack,
 	getStudioRuntimeConfig,
+	getDefaultCodingAgent,
 	getDefaultEditor,
 	configFile,
 }: {
@@ -92,6 +97,7 @@ export const startStudio = async ({
 	forceNew: boolean;
 	rspack: boolean;
 	getStudioRuntimeConfig: () => StudioRuntimeConfig;
+	getDefaultCodingAgent: () => DefaultCodingAgent | null;
 	getDefaultEditor: () => DefaultEditor | null;
 	configFile: string | null;
 }): Promise<StartStudioResult> => {
@@ -172,6 +178,7 @@ export const startStudio = async ({
 		forceNew,
 		rspack,
 		getStudioRuntimeConfig,
+		getDefaultCodingAgent,
 		getDefaultEditor,
 		configFile,
 	});

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -322,6 +322,7 @@ const getHandlerOptions = <T>({
 	publicDir: remotionRoot,
 	binariesDirectory: null,
 	configFile: null,
+	getDefaultCodingAgent: () => null,
 	getDefaultEditor: () => null,
 });
 

--- a/packages/studio-server/src/test/coding-agent-registry.test.ts
+++ b/packages/studio-server/src/test/coding-agent-registry.test.ts
@@ -1,0 +1,44 @@
+import {expect, test} from 'bun:test';
+import {discoverAvailableCodingAgents} from '../helpers/coding-agent-registry';
+
+test('discovers supported macOS coding agents without launching them', async () => {
+	const existingPaths = new Set([
+		'/Custom/Applications/ChatGPT.app',
+		'/Users/test/Applications/Claude.app',
+	]);
+	const codingAgents = await discoverAvailableCodingAgents({
+		platform: 'darwin',
+		homeDirectory: '/Users/test',
+		pathExists: (filePath) => existingPaths.has(filePath),
+		findMacApplications: (bundleIdentifier) =>
+			Promise.resolve(
+				bundleIdentifier === 'com.openai.codex'
+					? ['/Custom/Applications/ChatGPT.app']
+					: [],
+			),
+	});
+
+	expect(codingAgents).toEqual([
+		{
+			applicationPath: '/Custom/Applications/ChatGPT.app',
+			id: 'codex',
+			name: 'Codex',
+		},
+		{
+			applicationPath: '/Users/test/Applications/Claude.app',
+			id: 'claude-code',
+			name: 'Claude Code',
+		},
+	]);
+});
+
+test('does not report coding agents on unsupported platforms', async () => {
+	const codingAgents = await discoverAvailableCodingAgents({
+		platform: 'linux',
+		homeDirectory: '/home/test',
+		pathExists: () => true,
+		findMacApplications: () => Promise.resolve(['/Applications/ChatGPT.app']),
+	});
+
+	expect(codingAgents).toEqual([]);
+});

--- a/packages/studio-server/src/test/custom-editor.test.ts
+++ b/packages/studio-server/src/test/custom-editor.test.ts
@@ -182,6 +182,7 @@ test.skipIf(process.platform === 'win32')(
 				binariesDirectory: null,
 				configFile: null,
 				entryPoint: '',
+				getDefaultCodingAgent: () => null,
 				getDefaultEditor: () => ({
 					type: 'custom',
 					name: 'Acme Editor',
@@ -225,6 +226,7 @@ test('rejects an unknown editor ID at the open-in-editor route', async () => {
 		binariesDirectory: null,
 		configFile: null,
 		entryPoint: '',
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => null,
 		input: {
 			editorId: 'unknown-editor' as never,

--- a/packages/studio-server/src/test/default-coding-agent-route.test.ts
+++ b/packages/studio-server/src/test/default-coding-agent-route.test.ts
@@ -1,0 +1,60 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {
+	createFileWatcherRegistry,
+	setFileWatcherRegistry,
+} from '../file-watcher';
+import {updateDefaultCodingAgentHandler} from '../preview-server/routes/default-coding-agent';
+
+test('persists the selected coding agent through the route', async () => {
+	const directory = mkdtempSync(join(tmpdir(), 'remotion-coding-agent-'));
+	const configFile = join(directory, 'remotion.config.ts');
+	const cleanupFileWatcher = setFileWatcherRegistry(
+		createFileWatcherRegistry(),
+	);
+	writeFileSync(
+		configFile,
+		[
+			"import {Config} from '@remotion/cli/config';",
+			"Config.setDefaultCodingAgent('cursor');",
+			'Config.setOverwriteOutput(true);',
+			'',
+		].join('\n'),
+	);
+
+	try {
+		const response = await updateDefaultCodingAgentHandler({
+			binariesDirectory: null,
+			configFile,
+			entryPoint: '',
+			getDefaultCodingAgent: () => 'cursor',
+			getDefaultEditor: () => null,
+			input: {defaultCodingAgent: 'codex'},
+			logLevel: 'error',
+			methods: {
+				addJob: () => undefined,
+				cancelJob: () => undefined,
+				removeJob: () => undefined,
+			},
+			publicDir: '',
+			remotionRoot: directory,
+			request: {} as never,
+			response: {} as never,
+		});
+
+		expect(response).toEqual({success: true});
+		expect(readFileSync(configFile, 'utf8')).toBe(
+			[
+				"import {Config} from '@remotion/cli/config';",
+				'Config.setOverwriteOutput(true);',
+				"Config.setDefaultCodingAgent('codex');",
+				'',
+			].join('\n'),
+		);
+	} finally {
+		cleanupFileWatcher();
+		rmSync(directory, {force: true, recursive: true});
+	}
+});

--- a/packages/studio-server/src/test/default-editor-route.test.ts
+++ b/packages/studio-server/src/test/default-editor-route.test.ts
@@ -88,6 +88,7 @@ test('preserves commented and string references to the setter', () => {
 test('exposes only an opaque ID and name for a configured custom editor', async () => {
 	const response = await getDefaultEditorInfoHandler({
 		...apiHandlerContext,
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => ({
 			type: 'custom',
 			name: 'Acme Editor',
@@ -125,6 +126,7 @@ test('keeps the server-side custom editor definition when Studio selects it', as
 		const response = await updateDefaultEditorHandler({
 			...apiHandlerContext,
 			configFile,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => ({
 				type: 'custom',
 				name: 'Acme Editor',
@@ -150,6 +152,7 @@ test('rejects custom editor definitions sent by the browser', async () => {
 		const response = await updateDefaultEditorHandler({
 			...apiHandlerContext,
 			configFile,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			input: {
 				defaultEditor: {
@@ -191,6 +194,7 @@ test('removes the configured editor when selecting no preference', async () => {
 			binariesDirectory: null,
 			configFile,
 			entryPoint: '',
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => 'vscode',
 			input: {defaultEditor: null},
 			logLevel: 'error',

--- a/packages/studio-server/src/test/download-remote-asset.test.ts
+++ b/packages/studio-server/src/test/download-remote-asset.test.ts
@@ -68,6 +68,7 @@ test('follows validated redirects for remote assets', async () => {
 		const response = await downloadRemoteAssetHandler({
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			entryPoint: '',
 			input: {url: 'https://93.184.216.34/raw-link'},
@@ -138,6 +139,7 @@ test('blocks redirects to private IP addresses', async () => {
 			downloadRemoteAssetHandler({
 				binariesDirectory: null,
 				configFile: null,
+				getDefaultCodingAgent: () => null,
 				getDefaultEditor: () => null,
 				entryPoint: '',
 				input: {url: 'https://93.184.216.34/raw-link'},

--- a/packages/studio-server/src/test/file-source-route.test.ts
+++ b/packages/studio-server/src/test/file-source-route.test.ts
@@ -74,6 +74,7 @@ test('serves file source from an origin-less GET request', async () => {
 			entryPoint: '',
 			getAudioLatencyHint: () => null,
 			getCurrentInputProps: () => ({}),
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			getEnvVariables: () => ({}),
 			getRenderDefaults: () => ({}) as RenderDefaults,

--- a/packages/studio-server/src/test/handler.test.ts
+++ b/packages/studio-server/src/test/handler.test.ts
@@ -65,6 +65,7 @@ test('rejects cross-origin API requests before calling the handler', async () =>
 				didCallHandler = true;
 				return Promise.resolve({});
 			},
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			logLevel: 'info',
 			methods: {
@@ -97,6 +98,7 @@ test('allows same-origin API requests from non-local peers', async () => {
 		handler: ({input}) => {
 			return Promise.resolve({input});
 		},
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => null,
 		logLevel: 'info',
 		methods: {
@@ -139,6 +141,7 @@ test('rejects API requests without an Origin header before calling the handler',
 				didCallHandler = true;
 				return Promise.resolve({});
 			},
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			logLevel: 'info',
 			methods: {
@@ -171,6 +174,7 @@ test('allows GET API requests without an Origin header', async () => {
 		handler: ({input}) => {
 			return Promise.resolve({input});
 		},
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => null,
 		logLevel: 'info',
 		methods: {
@@ -210,6 +214,7 @@ test('allows HEAD API requests without an Origin header', async () => {
 		handler: ({input}) => {
 			return Promise.resolve({input});
 		},
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => null,
 		logLevel: 'info',
 		methods: {
@@ -252,6 +257,7 @@ test('rejects requests with a mismatched Origin scheme before calling the handle
 				didCallHandler = true;
 				return Promise.resolve({});
 			},
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			logLevel: 'info',
 			methods: {
@@ -284,6 +290,7 @@ test('allows same-origin API requests', async () => {
 		handler: ({getDefaultEditor, input}) => {
 			return Promise.resolve({defaultEditor: getDefaultEditor(), input});
 		},
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => 'cursor',
 		logLevel: 'info',
 		methods: {

--- a/packages/studio-server/src/test/insert-element.test.ts
+++ b/packages/studio-server/src/test/insert-element.test.ts
@@ -82,6 +82,7 @@ const makeFixture = () => {
 		return insertElementHandler({
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			entryPoint: compositionFile,
 			input,
@@ -123,6 +124,7 @@ const makeFixture = () => {
 		return prepareElementInstallHandler({
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 			entryPoint: compositionFile,
 			input,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -1936,6 +1936,7 @@ test('rejects composition insertion requests that traverse out of the project ro
 			publicDir: tempDir,
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 		});
 

--- a/packages/studio-server/src/test/save-multiple-effect-props.test.ts
+++ b/packages/studio-server/src/test/save-multiple-effect-props.test.ts
@@ -115,6 +115,7 @@ export const Comp = () => {
 			publicDir: '',
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 		});
 

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -191,6 +191,7 @@ test('saveSequenceProps saves inline caption patches as an undoable source edit'
 			publicDir: '',
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 		});
 
@@ -298,6 +299,7 @@ export const Comp = () => {
 			publicDir: '',
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 		});
 
@@ -412,6 +414,7 @@ export const Comp = () => {
 			publicDir: '',
 			binariesDirectory: null,
 			configFile: null,
+			getDefaultCodingAgent: () => null,
 			getDefaultEditor: () => null,
 		});
 

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -186,6 +186,7 @@ const getHandlerOptions = <T>({
 	publicDir: remotionRoot,
 	binariesDirectory: null,
 	configFile: null,
+	getDefaultCodingAgent: () => null,
 	getDefaultEditor: () => null,
 });
 

--- a/packages/studio-server/src/test/update-element-install-target.test.ts
+++ b/packages/studio-server/src/test/update-element-install-target.test.ts
@@ -28,6 +28,7 @@ const callHandler = ({
 	return updateElementInstallTargetHandler({
 		binariesDirectory: null,
 		configFile: null,
+		getDefaultCodingAgent: () => null,
 		getDefaultEditor: () => null,
 		entryPoint: '',
 		input,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -4,6 +4,7 @@ import type {
 	ChromeMode,
 	Codec,
 	ColorSpace,
+	DefaultCodingAgent,
 	LogLevel,
 	PixelFormat,
 	StillImageFormat,
@@ -1008,6 +1009,24 @@ export type UpdateDefaultEditorResponse =
 			reason: string;
 	  };
 
+export type GetDefaultCodingAgentInfoRequest = {};
+export type GetDefaultCodingAgentInfoResponse = {
+	defaultCodingAgent: DefaultCodingAgent | null;
+	installedCodingAgents: {id: DefaultCodingAgent; name: string}[];
+};
+
+export type UpdateDefaultCodingAgentRequest = {
+	defaultCodingAgent: DefaultCodingAgent | null;
+};
+export type UpdateDefaultCodingAgentResponse =
+	| {
+			success: true;
+	  }
+	| {
+			success: false;
+			reason: string;
+	  };
+
 export type PackageInstallSpec = {
 	readonly name: string;
 	readonly version: string | null;
@@ -1065,6 +1084,14 @@ export type ApiRoutes = {
 	>;
 	'/api/remove-render': ReqAndRes<RemoveRenderRequest, undefined>;
 	'/api/open-in-editor': ReqAndRes<OpenInEditorRequest, OpenInEditorResponse>;
+	'/api/default-coding-agent-info': ReqAndRes<
+		GetDefaultCodingAgentInfoRequest,
+		GetDefaultCodingAgentInfoResponse
+	>;
+	'/api/update-default-coding-agent': ReqAndRes<
+		UpdateDefaultCodingAgentRequest,
+		UpdateDefaultCodingAgentResponse
+	>;
 	'/api/find-in-file': ReqAndRes<FindInFileRequest, FindInFileResponse>;
 	'/api/open-in-file-explorer': ReqAndRes<OpenInFileExplorerRequest, void>;
 	'/api/register-client-render': ReqAndRes<CompletedClientRender, void>;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -47,12 +47,14 @@ export {
 	DuplicateEffectResponse,
 	DuplicateJsxNodeRequest,
 	DuplicateJsxNodeResponse,
+	EditorPickerId,
 	ElementInstallExpectedFileState,
 	ElementInstallRequest,
 	ElementInstallSource,
-	EditorPickerId,
 	FindInFileRequest,
 	FindInFileResponse,
+	GetDefaultCodingAgentInfoRequest,
+	GetDefaultCodingAgentInfoResponse,
 	GetDefaultEditorInfoRequest,
 	GetDefaultEditorInfoResponse,
 	GoogleFontSourceEdit,
@@ -121,6 +123,8 @@ export {
 	UnsubscribeFromSequencePropsRequest,
 	UpdateAvailableRequest,
 	UpdateAvailableResponse,
+	UpdateDefaultCodingAgentRequest,
+	UpdateDefaultCodingAgentResponse,
 	UpdateDefaultEditorRequest,
 	UpdateDefaultEditorResponse,
 	UpdateDefaultPropsRequest,
@@ -140,6 +144,10 @@ export {
 export type {BrowserStudioOperations} from './browser-studio-operations';
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {compositionDragDataToSymbolicatedStack} from './composition-drag-data';
+export {
+	getConfigFileChangeMessage,
+	type ConfigFileChangeType,
+} from './config-file-change';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {
 	detectFileType,
@@ -185,10 +193,6 @@ export {
 	type EffectPropClipboardDataParseResult,
 } from './effect-clipboard-data';
 export {EventSourceEvent} from './event-source-event';
-export {
-	getConfigFileChangeMessage,
-	type ConfigFileChangeType,
-} from './config-file-change';
 export {formatBytes} from './format-bytes';
 export {getAllSchemaKeys, getAssetSchemaKeys} from './get-all-keys';
 export {getDefaultOutLocation} from './get-default-out-name';

--- a/packages/studio/src/components/ConfigureDefaultEditorModal.tsx
+++ b/packages/studio/src/components/ConfigureDefaultEditorModal.tsx
@@ -1,5 +1,6 @@
 import type {
 	EditorPickerId,
+	GetDefaultCodingAgentInfoResponse,
 	GetDefaultEditorInfoResponse,
 } from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -77,9 +78,13 @@ export const DefaultEditorSettings: React.FC<{
 }> = ({onSaved}) => {
 	const [editorInfo, setEditorInfo] =
 		useState<GetDefaultEditorInfoResponse | null>(null);
+	const [codingAgentInfo, setCodingAgentInfo] =
+		useState<GetDefaultCodingAgentInfoResponse | null>(null);
 	const [selectedEditor, setSelectedEditor] = useState<EditorPickerId | null>(
 		null,
 	);
+	const [selectedCodingAgent, setSelectedCodingAgent] =
+		useState<GetDefaultCodingAgentInfoResponse['defaultCodingAgent']>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const editorValues = useMemo((): ComboboxValue[] => {
@@ -126,18 +131,66 @@ export const DefaultEditorSettings: React.FC<{
 
 		return [noPreference, ...installedEditors];
 	}, [editorInfo?.installedEditors, selectedEditor]);
+	const codingAgentValues = useMemo((): ComboboxValue[] => {
+		const noPreference: ComboboxValue = {
+			id: NO_PREFERENCE_ID,
+			keyHint: null,
+			label: 'No preference',
+			leftItem: selectedCodingAgent === null ? <Checkmark /> : null,
+			onClick: () => {
+				setSelectedCodingAgent(null);
+				setError(null);
+			},
+			quickSwitcherLabel: null,
+			subMenu: null,
+			type: 'item',
+			value: NO_PREFERENCE_ID,
+		};
+		const installedCodingAgents = (
+			codingAgentInfo?.installedCodingAgents ?? []
+		).map((codingAgent): ComboboxValue => {
+			return {
+				id: codingAgent.id,
+				keyHint: null,
+				label: codingAgent.name,
+				leftItem: selectedCodingAgent === codingAgent.id ? <Checkmark /> : null,
+				onClick: () => {
+					setSelectedCodingAgent(codingAgent.id);
+					setError(null);
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				type: 'item',
+				value: codingAgent.id,
+			};
+		});
+
+		return [noPreference, ...installedCodingAgents];
+	}, [codingAgentInfo?.installedCodingAgents, selectedCodingAgent]);
 
 	useEffect(() => {
 		const controller = new AbortController();
-		callApi('/api/default-editor-info', {}, controller.signal)
-			.then((response) => {
-				setEditorInfo(response);
+		Promise.all([
+			callApi('/api/default-editor-info', {}, controller.signal),
+			callApi('/api/default-coding-agent-info', {}, controller.signal),
+		])
+			.then(([editorResponse, codingAgentResponse]) => {
+				setEditorInfo(editorResponse);
 				setSelectedEditor(
-					response.defaultEditor !== null &&
-						response.installedEditors.some(
-							({id}) => id === response.defaultEditor,
+					editorResponse.defaultEditor !== null &&
+						editorResponse.installedEditors.some(
+							({id}) => id === editorResponse.defaultEditor,
 						)
-						? response.defaultEditor
+						? editorResponse.defaultEditor
+						: null,
+				);
+				setCodingAgentInfo(codingAgentResponse);
+				setSelectedCodingAgent(
+					codingAgentResponse.defaultCodingAgent !== null &&
+						codingAgentResponse.installedCodingAgents.some(
+							({id}) => id === codingAgentResponse.defaultCodingAgent,
+						)
+						? codingAgentResponse.defaultCodingAgent
 						: null,
 				);
 			})
@@ -153,18 +206,28 @@ export const DefaultEditorSettings: React.FC<{
 	}, []);
 
 	const submit = useCallback(async () => {
-		if (editorInfo === null) {
+		if (editorInfo === null || codingAgentInfo === null) {
 			return;
 		}
 
 		setIsSubmitting(true);
 		setError(null);
 		try {
-			const response = await callApi('/api/update-default-editor', {
+			const editorResponse = await callApi('/api/update-default-editor', {
 				defaultEditor: selectedEditor,
 			});
-			if (!response.success) {
-				setError(response.reason);
+			if (!editorResponse.success) {
+				setError(editorResponse.reason);
+				setIsSubmitting(false);
+				return;
+			}
+
+			const codingAgentResponse = await callApi(
+				'/api/update-default-coding-agent',
+				{defaultCodingAgent: selectedCodingAgent},
+			);
+			if (!codingAgentResponse.success) {
+				setError(codingAgentResponse.reason);
 				setIsSubmitting(false);
 				return;
 			}
@@ -174,13 +237,19 @@ export const DefaultEditorSettings: React.FC<{
 			setError((err as Error).message);
 			setIsSubmitting(false);
 		}
-	}, [editorInfo, onSaved, selectedEditor]);
+	}, [
+		codingAgentInfo,
+		editorInfo,
+		onSaved,
+		selectedCodingAgent,
+		selectedEditor,
+	]);
 
 	return (
 		<div style={container}>
 			<div style={content}>
 				<p style={title}>Default editor</p>
-				<p style={description}>This setting gets saved to your config file.</p>
+				<p style={description}>Used when Remotion Studio opens source files.</p>
 				<Spacing y={1} block />
 				{editorInfo === null && error === null ? (
 					<p style={description}>Loading installed editors...</p>
@@ -198,6 +267,28 @@ export const DefaultEditorSettings: React.FC<{
 						title="Default editor"
 					/>
 				)}
+				<Spacing y={2} block />
+				<p style={title}>Default coding agent</p>
+				<p style={description}>
+					Used when Remotion Studio hands a project to a coding agent.
+				</p>
+				<Spacing y={1} block />
+				{codingAgentInfo === null && error === null ? (
+					<p style={description}>Loading installed coding agents...</p>
+				) : null}
+				{codingAgentInfo?.installedCodingAgents.length === 0 ? (
+					<p style={description}>
+						No supported coding agents were found on this computer.
+					</p>
+				) : null}
+				{codingAgentInfo === null ? null : (
+					<Combobox
+						values={codingAgentValues}
+						selectedId={selectedCodingAgent ?? NO_PREFERENCE_ID}
+						style={comboBoxStyle}
+						title="Default coding agent"
+					/>
+				)}
 				{error ? (
 					<>
 						<Spacing y={1.5} />
@@ -212,7 +303,9 @@ export const DefaultEditorSettings: React.FC<{
 			<SettingsModalFooter>
 				<ModalButton
 					onClick={submit}
-					disabled={isSubmitting || editorInfo === null}
+					disabled={
+						isSubmitting || editorInfo === null || codingAgentInfo === null
+					}
 				>
 					{isSubmitting ? 'Saving...' : 'Save and reload'}
 				</ModalButton>


### PR DESCRIPTION
Related: #10128

## Summary

- add `Config.setDefaultCodingAgent()` and `--coding-agent` for Codex, Cursor, GitHub Copilot, and Claude Code
- detect installed coding-agent apps on macOS and add the picker to Settings > Apps
- persist the selection to `remotion.config.ts` with reload/reset handling, tests, and docs

## Testing

- focused builds for renderer, CLI, Studio Server, Studio Shared, and Studio
- focused lint and formatting for affected packages and docs
- 17 focused config, route, discovery, and adjacent editor tests
- route persistence test red/green verified
- docs preview cards regenerated