### PR TITLE
`@remotion/promo-pages`: Show country flags in homepage demo

### DIFF
--- a/packages/promo-pages/src/components/homepage/Demo/Cards.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/Cards.tsx
@@ -97,7 +97,7 @@ export const Cards: React.FC<{
 						/>
 					) : index === 2 ? (
 						<CurrentCountry
-							countryPaths={trending?.countryPaths ?? null}
+							countryFlag={trending?.countryFlag ?? null}
 							countryLabel={trending?.countryLabel ?? null}
 							theme={theme}
 						/>

--- a/packages/promo-pages/src/components/homepage/Demo/Comp.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/Comp.tsx
@@ -15,10 +15,7 @@ export type RemoteData = {
 	date: string | number;
 	temperatureInCelsius: number;
 	countryLabel: string;
-	countryPaths: {
-		d: string;
-		class: string;
-	}[];
+	countryFlag: string;
 };
 
 export type LocationAndTrending = {
@@ -41,7 +38,7 @@ export const getDataAndProps = async () => {
 				date: data.trending.dateFetched,
 				temperatureInCelsius: Math.round(data.temperature),
 				countryLabel: data.countryLabel,
-				countryPaths: data.countryPaths,
+				countryFlag: data.countryFlag,
 			};
 		});
 

--- a/packages/promo-pages/src/components/homepage/Demo/CurrentCountry.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/CurrentCountry.tsx
@@ -1,7 +1,7 @@
-import {getBoundingBox, resetPath} from '@remotion/paths';
 import React from 'react';
 import {
 	AbsoluteFill,
+	Img,
 	interpolate,
 	spring,
 	useCurrentFrame,
@@ -10,24 +10,15 @@ import {
 
 export const CurrentCountry: React.FC<{
 	readonly theme: 'dark' | 'light';
-	readonly countryPaths:
-		| {
-				d: string;
-				class: string;
-		  }[]
-		| null;
+	readonly countryFlag: string | null;
 	readonly countryLabel: string | null;
-}> = ({theme, countryPaths, countryLabel}) => {
+}> = ({theme, countryFlag, countryLabel}) => {
 	const {fps} = useVideoConfig();
 	const frame = useCurrentFrame();
 
-	if (!countryPaths) {
+	if (!countryFlag || !countryLabel) {
 		return null;
 	}
-
-	const joined = countryPaths.map((p) => p.d).join(' ');
-	const reset = resetPath(joined);
-	const boundingBox = getBoundingBox(reset);
 
 	const progress = spring({
 		fps,
@@ -37,20 +28,6 @@ export const CurrentCountry: React.FC<{
 
 	return (
 		<AbsoluteFill style={{overflow: 'hidden'}}>
-			<AbsoluteFill
-				style={{
-					transform: `scale(${progress})`,
-				}}
-			>
-				<svg
-					viewBox={boundingBox.viewBox}
-					style={{
-						scale: '0.8',
-					}}
-				>
-					<path fill={theme === 'light' ? '#bbb' : '#222'} d={reset} />
-				</svg>
-			</AbsoluteFill>
 			<AbsoluteFill
 				style={{
 					alignItems: 'center',
@@ -76,6 +53,10 @@ export const CurrentCountry: React.FC<{
 				</div>
 				<div
 					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						gap: 6,
 						lineHeight: 1.1,
 						fontFamily: 'GTPlanar',
 						textAlign: 'center',
@@ -89,7 +70,17 @@ export const CurrentCountry: React.FC<{
 							'translateX(' + interpolate(progress, [0, 1], [100, 0]) + '%)',
 					}}
 				>
-					{countryLabel}
+					<Img
+						src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(countryFlag)}`}
+						style={{
+							width: 38,
+							height: 29,
+							objectFit: 'cover',
+							borderRadius: 3,
+							flex: 'none',
+						}}
+					/>
+					<span>{countryLabel}</span>
 				</div>
 			</AbsoluteFill>
 		</AbsoluteFill>

--- a/packages/promo-pages/src/components/homepage/Demo/DemoRender.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/DemoRender.tsx
@@ -9,17 +9,12 @@ import {DoneCheckmark} from './DoneCheckmark';
 import {Progress} from './Progress';
 import {Spinner} from './Spinner';
 
-const countryPath = z.object({
-	d: z.string(),
-	class: z.string(),
-});
-
 const remoteData = z.object({
 	repos: z.array(z.string()),
 	date: z.string().or(z.number()),
 	temperatureInCelsius: z.number(),
 	countryLabel: z.string(),
-	countryPaths: z.array(countryPath),
+	countryFlag: z.string(),
 });
 
 const location = z.object({


### PR DESCRIPTION
## Summary

- use the country flag SVG returned by the homepage demo API
- show the flag directly beside the country name
- remove the country outline path data from the frontend contract and render schema

## Testing

- `bun run build`
- `bun run stylecheck`

## Related

- independent SVG data URI renderer fix: #10177
