### PR TITLE
`@remotion/codex-plugin`: Update example prompt

### DIFF
--- a/packages/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/codex-plugin/.codex-plugin/plugin.json
@@ -34,7 +34,7 @@
 		"termsOfServiceURL": "https://www.remotion.dev/docs/license/terms",
 		"defaultPrompt": [
 			"Create an animated chart with 5 bars",
-			"Make an animated call-to-action subscribe button for our YouTube channel",
+			"Make a promo video for a record store",
 			"Use Remotion to add captions and audio to a video composition."
 		],
 		"brandColor": "#0B84F3",


### PR DESCRIPTION
## Summary

- replace the YouTube subscribe-button example with a record-store promo prompt

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/codex-plugin`
