### PR TITLE
`@remotion/studio`: Deprecate `visualControl()`

### DIFF
--- a/packages/docs/docs/studio/visual-control.mdx
+++ b/packages/docs/docs/studio/visual-control.mdx
@@ -4,10 +4,10 @@ title: visualControl()
 crumb: '@remotion/studio'
 ---
 
-# visualControl()<AvailableFrom v="4.0.292" />
+# ~~visualControl()~~<AvailableFrom v="4.0.292" />
 
-:::warning
-**Preview feature:** A few issues are known, and filed under this [issue](https://github.com/remotion-dev/remotion/issues/5210).
+:::info Deprecated
+Remotion Studio now has integrated interactivity for most components, and we will further develop this interactivity rather than visual controls.
 :::
 
 Creates a control in the right sidebar of the [Remotion Studio](/docs/studio) that allows you to change a value.

--- a/packages/studio/src/api/visual-control.ts
+++ b/packages/studio/src/api/visual-control.ts
@@ -7,7 +7,7 @@ import {
 } from '../visual-controls/VisualControls';
 
 /**
- * @deprecated
+ * @deprecated Remotion Studio now has integrated interactivity for most components, and we will further develop this interactivity rather than visual controls.
  */
 export const visualControl: VisualControlRef['globalVisualControl'] = (
 	key,

--- a/packages/studio/src/api/visual-control.ts
+++ b/packages/studio/src/api/visual-control.ts
@@ -6,6 +6,9 @@ import {
 	type VisualControlRef,
 } from '../visual-controls/VisualControls';
 
+/**
+ * @deprecated
+ */
 export const visualControl: VisualControlRef['globalVisualControl'] = (
 	key,
 	value,


### PR DESCRIPTION
## Summary

- mark `visualControl()` as deprecated in the public TypeScript API
- mark its documentation page as deprecated and explain the focus on integrated Studio interactivity
- remove the obsolete preview-feature warning

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #5210

## Preview

- [`visualControl()` documentation](https://remotion-git-codex-deprecate-visual-control-remotion.vercel.app/docs/studio/visual-control)
