### PR TITLE
Speed up wide HTML-in-canvas renders by settling siblings in parallel

### DIFF
--- a/packages/web-renderer/src/html-in-canvas.ts
+++ b/packages/web-renderer/src/html-in-canvas.ts
@@ -182,14 +182,45 @@ export const supportsNestedHtmlInCanvas = (): Promise<boolean> => {
 	return nestedHtmlInCanvasSupport;
 };
 
-const countLayoutSubtreeCanvases = (element: HTMLElement): number => {
-	return Array.from(element.querySelectorAll('canvas')).filter(
-		(canvas) => (canvas as HTMLCanvasWithLayoutSubtree).layoutSubtree === true,
-	).length;
+const isLayoutSubtreeCanvas = (
+	element: Element,
+): element is HTMLCanvasWithLayoutSubtree => {
+	return (
+		element.localName === 'canvas' &&
+		(element as HTMLCanvasWithLayoutSubtree).layoutSubtree === true
+	);
+};
+
+export const getMaxLayoutSubtreeCanvasDepth = (
+	element: HTMLElement,
+): number => {
+	let maxDepth = 0;
+	const stack = Array.from(element.children, (child) => ({
+		element: child,
+		layoutSubtreeDepth: 0,
+	}));
+
+	while (stack.length > 0) {
+		const current = stack.pop()!;
+		const layoutSubtreeDepth =
+			current.layoutSubtreeDepth +
+			(isLayoutSubtreeCanvas(current.element) ? 1 : 0);
+		maxDepth = Math.max(maxDepth, layoutSubtreeDepth);
+
+		for (const child of current.element.children) {
+			stack.push({element: child, layoutSubtreeDepth});
+		}
+	}
+
+	return maxDepth;
 };
 
 export const containsLayoutSubtreeCanvas = (element: HTMLElement): boolean => {
-	return countLayoutSubtreeCanvases(element) > 0;
+	return getMaxLayoutSubtreeCanvasDepth(element) > 0;
+};
+
+export const getNestedPaintCycles = (maxDepth: number): number => {
+	return maxDepth === 0 ? 0 : maxDepth * 2 + 1;
 };
 
 export type HtmlInCanvasContext = {
@@ -276,14 +307,12 @@ export const drawWithHtmlInCanvas = async ({
 	scaledWidth,
 	scaledHeight,
 	waitForRenderReady,
-	useElementImage,
 }: {
 	htmlInCanvasContext: HtmlInCanvasContext;
 	element: HTMLElement;
 	scaledWidth: number;
 	scaledHeight: number;
 	waitForRenderReady: () => Promise<void>;
-	useElementImage: boolean;
 }): Promise<OffscreenCanvasRenderingContext2D> => {
 	const {ctx, layoutCanvas} = htmlInCanvasContext;
 
@@ -296,12 +325,13 @@ export const drawWithHtmlInCanvas = async ({
 	}
 
 	await waitForPaint(layoutCanvas);
-	// Each nested layout canvas needs one paint to run its async effect and a
-	// second paint to propagate the completed bitmap to its parent. One final
-	// cycle records the fully composed tree on the web renderer's root canvas.
-	const nestedPaintCycles = useElementImage
-		? countLayoutSubtreeCanvases(element) * 2 + 1
-		: 0;
+	const nestedLayoutSubtreeDepth = getMaxLayoutSubtreeCanvasDepth(element);
+	// Each nesting level needs one paint to run its async effects and a second
+	// paint to propagate the completed bitmap to its parent. Siblings settle in
+	// parallel during the same deepest-first paint traversal, so the safe bound
+	// is based on maximum depth rather than the total number of canvases. One
+	// final cycle records the fully composed tree on the root canvas.
+	const nestedPaintCycles = getNestedPaintCycles(nestedLayoutSubtreeDepth);
 	for (let i = 0; i < nestedPaintCycles; i++) {
 		await new Promise<void>((resolve) =>
 			requestAnimationFrame(() => resolve()),
@@ -311,7 +341,7 @@ export const drawWithHtmlInCanvas = async ({
 	}
 
 	ctx.reset();
-	if (useElementImage) {
+	if (nestedLayoutSubtreeDepth > 0) {
 		if (typeof layoutCanvas.captureElementImage !== 'function') {
 			throw new Error('canvas.captureElementImage() is unavailable');
 		}

--- a/packages/web-renderer/src/take-screenshot.ts
+++ b/packages/web-renderer/src/take-screenshot.ts
@@ -3,10 +3,7 @@ import {Internals} from 'remotion';
 import {compose} from './compose';
 import {containsUrlMaskImage} from './drawing/mask-image';
 import type {HtmlInCanvasContext} from './html-in-canvas';
-import {
-	containsLayoutSubtreeCanvas,
-	drawWithHtmlInCanvas,
-} from './html-in-canvas';
+import {drawWithHtmlInCanvas} from './html-in-canvas';
 import type {InternalState} from './internal-state';
 
 export type HtmlInCanvasLayerOutcome =
@@ -53,8 +50,6 @@ export const createLayer = async ({
 				shouldWarn: false,
 			});
 		} else {
-			const hasNestedHtmlInCanvas = containsLayoutSubtreeCanvas(element);
-
 			try {
 				const offCtx = await drawWithHtmlInCanvas({
 					htmlInCanvasContext,
@@ -62,7 +57,6 @@ export const createLayer = async ({
 					scaledWidth,
 					scaledHeight,
 					waitForRenderReady,
-					useElementImage: hasNestedHtmlInCanvas,
 				});
 				onHtmlInCanvasLayerOutcome({native: true});
 				return offCtx;

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -1,7 +1,9 @@
-import {Internals} from 'remotion';
+import {HtmlInCanvas, Internals} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {createScaffold} from '../create-scaffold';
 import {
+	getMaxLayoutSubtreeCanvasDepth,
+	getNestedPaintCycles,
 	setForceDisableHtmlInCanvasForTesting,
 	supportsNativeHtmlInCanvas,
 	supportsNestedHtmlInCanvas,
@@ -13,6 +15,168 @@ import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
 import {testImage} from './utils';
 
 setForceDisableHtmlInCanvasForTesting(false);
+
+const makeLayoutSubtreeCanvas = () => {
+	const canvas = document.createElement('canvas') as HTMLCanvasElement & {
+		layoutSubtree?: boolean;
+	};
+	canvas.layoutSubtree = true;
+	return canvas;
+};
+
+const siblingSentinelColors = Array.from({length: 24}, (_, index) => {
+	return [
+		32 + ((index * 47) % 192),
+		32 + ((index * 83) % 192),
+		32 + ((index * 131) % 192),
+	] as const;
+});
+
+const siblingSentinelSize = 16;
+const siblingSentinelColumns = 12;
+
+const siblingHtmlInCanvas = {
+	component: () => {
+		return (
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: `repeat(${siblingSentinelColumns}, ${siblingSentinelSize}px)`,
+				}}
+			>
+				{siblingSentinelColors.map((color) => (
+					<HtmlInCanvas
+						key={color.join('-')}
+						width={siblingSentinelSize}
+						height={siblingSentinelSize}
+						onPaint={async ({canvas}) => {
+							// Finish on a later rendering update so the root must wait for the
+							// sibling paint instead of capturing its initial transparent bitmap.
+							await new Promise<void>((resolve) =>
+								requestAnimationFrame(() => resolve()),
+							);
+							const context = canvas.getContext('2d');
+							if (!context) {
+								throw new Error('Could not get sibling sentinel context');
+							}
+
+							context.reset();
+							context.fillStyle = `rgb(${color.join(', ')})`;
+							context.fillRect(0, 0, siblingSentinelSize, siblingSentinelSize);
+						}}
+					>
+						<div />
+					</HtmlInCanvas>
+				))}
+			</div>
+		);
+	},
+	id: 'sibling-html-in-canvas',
+	width: siblingSentinelColumns * siblingSentinelSize,
+	height:
+		Math.ceil(siblingSentinelColors.length / siblingSentinelColumns) *
+		siblingSentinelSize,
+	fps: 30,
+	durationInFrames: 1,
+} as const;
+
+const getImageData = async (blob: Blob): Promise<ImageData> => {
+	const bitmap = await createImageBitmap(blob);
+	try {
+		const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+		const context = canvas.getContext('2d');
+		if (!context) {
+			throw new Error('Could not get rendered sibling context');
+		}
+
+		context.drawImage(bitmap, 0, 0);
+		return context.getImageData(0, 0, bitmap.width, bitmap.height);
+	} finally {
+		bitmap.close();
+	}
+};
+
+test('settles wide sibling HTML-in-canvas trees in parallel', () => {
+	const root = document.createElement('div');
+	for (let i = 0; i < 100; i++) {
+		const wrapper = document.createElement('div');
+		wrapper.appendChild(makeLayoutSubtreeCanvas());
+		root.appendChild(wrapper);
+	}
+
+	const depth = getMaxLayoutSubtreeCanvasDepth(root);
+	expect(depth).toBe(1);
+	expect(getNestedPaintCycles(depth)).toBe(3);
+});
+
+test('retains two settling cycles per nested HTML-in-canvas level', () => {
+	const root = document.createElement('div');
+	const outer = makeLayoutSubtreeCanvas();
+	const middle = makeLayoutSubtreeCanvas();
+	const inner = makeLayoutSubtreeCanvas();
+	root.appendChild(outer);
+	outer.appendChild(middle);
+	middle.appendChild(inner);
+
+	const depth = getMaxLayoutSubtreeCanvasDepth(root);
+	expect(depth).toBe(3);
+	expect(getNestedPaintCycles(depth)).toBe(7);
+});
+
+test('uses the deepest branch for mixed HTML-in-canvas trees', () => {
+	const root = document.createElement('div');
+	const shallow = makeLayoutSubtreeCanvas();
+	root.appendChild(shallow);
+
+	const deepWrapper = document.createElement('section');
+	const outer = makeLayoutSubtreeCanvas();
+	const middleWrapper = document.createElement('div');
+	const middle = makeLayoutSubtreeCanvas();
+	const inner = makeLayoutSubtreeCanvas();
+	root.appendChild(deepWrapper);
+	deepWrapper.appendChild(outer);
+	outer.appendChild(middleWrapper);
+	middleWrapper.appendChild(middle);
+	middle.appendChild(inner);
+
+	for (let i = 0; i < 20; i++) {
+		root.appendChild(makeLayoutSubtreeCanvas());
+	}
+
+	const depth = getMaxLayoutSubtreeCanvasDepth(root);
+	expect(depth).toBe(3);
+	expect(getNestedPaintCycles(depth)).toBe(7);
+});
+
+test('captures every async sibling HTML-in-canvas after three settling cycles', async () => {
+	const supportsNesting = await supportsNestedHtmlInCanvas();
+	if (!supportsNesting) {
+		return;
+	}
+
+	const rendered = await renderStillOnWeb({
+		composition: siblingHtmlInCanvas,
+		frame: 0,
+		inputProps: {},
+		licenseKey: 'free-license',
+	});
+	const imageData = await getImageData(await rendered.blob({format: 'png'}));
+
+	for (let index = 0; index < siblingSentinelColors.length; index++) {
+		const column = index % siblingSentinelColumns;
+		const row = Math.floor(index / siblingSentinelColumns);
+		const x = column * siblingSentinelSize + siblingSentinelSize / 2;
+		const y = row * siblingSentinelSize + siblingSentinelSize / 2;
+		const pixelOffset = (y * imageData.width + x) * 4;
+		const actual = Array.from(
+			imageData.data.slice(pixelOffset, pixelOffset + 4),
+		);
+		expect(actual, `sibling ${index}`).toEqual([
+			...siblingSentinelColors[index],
+			255,
+		]);
+	}
+});
 
 test('captures three nested HTML-in-canvas effect layers natively', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();


### PR DESCRIPTION
## Summary

`drawWithHtmlInCanvas()` currently schedules `2 * canvasCount + 1` settling cycles before capturing a nested HTML-in-canvas tree. That is conservative for a chain, but it serializes independent siblings even though Chromium dispatches nested canvas paint events deepest-first within the same rendering update.

This changes the bound to `2 * maxNestingDepth + 1`:

- sibling canvases settle during the same cycles;
- a chain keeps exactly the existing number of cycles;
- mixed trees use their deepest dependency path;
- depth is measured after the initial root paint, preserving the existing observation point for mounts and remounts.

The implementation remains conservative: it does not reduce the existing two cycles per nesting level.

Chromium's nested HTML-in-canvas implementation sorts paint events by descending DOM depth: https://chromium.googlesource.com/chromium/src/+/7cfce65f70cf60df4bb6847ac0c8b57b165a9212

## Performance

Measured with the real `renderStillOnWeb()` path in Chrome for Testing 152.0.7977.13 with `CanvasDrawElement` enabled. Each case is the median of three renders; every baseline/candidate PNG SHA-256 matched exactly.

| Scene | Before | After | Speedup |
|---|---:|---:|---:|
| 1 sibling, depth 1 (control) | 81.4 ms | 81.0 ms | 1.01x |
| 10 siblings, depth 1 | 381.4 ms | 81.8 ms | 4.66x |
| 50 siblings, depth 1 | 1710.8 ms | 81.9 ms | **20.89x** |
| 1 sibling, depth 3 (control) | 148.7 ms | 147.8 ms | 1.01x |
| 1 sibling, depth 5 (control) | 215.2 ms | 215.2 ms | 1.00x |
| 10 siblings, depth 3 | 1048.1 ms | 147.4 ms | **7.11x** |

For 50 siblings, root `requestPaint()` calls drop from 102 to 4. Depth-only controls are unchanged.

An 8-frame `renderMediaOnWeb()` benchmark with 32 sibling layers improved from a median 8.912 s to 0.635 s: **14.03x faster**. A separate checksum-enabled run copied every pre-encode `VideoFrame` to RGBA and measured **15.21x** while matching all 48 baseline/candidate frame hashes exactly. Internal timings localized the gain to frame creation (8730.2 ms → 481.8 ms, **18.12x**).

## Correctness and tests

- Added topology tests for wide siblings, nested chains, and mixed trees.
- Added a native Chrome 152 integration test with 24 sibling `<HtmlInCanvas>` components. Every async `onPaint` waits for a later animation frame before drawing a unique RGB sentinel; the final PNG is decoded and every tile's RGBA is checked.
- `@remotion/web-renderer` build passes.
- Targeted formatting, ESLint, TypeScript, and `git diff --check` pass.
- System Chrome 150 suite: 10/10 pass; unsupported native tests skip normally.
- Chrome 152 native tests for stills, videos, transient missing records, and async siblings pass.
- The existing forced software-composer golden differs under Chrome 152 in both clean baseline and candidate by the same 8,551 pixels, so it is unrelated to this native-path change.
