### PR TITLE
Internal: Add aggregate required CI check

### DIFF
--- a/.github/scripts/ci.test.ts
+++ b/.github/scripts/ci.test.ts
@@ -1,0 +1,174 @@
+import {describe, expect, test} from 'bun:test';
+import {
+	COMPATIBILITY_BUILD_MATRIX,
+	createCiPlan,
+	FULL_BUILD_MATRIX,
+	validateCiPlan,
+	validateRequiredCi,
+	type CiPlan,
+	type RequiredCiResults,
+} from './ci';
+
+const affected = (
+	tasks: Array<{
+		name: string;
+		packageName?: string;
+	}>,
+) =>
+	JSON.stringify({
+		data: {
+			affectedTasks: {
+				items: tasks.map(({name, packageName = '@remotion/core'}) => ({
+					name,
+					fullName: `${packageName}#${name}`,
+					package: {name: packageName},
+					reason: {__typename: 'FileChanged'},
+				})),
+			},
+		},
+	});
+
+const planFor = ({
+	tasks = [],
+	affectedJson,
+	detectorError = null,
+}: {
+	tasks?: Array<{name: string; packageName?: string}>;
+	affectedJson?: string | null;
+	detectorError?: string | null;
+} = {}) =>
+	createCiPlan({
+		full_ci: false,
+		affected_json: affectedJson === undefined ? affected(tasks) : affectedJson,
+		detector_error: detectorError,
+	});
+
+const skippedResults = (): RequiredCiResults => ({
+	detector: 'success',
+	lint: 'success',
+	lambda: 'skipped',
+	nextjs: 'skipped',
+	browser: 'skipped',
+	webrenderer: 'skipped',
+	ssr: 'skipped',
+	templates: 'skipped',
+	build_job: 'success',
+});
+
+describe('CI plan generation', () => {
+	test('selects only the compatibility build for docs tasks', () => {
+		const plan = planFor({
+			tasks: [
+				{name: 'make', packageName: 'docs'},
+				{name: 'test', packageName: 'docs'},
+			],
+		});
+
+		expect(plan.full_ci).toBe(false);
+		expect(plan.build).toBe(true);
+		expect(plan.build_matrix).toEqual(COMPATIBILITY_BUILD_MATRIX);
+		expect(plan.lambda).toBe(false);
+	});
+
+	test('allows no build or specialized tasks to be affected', () => {
+		const plan = planFor();
+		expect(plan.build).toBe(false);
+		expect(plan.build_matrix).toEqual(COMPATIBILITY_BUILD_MATRIX);
+	});
+
+	test('uses the full build matrix for a package source change', () => {
+		const plan = planFor({tasks: [{name: 'make'}, {name: 'test'}]});
+		expect(plan.build).toBe(true);
+		expect(plan.build_matrix).toEqual(FULL_BUILD_MATRIX);
+	});
+
+	test.each([
+		['lambda', 'testlambda'],
+		['nextjs', 'testnextjs'],
+		['browser', 'testwebcodecs'],
+		['browser', 'teste2e'],
+		['webrenderer', 'testwebrenderer'],
+		['webrenderer', 'testbrowserstudio'],
+		['ssr', 'testssr'],
+		['templates', 'testtemplates'],
+		['bundle_example', 'bundle-testbed'],
+	] as const)('maps %s from the %s task', (suite, task) => {
+		const plan = planFor({tasks: [{name: task}]});
+		expect(plan[suite]).toBe(true);
+	});
+
+	test('falls back to full CI after a Turborepo command failure', () => {
+		const plan = planFor({detectorError: 'turbo query affected exited 1'});
+		expect(plan.full_ci).toBe(true);
+		expect(plan.fallback_reason).toBe('turbo query affected exited 1');
+	});
+
+	test.each(['{"data":', '{"data":{}}'])(
+		'falls back after invalid Turborepo JSON',
+		(affectedJson) => {
+			const plan = planFor({affectedJson});
+			expect(plan.full_ci).toBe(true);
+			expect(plan.fallback_reason).not.toBeNull();
+		},
+	);
+
+	test('rejects a missing boolean output', () => {
+		const plan = planFor() as CiPlan & {lambda?: boolean};
+		delete plan.lambda;
+		expect(() => validateCiPlan(plan)).toThrow(
+			'CI plan value lambda must be a boolean',
+		);
+	});
+
+	test('rejects full CI that omits a suite', () => {
+		const plan = createCiPlan({
+			full_ci: true,
+			affected_json: null,
+			detector_error: null,
+		});
+		plan.templates = false;
+		expect(() => validateCiPlan(plan)).toThrow(
+			'Full CI must select every suite',
+		);
+	});
+});
+
+describe('Required CI result validation', () => {
+	const lambdaPlan = () => planFor({tasks: [{name: 'testlambda'}]});
+
+	test('accepts a selected successful job and unselected skipped jobs', () => {
+		const results = skippedResults();
+		results.lambda = 'success';
+		expect(() => validateRequiredCi(lambdaPlan(), results)).not.toThrow();
+	});
+
+	test.each(['failure', 'cancelled', 'skipped'])(
+		'rejects a selected job that is %s',
+		(result) => {
+			const results = skippedResults();
+			results.lambda = result;
+			expect(() => validateRequiredCi(lambdaPlan(), results)).toThrow(
+				`Selected suite lambda concluded with ${result}`,
+			);
+		},
+	);
+
+	test('accepts an unselected skipped job', () => {
+		expect(() => validateRequiredCi(planFor(), skippedResults())).not.toThrow();
+	});
+
+	test.each(['success', 'failure', 'cancelled'])(
+		'rejects an unselected job that concludes with %s',
+		(result) => {
+			const results = skippedResults();
+			results.browser = result;
+			expect(() => validateRequiredCi(planFor(), results)).toThrow(
+				`Unselected suite browser concluded with ${result}`,
+			);
+		},
+	);
+
+	test('temporarily accepts a successful unselected compatibility build', () => {
+		expect(() => validateRequiredCi(planFor(), skippedResults())).not.toThrow();
+	});
+});

