### PR TITLE
`@remotion/studio-protocol`: Allow license key setup from any HTTPS origin

### DIFF
--- a/packages/studio-protocol/src/set-license-key-in-studio.ts
+++ b/packages/studio-protocol/src/set-license-key-in-studio.ts
@@ -12,7 +12,6 @@ import {
 import {isRecord} from './validation';
 
 export type SetLicenseKeyInStudioErrorCode =
-	| 'unsupported-origin'
 	| 'invalid-license-key'
 	| 'no-compatible-studio'
 	| 'studio-upgrade-required'
@@ -45,7 +44,6 @@ export type SetLicenseKeyInStudioDependencies = {
 	readonly fetchFn: StudioProtocolFetcher;
 	readonly now: () => number;
 	readonly ports: readonly number[];
-	readonly pageOrigin: string | null;
 };
 
 export type StudioProtocolSetLicenseKeyRequest = {
@@ -56,42 +54,10 @@ export type StudioProtocolSetLicenseKeyRequest = {
 	readonly licenseKey: string;
 };
 
-const isAllowedLicenseKeyPageOrigin = (origin: string | null): boolean => {
-	if (origin === null) {
-		return false;
-	}
-
-	try {
-		const url = new URL(origin);
-		if (
-			url.protocol === 'http:' &&
-			(url.hostname === 'localhost' || url.hostname === '127.0.0.1')
-		) {
-			return true;
-		}
-
-		return (
-			url.origin === 'https://remotion.pro' ||
-			url.origin === 'https://www.remotion.pro'
-		);
-	} catch {
-		return false;
-	}
-};
-
 export const setLicenseKeyInStudioWithDependencies = async (
 	licenseKey: string,
 	dependencies: SetLicenseKeyInStudioDependencies,
 ): Promise<SetLicenseKeyInStudioResult> => {
-	if (!isAllowedLicenseKeyPageOrigin(dependencies.pageOrigin)) {
-		return {
-			success: false,
-			code: 'unsupported-origin',
-			message:
-				'Setting a Studio license key is only supported on remotion.pro and local development origins.',
-		};
-	}
-
 	if (!isValidPublicLicenseKey(licenseKey)) {
 		return {
 			success: false,
@@ -269,9 +235,5 @@ export const setLicenseKeyInStudio = ({
 	setLicenseKeyInStudioWithDependencies(licenseKey, {
 		fetchFn: fetch,
 		now: Date.now,
-		pageOrigin:
-			typeof globalThis.location === 'undefined'
-				? null
-				: globalThis.location.origin,
 		ports: studioProtocolProbePorts,
 	});

--- a/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
@@ -49,7 +49,6 @@ const jsonResponse = (value: unknown, status = 200) =>
 
 const dependencies = {
 	now: () => now,
-	pageOrigin: 'https://www.remotion.pro',
 	ports: [3000, 3001],
 };
 
@@ -122,20 +121,13 @@ test('requests confirmation in the most recently focused Studio project', async 
 	});
 });
 
-test('rejects unauthorized origins and malformed keys before discovery', async () => {
+test('rejects malformed keys before discovery', async () => {
 	let requests = 0;
 	const fetchFn = () => {
 		requests++;
 		return Promise.resolve(new Response(null, {status: 404}));
 	};
 
-	expect(
-		await setLicenseKeyInStudioWithDependencies(licenseKey, {
-			...dependencies,
-			fetchFn,
-			pageOrigin: 'https://example.com',
-		}),
-	).toMatchObject({success: false, code: 'unsupported-origin'});
 	expect(
 		await setLicenseKeyInStudioWithDependencies('rm_sec_private', {
 			...dependencies,

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -11,7 +11,6 @@ import {
 } from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {
-	getAllowedLicenseKeyOrigin,
 	getAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
 } from './origin-policy';
@@ -88,7 +87,7 @@ export const handleStudioProtocolDiscovery = ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({licenseKey: false, request, response});
+	setStudioProtocolCorsHeaders({request, response});
 	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
@@ -125,15 +124,12 @@ export const handleStudioProtocolDiscovery = ({
 							purpose: 'install-element',
 							target: installTarget,
 						});
-			const licenseKeyOrigin = getAllowedLicenseKeyOrigin(
-				request.headers.origin,
-			);
 			const issuedLicenseKeyTarget =
-				target === null || licenseKeyOrigin === null
+				target === null
 					? null
 					: issueStudioProtocolTarget({
 							now,
-							origin: licenseKeyOrigin,
+							origin: requestOrigin,
 							purpose: 'set-license-key',
 							target,
 						});

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -80,7 +80,7 @@ export const handleStudioProtocolInstall = async ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({licenseKey: false, request, response});
+	setStudioProtocolCorsHeaders({request, response});
 	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
@@ -5,7 +5,7 @@ import {consumeStudioProtocolTarget} from '../element-install-state';
 import type {LiveEventsServer} from '../live-events';
 import {parseRequestBody, RequestBodyTooLargeError} from '../parse-body';
 import {
-	getAllowedLicenseKeyOrigin,
+	getAllowedStudioProtocolOrigin,
 	setStudioProtocolCorsHeaders,
 } from './origin-policy';
 import {writeStudioProtocolError} from './protocol-response';
@@ -35,8 +35,8 @@ export const handleStudioProtocolLicenseKey = async ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({licenseKey: true, request, response});
-	const requestOrigin = getAllowedLicenseKeyOrigin(request.headers.origin);
+	setStudioProtocolCorsHeaders({request, response});
+	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',

--- a/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
@@ -23,44 +23,14 @@ export const getAllowedStudioProtocolOrigin = (
 	}
 };
 
-export const getAllowedLicenseKeyOrigin = (
-	origin: string | undefined,
-): string | null => {
-	if (!origin) {
-		return null;
-	}
-
-	try {
-		const url = new URL(origin);
-		if (isLoopbackHttp(url)) {
-			return url.origin;
-		}
-
-		if (
-			url.origin === 'https://remotion.pro' ||
-			url.origin === 'https://www.remotion.pro'
-		) {
-			return url.origin;
-		}
-
-		return null;
-	} catch {
-		return null;
-	}
-};
-
 export const setStudioProtocolCorsHeaders = ({
-	licenseKey,
 	request,
 	response,
 }: {
-	readonly licenseKey: boolean;
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): void => {
-	const origin = licenseKey
-		? getAllowedLicenseKeyOrigin(request.headers.origin)
-		: getAllowedStudioProtocolOrigin(request.headers.origin);
+	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	if (origin === null) {
 		return;
 	}
@@ -77,18 +47,14 @@ export const setStudioProtocolCorsHeaders = ({
 };
 
 export const handleStudioProtocolOptions = ({
-	licenseKey,
 	request,
 	response,
 }: {
-	readonly licenseKey: boolean;
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): Promise<void> => {
-	setStudioProtocolCorsHeaders({licenseKey, request, response});
-	const origin = licenseKey
-		? getAllowedLicenseKeyOrigin(request.headers.origin)
-		: getAllowedStudioProtocolOrigin(request.headers.origin);
+	setStudioProtocolCorsHeaders({request, response});
+	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
 	response.writeHead(origin === null ? 403 : 204);
 	response.end();
 	return Promise.resolve();

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -451,7 +451,6 @@ export const handleRoutes = ({
 	) {
 		if (request.method === 'OPTIONS') {
 			return handleStudioProtocolOptions({
-				licenseKey: url.pathname === '/api/studio-protocol/license-key',
 				request,
 				response,
 			});

--- a/packages/studio-server/src/test/studio-protocol-routes.test.ts
+++ b/packages/studio-server/src/test/studio-protocol-routes.test.ts
@@ -139,7 +139,6 @@ test('discovers an exact Studio target and delivers one install request over HTT
 		const {pathname} = new URL(request.url ?? '/', 'http://localhost');
 		if (request.method === 'OPTIONS') {
 			handleStudioProtocolOptions({
-				licenseKey: false,
 				request,
 				response,
 			}).catch((error) => response.destroy(error));
@@ -397,7 +396,6 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 		const {pathname} = new URL(request.url ?? '/', 'http://localhost');
 		if (request.method === 'OPTIONS') {
 			handleStudioProtocolOptions({
-				licenseKey: pathname === '/api/studio-protocol/license-key',
 				request,
 				response,
 			}).catch((error) => response.destroy(error));
@@ -432,31 +430,20 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 		}
 
 		const origin = `http://127.0.0.1:${address.port}`;
-		const deniedPreflight = await fetch(
+		const licenseKeyPreflight = await fetch(
 			`${origin}/api/studio-protocol/license-key`,
 			{
 				method: 'OPTIONS',
 				headers: {Origin: 'https://example.com'},
 			},
 		);
-		expect(deniedPreflight.status).toBe(403);
-		expect(
-			deniedPreflight.headers.get('access-control-allow-origin'),
-		).toBeNull();
-
-		const untrustedDiscovery = await fetch(`${origin}/api/studio-protocol`, {
-			headers: {Origin: 'https://example.com'},
-		});
-		expect(untrustedDiscovery.status).toBe(200);
-		expect(await untrustedDiscovery.json()).toMatchObject({
-			capabilities: [
-				{type: 'install-element', target: null},
-				{type: 'set-license-key', target: null},
-			],
-		});
+		expect(licenseKeyPreflight.status).toBe(204);
+		expect(licenseKeyPreflight.headers.get('access-control-allow-origin')).toBe(
+			'https://example.com',
+		);
 
 		const discovery = await fetch(`${origin}/api/studio-protocol`, {
-			headers: {Origin: 'https://www.remotion.pro'},
+			headers: {Origin: 'https://example.com'},
 		});
 		const descriptor = (await discovery.json()) as {
 			capabilities: [
@@ -481,7 +468,7 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Origin: 'https://www.remotion.pro',
+					Origin: 'https://example.com',
 				},
 				body: JSON.stringify({...body, licenseKey: 'rm_sec_private'}),
 			},
@@ -497,7 +484,7 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				Origin: 'https://www.remotion.pro',
+				Origin: 'https://example.com',
 			},
 			body: JSON.stringify(body),
 		});
@@ -519,7 +506,7 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				Origin: 'https://www.remotion.pro',
+				Origin: 'https://example.com',
 			},
 			body: JSON.stringify(body),
 		});
@@ -532,7 +519,7 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 		expect(focusedUrls).toHaveLength(1);
 
 		const noConfigDiscovery = await fetch(`${origin}/api/studio-protocol`, {
-			headers: {Origin: 'https://www.remotion.pro'},
+			headers: {Origin: 'https://example.com'},
 		});
 		const noConfigDescriptor = (await noConfigDiscovery.json()) as {
 			capabilities: [
@@ -547,7 +534,7 @@ test('opens a license key confirmation in the focused Studio project over HTTP',
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					Origin: 'https://www.remotion.pro',
+					Origin: 'https://example.com',
 				},
 				body: JSON.stringify({
 					...body,


### PR DESCRIPTION
## Summary

- allow Studio license key setup from any HTTPS origin
- use the standard Studio Protocol origin policy for discovery, preflight, and license key requests
- retain loopback HTTP support and the focused Studio confirmation flow

## Testing

- `bun test packages/studio-protocol/src/test/set-license-key-in-studio.test.ts packages/studio-server/src/test/studio-protocol-routes.test.ts`
- `bun run build`
- `bun run stylecheck`
