### PR TITLE
`remotion`: Add fine-grained runtime value reactivity

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -7,6 +7,10 @@ import type {EffectDefinition} from './effects/effect-types.js';
 import type {InteractivitySchema} from './interactivity-schema.js';
 import type {NonceHistory} from './nonce.js';
 import type {InferProps, PropsIfHasProps} from './props-if-has-props.js';
+import type {
+	RuntimeValueSnapshot,
+	RuntimeValueStore,
+} from './runtime-value-store.js';
 
 export type TComposition<
 	Schema extends AnyZodObject,
@@ -102,13 +106,17 @@ export type LoopDisplay = {
 
 export type JsxComponentIdentity = string;
 
-export type SequenceControls = {
+export type SequenceRegistrationControls = {
 	schema: InteractivitySchema;
-	currentRuntimeValueDotNotation: Record<string, unknown>;
+	runtimeValues: RuntimeValueStore;
 	overrideId: string;
 	supportsEffects: boolean;
 	componentIdentity: JsxComponentIdentity | null;
 	componentName: string;
+};
+
+export type SequenceControls = SequenceRegistrationControls & {
+	currentRuntimeValueDotNotation: RuntimeValueSnapshot;
 };
 
 export type TSequence = {
@@ -125,7 +133,7 @@ export type TSequence = {
 	getStack: () => string | null;
 	premountDisplay: number | null;
 	postmountDisplay: number | null;
-	controls: SequenceControls | null;
+	controls: SequenceRegistrationControls | null;
 	refForOutline: React.RefObject<Element | null> | null;
 	effects: readonly EffectDefinition<unknown>[];
 	isInsideSeries: boolean;

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -9,7 +9,11 @@ import React, {
 	useState,
 } from 'react';
 import {AbsoluteFillElement} from './AbsoluteFillElement.js';
-import type {LoopDisplay, SequenceControls} from './CompositionManager.js';
+import type {
+	LoopDisplay,
+	SequenceControls,
+	SequenceRegistrationControls,
+} from './CompositionManager.js';
 import type {EffectDefinition} from './effects/effect-types.js';
 import {getStackForControls} from './enable-sequence-stack-traces.js';
 import {Freeze} from './freeze.js';
@@ -402,6 +406,41 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 						: registeredFrozenFrame) *
 						isMedia.data.playbackRate
 			: null;
+	const controlsSchema = controls?.schema;
+	const controlsRuntimeValues = controls?.runtimeValues;
+	const controlsOverrideId = controls?.overrideId;
+	const controlsSupportsEffects = controls?.supportsEffects;
+	const controlsComponentIdentity = controls?.componentIdentity;
+	const controlsComponentName = controls?.componentName;
+	const registrationControls =
+		useMemo((): SequenceRegistrationControls | null => {
+			if (
+				controlsSchema === undefined ||
+				controlsRuntimeValues === undefined ||
+				controlsOverrideId === undefined ||
+				controlsSupportsEffects === undefined ||
+				controlsComponentIdentity === undefined ||
+				controlsComponentName === undefined
+			) {
+				return null;
+			}
+
+			return {
+				schema: controlsSchema,
+				runtimeValues: controlsRuntimeValues,
+				overrideId: controlsOverrideId,
+				supportsEffects: controlsSupportsEffects,
+				componentIdentity: controlsComponentIdentity,
+				componentName: controlsComponentName,
+			};
+		}, [
+			controlsComponentIdentity,
+			controlsComponentName,
+			controlsOverrideId,
+			controlsRuntimeValues,
+			controlsSchema,
+			controlsSupportsEffects,
+		]);
 
 	useEffect(() => {
 		if (!env.isStudio) {
@@ -412,7 +451,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			if (isMedia.type === 'image') {
 				registerSequence({
 					type: 'image',
-					controls: controls ?? null,
+					controls: registrationControls,
 					effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
 					displayName: timelineClipName,
 					documentationLink: resolvedDocumentationLink,
@@ -436,7 +475,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			} else {
 				registerSequence({
 					type: isMedia.type,
-					controls: controls ?? null,
+					controls: registrationControls,
 					effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
 					displayName: timelineClipName,
 					documentationLink: resolvedDocumentationLink,
@@ -485,7 +524,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			getStack: () => stackRef.current,
 			premountDisplay: premountDisplay ?? null,
 			postmountDisplay: postmountDisplay ?? null,
-			controls: controls ?? null,
+			controls: registrationControls,
 			effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
 			refForOutline: refForOutline ?? null,
 			isInsideSeries,
@@ -513,7 +552,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		premountDisplay,
 		postmountDisplay,
 		env.isStudio,
-		controls,
+		registrationControls,
 		_remotionInternalEffects,
 		isMedia,
 		resolvedDocumentationLink,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ import type {
 	JsxComponentIdentity,
 	LoopDisplay,
 	SequenceControls,
+	SequenceRegistrationControls,
 	TRenderAsset,
 } from './CompositionManager.js';
 import type {DelayRenderScope} from './delay-render.js';
@@ -33,6 +34,10 @@ import {checkMultipleRemotionVersions} from './multiple-versions-warning.js';
 import {Null} from './Null.js';
 import type {ProResProfile} from './prores-profile.js';
 import type {PixelFormat, VideoImageFormat} from './render-types.js';
+import type {
+	RuntimeValueSnapshot,
+	RuntimeValueStore,
+} from './runtime-value-store.js';
 import {Sequence} from './Sequence.js';
 import type {UseBufferState} from './use-buffer-state';
 import type {VideoConfig} from './video-config.js';
@@ -348,7 +353,10 @@ export type {
 	DelayRenderScope,
 	JsxComponentIdentity,
 	LoopDisplay,
+	RuntimeValueSnapshot,
+	RuntimeValueStore,
 	SequenceControls,
+	SequenceRegistrationControls,
 	InteractivitySchemaField,
 	InteractivitySchema,
 	UseBufferState,

--- a/packages/core/src/runtime-value-store.ts
+++ b/packages/core/src/runtime-value-store.ts
@@ -1,0 +1,42 @@
+export type RuntimeValueSnapshot = Readonly<Record<string, unknown>>;
+
+export type RuntimeValueStore = {
+	getSnapshot: () => RuntimeValueSnapshot;
+	subscribe: (listener: () => void) => () => void;
+};
+
+export type RuntimeValueStoreController = {
+	store: RuntimeValueStore;
+	setSnapshot: (newSnapshot: RuntimeValueSnapshot) => void;
+};
+
+export const createRuntimeValueStore = (
+	initialSnapshot: RuntimeValueSnapshot,
+): RuntimeValueStoreController => {
+	let snapshot = initialSnapshot;
+	const listeners = new Set<() => void>();
+
+	const store: RuntimeValueStore = {
+		getSnapshot: () => snapshot,
+		subscribe: (listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+	};
+
+	return {
+		store,
+		setSnapshot: (newSnapshot) => {
+			if (snapshot === newSnapshot) {
+				return;
+			}
+
+			snapshot = newSnapshot;
+			for (const listener of listeners) {
+				listener();
+			}
+		},
+	};
+};

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -6,7 +6,11 @@ import {
 	AnimatedImage,
 	animatedImageSchema,
 } from '../animated-image/AnimatedImage.js';
-import type {SequenceControls, TSequence} from '../CompositionManager.js';
+import type {
+	SequenceControls,
+	SequenceRegistrationControls,
+	TSequence,
+} from '../CompositionManager.js';
 import type {
 	EffectDefinition,
 	EffectDescriptor,
@@ -236,6 +240,93 @@ test('Sequence calls registerSequence exactly once on mount', () => {
 	expect(registerCalls).toBe(1);
 });
 
+test('Interactive runtime values update mounted consumers without re-registering the sequence', () => {
+	const registeredSequences: TSequence[] = [];
+	const onRegisterSequence = (sequence: TSequence) => {
+		registeredSequences.push(sequence);
+	};
+
+	const renderInteractiveDiv = (opacity: number, color: string) => (
+		<SequenceTestWrapper onRegisterSequence={onRegisterSequence}>
+			<Interactive.Div style={{color, opacity}}>Hello</Interactive.Div>
+		</SequenceTestWrapper>
+	);
+	const producer = render(renderInteractiveDiv(0.25, 'red'));
+	const controls = registeredSequences.find(
+		(sequence) => sequence.displayName === '<Interactive.Div>',
+	)?.controls;
+	if (!controls) {
+		throw new Error('Expected Interactive.Div controls');
+	}
+
+	let consumerRenders = 0;
+	const RuntimeOpacity: React.FC<{
+		readonly controls: SequenceRegistrationControls;
+	}> = ({controls: consumerControls}) => {
+		consumerRenders++;
+		const opacity = React.useSyncExternalStore(
+			consumerControls.runtimeValues.subscribe,
+			() => consumerControls.runtimeValues.getSnapshot()['style.opacity'],
+		);
+
+		return <output>{String(opacity)}</output>;
+	};
+
+	const consumer = render(<RuntimeOpacity controls={controls} />);
+
+	expect(consumer.getByText('0.25')).toBeTruthy();
+	expect(consumerRenders).toBe(1);
+	expect(registeredSequences).toHaveLength(1);
+
+	producer.rerender(renderInteractiveDiv(0.75, 'red'));
+	expect(consumer.getByText('0.75')).toBeTruthy();
+	expect(consumerRenders).toBe(2);
+	expect(registeredSequences).toHaveLength(1);
+
+	producer.rerender(renderInteractiveDiv(0.75, 'blue'));
+	expect(consumer.getByText('0.75')).toBeTruthy();
+	expect(consumerRenders).toBe(2);
+	expect(registeredSequences).toHaveLength(1);
+});
+
+test('Interactive runtime values are published only after a render commits', () => {
+	const registeredSequences: TSequence[] = [];
+	const onRegisterSequence = (sequence: TSequence) => {
+		registeredSequences.push(sequence);
+	};
+
+	const never = new Promise<never>(() => undefined);
+	const Suspend: React.FC<{readonly active: boolean}> = ({active}) => {
+		if (active) {
+			throw never;
+		}
+
+		return null;
+	};
+
+	const renderInteractiveDiv = (opacity: number, suspend: boolean) => (
+		<React.Suspense fallback={<span>Suspended</span>}>
+			<SequenceTestWrapper onRegisterSequence={onRegisterSequence}>
+				<Interactive.Div style={{opacity}}>
+					<Suspend active={suspend} />
+				</Interactive.Div>
+			</SequenceTestWrapper>
+		</React.Suspense>
+	);
+	const producer = render(renderInteractiveDiv(0.25, false));
+	const controls = registeredSequences.find(
+		(sequence) => sequence.displayName === '<Interactive.Div>',
+	)?.controls;
+	if (!controls) {
+		throw new Error('Expected Interactive.Div controls');
+	}
+
+	producer.rerender(renderInteractiveDiv(0.75, true));
+
+	expect(producer.getByText('Suspended')).toBeTruthy();
+	expect(controls.runtimeValues.getSnapshot()['style.opacity']).toBe(0.25);
+});
+
 test('Sequence registers its documentation link', () => {
 	const registeredSequences: TSequence[] = [];
 
@@ -388,7 +479,7 @@ test('Series.Sequence registers with its own visual controls', () => {
 	expect(
 		seriesSequences.map(
 			(sequence) =>
-				sequence.controls?.currentRuntimeValueDotNotation.durationInFrames,
+				sequence.controls?.runtimeValues.getSnapshot().durationInFrames,
 		),
 	).toEqual([10, 20]);
 	expect(seriesSequences.map((sequence) => sequence.getStack())).toEqual([

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -1,4 +1,10 @@
-import React, {forwardRef, useContext, useMemo, useState} from 'react';
+import React, {
+	forwardRef,
+	useContext,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from 'react';
 import type {
 	JsxComponentIdentity,
 	SequenceControls,
@@ -17,6 +23,7 @@ import {
 	extendSchemaWithSequenceName,
 	type InteractivitySchema,
 } from './interactivity-schema.js';
+import {createRuntimeValueStore} from './runtime-value-store.js';
 import {OverrideIdsToNodePathsGettersContext} from './sequence-node-path.js';
 import {
 	VisualModeDragOverridesContext,
@@ -262,18 +269,29 @@ export const withInteractivitySchema = <
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 			runtimeValues,
 		);
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [runtimeValueStore] = useState(() =>
+			createRuntimeValueStore(currentRuntimeValueDotNotation),
+		);
+		// Publishing in a layout effect ensures that abandoned renders cannot expose
+		// uncommitted runtime values to Studio consumers.
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		useLayoutEffect(() => {
+			runtimeValueStore.setSnapshot(currentRuntimeValueDotNotation);
+		}, [currentRuntimeValueDotNotation, runtimeValueStore]);
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const controls = useMemo((): SequenceControls => {
 			return {
 				schema: schemaWithSequenceName,
 				currentRuntimeValueDotNotation,
+				runtimeValues: runtimeValueStore.store,
 				overrideId,
 				supportsEffects,
 				componentIdentity,
 				componentName,
 			};
-		}, [currentRuntimeValueDotNotation, overrideId]);
+		}, [currentRuntimeValueDotNotation, overrideId, runtimeValueStore.store]);
 		setStackForControls(controls, internalStack);
 
 		// 3. Apply drag/code overrides on top of the runtime values.

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -78,7 +78,8 @@ export const GlobalKeybindings: React.FC = () => {
 				return false;
 			}
 
-			const {schema, currentRuntimeValueDotNotation} = track.sequence.controls;
+			const {schema, runtimeValues} = track.sequence.controls;
+			const currentRuntimeValueDotNotation = runtimeValues.getSnapshot();
 			if (
 				!hasOwnProperty(schema, fieldKey) &&
 				!hasOwnProperty(currentRuntimeValueDotNotation, fieldKey)

--- a/packages/studio/src/components/InlineCaptionInspector.tsx
+++ b/packages/studio/src/components/InlineCaptionInspector.tsx
@@ -7,7 +7,10 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import type {SequenceControls, SequencePropsSubscriptionKey} from 'remotion';
+import type {
+	SequencePropsSubscriptionKey,
+	SequenceRegistrationControls,
+} from 'remotion';
 import {Internals} from 'remotion';
 import type {CodePosition} from '../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
@@ -50,7 +53,7 @@ const getCaptionPatches = ({
 
 export const InlineCaptionInspector: React.FC<{
 	readonly captions: Caption[];
-	readonly controls: SequenceControls;
+	readonly controls: SequenceRegistrationControls;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly readOnlyStudio: boolean;
 	readonly validatedLocation: CodePosition;

--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -3,6 +3,7 @@ import {Internals, type CanUpdateSequencePropStatus} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {useRuntimeValues} from '../../helpers/use-runtime-values';
 import {AlignBottomIcon} from '../../icons/align-bottom';
 import {AlignCenterHorizontalIcon} from '../../icons/align-center-horizontal';
 import {AlignCenterVerticalIcon} from '../../icons/align-center-vertical';
@@ -72,6 +73,7 @@ const AlignmentButton: React.FC<{
 export const AlignmentControls: React.FC<{
 	readonly track: TimelineTrackData;
 }> = ({track}) => {
+	const runtimeValues = useRuntimeValues(track.sequence.controls);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {getDragOverrides} = useContext(
@@ -118,8 +120,7 @@ export const AlignmentControls: React.FC<{
 
 			const activeSchema = getSelectedOutlineActiveSchema({
 				schema: track.sequence.controls.schema,
-				currentRuntimeValueDotNotation:
-					track.sequence.controls.currentRuntimeValueDotNotation,
+				currentRuntimeValueDotNotation: runtimeValues,
 				dragOverrides,
 				propStatus: nodePropStatuses,
 				frame: sourceFrame,
@@ -234,6 +235,7 @@ export const AlignmentControls: React.FC<{
 			currentCompositionMetadata,
 			timelinePosition,
 			propStatuses,
+			runtimeValues,
 			getDragOverrides,
 			setPropStatuses,
 		],
@@ -259,8 +261,7 @@ export const AlignmentControls: React.FC<{
 
 	const renderActiveSchema = getSelectedOutlineActiveSchema({
 		schema: track.sequence.controls.schema,
-		currentRuntimeValueDotNotation:
-			track.sequence.controls.currentRuntimeValueDotNotation,
+		currentRuntimeValueDotNotation: runtimeValues,
 		dragOverrides: renderDragOverrides,
 		propStatus: renderNodePropStatuses,
 		frame: renderSourceFrame,

--- a/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
@@ -6,6 +6,7 @@ import {
 	getEffectFieldsToShow,
 	getFieldsToShow,
 } from '../../helpers/timeline-layout';
+import {useRuntimeValues} from '../../helpers/use-runtime-values';
 import {Plus} from '../../icons/plus';
 import {renderFrame} from '../../state/render-frame';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
@@ -53,6 +54,7 @@ export const EasingInspector: React.FC<{
 	readonly selection: EasingSelection;
 }> = ({selection}) => {
 	const track = useTrackForSelection(selection);
+	const runtimeValues = useRuntimeValues(track?.sequence.controls ?? null);
 	const videoConfig = useVideoConfig();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const {sequences} = useContext(Internals.SequenceManager);
@@ -101,8 +103,7 @@ export const EasingInspector: React.FC<{
 
 			const sequenceFields = getFieldsToShow({
 				schema: track.sequence.controls.schema,
-				currentRuntimeValueDotNotation:
-					track.sequence.controls.currentRuntimeValueDotNotation,
+				currentRuntimeValueDotNotation: runtimeValues,
 				getDragOverrides,
 				propStatuses,
 				nodePath: easingUpdate.nodePath,
@@ -158,6 +159,7 @@ export const EasingInspector: React.FC<{
 		getDragOverrides,
 		getEffectDragOverrides,
 		propStatuses,
+		runtimeValues,
 		track,
 	]);
 	const fieldLabel = easingDetails?.fieldLabel ?? null;

--- a/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
@@ -24,6 +24,7 @@ import {
 	type EffectSchemaFieldInfo,
 	type SchemaFieldInfo,
 } from '../../helpers/timeline-layout';
+import {useRuntimeValues} from '../../helpers/use-runtime-values';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {InputDragger} from '../NewComposition/InputDragger';
 import {
@@ -144,6 +145,7 @@ export const KeyframeInspector: React.FC<{
 	readonly selection: Extract<TimelineSelection, {type: 'keyframe'}>;
 }> = ({selection}) => {
 	const track = useTrackForSelection(selection);
+	const runtimeValues = useRuntimeValues(track?.sequence.controls ?? null);
 	const videoConfig = useVideoConfig();
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {
@@ -187,8 +189,7 @@ export const KeyframeInspector: React.FC<{
 		if (keyframeField.type === 'sequence') {
 			const sequenceFields = getFieldsToShow({
 				schema: track.sequence.controls.schema,
-				currentRuntimeValueDotNotation:
-					track.sequence.controls.currentRuntimeValueDotNotation,
+				currentRuntimeValueDotNotation: runtimeValues,
 				getDragOverrides,
 				propStatuses,
 				nodePath,
@@ -271,6 +272,7 @@ export const KeyframeInspector: React.FC<{
 		getDragOverrides,
 		getEffectDragOverrides,
 		propStatuses,
+		runtimeValues,
 		selection,
 		track,
 	]);

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -365,7 +365,7 @@ export const InspectorSequenceSection: React.FC<{
 	keyframeDisplayOffset,
 	renderTransformControls,
 }) => {
-	const {tree, propStatuses} = useTimelineExpandedTree({
+	const {tree, propStatuses, runtimeValues} = useTimelineExpandedTree({
 		sequence,
 		nodePathInfo,
 		includeTextContent: true,
@@ -387,7 +387,10 @@ export const InspectorSequenceSection: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {setSelectedModal} = useContext(ModalsContext);
 	const selectAsset = useSelectAsset();
-	const mediaSrc = getTimelineAssetSrcFromSchema(sequence.controls);
+	const mediaSrc = getTimelineAssetSrcFromSchema(
+		sequence.controls,
+		runtimeValues,
+	);
 	const assetSelectionInitialQuery = getAssetSearchQueryForComponent(
 		sequence.controls.componentIdentity,
 	);
@@ -624,7 +627,7 @@ export const InspectorSequenceSection: React.FC<{
 	);
 	const inlineCaptionValue =
 		schema.captions?.type === 'remotion-captions'
-			? sequence.controls.currentRuntimeValueDotNotation.captions
+			? runtimeValues.captions
 			: null;
 	const inlineCaptions = Array.isArray(inlineCaptionValue)
 		? (inlineCaptionValue as Caption[])

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -12,7 +12,6 @@ import {
 	Internals,
 	type GetDragOverrides,
 	type InteractivitySchema,
-	type TSequence,
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
@@ -22,6 +21,7 @@ import {
 } from '../helpers/interactivity-enabled';
 import {useIsFullscreen} from '../helpers/use-is-fullscreen';
 import {useKeybinding} from '../helpers/use-keybinding';
+import {useRuntimeValueSnapshots} from '../helpers/use-runtime-values';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
@@ -129,18 +129,18 @@ export {selectedOutlineDragThresholdPx} from './selected-outline-types';
 
 const getEffectiveCropValue = ({
 	activeSchema,
-	controls,
 	dragOverrides,
 	fieldKey,
 	frame,
 	propStatuses,
+	runtimeValues,
 }: {
 	readonly activeSchema: InteractivitySchema | null;
-	readonly controls: NonNullable<TSequence['controls']> | null;
 	readonly dragOverrides: ReturnType<GetDragOverrides>;
 	readonly fieldKey: string;
 	readonly frame: number;
 	readonly propStatuses: ReturnType<typeof Internals.getPropStatusesCtx>;
+	readonly runtimeValues: Readonly<Record<string, unknown>>;
 }): number => {
 	const fieldSchema = activeSchema?.[fieldKey];
 	if (fieldSchema?.type !== 'number') {
@@ -157,8 +157,7 @@ const getEffectiveCropValue = ({
 					frame,
 					shouldResortToDefaultValueIfUndefined: true,
 				})
-			: (controls?.currentRuntimeValueDotNotation[fieldKey] ??
-				fieldSchema.default);
+			: (runtimeValues[fieldKey] ?? fieldSchema.default);
 
 	return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 };
@@ -727,6 +726,59 @@ export const SelectedOutlineOverlay: React.FC<{
 		},
 		[selectItem],
 	);
+	const outlineRuntimeControls = useMemo(() => {
+		if (
+			isFullscreen ||
+			!isStudioSelectionEnabled() ||
+			!previewSelectionAvailable ||
+			!editorShowOutlines
+		) {
+			return [];
+		}
+
+		const selectedSequenceKeys = getSelectedSequenceKeys(selectedItems);
+		const sequenceKeysContainingSelection =
+			getSequenceKeysContainingSelection(selectedItems);
+		return getSequencesWithSelectableOutlines({
+			sequences,
+			overrideIdsToNodePaths: overrideIdToNodePathMappings,
+			compositions,
+			timelinePosition,
+		}).flatMap(({key, sequence}) => {
+			if (
+				!selectedSequenceKeys.has(key) &&
+				!sequenceKeysContainingSelection.has(key) &&
+				hoveredSequence?.key !== key
+			) {
+				return [];
+			}
+
+			return sequence.controls ? [sequence.controls] : [];
+		});
+	}, [
+		compositions,
+		editorShowOutlines,
+		hoveredSequence?.key,
+		isFullscreen,
+		overrideIdToNodePathMappings,
+		previewSelectionAvailable,
+		selectedItems,
+		sequences,
+		timelinePosition,
+	]);
+	const outlineRuntimeSnapshots = useRuntimeValueSnapshots(
+		outlineRuntimeControls,
+	);
+	const outlineRuntimeValuesByStore = useMemo(
+		() =>
+			new Map(
+				outlineRuntimeControls.map((controls, index) => [
+					controls.runtimeValues,
+					outlineRuntimeSnapshots[index],
+				]),
+			),
+		[outlineRuntimeControls, outlineRuntimeSnapshots],
+	);
 
 	const outlineTargets = useMemo((): SelectedOutlineTarget[] => {
 		if (
@@ -771,11 +823,14 @@ export const SelectedOutlineOverlay: React.FC<{
 			);
 			const sourceFrame = timelinePosition - keyframeDisplayOffset;
 			const dragOverrides = getDragOverrides(nodePath) ?? {};
+			const runtimeValues = controls
+				? (outlineRuntimeValuesByStore.get(controls.runtimeValues) ??
+					controls.runtimeValues.getSnapshot())
+				: {};
 			const activeSchema = controls
 				? getSelectedOutlineActiveSchema({
 						schema: controls.schema,
-						currentRuntimeValueDotNotation:
-							controls.currentRuntimeValueDotNotation,
+						currentRuntimeValueDotNotation: runtimeValues,
 						dragOverrides,
 						propStatus: nodePropStatuses,
 						frame: sourceFrame,
@@ -784,35 +839,35 @@ export const SelectedOutlineOverlay: React.FC<{
 			const cropValues = {
 				cropLeft: getEffectiveCropValue({
 					activeSchema,
-					controls,
 					dragOverrides,
 					fieldKey: cropFieldKeys.left,
 					frame: sourceFrame,
 					propStatuses: nodePropStatuses,
+					runtimeValues,
 				}),
 				cropRight: getEffectiveCropValue({
 					activeSchema,
-					controls,
 					dragOverrides,
 					fieldKey: cropFieldKeys.right,
 					frame: sourceFrame,
 					propStatuses: nodePropStatuses,
+					runtimeValues,
 				}),
 				cropTop: getEffectiveCropValue({
 					activeSchema,
-					controls,
 					dragOverrides,
 					fieldKey: cropFieldKeys.top,
 					frame: sourceFrame,
 					propStatuses: nodePropStatuses,
+					runtimeValues,
 				}),
 				cropBottom: getEffectiveCropValue({
 					activeSchema,
-					controls,
 					dragOverrides,
 					fieldKey: cropFieldKeys.bottom,
 					frame: sourceFrame,
 					propStatuses: nodePropStatuses,
+					runtimeValues,
 				}),
 			};
 			const crop = Internals.resolveSequenceCrop(cropValues);
@@ -1082,6 +1137,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		sequences,
 		compositions,
 		timelinePosition,
+		outlineRuntimeValuesByStore,
 	]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -21,10 +21,7 @@ import {
 } from '../helpers/interactivity-enabled';
 import {useIsFullscreen} from '../helpers/use-is-fullscreen';
 import {useKeybinding} from '../helpers/use-keybinding';
-import {
-	getRuntimeValueSnapshot,
-	useRuntimeValueSnapshots,
-} from '../helpers/use-runtime-values';
+import {useRuntimeValueSnapshots} from '../helpers/use-runtime-values';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
@@ -772,11 +769,11 @@ export const SelectedOutlineOverlay: React.FC<{
 	const outlineRuntimeSnapshots = useRuntimeValueSnapshots(
 		outlineRuntimeControls,
 	);
-	const outlineRuntimeValuesByControls = useMemo(
+	const outlineRuntimeValuesByStore = useMemo(
 		() =>
 			new Map(
 				outlineRuntimeControls.map((controls, index) => [
-					controls,
+					controls.runtimeValues,
 					outlineRuntimeSnapshots[index],
 				]),
 			),
@@ -827,8 +824,8 @@ export const SelectedOutlineOverlay: React.FC<{
 			const sourceFrame = timelinePosition - keyframeDisplayOffset;
 			const dragOverrides = getDragOverrides(nodePath) ?? {};
 			const runtimeValues = controls
-				? (outlineRuntimeValuesByControls.get(controls) ??
-					getRuntimeValueSnapshot(controls))
+				? (outlineRuntimeValuesByStore.get(controls.runtimeValues) ??
+					controls.runtimeValues.getSnapshot())
 				: {};
 			const activeSchema = controls
 				? getSelectedOutlineActiveSchema({
@@ -1140,7 +1137,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		sequences,
 		compositions,
 		timelinePosition,
-		outlineRuntimeValuesByControls,
+		outlineRuntimeValuesByStore,
 	]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -21,7 +21,10 @@ import {
 } from '../helpers/interactivity-enabled';
 import {useIsFullscreen} from '../helpers/use-is-fullscreen';
 import {useKeybinding} from '../helpers/use-keybinding';
-import {useRuntimeValueSnapshots} from '../helpers/use-runtime-values';
+import {
+	getRuntimeValueSnapshot,
+	useRuntimeValueSnapshots,
+} from '../helpers/use-runtime-values';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
@@ -769,11 +772,11 @@ export const SelectedOutlineOverlay: React.FC<{
 	const outlineRuntimeSnapshots = useRuntimeValueSnapshots(
 		outlineRuntimeControls,
 	);
-	const outlineRuntimeValuesByStore = useMemo(
+	const outlineRuntimeValuesByControls = useMemo(
 		() =>
 			new Map(
 				outlineRuntimeControls.map((controls, index) => [
-					controls.runtimeValues,
+					controls,
 					outlineRuntimeSnapshots[index],
 				]),
 			),
@@ -824,8 +827,8 @@ export const SelectedOutlineOverlay: React.FC<{
 			const sourceFrame = timelinePosition - keyframeDisplayOffset;
 			const dragOverrides = getDragOverrides(nodePath) ?? {};
 			const runtimeValues = controls
-				? (outlineRuntimeValuesByStore.get(controls.runtimeValues) ??
-					controls.runtimeValues.getSnapshot())
+				? (outlineRuntimeValuesByControls.get(controls) ??
+					getRuntimeValueSnapshot(controls))
 				: {};
 			const activeSchema = controls
 				? getSelectedOutlineActiveSchema({
@@ -1137,7 +1140,7 @@ export const SelectedOutlineOverlay: React.FC<{
 		sequences,
 		compositions,
 		timelinePosition,
-		outlineRuntimeValuesByStore,
+		outlineRuntimeValuesByControls,
 	]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -243,6 +243,7 @@ const resolveKeyframeControlTarget = ({
 		propStatuses,
 		includeTextContent: false,
 		includeSourceControls: false,
+		runtimeValues: null,
 	});
 	const fieldNode = findFieldNode(
 		tree,

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -913,6 +913,7 @@ export const getSelectableTimelineItems = ({
 			propStatuses,
 			includeTextContent: false,
 			includeSourceControls: false,
+			runtimeValues: null,
 		});
 		const filteredTree = filterTimelineExpandedTree({
 			nodes: tree,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -29,6 +29,10 @@ import {
 	TIMELINE_LIST_ITEM_ROW_HEIGHT,
 } from '../../helpers/timeline-layout';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {
+	useRuntimeValue,
+	useRuntimeValueSelector,
+} from '../../helpers/use-runtime-values';
 import {ModalsContext} from '../../state/modals';
 import {useTimelineSequenceHover} from '../../state/timeline-sequence-hover';
 import {callApi} from '../call-api';
@@ -659,17 +663,16 @@ const TimelineSequenceItemInner: React.FC<{
 	}, [nodePathInfo, toggleTrack]);
 
 	const codeHiddenStatus = propStatusesForOverride?.hidden;
+	const runtimeHidden = useRuntimeValue(sequence.controls, 'hidden');
 
 	const isItemHidden = useMemo(() => {
 		const propStatus =
 			codeHiddenStatus && codeHiddenStatus.status === 'static'
 				? codeHiddenStatus.codeValue
 				: undefined;
-		const runtimeValue =
-			sequence.controls?.currentRuntimeValueDotNotation.hidden;
-		const effective = (propStatus ?? runtimeValue) as boolean | undefined;
+		const effective = (propStatus ?? runtimeHidden) as boolean | undefined;
 		return effective ?? false;
-	}, [codeHiddenStatus, sequence.controls?.currentRuntimeValueDotNotation]);
+	}, [codeHiddenStatus, runtimeHidden]);
 
 	const onToggleVisibility = useCallback(
 		(type: 'enable' | 'disable') => {
@@ -875,32 +878,29 @@ const TimelineSequenceItemInner: React.FC<{
 		nodePathInfo?.supportsEffects === true &&
 		previewInteractive &&
 		Boolean(validatedLocation?.source);
-	const canCrop = useMemo(() => {
-		if (
-			!previewInteractive ||
-			!sequence.controls ||
-			!nodePathInfo ||
-			!propStatusesForOverride ||
-			!validatedLocation?.source
-		) {
-			return false;
-		}
+	const canCrop = useRuntimeValueSelector({
+		controls: sequence.controls,
+		selector: (runtimeValues) => {
+			if (
+				!previewInteractive ||
+				!sequence.controls ||
+				!nodePathInfo ||
+				!propStatusesForOverride ||
+				!validatedLocation?.source
+			) {
+				return false;
+			}
 
-		const activeSchema = Internals.flattenActiveSchema(
-			sequence.controls.schema,
-			(key) => sequence.controls?.currentRuntimeValueDotNotation[key],
-		);
-		return canEditSelectedOutlineCrop({
-			schema: activeSchema,
-			propStatuses: propStatusesForOverride,
-		});
-	}, [
-		nodePathInfo,
-		previewInteractive,
-		propStatusesForOverride,
-		sequence.controls,
-		validatedLocation?.source,
-	]);
+			const activeSchema = Internals.flattenActiveSchema(
+				sequence.controls.schema,
+				(key) => runtimeValues[key],
+			);
+			return canEditSelectedOutlineCrop({
+				schema: activeSchema,
+				propStatuses: propStatusesForOverride,
+			});
+		},
+	});
 
 	const onAddEffect = useCallback(() => {
 		if (

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -27,6 +27,7 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {startPointerSession} from '../../helpers/pointer-session';
 import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
+import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 import {EditorSnappingContext} from '../../state/editor-snapping';
 import {
 	forceSpecificCursor,
@@ -321,8 +322,9 @@ const getTrimBeforePlaybackRate = (sequence: TSequence) => {
 		return 1;
 	}
 
-	const runtimePlaybackRate =
-		sequence.controls?.runtimeValues.getSnapshot().playbackRate;
+	const runtimePlaybackRate = getRuntimeValueSnapshot(
+		sequence.controls,
+	).playbackRate;
 	return typeof runtimePlaybackRate === 'number' ? runtimePlaybackRate : 1;
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -322,7 +322,7 @@ const getTrimBeforePlaybackRate = (sequence: TSequence) => {
 	}
 
 	const runtimePlaybackRate =
-		sequence.controls?.currentRuntimeValueDotNotation.playbackRate;
+		sequence.controls?.runtimeValues.getSnapshot().playbackRate;
 	return typeof runtimePlaybackRate === 'number' ? runtimePlaybackRate : 1;
 };
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -27,7 +27,6 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {startPointerSession} from '../../helpers/pointer-session';
 import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
-import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 import {EditorSnappingContext} from '../../state/editor-snapping';
 import {
 	forceSpecificCursor,
@@ -322,9 +321,8 @@ const getTrimBeforePlaybackRate = (sequence: TSequence) => {
 		return 1;
 	}
 
-	const runtimePlaybackRate = getRuntimeValueSnapshot(
-		sequence.controls,
-	).playbackRate;
+	const runtimePlaybackRate =
+		sequence.controls?.runtimeValues.getSnapshot().playbackRate;
 	return typeof runtimePlaybackRate === 'number' ? runtimePlaybackRate : 1;
 };
 

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -9,7 +9,6 @@ import type {
 	TSequence,
 } from 'remotion';
 import {Internals} from 'remotion';
-import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {getSequencePropResetChanges} from './get-sequence-prop-reset-changes';
 import {saveMultipleEffectProps} from './save-effect-prop';
@@ -171,7 +170,7 @@ export const getTimelinePropResetTargets = ({
 			const {merged: sequenceValuesDotNotation} =
 				Internals.computeEffectiveSchemaValuesDotNotation({
 					schema: sequence.controls.schema,
-					currentValue: getRuntimeValueSnapshot(sequence.controls),
+					currentValue: sequence.controls.runtimeValues.getSnapshot(),
 					overrideValues: {},
 					propStatus: sequencePropStatus,
 					frame: null,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -170,7 +170,7 @@ export const getTimelinePropResetTargets = ({
 			const {merged: sequenceValuesDotNotation} =
 				Internals.computeEffectiveSchemaValuesDotNotation({
 					schema: sequence.controls.schema,
-					currentValue: sequence.controls.currentRuntimeValueDotNotation,
+					currentValue: sequence.controls.runtimeValues.getSnapshot(),
 					overrideValues: {},
 					propStatus: sequencePropStatus,
 					frame: null,

--- a/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
+++ b/packages/studio/src/components/Timeline/reset-selected-timeline-props.ts
@@ -9,6 +9,7 @@ import type {
 	TSequence,
 } from 'remotion';
 import {Internals} from 'remotion';
+import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {getSequencePropResetChanges} from './get-sequence-prop-reset-changes';
 import {saveMultipleEffectProps} from './save-effect-prop';
@@ -170,7 +171,7 @@ export const getTimelinePropResetTargets = ({
 			const {merged: sequenceValuesDotNotation} =
 				Internals.computeEffectiveSchemaValuesDotNotation({
 					schema: sequence.controls.schema,
-					currentValue: sequence.controls.runtimeValues.getSnapshot(),
+					currentValue: getRuntimeValueSnapshot(sequence.controls),
 					overrideValues: {},
 					propStatus: sequencePropStatus,
 					frame: null,

--- a/packages/studio/src/components/Timeline/timeline-asset-link.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-link.ts
@@ -1,5 +1,5 @@
 import {getAssetSchemaKeys} from '@remotion/studio-shared';
-import type {SequenceControls} from 'remotion';
+import type {SequenceRegistrationControls} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {pushUrl} from '../../helpers/url-state';
 
@@ -38,13 +38,14 @@ export const splitRemoteSourceForMiddleEllipsis = (src: string) => {
 };
 
 export const getTimelineAssetSrcFromSchema = (
-	controls: SequenceControls | null,
+	controls: SequenceRegistrationControls | null,
+	runtimeValues = controls?.runtimeValues.getSnapshot(),
 ): string | null => {
 	if (!controls || !getAssetSchemaKeys(controls.schema).includes('src')) {
 		return null;
 	}
 
-	const {src} = controls.currentRuntimeValueDotNotation;
+	const {src} = runtimeValues ?? {};
 	return typeof src === 'string' ? src : null;
 };
 

--- a/packages/studio/src/components/Timeline/timeline-asset-link.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-link.ts
@@ -2,7 +2,6 @@ import {getAssetSchemaKeys} from '@remotion/studio-shared';
 import type {SequenceRegistrationControls} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {pushUrl} from '../../helpers/url-state';
-import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 
 type LinkInfo =
 	| {
@@ -40,7 +39,7 @@ export const splitRemoteSourceForMiddleEllipsis = (src: string) => {
 
 export const getTimelineAssetSrcFromSchema = (
 	controls: SequenceRegistrationControls | null,
-	runtimeValues = getRuntimeValueSnapshot(controls),
+	runtimeValues = controls?.runtimeValues.getSnapshot(),
 ): string | null => {
 	if (!controls || !getAssetSchemaKeys(controls.schema).includes('src')) {
 		return null;

--- a/packages/studio/src/components/Timeline/timeline-asset-link.ts
+++ b/packages/studio/src/components/Timeline/timeline-asset-link.ts
@@ -2,6 +2,7 @@ import {getAssetSchemaKeys} from '@remotion/studio-shared';
 import type {SequenceRegistrationControls} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {pushUrl} from '../../helpers/url-state';
+import {getRuntimeValueSnapshot} from '../../helpers/use-runtime-values';
 
 type LinkInfo =
 	| {
@@ -39,7 +40,7 @@ export const splitRemoteSourceForMiddleEllipsis = (src: string) => {
 
 export const getTimelineAssetSrcFromSchema = (
 	controls: SequenceRegistrationControls | null,
-	runtimeValues = controls?.runtimeValues.getSnapshot(),
+	runtimeValues = getRuntimeValueSnapshot(controls),
 ): string | null => {
 	if (!controls || !getAssetSchemaKeys(controls.schema).includes('src')) {
 		return null;

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -8,6 +8,7 @@ import {
 	getTreeRowHeight,
 } from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
+import {useRuntimeValues} from '../../helpers/use-runtime-values';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getNodeHasKeyframes, getNodeKeyframes} from './get-node-keyframes';
 import type {getTimelineKeyframes} from './get-timeline-keyframes';
@@ -88,6 +89,7 @@ export const useExpandedTrackKeyframeRows = ({
 		Internals.VisualModeDragOverridesContext,
 	);
 	const {selectedItems} = useTimelineSelection();
+	const runtimeValues = useRuntimeValues(sequence.controls);
 
 	const tree = useMemo(
 		() =>
@@ -99,6 +101,7 @@ export const useExpandedTrackKeyframeRows = ({
 				propStatuses,
 				includeTextContent: false,
 				includeSourceControls: false,
+				runtimeValues,
 			}),
 		[
 			propStatuses,
@@ -106,6 +109,7 @@ export const useExpandedTrackKeyframeRows = ({
 			getEffectDragOverrides,
 			nodePathInfo,
 			sequence,
+			runtimeValues,
 		],
 	);
 

--- a/packages/studio/src/components/Timeline/use-timeline-expanded-tree.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-expanded-tree.ts
@@ -2,6 +2,7 @@ import {useContext, useMemo} from 'react';
 import {Internals, type TSequence} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {buildTimelineTree} from '../../helpers/timeline-layout';
+import {useRuntimeValues} from '../../helpers/use-runtime-values';
 import {
 	ExpandedTracksGetterContext,
 	ExpandedTracksSetterContext,
@@ -34,6 +35,7 @@ export const useTimelineExpandedTree = ({
 		Internals.VisualModeDragOverridesContext,
 	);
 	const {selectedItems} = useTimelineSelection();
+	const runtimeValues = useRuntimeValues(sequence.controls);
 
 	const tree = useMemo(
 		() =>
@@ -45,6 +47,7 @@ export const useTimelineExpandedTree = ({
 				propStatuses: visualModePropStatuses,
 				includeTextContent,
 				includeSourceControls,
+				runtimeValues,
 			}),
 		[
 			sequence,
@@ -54,6 +57,7 @@ export const useTimelineExpandedTree = ({
 			visualModePropStatuses,
 			includeTextContent,
 			includeSourceControls,
+			runtimeValues,
 		],
 	);
 	const selectedRowKeys = useMemo(
@@ -91,6 +95,7 @@ export const useTimelineExpandedTree = ({
 		filteredTree,
 		getIsExpanded,
 		propStatuses: visualModePropStatuses,
+		runtimeValues,
 		toggleTrack,
 		tree,
 	};

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -60,11 +60,11 @@ export const useTimelineHeight = ({
 		[getIsExpanded, previewServerConnected, shown],
 	);
 	const runtimeValueSnapshots = useRuntimeValueSnapshots(expandedControls);
-	const runtimeValuesByControls = useMemo(
+	const runtimeValuesByStore = useMemo(
 		() =>
 			new Map(
 				expandedControls.map((controls, index) => [
-					controls,
+					controls.runtimeValues,
 					runtimeValueSnapshots[index],
 				]),
 			),
@@ -95,7 +95,9 @@ export const useTimelineHeight = ({
 					includeTextContent: false,
 					includeSourceControls: false,
 					runtimeValues: track.sequence.controls
-						? (runtimeValuesByControls.get(track.sequence.controls) ?? null)
+						? (runtimeValuesByStore.get(
+								track.sequence.controls.runtimeValues,
+							) ?? null)
 						: null,
 				});
 				const filteredTree = filterTimelineExpandedTree({
@@ -148,6 +150,6 @@ export const useTimelineHeight = ({
 		getDragOverrides,
 		getEffectDragOverrides,
 		selectedRowKeys,
-		runtimeValuesByControls,
+		runtimeValuesByStore,
 	]);
 };

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -95,8 +95,10 @@ export const useTimelineHeight = ({
 					includeTextContent: false,
 					includeSourceControls: false,
 					runtimeValues: track.sequence.controls
-						? runtimeValuesByStore.get(track.sequence.controls.runtimeValues)
-						: undefined,
+						? (runtimeValuesByStore.get(
+								track.sequence.controls.runtimeValues,
+							) ?? null)
+						: null,
 				});
 				const filteredTree = filterTimelineExpandedTree({
 					nodes: tree,

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -9,6 +9,7 @@ import {
 	getTreeRowHeight,
 	TIMELINE_ITEM_BORDER_BOTTOM,
 } from '../../helpers/timeline-layout';
+import {useRuntimeValueSnapshots} from '../../helpers/use-runtime-values';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getNodeHasKeyframes} from './get-node-keyframes';
 import {MAX_TIMELINE_TRACKS_NOTICE_HEIGHT} from './MaxTimelineTracks';
@@ -42,6 +43,33 @@ export const useTimelineHeight = ({
 		() => getSelectedTimelineExpandedRowKeys(selectedItems),
 		[selectedItems],
 	);
+	const expandedControls = useMemo(
+		() =>
+			shown.flatMap((track) => {
+				if (
+					!previewServerConnected ||
+					track.nodePathInfo === null ||
+					!getIsExpanded(track.nodePathInfo) ||
+					track.sequence.controls === null
+				) {
+					return [];
+				}
+
+				return [track.sequence.controls];
+			}),
+		[getIsExpanded, previewServerConnected, shown],
+	);
+	const runtimeValueSnapshots = useRuntimeValueSnapshots(expandedControls);
+	const runtimeValuesByStore = useMemo(
+		() =>
+			new Map(
+				expandedControls.map((controls, index) => [
+					controls.runtimeValues,
+					runtimeValueSnapshots[index],
+				]),
+			),
+		[expandedControls, runtimeValueSnapshots],
+	);
 
 	return useMemo(() => {
 		const tracksHeight = shown.reduce((acc, track) => {
@@ -66,6 +94,9 @@ export const useTimelineHeight = ({
 					propStatuses,
 					includeTextContent: false,
 					includeSourceControls: false,
+					runtimeValues: track.sequence.controls
+						? runtimeValuesByStore.get(track.sequence.controls.runtimeValues)
+						: undefined,
 				});
 				const filteredTree = filterTimelineExpandedTree({
 					nodes: tree,
@@ -117,5 +148,6 @@ export const useTimelineHeight = ({
 		getDragOverrides,
 		getEffectDragOverrides,
 		selectedRowKeys,
+		runtimeValuesByStore,
 	]);
 };

--- a/packages/studio/src/components/Timeline/use-timeline-height.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-height.ts
@@ -60,11 +60,11 @@ export const useTimelineHeight = ({
 		[getIsExpanded, previewServerConnected, shown],
 	);
 	const runtimeValueSnapshots = useRuntimeValueSnapshots(expandedControls);
-	const runtimeValuesByStore = useMemo(
+	const runtimeValuesByControls = useMemo(
 		() =>
 			new Map(
 				expandedControls.map((controls, index) => [
-					controls.runtimeValues,
+					controls,
 					runtimeValueSnapshots[index],
 				]),
 			),
@@ -95,9 +95,7 @@ export const useTimelineHeight = ({
 					includeTextContent: false,
 					includeSourceControls: false,
 					runtimeValues: track.sequence.controls
-						? (runtimeValuesByStore.get(
-								track.sequence.controls.runtimeValues,
-							) ?? null)
+						? (runtimeValuesByControls.get(track.sequence.controls) ?? null)
 						: null,
 				});
 				const filteredTree = filterTimelineExpandedTree({
@@ -150,6 +148,6 @@ export const useTimelineHeight = ({
 		getDragOverrides,
 		getEffectDragOverrides,
 		selectedRowKeys,
-		runtimeValuesByStore,
+		runtimeValuesByControls,
 	]);
 };

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -100,7 +100,7 @@ export const buildTimelineTree = ({
 	propStatuses: PropStatuses;
 	includeTextContent: boolean;
 	includeSourceControls: boolean;
-	runtimeValues?: Readonly<Record<string, unknown>>;
+	runtimeValues: Readonly<Record<string, unknown>> | null;
 }): TimelineTreeNode[] => {
 	const roots: TimelineTreeNode[] = [];
 	const {sequenceSubscriptionKey, index, auxiliaryKeys, supportsEffects} =
@@ -109,7 +109,9 @@ export const buildTimelineTree = ({
 	const controlFields = getFieldsToShow({
 		schema: sequence.controls!.schema,
 		currentRuntimeValueDotNotation:
-			runtimeValues ?? sequence.controls!.runtimeValues.getSnapshot(),
+			runtimeValues !== null
+				? runtimeValues
+				: sequence.controls!.runtimeValues.getSnapshot(),
 		getDragOverrides,
 		propStatuses,
 		nodePath: sequenceSubscriptionKey,
@@ -258,6 +260,7 @@ export const getExpandedTrackHeight = ({
 		propStatuses,
 		includeTextContent: false,
 		includeSourceControls: false,
+		runtimeValues: null,
 	});
 	const flat = flattenVisibleTreeNodes({nodes: tree, getIsExpanded});
 

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -20,7 +20,6 @@ import type {
 } from 'remotion';
 import type {GetIsExpanded} from '../components/ExpandedTracksProvider';
 import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
-import {getRuntimeValueSnapshot} from './use-runtime-values';
 
 export {
 	SCHEMA_FIELD_GROUPS,
@@ -112,7 +111,7 @@ export const buildTimelineTree = ({
 		currentRuntimeValueDotNotation:
 			runtimeValues !== null
 				? runtimeValues
-				: getRuntimeValueSnapshot(sequence.controls),
+				: sequence.controls!.runtimeValues.getSnapshot(),
 		getDragOverrides,
 		propStatuses,
 		nodePath: sequenceSubscriptionKey,

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -20,6 +20,7 @@ import type {
 } from 'remotion';
 import type {GetIsExpanded} from '../components/ExpandedTracksProvider';
 import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
+import {getRuntimeValueSnapshot} from './use-runtime-values';
 
 export {
 	SCHEMA_FIELD_GROUPS,
@@ -111,7 +112,7 @@ export const buildTimelineTree = ({
 		currentRuntimeValueDotNotation:
 			runtimeValues !== null
 				? runtimeValues
-				: sequence.controls!.runtimeValues.getSnapshot(),
+				: getRuntimeValueSnapshot(sequence.controls),
 		getDragOverrides,
 		propStatuses,
 		nodePath: sequenceSubscriptionKey,

--- a/packages/studio/src/helpers/timeline-layout.ts
+++ b/packages/studio/src/helpers/timeline-layout.ts
@@ -91,6 +91,7 @@ export const buildTimelineTree = ({
 	propStatuses,
 	includeTextContent,
 	includeSourceControls,
+	runtimeValues,
 }: {
 	sequence: TSequence;
 	nodePathInfo: SequenceNodePathInfo;
@@ -99,6 +100,7 @@ export const buildTimelineTree = ({
 	propStatuses: PropStatuses;
 	includeTextContent: boolean;
 	includeSourceControls: boolean;
+	runtimeValues?: Readonly<Record<string, unknown>>;
 }): TimelineTreeNode[] => {
 	const roots: TimelineTreeNode[] = [];
 	const {sequenceSubscriptionKey, index, auxiliaryKeys, supportsEffects} =
@@ -107,7 +109,7 @@ export const buildTimelineTree = ({
 	const controlFields = getFieldsToShow({
 		schema: sequence.controls!.schema,
 		currentRuntimeValueDotNotation:
-			sequence.controls!.currentRuntimeValueDotNotation,
+			runtimeValues ?? sequence.controls!.runtimeValues.getSnapshot(),
 		getDragOverrides,
 		propStatuses,
 		nodePath: sequenceSubscriptionKey,

--- a/packages/studio/src/helpers/use-runtime-values.ts
+++ b/packages/studio/src/helpers/use-runtime-values.ts
@@ -1,0 +1,115 @@
+import {useCallback, useMemo, useSyncExternalStore} from 'react';
+import type {SequenceRegistrationControls} from 'remotion';
+
+const EMPTY_RUNTIME_VALUES: Readonly<Record<string, unknown>> = {};
+const EMPTY_RUNTIME_VALUE_STORE = {
+	getSnapshot: () => EMPTY_RUNTIME_VALUES,
+	subscribe: () => () => undefined,
+};
+
+export const useRuntimeValues = (
+	controls: SequenceRegistrationControls | null,
+): Readonly<Record<string, unknown>> => {
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	return useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getSnapshot,
+	);
+};
+
+export const useRuntimeValue = (
+	controls: SequenceRegistrationControls | null,
+	key: string,
+): unknown => {
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	const getSnapshot = useCallback(() => store.getSnapshot()[key], [key, store]);
+
+	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+};
+
+export const useRuntimeValueSelector = <T>({
+	controls,
+	selector,
+	isEqual = Object.is,
+}: {
+	controls: SequenceRegistrationControls | null;
+	selector: (values: Readonly<Record<string, unknown>>) => T;
+	isEqual?: (first: T, second: T) => boolean;
+}): T => {
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	const selectedStore = useMemo(() => {
+		let lastSource = store.getSnapshot();
+		let lastSelection = selector(lastSource);
+
+		const getSnapshot = () => {
+			const nextSource = store.getSnapshot();
+			if (nextSource === lastSource) {
+				return lastSelection;
+			}
+
+			lastSource = nextSource;
+			const nextSelection = selector(nextSource);
+			if (!isEqual(lastSelection, nextSelection)) {
+				lastSelection = nextSelection;
+			}
+
+			return lastSelection;
+		};
+
+		return {
+			getSnapshot,
+			subscribe: store.subscribe,
+		};
+	}, [isEqual, selector, store]);
+
+	return useSyncExternalStore(
+		selectedStore.subscribe,
+		selectedStore.getSnapshot,
+		selectedStore.getSnapshot,
+	);
+};
+
+export const useRuntimeValueSnapshots = (
+	controls: readonly SequenceRegistrationControls[],
+): readonly Readonly<Record<string, unknown>>[] => {
+	const stores = useMemo(
+		() => controls.map((control) => control.runtimeValues),
+		[controls],
+	);
+	const aggregateStore = useMemo(() => {
+		let lastSnapshots = stores.map((store) => store.getSnapshot());
+		const getSnapshot = () => {
+			const nextSnapshots = stores.map((store) => store.getSnapshot());
+			if (
+				nextSnapshots.length === lastSnapshots.length &&
+				nextSnapshots.every(
+					(snapshot, index) => snapshot === lastSnapshots[index],
+				)
+			) {
+				return lastSnapshots;
+			}
+
+			lastSnapshots = nextSnapshots;
+			return lastSnapshots;
+		};
+
+		return {
+			getSnapshot,
+			subscribe: (listener: () => void) => {
+				const unsubscribers = stores.map((store) => store.subscribe(listener));
+				return () => {
+					for (const unsubscribe of unsubscribers) {
+						unsubscribe();
+					}
+				};
+			},
+		};
+	}, [stores]);
+
+	return useSyncExternalStore(
+		aggregateStore.subscribe,
+		aggregateStore.getSnapshot,
+		aggregateStore.getSnapshot,
+	);
+};

--- a/packages/studio/src/helpers/use-runtime-values.ts
+++ b/packages/studio/src/helpers/use-runtime-values.ts
@@ -1,11 +1,50 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react';
-import type {SequenceRegistrationControls} from 'remotion';
+import type {RuntimeValueStore, SequenceRegistrationControls} from 'remotion';
 
 const EMPTY_RUNTIME_VALUES: Readonly<Record<string, unknown>> = {};
 const EMPTY_RUNTIME_VALUE_STORE = {
 	getSnapshot: () => EMPTY_RUNTIME_VALUES,
 	subscribe: () => () => undefined,
 };
+const LEGACY_RUNTIME_VALUE_STORES = new WeakMap<
+	SequenceRegistrationControls,
+	RuntimeValueStore
+>();
+
+type LegacySequenceRegistrationControls = SequenceRegistrationControls & {
+	currentRuntimeValueDotNotation?: Readonly<Record<string, unknown>>;
+};
+
+export const getRuntimeValueStore = (
+	controls: SequenceRegistrationControls | null,
+): RuntimeValueStore => {
+	if (!controls) {
+		return EMPTY_RUNTIME_VALUE_STORE;
+	}
+
+	if (controls.runtimeValues) {
+		return controls.runtimeValues;
+	}
+
+	const existing = LEGACY_RUNTIME_VALUE_STORES.get(controls);
+	if (existing) {
+		return existing;
+	}
+
+	const legacyControls = controls as LegacySequenceRegistrationControls;
+	const legacyStore: RuntimeValueStore = {
+		getSnapshot: () =>
+			legacyControls.currentRuntimeValueDotNotation ?? EMPTY_RUNTIME_VALUES,
+		subscribe: EMPTY_RUNTIME_VALUE_STORE.subscribe,
+	};
+	LEGACY_RUNTIME_VALUE_STORES.set(controls, legacyStore);
+	return legacyStore;
+};
+
+export const getRuntimeValueSnapshot = (
+	controls: SequenceRegistrationControls | null,
+): Readonly<Record<string, unknown>> =>
+	getRuntimeValueStore(controls).getSnapshot();
 
 type RuntimeValueSelectorResult =
 	| string
@@ -19,7 +58,7 @@ type RuntimeValueSelectorResult =
 export const useRuntimeValues = (
 	controls: SequenceRegistrationControls | null,
 ): Readonly<Record<string, unknown>> => {
-	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	const store = getRuntimeValueStore(controls);
 	return useSyncExternalStore(
 		store.subscribe,
 		store.getSnapshot,
@@ -31,7 +70,7 @@ export const useRuntimeValue = (
 	controls: SequenceRegistrationControls | null,
 	key: string,
 ): unknown => {
-	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	const store = getRuntimeValueStore(controls);
 	const getSnapshot = useCallback(() => store.getSnapshot()[key], [key, store]);
 
 	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
@@ -46,7 +85,7 @@ export const useRuntimeValueSelector = <T extends RuntimeValueSelectorResult>({
 	selector: (values: Readonly<Record<string, unknown>>) => T;
 	isEqual?: (first: T, second: T) => boolean;
 }): T => {
-	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
+	const store = getRuntimeValueStore(controls);
 	const selectedStore = useMemo(() => {
 		let lastSource = store.getSnapshot();
 		let lastSelection = selector(lastSource);
@@ -83,7 +122,7 @@ export const useRuntimeValueSnapshots = (
 	controls: readonly SequenceRegistrationControls[],
 ): readonly Readonly<Record<string, unknown>>[] => {
 	const stores = useMemo(
-		() => controls.map((control) => control.runtimeValues),
+		() => controls.map((control) => getRuntimeValueStore(control)),
 		[controls],
 	);
 	const aggregateStore = useMemo(() => {

--- a/packages/studio/src/helpers/use-runtime-values.ts
+++ b/packages/studio/src/helpers/use-runtime-values.ts
@@ -7,6 +7,15 @@ const EMPTY_RUNTIME_VALUE_STORE = {
 	subscribe: () => () => undefined,
 };
 
+type RuntimeValueSelectorResult =
+	| string
+	| number
+	| boolean
+	| bigint
+	| symbol
+	| null
+	| undefined;
+
 export const useRuntimeValues = (
 	controls: SequenceRegistrationControls | null,
 ): Readonly<Record<string, unknown>> => {
@@ -28,7 +37,7 @@ export const useRuntimeValue = (
 	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 };
 
-export const useRuntimeValueSelector = <T>({
+export const useRuntimeValueSelector = <T extends RuntimeValueSelectorResult>({
 	controls,
 	selector,
 	isEqual = Object.is,

--- a/packages/studio/src/helpers/use-runtime-values.ts
+++ b/packages/studio/src/helpers/use-runtime-values.ts
@@ -1,50 +1,11 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react';
-import type {RuntimeValueStore, SequenceRegistrationControls} from 'remotion';
+import type {SequenceRegistrationControls} from 'remotion';
 
 const EMPTY_RUNTIME_VALUES: Readonly<Record<string, unknown>> = {};
 const EMPTY_RUNTIME_VALUE_STORE = {
 	getSnapshot: () => EMPTY_RUNTIME_VALUES,
 	subscribe: () => () => undefined,
 };
-const LEGACY_RUNTIME_VALUE_STORES = new WeakMap<
-	SequenceRegistrationControls,
-	RuntimeValueStore
->();
-
-type LegacySequenceRegistrationControls = SequenceRegistrationControls & {
-	currentRuntimeValueDotNotation?: Readonly<Record<string, unknown>>;
-};
-
-export const getRuntimeValueStore = (
-	controls: SequenceRegistrationControls | null,
-): RuntimeValueStore => {
-	if (!controls) {
-		return EMPTY_RUNTIME_VALUE_STORE;
-	}
-
-	if (controls.runtimeValues) {
-		return controls.runtimeValues;
-	}
-
-	const existing = LEGACY_RUNTIME_VALUE_STORES.get(controls);
-	if (existing) {
-		return existing;
-	}
-
-	const legacyControls = controls as LegacySequenceRegistrationControls;
-	const legacyStore: RuntimeValueStore = {
-		getSnapshot: () =>
-			legacyControls.currentRuntimeValueDotNotation ?? EMPTY_RUNTIME_VALUES,
-		subscribe: EMPTY_RUNTIME_VALUE_STORE.subscribe,
-	};
-	LEGACY_RUNTIME_VALUE_STORES.set(controls, legacyStore);
-	return legacyStore;
-};
-
-export const getRuntimeValueSnapshot = (
-	controls: SequenceRegistrationControls | null,
-): Readonly<Record<string, unknown>> =>
-	getRuntimeValueStore(controls).getSnapshot();
 
 type RuntimeValueSelectorResult =
 	| string
@@ -58,7 +19,7 @@ type RuntimeValueSelectorResult =
 export const useRuntimeValues = (
 	controls: SequenceRegistrationControls | null,
 ): Readonly<Record<string, unknown>> => {
-	const store = getRuntimeValueStore(controls);
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
 	return useSyncExternalStore(
 		store.subscribe,
 		store.getSnapshot,
@@ -70,7 +31,7 @@ export const useRuntimeValue = (
 	controls: SequenceRegistrationControls | null,
 	key: string,
 ): unknown => {
-	const store = getRuntimeValueStore(controls);
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
 	const getSnapshot = useCallback(() => store.getSnapshot()[key], [key, store]);
 
 	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
@@ -85,7 +46,7 @@ export const useRuntimeValueSelector = <T extends RuntimeValueSelectorResult>({
 	selector: (values: Readonly<Record<string, unknown>>) => T;
 	isEqual?: (first: T, second: T) => boolean;
 }): T => {
-	const store = getRuntimeValueStore(controls);
+	const store = controls?.runtimeValues ?? EMPTY_RUNTIME_VALUE_STORE;
 	const selectedStore = useMemo(() => {
 		let lastSource = store.getSnapshot();
 		let lastSelection = selector(lastSource);
@@ -122,7 +83,7 @@ export const useRuntimeValueSnapshots = (
 	controls: readonly SequenceRegistrationControls[],
 ): readonly Readonly<Record<string, unknown>>[] => {
 	const stores = useMemo(
-		() => controls.map((control) => getRuntimeValueStore(control)),
+		() => controls.map((control) => control.runtimeValues),
 		[controls],
 	);
 	const aggregateStore = useMemo(() => {

--- a/packages/studio/src/test/make-runtime-value-store.ts
+++ b/packages/studio/src/test/make-runtime-value-store.ts
@@ -1,0 +1,8 @@
+import type {RuntimeValueStore} from 'remotion';
+
+export const makeRuntimeValueStore = (
+	snapshot: Readonly<Record<string, unknown>>,
+): RuntimeValueStore => ({
+	getSnapshot: () => snapshot,
+	subscribe: () => () => undefined,
+});

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -14,6 +14,7 @@ import {
 	splitSelectedTimelineItems,
 } from '../components/Timeline/split-selected-timeline-item';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
+import {makeRuntimeValueStore} from './make-runtime-value-store';
 
 const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
 	absolutePath: '/tmp/Comp.tsx',
@@ -51,7 +52,7 @@ const makeSequence = (overrides: Partial<TSequence> = {}): TSequence =>
 		postmountDisplay: null,
 		controls: {
 			schema: {},
-			currentRuntimeValueDotNotation: {},
+			runtimeValues: makeRuntimeValueStore({}),
 			overrideId: 'override',
 			supportsEffects: true,
 			componentIdentity: null,
@@ -154,7 +155,7 @@ test('getTimelineSequenceSplitEligibility rejects non-editable sequence shapes',
 			sequence: makeSequence({
 				controls: {
 					schema: {},
-					currentRuntimeValueDotNotation: {},
+					runtimeValues: makeRuntimeValueStore({}),
 					overrideId: 'override',
 					supportsEffects: true,
 					componentIdentity: 'dev.remotion.remotion.Solid',

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -16,6 +16,7 @@ import {
 	getSchemaFieldGroup,
 	type TimelineTreeNode,
 } from '../helpers/timeline-layout';
+import {makeRuntimeValueStore} from './make-runtime-value-store';
 
 const getStack = () => null;
 
@@ -39,7 +40,7 @@ const makeControls = (
 	overrideId: string,
 ): NonNullable<TSequence['controls']> => ({
 	schema: {},
-	currentRuntimeValueDotNotation: {},
+	runtimeValues: makeRuntimeValueStore({}),
 	overrideId,
 	supportsEffects: false,
 	componentIdentity: null,

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -155,6 +155,7 @@ import {
 	loadEditorShowOutlinesOption,
 	persistEditorShowOutlinesOption,
 } from '../state/editor-outlines';
+import {makeRuntimeValueStore} from './make-runtime-value-store';
 
 const makeKey = (
 	nodePath: SequenceNodePath,
@@ -270,7 +271,7 @@ const makeTimelineSequence = ({
 		postmountDisplay,
 		controls: {
 			schema,
-			currentRuntimeValueDotNotation,
+			runtimeValues: makeRuntimeValueStore(currentRuntimeValueDotNotation),
 			overrideId,
 			supportsEffects: true,
 			componentIdentity,

--- a/packages/studio/src/test/timeline-video-info.test.ts
+++ b/packages/studio/src/test/timeline-video-info.test.ts
@@ -1,5 +1,9 @@
 import {afterEach, expect, test} from 'bun:test';
-import type {InteractivitySchema, SequenceControls, TSequence} from 'remotion';
+import type {
+	InteractivitySchema,
+	SequenceRegistrationControls,
+	TSequence,
+} from 'remotion';
 import {getTimelineMediaStartFrame} from '../components/Timeline/get-timeline-media-start-frame';
 import {getTimelineMediaVisualizationLayout} from '../components/Timeline/get-timeline-media-visualization-layout';
 import {getTimelineVideoInfoWidths} from '../components/Timeline/get-timeline-video-info-widths';
@@ -12,6 +16,7 @@ import {
 import {getTimelineVideoFilmstripTimes} from '../components/Timeline/timeline-video-filmstrip-times';
 import {toFileToken} from '../components/Timeline/TimelineAssetField';
 import {isVideoWithLastFrameHold} from '../helpers/is-video-with-last-frame-hold';
+import {makeRuntimeValueStore} from './make-runtime-value-store';
 
 type TestWindow = Pick<
 	Window,
@@ -67,10 +72,10 @@ const makeSequenceControls = ({
 }: {
 	schema: InteractivitySchema;
 	currentRuntimeValueDotNotation: Record<string, unknown>;
-}): SequenceControls => ({
+}): SequenceRegistrationControls => ({
 	componentIdentity: null,
 	componentName: 'Test',
-	currentRuntimeValueDotNotation,
+	runtimeValues: makeRuntimeValueStore(currentRuntimeValueDotNotation),
 	overrideId: 'test',
 	schema,
 	supportsEffects: false,

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -10,7 +10,7 @@ import {
 	type DragOverrides,
 	type OverrideIdToNodePaths,
 	type PropStatuses,
-	type SequenceControls,
+	type SequenceRegistrationControls,
 } from 'remotion';
 import {linearTiming} from '../timings/linear-timing.js';
 import {TransitionSeries} from '../TransitionSeries.js';
@@ -22,7 +22,7 @@ afterEach(() => {
 type RegisteredSequence = {
 	readonly displayName: string;
 	readonly getStack: () => string | null;
-	readonly controls: SequenceControls | null;
+	readonly controls: SequenceRegistrationControls | null;
 	readonly duration: number;
 	readonly from: number;
 	readonly trimBefore: number | null;
@@ -197,9 +197,8 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 				sequence.getStack() === childSequenceStack &&
 				sequence.controls?.componentIdentity ===
 					'dev.remotion.transitions.TransitionSeries.Sequence' &&
-				sequence.controls.currentRuntimeValueDotNotation.durationInFrames ===
-					10 &&
-				sequence.controls.currentRuntimeValueDotNotation.trimBefore === 4 &&
+				sequence.controls.runtimeValues.getSnapshot().durationInFrames === 10 &&
+				sequence.controls.runtimeValues.getSnapshot().trimBefore === 4 &&
 				sequence.trimBefore === 4,
 		),
 	).toBe(true);


### PR DESCRIPTION
## Summary

- publish interactive runtime values through a stable, commit-safe external store
- subscribe Studio consumers to individual fields, selectors, or scoped snapshots
- keep sequence registration stable as runtime values change
- cover granular updates and abandoned renders with regression tests

## Testing

- `bun run build`
- `bun run stylecheck`
- core tests: 38 passing
- Studio tests: 562 passing
- transitions tests: 3 passing

Closes #10135