--- a/.github/scripts/ci.test.ts
+++ b/.github/scripts/ci.test.ts
@@ -1,8 +1,8 @@
 import {describe, expect, test} from 'bun:test';
 import {
-	COMPATIBILITY_BUILD_MATRIX,
 	createCiPlan,
 	FULL_BUILD_MATRIX,
+	MINIMAL_BUILD_MATRIX,
 	validateCiPlan,
 	validateRequiredCi,
 	type CiPlan,
@@ -52,11 +52,11 @@ const skippedResults = (): RequiredCiResults => ({
 	webrenderer: 'skipped',
 	ssr: 'skipped',
 	templates: 'skipped',
-	build_job: 'success',
+	build_job: 'skipped',
 });
 
 describe('CI plan generation', () => {
-	test('selects only the compatibility build for docs tasks', () => {
+	test('selects only the minimal build matrix for docs tasks', () => {
 		const plan = planFor({
 			tasks: [
 				{name: 'make', packageName: 'docs'},
@@ -66,14 +66,14 @@ describe('CI plan generation', () => {
 
 		expect(plan.full_ci).toBe(false);
 		expect(plan.build).toBe(true);
-		expect(plan.build_matrix).toEqual(COMPATIBILITY_BUILD_MATRIX);
+		expect(plan.build_matrix).toEqual(MINIMAL_BUILD_MATRIX);
 		expect(plan.lambda).toBe(false);
 	});
 
 	test('allows no build or specialized tasks to be affected', () => {
 		const plan = planFor();
 		expect(plan.build).toBe(false);
-		expect(plan.build_matrix).toEqual(COMPATIBILITY_BUILD_MATRIX);
+		expect(plan.build_matrix).toEqual(MINIMAL_BUILD_MATRIX);
 	});
 
 	test('uses the full build matrix for a package source change', () => {
@@ -168,7 +168,11 @@ describe('Required CI result validation', () => {
 		},
 	);
 
-	test('temporarily accepts a successful unselected compatibility build', () => {
-		expect(() => validateRequiredCi(planFor(), skippedResults())).not.toThrow();
+	test('rejects an unselected successful build', () => {
+		const results = skippedResults();
+		results.build_job = 'success';
+		expect(() => validateRequiredCi(planFor(), results)).toThrow(
+			'Unselected suite build_job concluded with success',
+		);
 	});
 });

--- a/.github/scripts/ci.ts
+++ b/.github/scripts/ci.ts
@@ -18,13 +18,8 @@ export const FULL_BUILD_MATRIX: BuildMatrix = {
 	],
 };
 
-// Keep the historical Ubuntu and Windows contexts alive until the ruleset migration
-// is complete. Entries with run_build=false are compatibility no-ops.
-export const COMPATIBILITY_BUILD_MATRIX: BuildMatrix = {
-	include: [
-		{os: 'ubuntu-latest', node_version: 16, run_build: true},
-		{os: 'windows-latest', node_version: 16, run_build: false},
-	],
+export const MINIMAL_BUILD_MATRIX: BuildMatrix = {
+	include: [{os: 'ubuntu-latest', node_version: 16, run_build: true}],
 };
 
 const TASKS_BY_SUITE = {
@@ -180,7 +175,7 @@ export const validateCiPlan = (value: unknown): CiPlan => {
 		}
 		const validAffectedMatrices = [
 			FULL_BUILD_MATRIX,
-			COMPATIBILITY_BUILD_MATRIX,
+			MINIMAL_BUILD_MATRIX,
 		].some((candidate) => JSON.stringify(matrix) === JSON.stringify(candidate));
 		if (!validAffectedMatrices) {
 			throw new Error('Affected CI has an unrecognized build matrix');
@@ -231,9 +226,7 @@ export const createCiPlan = (input: PlannerInput): CiPlan => {
 			templates: selected('templates'),
 			build,
 			bundle_example: bundleExample,
-			build_matrix: hasNonDocsBuild
-				? FULL_BUILD_MATRIX
-				: COMPATIBILITY_BUILD_MATRIX,
+			build_matrix: hasNonDocsBuild ? FULL_BUILD_MATRIX : MINIMAL_BUILD_MATRIX,
 			fallback_reason: null,
 			affected_reasons: reasons,
 		});
@@ -288,11 +281,6 @@ export const validateRequiredCi = (
 			throw new Error(`Selected suite ${suite} concluded with ${result}`);
 		}
 		if (!selected && result !== 'skipped') {
-			// Temporary migration exception: the build matrix emits the historical
-			// Ubuntu/Windows required contexts even when no build work is selected.
-			if (suite === 'build_job' && result === 'success') {
-				continue;
-			}
 			throw new Error(`Unselected suite ${suite} concluded with ${result}`);
 		}
 	}

--- a/.github/scripts/ci.ts
+++ b/.github/scripts/ci.ts
@@ -292,7 +292,20 @@ const commandSucceeded = (command: string[]) => {
 	);
 };
 
-const appendPlanOutputs = (plan: CiPlan) => {
+const commandOutput = (command: string[]) => {
+	const result = Bun.spawnSync(command, {stdout: 'pipe', stderr: 'inherit'});
+	if (result.exitCode !== 0) {
+		return null;
+	}
+
+	return new TextDecoder().decode(result.stdout).trim();
+};
+
+const appendPlanOutputs = (
+	plan: CiPlan,
+	scmBase: string | null,
+	scmHead: string | null,
+) => {
 	const githubOutput = process.env.GITHUB_OUTPUT;
 	if (!githubOutput) {
 		throw new Error('GITHUB_OUTPUT is not set');
@@ -302,6 +315,9 @@ const appendPlanOutputs = (plan: CiPlan) => {
 		githubOutput,
 		[
 			`plan=${JSON.stringify(plan)}`,
+			`full_ci=${plan.full_ci}`,
+			`scm_base=${scmBase ?? ''}`,
+			`scm_head=${scmHead ?? ''}`,
 			`lambda=${plan.lambda}`,
 			`nextjs=${plan.nextjs}`,
 			`browser=${plan.browser}`,
@@ -316,7 +332,11 @@ const appendPlanOutputs = (plan: CiPlan) => {
 	);
 };
 
-const appendPlanSummary = (plan: CiPlan) => {
+const appendPlanSummary = (
+	plan: CiPlan,
+	scmBase: string | null,
+	scmHead: string | null,
+) => {
 	const githubStepSummary = process.env.GITHUB_STEP_SUMMARY;
 	if (!githubStepSummary) {
 		throw new Error('GITHUB_STEP_SUMMARY is not set');
@@ -335,6 +355,9 @@ const appendPlanSummary = (plan: CiPlan) => {
 			'### Required CI plan',
 			'',
 			`- Full CI: ${plan.full_ci}`,
+			...(scmBase && scmHead
+				? [`- Compared commits: \`${scmBase}\` → \`${scmHead}\``]
+				: []),
 			`- Selected suites: ${selected.length ? selected.map((suite) => `\`${suite}\``).join(', ') : 'none'}`,
 			`- Skipped suites: ${skipped.length ? skipped.map((suite) => `\`${suite}\``).join(', ') : 'none'}`,
 			...(plan.fallback_reason
@@ -348,38 +371,53 @@ const appendPlanSummary = (plan: CiPlan) => {
 	);
 };
 
-const createPlanFromEnvironment = () => {
+const createPlanFromEnvironment = (): {
+	plan: CiPlan;
+	scmBase: string | null;
+	scmHead: string | null;
+} => {
 	const eventName = process.env.GITHUB_EVENT_NAME;
 	const ref = process.env.GITHUB_REF;
 	if (!eventName || !ref) {
-		return createCiPlan({
-			full_ci: false,
-			affected_json: null,
-			detector_error: 'GitHub event metadata is missing',
-		});
+		return {
+			plan: createCiPlan({
+				full_ci: false,
+				affected_json: null,
+				detector_error: 'GitHub event metadata is missing',
+			}),
+			scmBase: null,
+			scmHead: null,
+		};
 	}
 	if (eventName === 'push' && ref === 'refs/heads/main') {
-		return createCiPlan({
-			full_ci: true,
-			affected_json: null,
-			detector_error: null,
-		});
+		return {
+			plan: createCiPlan({
+				full_ci: true,
+				affected_json: null,
+				detector_error: null,
+			}),
+			scmBase: null,
+			scmHead: null,
+		};
 	}
 
-	const base = process.env.TURBO_SCM_BASE;
-	const head = process.env.TURBO_SCM_HEAD;
+	const head = process.env.GITHUB_SHA;
+	const base = head ? commandOutput(['git', 'rev-parse', `${head}^1`]) : null;
 	if (
 		!base ||
 		!head ||
-		!commandSucceeded(['git', 'cat-file', '-e', `${base}^{commit}`]) ||
-		!commandSucceeded(['git', 'cat-file', '-e', `${head}^{commit}`]) ||
+		!commandSucceeded(['git', 'cat-file', '-e', `${head}^2`]) ||
 		!commandSucceeded(['git', 'merge-base', '--is-ancestor', base, head])
 	) {
-		return createCiPlan({
-			full_ci: false,
-			affected_json: null,
-			detector_error: 'Git base/head resolution was unsafe',
-		});
+		return {
+			plan: createCiPlan({
+				full_ci: false,
+				affected_json: null,
+				detector_error: 'GitHub PR merge commit resolution was unsafe',
+			}),
+			scmBase: null,
+			scmHead: null,
+		};
 	}
 
 	try {
@@ -392,32 +430,44 @@ const createPlanFromEnvironment = () => {
 		}
 		const query = Bun.spawnSync(
 			['bunx', `turbo@${turboVersion}`, 'query', 'affected'],
-			{stdout: 'pipe', stderr: 'inherit'},
+			{
+				stdout: 'pipe',
+				stderr: 'inherit',
+				env: {...process.env, TURBO_SCM_BASE: base, TURBO_SCM_HEAD: head},
+			},
 		);
 		if (query.exitCode !== 0) {
 			throw new Error('turbo query affected failed');
 		}
 
-		return createCiPlan({
-			full_ci: false,
-			affected_json: new TextDecoder().decode(query.stdout),
-			detector_error: null,
-		});
+		return {
+			plan: createCiPlan({
+				full_ci: false,
+				affected_json: new TextDecoder().decode(query.stdout),
+				detector_error: null,
+			}),
+			scmBase: base,
+			scmHead: head,
+		};
 	} catch (error) {
-		return createCiPlan({
-			full_ci: false,
-			affected_json: null,
-			detector_error: error instanceof Error ? error.message : String(error),
-		});
+		return {
+			plan: createCiPlan({
+				full_ci: false,
+				affected_json: null,
+				detector_error: error instanceof Error ? error.message : String(error),
+			}),
+			scmBase: base,
+			scmHead: head,
+		};
 	}
 };
 
 if (import.meta.main) {
 	const command = process.argv[2];
 	if (command === 'plan') {
-		const plan = createPlanFromEnvironment();
-		appendPlanOutputs(plan);
-		appendPlanSummary(plan);
+		const {plan, scmBase, scmHead} = createPlanFromEnvironment();
+		appendPlanOutputs(plan, scmBase, scmHead);
+		appendPlanSummary(plan, scmBase, scmHead);
 		console.log(JSON.stringify(plan, null, 2));
 	} else if (command === 'validate') {
 		const planJson = process.env.CI_PLAN;

--- a/.github/scripts/ci.ts
+++ b/.github/scripts/ci.ts
@@ -1,0 +1,445 @@
+import {appendFileSync, readFileSync} from 'node:fs';
+
+export const CI_PLAN_SCHEMA_VERSION = 1;
+
+export type BuildMatrix = {
+	include: Array<{
+		os: 'ubuntu-latest' | 'windows-latest' | 'macos-latest';
+		node_version: 16 | 25;
+		run_build: boolean;
+	}>;
+};
+
+export const FULL_BUILD_MATRIX: BuildMatrix = {
+	include: [
+		{os: 'ubuntu-latest', node_version: 16, run_build: true},
+		{os: 'windows-latest', node_version: 16, run_build: true},
+		{os: 'macos-latest', node_version: 25, run_build: true},
+	],
+};
+
+// Keep the historical Ubuntu and Windows contexts alive until the ruleset migration
+// is complete. Entries with run_build=false are compatibility no-ops.
+export const COMPATIBILITY_BUILD_MATRIX: BuildMatrix = {
+	include: [
+		{os: 'ubuntu-latest', node_version: 16, run_build: true},
+		{os: 'windows-latest', node_version: 16, run_build: false},
+	],
+};
+
+const TASKS_BY_SUITE = {
+	lambda: ['testlambda'],
+	nextjs: ['testnextjs'],
+	browser: ['testwebcodecs', 'teste2e'],
+	webrenderer: ['testwebrenderer', 'testbrowserstudio'],
+	ssr: ['testssr'],
+	templates: ['testtemplates'],
+	build: ['make', 'test'],
+	bundle_example: ['bundle-testbed'],
+} as const;
+
+const BOOLEAN_PLAN_KEYS = [
+	'full_ci',
+	'lambda',
+	'nextjs',
+	'browser',
+	'webrenderer',
+	'ssr',
+	'templates',
+	'build',
+	'bundle_example',
+] as const;
+
+export type CiPlan = {
+	schema_version: 1;
+	full_ci: boolean;
+	lambda: boolean;
+	nextjs: boolean;
+	browser: boolean;
+	webrenderer: boolean;
+	ssr: boolean;
+	templates: boolean;
+	build: boolean;
+	bundle_example: boolean;
+	build_matrix: BuildMatrix;
+	fallback_reason: string | null;
+	affected_reasons: string[];
+};
+
+type PlannerInput = {
+	full_ci: boolean;
+	affected_json: string | null;
+	detector_error: string | null;
+};
+
+type AffectedTask = {
+	name: string;
+	fullName: string;
+	package: {name: string};
+	reason: {__typename: string};
+};
+
+const fullPlan = (
+	fallbackReason: string | null,
+	affectedReasons: string[],
+): CiPlan => ({
+	schema_version: CI_PLAN_SCHEMA_VERSION,
+	full_ci: true,
+	lambda: true,
+	nextjs: true,
+	browser: true,
+	webrenderer: true,
+	ssr: true,
+	templates: true,
+	build: true,
+	bundle_example: true,
+	build_matrix: FULL_BUILD_MATRIX,
+	fallback_reason: fallbackReason,
+	affected_reasons: affectedReasons,
+});
+
+const readAffectedTasks = (affectedJson: string): AffectedTask[] => {
+	const parsed = JSON.parse(affectedJson) as {
+		data?: {affectedTasks?: {items?: unknown}};
+	};
+	const items = parsed.data?.affectedTasks?.items;
+	if (!Array.isArray(items)) {
+		throw new Error('Turborepo output has no affected task list');
+	}
+
+	for (const item of items) {
+		const task = item as Partial<AffectedTask>;
+		if (
+			typeof task.name !== 'string' ||
+			typeof task.fullName !== 'string' ||
+			typeof task.package?.name !== 'string' ||
+			typeof task.reason?.__typename !== 'string'
+		) {
+			throw new Error('Turborepo output contains an invalid affected task');
+		}
+	}
+
+	return items as AffectedTask[];
+};
+
+export const validateCiPlan = (value: unknown): CiPlan => {
+	if (!value || typeof value !== 'object') {
+		throw new Error('CI plan must be an object');
+	}
+
+	const plan = value as CiPlan;
+	if (plan.schema_version !== CI_PLAN_SCHEMA_VERSION) {
+		throw new Error(`Unsupported CI plan schema: ${plan.schema_version}`);
+	}
+	for (const key of BOOLEAN_PLAN_KEYS) {
+		if (typeof plan[key] !== 'boolean') {
+			throw new Error(`CI plan value ${key} must be a boolean`);
+		}
+	}
+	if (
+		plan.fallback_reason !== null &&
+		typeof plan.fallback_reason !== 'string'
+	) {
+		throw new Error('CI plan fallback_reason must be a string or null');
+	}
+	if (
+		!Array.isArray(plan.affected_reasons) ||
+		plan.affected_reasons.some((reason) => typeof reason !== 'string')
+	) {
+		throw new Error('CI plan affected_reasons must be a string array');
+	}
+
+	const matrix = plan.build_matrix;
+	if (
+		!matrix ||
+		!Array.isArray(matrix.include) ||
+		matrix.include.length === 0
+	) {
+		throw new Error('CI plan build_matrix must contain entries');
+	}
+	for (const entry of matrix.include) {
+		if (
+			!['ubuntu-latest', 'windows-latest', 'macos-latest'].includes(entry.os) ||
+			![16, 25].includes(entry.node_version) ||
+			typeof entry.run_build !== 'boolean'
+		) {
+			throw new Error('CI plan contains an invalid build matrix entry');
+		}
+	}
+
+	if (plan.full_ci) {
+		if (BOOLEAN_PLAN_KEYS.slice(1).some((key) => !plan[key])) {
+			throw new Error('Full CI must select every suite');
+		}
+		if (JSON.stringify(matrix) !== JSON.stringify(FULL_BUILD_MATRIX)) {
+			throw new Error('Full CI must use the full build matrix');
+		}
+	} else {
+		if (plan.fallback_reason !== null) {
+			throw new Error('A fallback plan must select full CI');
+		}
+		const validAffectedMatrices = [
+			FULL_BUILD_MATRIX,
+			COMPATIBILITY_BUILD_MATRIX,
+		].some((candidate) => JSON.stringify(matrix) === JSON.stringify(candidate));
+		if (!validAffectedMatrices) {
+			throw new Error('Affected CI has an unrecognized build matrix');
+		}
+	}
+
+	return plan;
+};
+
+export const createCiPlan = (input: PlannerInput): CiPlan => {
+	const reasons: string[] = [];
+	if (input.detector_error !== null) {
+		return validateCiPlan(fullPlan(input.detector_error, reasons));
+	}
+	if (input.full_ci) {
+		return validateCiPlan(fullPlan(null, reasons));
+	}
+	if (input.affected_json === null) {
+		return validateCiPlan(
+			fullPlan('Turborepo output was not provided', reasons),
+		);
+	}
+
+	try {
+		const tasks = readAffectedTasks(input.affected_json);
+		for (const task of tasks) {
+			reasons.push(`${task.fullName} (${task.reason.__typename})`);
+		}
+		const names = new Set(tasks.map((task) => task.name));
+		const selected = (suite: keyof typeof TASKS_BY_SUITE) =>
+			TASKS_BY_SUITE[suite].some((task) => names.has(task));
+		const build = selected('build');
+		const bundleExample = selected('bundle_example');
+		const hasNonDocsBuild = tasks.some(
+			(task) =>
+				(task.name === 'make' || task.name === 'test') &&
+				task.package.name !== 'docs',
+		);
+
+		return validateCiPlan({
+			schema_version: CI_PLAN_SCHEMA_VERSION,
+			full_ci: false,
+			lambda: selected('lambda'),
+			nextjs: selected('nextjs'),
+			browser: selected('browser'),
+			webrenderer: selected('webrenderer'),
+			ssr: selected('ssr'),
+			templates: selected('templates'),
+			build,
+			bundle_example: bundleExample,
+			build_matrix: hasNonDocsBuild
+				? FULL_BUILD_MATRIX
+				: COMPATIBILITY_BUILD_MATRIX,
+			fallback_reason: null,
+			affected_reasons: reasons,
+		});
+	} catch (error) {
+		return validateCiPlan(
+			fullPlan(error instanceof Error ? error.message : String(error), reasons),
+		);
+	}
+};
+
+const getSelectedSuites = (plan: CiPlan) => ({
+	lambda: plan.lambda,
+	nextjs: plan.nextjs,
+	browser: plan.browser,
+	webrenderer: plan.webrenderer,
+	ssr: plan.ssr,
+	templates: plan.templates,
+	build_job: plan.build || plan.bundle_example,
+});
+
+type SuiteKey = keyof ReturnType<typeof getSelectedSuites>;
+
+export type RequiredCiResults = {
+	detector: string;
+	lint: string;
+	lambda: string;
+	nextjs: string;
+	browser: string;
+	webrenderer: string;
+	ssr: string;
+	templates: string;
+	build_job: string;
+};
+
+export const validateRequiredCi = (
+	planValue: unknown,
+	results: RequiredCiResults,
+) => {
+	const plan = validateCiPlan(planValue);
+	if (results.detector !== 'success') {
+		throw new Error(`Detector concluded with ${results.detector}`);
+	}
+	if (results.lint !== 'success') {
+		throw new Error(`Lint concluded with ${results.lint}`);
+	}
+
+	const selectedSuites = getSelectedSuites(plan);
+	for (const suite of Object.keys(selectedSuites) as SuiteKey[]) {
+		const selected = selectedSuites[suite];
+		const result = results[suite];
+		if (selected && result !== 'success') {
+			throw new Error(`Selected suite ${suite} concluded with ${result}`);
+		}
+		if (!selected && result !== 'skipped') {
+			// Temporary migration exception: the build matrix emits the historical
+			// Ubuntu/Windows required contexts even when no build work is selected.
+			if (suite === 'build_job' && result === 'success') {
+				continue;
+			}
+			throw new Error(`Unselected suite ${suite} concluded with ${result}`);
+		}
+	}
+};
+
+const commandSucceeded = (command: string[]) => {
+	return (
+		Bun.spawnSync(command, {stdout: 'ignore', stderr: 'inherit'}).exitCode === 0
+	);
+};
+
+const appendPlanOutputs = (plan: CiPlan) => {
+	const githubOutput = process.env.GITHUB_OUTPUT;
+	if (!githubOutput) {
+		throw new Error('GITHUB_OUTPUT is not set');
+	}
+
+	appendFileSync(
+		githubOutput,
+		[
+			`plan=${JSON.stringify(plan)}`,
+			`lambda=${plan.lambda}`,
+			`nextjs=${plan.nextjs}`,
+			`browser=${plan.browser}`,
+			`webrenderer=${plan.webrenderer}`,
+			`ssr=${plan.ssr}`,
+			`templates=${plan.templates}`,
+			`build=${plan.build}`,
+			`bundle_example=${plan.bundle_example}`,
+			`build_matrix=${JSON.stringify(plan.build_matrix)}`,
+			'',
+		].join('\n'),
+	);
+};
+
+const appendPlanSummary = (plan: CiPlan) => {
+	const githubStepSummary = process.env.GITHUB_STEP_SUMMARY;
+	if (!githubStepSummary) {
+		throw new Error('GITHUB_STEP_SUMMARY is not set');
+	}
+
+	const suites = getSelectedSuites(plan);
+	const selected = Object.entries(suites)
+		.filter(([, isSelected]) => isSelected)
+		.map(([suite]) => suite);
+	const skipped = Object.entries(suites)
+		.filter(([, isSelected]) => !isSelected)
+		.map(([suite]) => suite);
+	appendFileSync(
+		githubStepSummary,
+		[
+			'### Required CI plan',
+			'',
+			`- Full CI: ${plan.full_ci}`,
+			`- Selected suites: ${selected.length ? selected.map((suite) => `\`${suite}\``).join(', ') : 'none'}`,
+			`- Skipped suites: ${skipped.length ? skipped.map((suite) => `\`${suite}\``).join(', ') : 'none'}`,
+			...(plan.fallback_reason
+				? [`- Fallback reason: ${plan.fallback_reason}`]
+				: []),
+			'',
+			'#### Affected Turborepo tasks',
+			...plan.affected_reasons.map((reason) => `- \`${reason}\``),
+			'',
+		].join('\n'),
+	);
+};
+
+const createPlanFromEnvironment = () => {
+	const eventName = process.env.GITHUB_EVENT_NAME;
+	const ref = process.env.GITHUB_REF;
+	if (!eventName || !ref) {
+		return createCiPlan({
+			full_ci: false,
+			affected_json: null,
+			detector_error: 'GitHub event metadata is missing',
+		});
+	}
+	if (eventName === 'push' && ref === 'refs/heads/main') {
+		return createCiPlan({
+			full_ci: true,
+			affected_json: null,
+			detector_error: null,
+		});
+	}
+
+	const base = process.env.TURBO_SCM_BASE;
+	const head = process.env.TURBO_SCM_HEAD;
+	if (
+		!base ||
+		!head ||
+		!commandSucceeded(['git', 'cat-file', '-e', `${base}^{commit}`]) ||
+		!commandSucceeded(['git', 'cat-file', '-e', `${head}^{commit}`]) ||
+		!commandSucceeded(['git', 'merge-base', '--is-ancestor', base, head])
+	) {
+		return createCiPlan({
+			full_ci: false,
+			affected_json: null,
+			detector_error: 'Git base/head resolution was unsafe',
+		});
+	}
+
+	try {
+		const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+			dependencies?: {turbo?: string};
+		};
+		const turboVersion = packageJson.dependencies?.turbo;
+		if (!turboVersion) {
+			throw new Error('Could not determine the Turborepo version');
+		}
+		const query = Bun.spawnSync(
+			['bunx', `turbo@${turboVersion}`, 'query', 'affected'],
+			{stdout: 'pipe', stderr: 'inherit'},
+		);
+		if (query.exitCode !== 0) {
+			throw new Error('turbo query affected failed');
+		}
+
+		return createCiPlan({
+			full_ci: false,
+			affected_json: new TextDecoder().decode(query.stdout),
+			detector_error: null,
+		});
+	} catch (error) {
+		return createCiPlan({
+			full_ci: false,
+			affected_json: null,
+			detector_error: error instanceof Error ? error.message : String(error),
+		});
+	}
+};
+
+if (import.meta.main) {
+	const command = process.argv[2];
+	if (command === 'plan') {
+		const plan = createPlanFromEnvironment();
+		appendPlanOutputs(plan);
+		appendPlanSummary(plan);
+		console.log(JSON.stringify(plan, null, 2));
+	} else if (command === 'validate') {
+		const planJson = process.env.CI_PLAN;
+		const resultsJson = process.env.CI_RESULTS;
+		if (!planJson || !resultsJson) {
+			throw new Error('CI_PLAN and CI_RESULTS must be set');
+		}
+		validateRequiredCi(JSON.parse(planJson), JSON.parse(resultsJson));
+		console.log('Every selected required CI suite succeeded.');
+	} else {
+		throw new Error('Usage: ci.ts <plan|validate>');
+	}
+}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,21 +72,6 @@ jobs:
         timeout-minutes: 10
         run: |
           cd packages/lambda && bunx remotion browser ensure && bun test src/test/integration --run
-  lambda-tests-required:
-    needs: [affected, lambda-tests]
-    if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
-    name: Lambda integration
-    steps:
-      - name: Verify Lambda integration result
-        env:
-          RESULT: ${{ needs.lambda-tests.result }}
-        run: |
-          if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
-            echo "Lambda integration tests concluded with $RESULT."
-            exit 1
-          fi
-          echo "Lambda integration tests concluded with $RESULT."
   nextjs-tests:
     needs: affected
     if: ${{ needs.affected.outputs.nextjs == 'true' }}
@@ -202,21 +187,6 @@ jobs:
         timeout-minutes: 10
         run: |
           cd packages/it-tests && bun test src/monorepo --run --timeout 40000
-  ssr-tests-required:
-    needs: [affected, ssr-tests]
-    if: ${{ always() && !cancelled() }}
-    runs-on: ubuntu-latest
-    name: SSR + Monorepo checks
-    steps:
-      - name: Verify SSR and monorepo result
-        env:
-          RESULT: ${{ needs.ssr-tests.result }}
-        run: |
-          if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
-            echo "SSR and monorepo tests concluded with $RESULT."
-            exit 1
-          fi
-          echo "SSR and monorepo tests concluded with $RESULT."
   template-tests:
     name: Template integration on ${{ matrix.os }}
     needs: affected
@@ -289,36 +259,27 @@ jobs:
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
     needs: affected
-    if: ${{ !cancelled() }}
+    if: ${{ needs.affected.outputs.build == 'true' || needs.affected.outputs.bundle_example == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":true},{"os":"macos-latest","node_version":25,"run_build":true}]}') }}
+      matrix: ${{ fromJSON(needs.affected.outputs.build_matrix) }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
-      RUN_BUILD: ${{ matrix.run_build && needs.affected.outputs.build == 'true' }}
-      RUN_BUNDLE: ${{ needs.affected.outputs.bundle_example == 'true' }}
-      RUN_BUILD_JOB: ${{ (matrix.run_build && needs.affected.outputs.build == 'true') || (matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true') }}
     steps:
-      - name: No affected build tasks
-        if: env.RUN_BUILD_JOB != 'true'
-        run: echo "No build tasks are affected."
-      - if: env.RUN_BUILD_JOB == 'true'
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: blob:none
-      - if: env.RUN_BUILD_JOB == 'true'
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
-      - if: env.RUN_BUILD_JOB == 'true'
-        uses: oven-sh/setup-bun@v2.1.2
+      - uses: oven-sh/setup-bun@v2.1.2
         with:
           bun-version: 1.3.3
       - name: Cache Bun dependencies (Windows)
-        if: env.RUN_BUILD_JOB == 'true' && matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest'
         uses: actions/cache@v5
         with:
           path: D:\.bun\install\cache
@@ -326,18 +287,16 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-bun-
       - name: Install
-        if: env.RUN_BUILD_JOB == 'true'
         run: bun ci
       - name: Cache Turbo
-        if: env.RUN_BUILD_JOB == 'true'
         uses: rharkor/caching-for-turbo@v2.3.11
       - name: Build & Test
-        if: env.RUN_BUILD == 'true'
+        if: needs.affected.outputs.build == 'true'
         timeout-minutes: 30
         run: |
           bunx turbo run make test ${{ github.event_name == 'pull_request' && '--affected' || '' }} --concurrency=1 --no-update-notifier
       - name: Bundle example
-        if: matrix.os == 'ubuntu-latest' && env.RUN_BUNDLE == 'true'
+        if: matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true'
         run: |
           bunx turbo run bundle-testbed --filter=@remotion/example --no-update-notifier
   required-ci:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ name: Install and Test
 
 concurrency:
   group: install-and-test-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_COLOR: 1
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 5
     name: Determine affected tests
     outputs:
+      plan: ${{ steps.query.outputs.plan }}
       lambda: ${{ steps.query.outputs.lambda }}
       nextjs: ${{ steps.query.outputs.nextjs }}
       browser: ${{ steps.query.outputs.browser }}
@@ -38,88 +39,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2.1.2
         with:
           bun-version: 1.3.3
-      - name: Query Turborepo task graph
+      - name: Query Turborepo task graph and create CI plan
         id: query
-        run: |
-          set -euo pipefail
-
-          full_matrix='{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":true},{"os":"macos-latest","node_version":25,"run_build":true}]}'
-          required_matrix='{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":false}]}'
-
-          run_all_test_groups() {
-            for output in lambda nextjs browser webrenderer ssr templates build bundle_example; do
-              echo "$output=true" >> "$GITHUB_OUTPUT"
-            done
-            echo "build_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
-          }
-
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            echo "Push to main. Running all test groups."
-            run_all_test_groups
-            echo "### Full CI after push to main" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          turbo_version=$(jq -r '.dependencies.turbo' package.json)
-          if ! bunx "turbo@$turbo_version" query affected > affected.json; then
-            echo "Could not determine affected tasks. Running all test groups."
-            run_all_test_groups
-            exit 0
-          fi
-
-          task_is_affected() {
-            jq -e --arg task "$1" \
-              'any(.data.affectedTasks.items[]; .name == $task)' \
-              affected.json > /dev/null
-          }
-
-          set_from_tasks() {
-            output=$1
-            shift
-            affected=false
-            for task in "$@"; do
-              if task_is_affected "$task"; then
-                affected=true
-              fi
-            done
-
-            echo "$output=$affected" >> "$GITHUB_OUTPUT"
-          }
-
-          set_from_tasks lambda testlambda
-          set_from_tasks nextjs testnextjs
-          set_from_tasks browser testwebcodecs teste2e
-          set_from_tasks webrenderer testwebrenderer testbrowserstudio
-          set_from_tasks ssr testssr
-          set_from_tasks templates testtemplates
-          set_from_tasks bundle_example bundle-testbed
-
-          build=false
-          build_matrix=$required_matrix
-          if jq -e \
-            'any(.data.affectedTasks.items[]; .name == "make" or .name == "test")' \
-            affected.json > /dev/null; then
-            build=true
-          fi
-
-          if jq -e \
-            'any(.data.affectedTasks.items[]; (.name == "make" or .name == "test") and .package.name != "docs")' \
-            affected.json > /dev/null; then
-            build_matrix=$full_matrix
-          fi
-
-          echo "build=$build" >> "$GITHUB_OUTPUT"
-          echo "build_matrix=$build_matrix" >> "$GITHUB_OUTPUT"
-
-          {
-            echo '### Affected Turborepo tasks'
-            echo
-            jq -r '.data.affectedTasks.items[] | "- `\(.fullName)` (\(.reason.__typename))"' affected.json
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: bun .github/scripts/ci.ts plan
 
   lambda-tests:
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.lambda == 'true') }}
+    if: ${{ needs.affected.outputs.lambda == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Lambda integration tests
@@ -163,7 +89,7 @@ jobs:
           echo "Lambda integration tests concluded with $RESULT."
   nextjs-tests:
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.nextjs == 'true') }}
+    if: ${{ needs.affected.outputs.nextjs == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Next.js SSR build
@@ -185,7 +111,7 @@ jobs:
           bun run testnextjs
   browser-tests:
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.browser == 'true') }}
+    if: ${{ needs.affected.outputs.browser == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 30
     name: Browser tests
@@ -213,7 +139,7 @@ jobs:
           bun run teste2e
   webrenderer-tests:
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.webrenderer == 'true') }}
+    if: ${{ needs.affected.outputs.webrenderer == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 30
     name: Web renderer tests
@@ -239,7 +165,7 @@ jobs:
           bun run testbrowserstudio
   ssr-tests:
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.ssr == 'true') }}
+    if: ${{ needs.affected.outputs.ssr == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: SSR + Monorepo tests
@@ -294,7 +220,7 @@ jobs:
   template-tests:
     name: Template integration on ${{ matrix.os }}
     needs: affected
-    if: ${{ !cancelled() && (needs.affected.result != 'success' || needs.affected.outputs.templates == 'true') }}
+    if: ${{ needs.affected.outputs.templates == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -332,7 +258,7 @@ jobs:
           bun run testtemplates
   lint:
     needs: affected
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Linting + Formatting
@@ -358,6 +284,8 @@ jobs:
         run: |
           bunx turbo run lint formatting ${{ github.event_name == 'pull_request' && '--affected' || '' }} --no-update-notifier
           bun run checkskills
+      - name: Test CI planning contract
+        run: bun test ./.github/scripts/ci.test.ts
   build:
     name: Build Node ${{ matrix.node_version }} on ${{ matrix.os }}
     needs: affected
@@ -369,9 +297,9 @@ jobs:
       matrix: ${{ fromJSON(needs.affected.outputs.build_matrix || '{"include":[{"os":"ubuntu-latest","node_version":16,"run_build":true},{"os":"windows-latest","node_version":16,"run_build":true},{"os":"macos-latest","node_version":25,"run_build":true}]}') }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
-      RUN_BUILD: ${{ matrix.run_build && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true') }}
-      RUN_BUNDLE: ${{ needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true' }}
-      RUN_BUILD_JOB: ${{ (matrix.run_build && (needs.affected.result != 'success' || needs.affected.outputs.build == 'true')) || (matrix.os == 'ubuntu-latest' && (needs.affected.result != 'success' || needs.affected.outputs.bundle_example == 'true')) }}
+      RUN_BUILD: ${{ matrix.run_build && needs.affected.outputs.build == 'true' }}
+      RUN_BUNDLE: ${{ needs.affected.outputs.bundle_example == 'true' }}
+      RUN_BUILD_JOB: ${{ (matrix.run_build && needs.affected.outputs.build == 'true') || (matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true') }}
     steps:
       - name: No affected build tasks
         if: env.RUN_BUILD_JOB != 'true'
@@ -412,3 +340,29 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && env.RUN_BUNDLE == 'true'
         run: |
           bunx turbo run bundle-testbed --filter=@remotion/example --no-update-notifier
+  required-ci:
+    name: Required CI
+    if: ${{ always() }}
+    needs:
+      - affected
+      - lint
+      - build
+      - lambda-tests
+      - nextjs-tests
+      - browser-tests
+      - webrenderer-tests
+      - ssr-tests
+      - template-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2.1.2
+        with:
+          bun-version: 1.3.3
+      - name: Validate required CI results
+        env:
+          CI_PLAN: ${{ needs.affected.outputs.plan }}
+          CI_RESULTS: >-
+            {"detector":"${{ needs.affected.result }}","lint":"${{ needs.lint.result }}","build_job":"${{ needs.build.result }}","lambda":"${{ needs.lambda-tests.result }}","nextjs":"${{ needs.nextjs-tests.result }}","browser":"${{ needs.browser-tests.result }}","webrenderer":"${{ needs.webrenderer-tests.result }}","ssr":"${{ needs.ssr-tests.result }}","templates":"${{ needs.template-tests.result }}"}
+        run: bun .github/scripts/ci.ts validate

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,8 +13,6 @@ env:
   FORCE_COLOR: 1
   TURBO_TELEMETRY_DISABLED: 1
   TURBO_NO_UPDATE_NOTIFIER: 1
-  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-  TURBO_SCM_HEAD: ${{ github.sha }}
 jobs:
   affected:
     runs-on: ubuntu-latest
@@ -22,6 +20,9 @@ jobs:
     name: Determine affected tests
     outputs:
       plan: ${{ steps.query.outputs.plan }}
+      full_ci: ${{ steps.query.outputs.full_ci }}
+      scm_base: ${{ steps.query.outputs.scm_base }}
+      scm_head: ${{ steps.query.outputs.scm_head }}
       lambda: ${{ steps.query.outputs.lambda }}
       nextjs: ${{ steps.query.outputs.nextjs }}
       browser: ${{ steps.query.outputs.browser }}
@@ -232,6 +233,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Linting + Formatting
+    env:
+      TURBO_SCM_BASE: ${{ needs.affected.outputs.scm_base }}
+      TURBO_SCM_HEAD: ${{ needs.affected.outputs.scm_head }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -252,7 +256,7 @@ jobs:
       - name: Perform stylecheck
         timeout-minutes: 10
         run: |
-          bunx turbo run lint formatting ${{ github.event_name == 'pull_request' && '--affected' || '' }} --no-update-notifier
+          bunx turbo run lint formatting ${{ github.event_name == 'pull_request' && needs.affected.outputs.full_ci != 'true' && '--affected' || '' }} --no-update-notifier
           bun run checkskills
       - name: Test CI planning contract
         run: bun test ./.github/scripts/ci.test.ts
@@ -267,6 +271,8 @@ jobs:
       matrix: ${{ fromJSON(needs.affected.outputs.build_matrix) }}
     env:
       BUN_INSTALL_CACHE_DIR: ${{ matrix.os == 'windows-latest' && 'D:\.bun\install\cache' || '' }}
+      TURBO_SCM_BASE: ${{ needs.affected.outputs.scm_base }}
+      TURBO_SCM_HEAD: ${{ needs.affected.outputs.scm_head }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -294,7 +300,7 @@ jobs:
         if: needs.affected.outputs.build == 'true'
         timeout-minutes: 30
         run: |
-          bunx turbo run make test ${{ github.event_name == 'pull_request' && '--affected' || '' }} --concurrency=1 --no-update-notifier
+          bunx turbo run make test ${{ github.event_name == 'pull_request' && needs.affected.outputs.full_ci != 'true' && '--affected' || '' }} --concurrency=1 --no-update-notifier
       - name: Bundle example
         if: matrix.os == 'ubuntu-latest' && needs.affected.outputs.bundle_example == 'true'
         run: |


### PR DESCRIPTION
## Summary

Adds a stable `Required CI` aggregate check for affected pull request workflows.

The affected-task planner produces and validates an explicit CI plan from Turborepo. The aggregate check verifies that every selected suite ran successfully and every unselected suite was actually skipped. Detector failures fall back to full CI, while pushes to `main` continue running the full suite.

After this PR emits `Required CI`, the repository ruleset must be updated before merge to require Vercel, lint, and `Required CI`, and to remove the historical Build, Lambda, and SSR required contexts.

## Changes

- Move affected-task planning, output generation, and summaries out of workflow shell into a tested TypeScript script.
- Add strict plan and job-result validation.
- Add the static `Required CI` aggregate job.
- Include selected suites, skipped suites, affected tasks, fallback reasons, and the compared commit range in the job summary.
- Compare the synthetic PR merge commit with its first parent so unrelated changes newly added to the base branch do not select extra suites.
- Pass the same resolved commit range to affected lint and build tasks.
- Genuinely skip unselected specialized and build jobs.
- Use a minimal Ubuntu matrix for docs-only build work and the full matrix for non-doc build work.
- Remove the historical Lambda, SSR, Ubuntu, and Windows compatibility checks and no-ops.
- Continue full CI on pushes to `main` while cancelling only obsolete pull request runs.

## Verification

- `bun test ./.github/scripts/ci.test.ts`
- `actionlint -verbose .github/workflows/push.yml`
- `act -W .github/workflows/push.yml -l`
- `bunx oxfmt --check .github/scripts/ci.ts .github/scripts/ci.test.ts .github/workflows/push.yml`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
- Verified the corrected commit range against the previously failing PR merge commit: only the three `.github` files were included and Turborepo selected zero tasks.