### PR TITLE
Elements: Remove broken Studio installation link

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -32,7 +32,7 @@ type ElementPageProps = {
 type InstallStatus =
 	| {type: 'idle'}
 	| {type: 'installing'}
-	| {type: 'success'; message: string; studioUrl: string}
+	| {type: 'success'; message: string}
 	| {type: 'error'; message: string};
 
 export const ElementPage: React.FC<ElementPageProps> = ({
@@ -111,7 +111,6 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 		setInstallStatus({
 			type: 'success',
 			message: `Sent to ${target.projectName ?? 'Remotion Studio'} / ${target.compositionId}. Confirm the installation in Studio.`,
-			studioUrl: target.studioOrigin,
 		});
 	}, [elementPayload]);
 
@@ -216,16 +215,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 											: styles.errorStatus
 									}
 								>
-									{installStatus.message}{' '}
-									{installStatus.type === 'success' ? (
-										<a
-											href={installStatus.studioUrl}
-											rel="noreferrer"
-											target="_blank"
-										>
-											Open Studio
-										</a>
-									) : null}
+									{installStatus.message}
 								</p>
 							) : null}
 						</>


### PR DESCRIPTION
## Summary

Removes the **Open Studio** link from the successful Elements installation message. Opening that URL launches a new Studio frontend, which does not contain the pending installation confirmation dialog.

The confirmation message now only instructs users to return to the Studio instance where the installation request was sent.

## Verification

- `bun run build`
- `bun run stylecheck`
