### PR TITLE
Docs: Refine AI plugins navigation

### DIFF
--- a/packages/docs/docs/ai/plugins.mdx
+++ b/packages/docs/docs/ai/plugins.mdx
@@ -12,7 +12,9 @@ Remotion maintains plugins for AI coding agents. Each plugin includes [Remotion 
 
 Use the Remotion plugin in Codex in the ChatGPT desktop app.
 
-<CreateWithChatGPTButton />
+<div style={{marginBottom: 16}}>
+  <CreateWithChatGPTButton />
+</div>
 
 [Install and use the Codex plugin](/docs/ai/codex-plugin).
 

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -1424,7 +1424,19 @@ const sidebars: SidebarsConfig = {
 			items: [
 				'ai/coding-agents',
 				'ai/skills',
-				'ai/plugins',
+				{
+					type: 'category',
+					label: 'Plugins',
+					link: {
+						type: 'doc',
+						id: 'ai/plugins',
+					},
+					items: [
+						'ai/claude-code-plugin',
+						'ai/codex-plugin',
+						'ai/kimi-code-plugin',
+					],
+				},
 				'ai/bolt',
 				'ai/chatbot',
 				'ai/generate',


### PR DESCRIPTION
## Summary

- group the individual Claude Code, Codex, and Kimi Code pages under a linked Plugins sidebar category
- keep the Plugins overview as the category landing page
- add spacing below the ChatGPT creation button

## Testing

- `bun run build`
- `bun run stylecheck`
- Docusaurus production build

## Preview

- [AI plugins overview](https://remotion-git-codex-refine-ai-plugins-sidebar-remotion.vercel.app/docs/ai/plugins)
