### PR TITLE
`@remotion/studio-protocol`: Restore Chrome tab switching during Element drags

### DIFF
--- a/packages/docs/docs/studio-protocol/set-studio-drag-data.mdx
+++ b/packages/docs/docs/studio-protocol/set-studio-drag-data.mdx
@@ -54,6 +54,8 @@ The value returned by [`createElementPayload()`](/docs/studio-protocol/create-el
 
 The protocol MIME type contains dimensions and duration metadata so Studio can show a preview before reading the payload.
 
+A `text/plain` fallback is also written so you can switch browser tabs while dragging an Element. The structured payload remains available through the protocol MIME type.
+
 `setStudioDragData()` does not call `setDragImage()`. The website owns the visual drag image.
 
 ## Compatibility

--- a/packages/studio-protocol/src/drag-transport.ts
+++ b/packages/studio-protocol/src/drag-transport.ts
@@ -16,4 +16,5 @@ export const setStudioDragData = ({
 
 	dataTransfer.effectAllowed = 'copy';
 	dataTransfer.setData(dragData.mimeType, dragData.payload);
+	dataTransfer.setData('text/plain', dragData.payload);
 };

--- a/packages/studio-protocol/src/test/element-payload.test.ts
+++ b/packages/studio-protocol/src/test/element-payload.test.ts
@@ -53,22 +53,22 @@ test('creates one canonical Element payload for HTTP and drag transports', () =>
 	setStudioDragData({dataTransfer, payload});
 
 	expect(dataTransfer.effectAllowed).toBe('copy');
-	const [mimeType] = data.keys();
-	expect(mimeType).toBe(
-		'application/vnd.remotion.drag+json;v=1;type=element;width=800;height=200;duration=90',
-	);
-	expect(
-		parseDragData({mimeType: mimeType!, payload: data.get(mimeType!)!}),
-	).toMatchObject({
-		type: 'element',
-		data: {
-			element: {
-				displayName: 'Lower Third',
-				installationMode: 'component-owned-sequence',
+	const mimeType =
+		'application/vnd.remotion.drag+json;v=1;type=element;width=800;height=200;duration=90';
+	expect([...data.keys()]).toEqual([mimeType, 'text/plain']);
+	expect(data.get('text/plain')).toBe(data.get(mimeType));
+	expect(parseDragData({mimeType, payload: data.get(mimeType)!})).toMatchObject(
+		{
+			type: 'element',
+			data: {
+				element: {
+					displayName: 'Lower Third',
+					installationMode: 'component-owned-sequence',
+				},
 			},
+			preview: {width: 800, height: 200, durationInFrames: 90},
 		},
-		preview: {width: 800, height: 200, durationInFrames: 90},
-	});
+	);
 });
 
 test('defaults new Element payloads to wrapped installation', () => {


### PR DESCRIPTION
## Summary

- add a `text/plain` representation to Element drag data so Chrome can activate hovered tabs
- preserve the structured Element payload in the Remotion protocol MIME type
- document and test the multi-format drag contract

Closes #10146

## Verification

- `cd packages/studio-protocol && bun run test`
- `bun run build`
- `bun run stylecheck`

Manual Chrome tab-strip verification was not performed.

## Preview

- [`setStudioDragData()` documentation](https://remotion-git-fix-10146-element-tab-drag-remotion.vercel.app/docs/studio-protocol/set-studio-drag-data)
