### PR TITLE
`@remotion/promo-pages`: top-align pricing section toggles and wrap status label

### DIFF
--- a/packages/promo-pages/src/components/homepage/FreePricing.tsx
+++ b/packages/promo-pages/src/components/homepage/FreePricing.tsx
@@ -238,7 +238,7 @@ const SectionCheckbox: React.FC<{
 }> = ({checked, onChange, title, subtitle, children}) => {
 	return (
 		<div
-			className="flex flex-row gap-3 cursor-pointer select-none items-center"
+			className="flex flex-row flex-wrap items-start gap-x-3 gap-y-1 cursor-pointer select-none"
 			onClick={() => onChange(!checked)}
 		>
 			<Switch
@@ -246,17 +246,16 @@ const SectionCheckbox: React.FC<{
 				onToggle={() => onChange(!checked)}
 				aria-label={title}
 			/>
-			<div className="flex flex-col">
+			<div className="flex min-w-0 flex-1 flex-col">
 				<div className="fontbrand font-bold text-lg flex flex-row items-center gap-1">
 					{title}
 					{children}
 				</div>
 				<div className="text-muted fontbrand text-sm">{subtitle}</div>
 			</div>
-			<div className="flex-1" />
 			<div
 				className={cn(
-					'fontbrand text-muted transition-opacity duration-150',
+					'fontbrand text-muted transition-opacity duration-150 ml-auto shrink-0 self-start text-right whitespace-normal',
 					checked ? 'hidden' : 'opacity-100',
 				)}
 			>


### PR DESCRIPTION
Closes https://github.com/remotion-dev/remotion/issues/9892

## Problem

On the homepage pricing table, the `SectionCheckbox` rows for **Remotion for Automators** and **Remotion for Creators** center-aligned the switch with the title and the **Not selected** status label stayed on the same line, overlapping the title/subtitle when the viewport was narrow.

## Triage / Root cause

The `SectionCheckbox` container used `items-center` and a fixed `flex-1` spacer to push the status label to the right. The label was not allowed to wrap, so it could run into the title column as space shrank.

## Fix

- In `packages/promo-pages/src/components/homepage/FreePricing.tsx`:
  - Change the `SectionCheckbox` row to `items-start flex-wrap` with `gap-x-3 gap-y-1` so the switch top-aligns with multi-line titles and the row wraps on narrow widths.
  - Make the title/subtitle column `min-w-0 flex-1` so it can shrink and wrap instead of being pushed out.
  - Replace the `flex-1` spacer with `ml-auto` on the status label, and add `shrink-0 self-start text-right whitespace-normal` so the label can wrap onto the next line and stays right-aligned.

## Verification

- `bun run lint` in `packages/promo-pages` passed.
- `bun run build --filter='@remotion/promo-pages'` passed.
- `oxfmt packages/promo-pages/src/components/homepage/FreePricing.tsx --write` produced no changes.

## Preview

- [Homepage (pricing table)](https://remotion-git-fork-garudaccs-fix-pricing-table-s-aa7080-remotion.vercel.app/)