### PR TITLE
Skills: Avoid computed interactive names

### DIFF
--- a/packages/skills/skills/remotion-interactivity/SKILL.md
+++ b/packages/skills/skills/remotion-interactivity/SKILL.md
@@ -44,6 +44,7 @@ Use a prop or variable only when the text is dynamic or reused.
 ## Give interactive elements a descriptive name
 
 Add a `name` prop to elements to make them easily identifyable.
+Avoid computed names, hardcode them.
 
 ```tsx title="Interactive names"
 <>


### PR DESCRIPTION
## Summary

- Tell agents to hardcode interactive element names
- Discourage computed `name` props in the interactivity skill

## Validation

- `bunx oxfmt packages/skills/skills/remotion-interactivity/SKILL.md --write`
- `bun run build`
- `bun run stylecheck`
