### PR TITLE
`@remotion/promo-pages`: Unbox community stats

### DIFF
--- a/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
+++ b/packages/promo-pages/src/components/homepage/CommunityStatsItems.tsx
@@ -47,7 +47,7 @@ const Pill: React.FC<{
 		<div
 			className={cn(
 				className,
-				'card leading-none flex flex-wrap justify-center items-center min-w-[200px] min-h-[80px] max-h-[110px] flex-1 p-0',
+				'leading-none flex flex-wrap justify-center items-center min-w-[200px] min-h-[80px] max-h-[110px] flex-1 p-0',
 			)}
 		>
 			{children}


### PR DESCRIPTION
## Summary

- Remove the card treatment from the homepage community statistics
- Preserve the existing layout, colors, sizing, icons, and links

## Testing

- `bun run build`
- `bun run stylecheck`
