### PR TITLE
`remotion`: Allow AbsoluteFill outside compositions in Studio

### DIFF
--- a/packages/core/src/test/absolute-fill.test.tsx
+++ b/packages/core/src/test/absolute-fill.test.tsx
@@ -1,12 +1,35 @@
 import {expect, test} from 'bun:test';
 import {renderToString} from 'react-dom/server';
 import {AbsoluteFill} from '../AbsoluteFill.js';
+import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
 
 test('AbsoluteFill renders outside a composition', () => {
 	const markup = renderToString(
 		<AbsoluteFill className="layer" style={{backgroundColor: 'red'}}>
 			Content
 		</AbsoluteFill>,
+	);
+
+	expect(markup).toContain('Content');
+	expect(markup).toContain('class="layer"');
+	expect(markup).toContain('background-color:red');
+});
+
+test('AbsoluteFill renders outside a composition in the Studio', () => {
+	const markup = renderToString(
+		<RemotionEnvironmentContext.Provider
+			value={{
+				isStudio: true,
+				isRendering: false,
+				isPlayer: false,
+				isReadOnlyStudio: false,
+				isClientSideRendering: false,
+			}}
+		>
+			<AbsoluteFill className="layer" style={{backgroundColor: 'red'}}>
+				Content
+			</AbsoluteFill>
+		</RemotionEnvironmentContext.Provider>,
 	);
 
 	expect(markup).toContain('Content');

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -5,6 +5,7 @@ import React, {
 	useMemo,
 	useState,
 } from 'react';
+import {CanUseRemotionHooks} from './CanUseRemotionHooks.js';
 import type {
 	JsxComponentIdentity,
 	SequenceControls,
@@ -189,8 +190,9 @@ export const withInteractivitySchema = <
 		} = props as Props & {readonly _remotionInternalStack?: string};
 		const cleanProps = propsWithoutInternalStack as Props;
 		const env = useRemotionEnvironment();
+		const canUseRemotionHooks = useContext(CanUseRemotionHooks);
 
-		if (!env.isStudio || env.isRendering) {
+		if (!env.isStudio || env.isRendering || !canUseRemotionHooks) {
 			return React.createElement(Component, {
 				...cleanProps,
 				controls: null,


### PR DESCRIPTION
## Summary

- bypass visual-mode interactivity when a component is outside a composition
- restore `AbsoluteFill` usage in Studio UI, including the Ask AI modal
- add regression coverage for rendering `AbsoluteFill` outside a composition while in the Studio environment

## Tests

- `bun test packages/core/src/test/absolute-fill.test.tsx`
- `bun run build`
- `bun run stylecheck`

Closes #10112
