### PR TITLE
`@remotion/browser-studio`: Resolve workspace packages from repository

### DIFF
--- a/packages/browser-studio/README.md
+++ b/packages/browser-studio/README.md
@@ -5,3 +5,11 @@ Run Remotion Studio in the browser
 ## Usage
 
 This is an internal package and has no documentation.
+
+## Dependency resolution
+
+By default, Browser Studio resolves published package versions through `esm.sh`.
+Repository development and E2E tests set `workspacePackageBaseUrl` and serve
+every `remotion` and `@remotion/*` export from the current checkout's build
+artifacts instead. Third-party packages intentionally continue to use the
+external resolver.

--- a/packages/browser-studio/bundle.ts
+++ b/packages/browser-studio/bundle.ts
@@ -3,6 +3,7 @@ import {build} from 'bun';
 import {getBrowserStudioDependencyVersionsForBuild} from './src/dev/get-dependency-versions-for-build';
 import {getBrowserStudioReactRefreshFilesForBuild} from './src/dev/get-react-refresh-files-for-build';
 import {getBrowserStudioSetupEnvironmentForBuild} from './src/dev/get-setup-environment-for-build';
+import {getBrowserStudioWorkspacePackageExportsForBuild} from './src/dev/get-workspace-package-exports-for-build';
 import {studioRenderEntryExternal} from './src/dev/studio-render-entry-external';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -13,6 +14,8 @@ console.time('Generated.');
 const dependencyVersions = getBrowserStudioDependencyVersionsForBuild();
 const reactRefreshFiles = getBrowserStudioReactRefreshFilesForBuild();
 const setupEnvironment = getBrowserStudioSetupEnvironmentForBuild();
+const workspacePackageExports =
+	getBrowserStudioWorkspacePackageExportsForBuild();
 const output = await build({
 	entrypoints: [
 		'src/index.tsx',
@@ -24,6 +27,9 @@ const output = await build({
 		__BROWSER_STUDIO_DEPENDENCY_VERSIONS__: JSON.stringify(dependencyVersions),
 		__BROWSER_STUDIO_REACT_REFRESH_FILES__: JSON.stringify(reactRefreshFiles),
 		__BROWSER_STUDIO_SETUP_ENVIRONMENT__: JSON.stringify(setupEnvironment),
+		__BROWSER_STUDIO_WORKSPACE_PACKAGE_EXPORTS__: JSON.stringify(
+			workspacePackageExports,
+		),
 	},
 	external: [
 		'@remotion/studio-shared/studio-entry-points',

--- a/packages/browser-studio/e2e/app.tsx
+++ b/packages/browser-studio/e2e/app.tsx
@@ -4,6 +4,16 @@ import {
 } from '@remotion/browser-studio';
 import {createRoot} from 'react-dom/client';
 
+const project = createBlankTemplateProject();
+project.files['/project/src/index.ts'] =
+	`import {fade} from '@remotion/transitions/fade';
+import {registerRoot} from 'remotion';
+import {RemotionRoot} from './Root';
+
+void fade;
+registerRoot(RemotionRoot);
+`;
+
 const root = document.getElementById('root');
 if (!root) {
 	throw new Error('Could not find root element');
@@ -12,7 +22,11 @@ if (!root) {
 createRoot(root).render(
 	<BrowserStudio
 		iframeSrc="/frame.html"
-		project={createBlankTemplateProject()}
+		project={project}
 		readOnly={false}
+		workspacePackageBaseUrl={
+			new URL('/__remotion_browser_studio_workspace__/', window.location.href)
+				.href
+		}
 	/>,
 );

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -4,14 +4,31 @@ test('loads the Browser Studio canvas and enables Visual Mode', async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
+	const remoteRemotionRequests: string[] = [];
 	const updateAvailableRequests: string[] = [];
+	const workspacePackageRequests: string[] = [];
 	let rejectPageError: (error: Error) => void = () => undefined;
 	const pageError = new Promise<never>((_resolve, reject) => {
 		rejectPageError = reject;
 	});
 	page.on('request', (request) => {
-		if (new URL(request.url()).pathname === '/api/update-available') {
+		const requestUrl = new URL(request.url());
+		if (requestUrl.pathname === '/api/update-available') {
 			updateAvailableRequests.push(request.url());
+		}
+
+		if (
+			requestUrl.pathname.startsWith('/__remotion_browser_studio_workspace__/')
+		) {
+			workspacePackageRequests.push(requestUrl.pathname);
+		}
+
+		if (
+			requestUrl.hostname === 'esm.sh' &&
+			(decodeURIComponent(requestUrl.pathname).includes('/@remotion/') ||
+				/^\/remotion(?:@|\/|$)/.test(requestUrl.pathname))
+		) {
+			remoteRemotionRequests.push(request.url());
 		}
 	});
 	page.on('pageerror', (error) => {
@@ -43,6 +60,16 @@ test('loads the Browser Studio canvas and enables Visual Mode', async ({
 	]);
 
 	expect(pageErrors).toEqual([]);
+	expect(workspacePackageRequests).toContain(
+		'/__remotion_browser_studio_workspace__/packages/core/dist/esm/index.mjs',
+	);
+	expect(workspacePackageRequests).toContain(
+		'/__remotion_browser_studio_workspace__/packages/studio/dist/esm/previewEntry.mjs',
+	);
+	expect(workspacePackageRequests).toContain(
+		'/__remotion_browser_studio_workspace__/packages/transitions/dist/esm/fade.mjs',
+	);
+	expect(remoteRemotionRequests).toEqual([]);
 	expect(updateAvailableRequests).toEqual([]);
 });
 

--- a/packages/browser-studio/e2e/server.ts
+++ b/packages/browser-studio/e2e/server.ts
@@ -3,6 +3,9 @@ import {rspack} from '@rspack/core';
 
 const port = Number(process.env.PORT ?? 62338);
 const outputPath = path.join(import.meta.dir, '..', 'dist', 'e2e');
+const repoDir = path.join(import.meta.dir, '..', '..', '..');
+const workspacePackagesDir = path.join(repoDir, 'packages');
+const workspacePackagePath = '/__remotion_browser_studio_workspace__/';
 
 const compile = () =>
 	new Promise<void>((resolve, reject) => {
@@ -83,6 +86,24 @@ Bun.serve({
 			return new Response(document('', null), {
 				headers: {...headers, 'Content-Type': 'text/html'},
 			});
+		}
+
+		if (url.pathname.startsWith(workspacePackagePath)) {
+			const relativePath = url.pathname.slice(workspacePackagePath.length);
+			const workspaceFilePath = path.join(
+				repoDir,
+				path.normalize(relativePath),
+			);
+			if (!workspaceFilePath.startsWith(`${workspacePackagesDir}${path.sep}`)) {
+				return new Response('Not found', {status: 404, headers});
+			}
+
+			const workspaceFile = Bun.file(workspaceFilePath);
+			if (!(await workspaceFile.exists())) {
+				return new Response('Not found', {status: 404, headers});
+			}
+
+			return new Response(workspaceFile, {headers});
 		}
 
 		const filePath = path.join(outputPath, url.pathname);

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -83,6 +83,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	dependencyResolver,
 	onCompileStateChange,
 	onProjectChange,
+	workspacePackageBaseUrl,
 }) => {
 	const [state, setState] = useState<CompileState>(makeInitialState);
 	const [iframeHtml, setIframeHtml] = useState<string | null>(null);
@@ -319,6 +320,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 				),
 			),
 			project: activeProjectRef.current,
+			workspacePackageBaseUrl: workspacePackageBaseUrl ?? null,
 		};
 
 		worker.postMessage(request);
@@ -335,6 +337,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 		hmrAssetManager,
 		publicFileManager,
 		readOnly,
+		workspacePackageBaseUrl,
 		activeProject.entryPoint,
 		activeProject.rootDir,
 	]);

--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -15,6 +15,10 @@ import {
 	browserStudioVirtualFilePaths,
 	getBrowserStudioVirtualFiles,
 } from './virtual-files';
+import {
+	getBrowserStudioWorkspacePackageExports,
+	resolveBrowserStudioWorkspacePackage,
+} from './workspace-package-exports';
 
 type BuiltinMemFs = typeof RspackBrowser.builtinMemFs;
 type Compiler = RspackBrowser.Compiler;
@@ -237,12 +241,14 @@ const getBrowserStudioHmrRuntimePlugin = (
 const createCompiler = async ({
 	dependencyResolutions,
 	project,
+	workspacePackageBaseUrl,
 }: Extract<BrowserStudioWorkerCompileRequest, {type: 'init'}>) => {
 	const rspackBrowser = await loadRspackBrowser();
 	const {BrowserHttpImportEsmPlugin, builtinMemFs, rspack} = rspackBrowser;
 	writeInitialFiles({builtinMemFs, project});
 
 	const resolvedVersions = {...browserStudioDependencyVersions};
+	const workspacePackageExports = getBrowserStudioWorkspacePackageExports();
 	const resolvedUrls: Record<string, string> = {};
 	for (const [name, resolution] of Object.entries(dependencyResolutions)) {
 		applyDependencyResolution({
@@ -273,7 +279,11 @@ const createCompiler = async ({
 		entry: {bundle: {asyncChunks: false, import: entryPoints}},
 		experiments: {
 			buildHttp: {
-				allowedUris: ['https://esm.sh/', `${self.location.origin}/`],
+				allowedUris: [
+					'https://esm.sh/',
+					`${self.location.origin}/`,
+					...(workspacePackageBaseUrl ? [workspacePackageBaseUrl] : []),
+				],
 				cacheLocation: false,
 			},
 		},
@@ -351,6 +361,17 @@ const createCompiler = async ({
 				dependencyUrl: ({request}) => {
 					if (!isBarePackageImport(request)) {
 						return undefined;
+					}
+
+					if (workspacePackageBaseUrl) {
+						const workspacePackageUrl = resolveBrowserStudioWorkspacePackage({
+							baseUrl: workspacePackageBaseUrl,
+							packages: workspacePackageExports,
+							request,
+						});
+						if (workspacePackageUrl) {
+							return workspacePackageUrl;
+						}
 					}
 
 					const packageName = getPackageName(request);

--- a/packages/browser-studio/src/dev/get-dependency-versions-for-build.ts
+++ b/packages/browser-studio/src/dev/get-dependency-versions-for-build.ts
@@ -25,7 +25,12 @@ const getWorkspacePackageVersions = () => {
 	for (const packageJsonPath of packageJsonGlob.scanSync({cwd: repoDir})) {
 		const packageJson = readPackageJson(join(repoDir, packageJsonPath));
 
-		if (!packageJson.name || !packageJson.version) {
+		if (
+			!packageJson.name ||
+			!packageJson.version ||
+			(packageJson.name !== 'remotion' &&
+				!packageJson.name.startsWith('@remotion/'))
+		) {
 			continue;
 		}
 
@@ -109,6 +114,7 @@ export const getBrowserStudioDependencyVersionsForBuild = (): Record<
 	}
 
 	const workspacePackageVersions = getWorkspacePackageVersions();
+	Object.assign(dependencySpecs, workspacePackageVersions);
 
 	return Object.fromEntries(
 		Object.entries(dependencySpecs)

--- a/packages/browser-studio/src/dev/get-workspace-package-exports-for-build.ts
+++ b/packages/browser-studio/src/dev/get-workspace-package-exports-for-build.ts
@@ -1,0 +1,72 @@
+import {readFileSync} from 'node:fs';
+import {dirname, join, relative, sep} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {BrowserStudioWorkspacePackageExports} from '../workspace-package-exports';
+
+type ConditionalExport = {
+	readonly default?: string;
+	readonly import?: string;
+	readonly module?: string;
+};
+
+type PackageJson = {
+	readonly exports?: Record<string, string | ConditionalExport>;
+	readonly name?: string;
+};
+
+const packageDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const repoDir = join(packageDir, '..', '..');
+
+const readPackageJson = (path: string): PackageJson =>
+	JSON.parse(readFileSync(path, 'utf-8')) as PackageJson;
+
+const getBrowserExport = (value: string | ConditionalExport) => {
+	if (typeof value === 'string') {
+		return value;
+	}
+
+	return value.module ?? value.import ?? value.default ?? null;
+};
+
+export const getBrowserStudioWorkspacePackageExportsForBuild =
+	(): BrowserStudioWorkspacePackageExports => {
+		const packageJsonGlob = new Bun.Glob('packages/**/package.json');
+		const packages: BrowserStudioWorkspacePackageExports = {};
+
+		for (const packageJsonPath of packageJsonGlob.scanSync({cwd: repoDir})) {
+			const absolutePackageJsonPath = join(repoDir, packageJsonPath);
+			const packageJson = readPackageJson(absolutePackageJsonPath);
+			if (
+				!packageJson.name ||
+				(packageJson.name !== 'remotion' &&
+					!packageJson.name.startsWith('@remotion/'))
+			) {
+				continue;
+			}
+
+			const browserExports = Object.fromEntries(
+				Object.entries(packageJson.exports ?? {}).flatMap(
+					([subpath, value]) => {
+						const target = getBrowserExport(value);
+						return target ? [[subpath, target]] : [];
+					},
+				),
+			);
+			if (Object.keys(browserExports).length === 0) {
+				continue;
+			}
+
+			packages[packageJson.name] = {
+				exports: browserExports,
+				packageRoot: relative(repoDir, dirname(absolutePackageJsonPath))
+					.split(sep)
+					.join('/'),
+			};
+		}
+
+		return Object.fromEntries(
+			Object.entries(packages).sort(([left], [right]) =>
+				left.localeCompare(right),
+			),
+		);
+	};

--- a/packages/browser-studio/src/dev/index.tsx
+++ b/packages/browser-studio/src/dev/index.tsx
@@ -13,5 +13,9 @@ createRoot(root).render(
 		iframeSrc="/frame.html"
 		project={createBlankTemplateProject()}
 		readOnly={false}
+		workspacePackageBaseUrl={
+			new URL('/__remotion_browser_studio_workspace__/', window.location.href)
+				.href
+		}
 	/>,
 );

--- a/packages/browser-studio/src/dev/server.ts
+++ b/packages/browser-studio/src/dev/server.ts
@@ -4,10 +4,14 @@ import {build} from 'bun';
 import {getBrowserStudioDependencyVersionsForBuild} from './get-dependency-versions-for-build';
 import {getBrowserStudioReactRefreshFilesForBuild} from './get-react-refresh-files-for-build';
 import {getBrowserStudioSetupEnvironmentForBuild} from './get-setup-environment-for-build';
+import {getBrowserStudioWorkspacePackageExportsForBuild} from './get-workspace-package-exports-for-build';
 import {studioRenderEntryExternal} from './studio-render-entry-external';
 
 const port = Number(process.env.PORT ?? 62338);
 const outDir = path.join(import.meta.dir, '..', '..', 'dist', 'dev');
+const repoDir = path.join(import.meta.dir, '..', '..', '..', '..');
+const workspacePackagesDir = path.join(repoDir, 'packages');
+const workspacePackagePath = '/__remotion_browser_studio_workspace__/';
 
 const headers = {
 	'Cross-Origin-Embedder-Policy': 'credentialless',
@@ -68,6 +72,8 @@ const buildDevAssets = async () => {
 	const dependencyVersions = getBrowserStudioDependencyVersionsForBuild();
 	const reactRefreshFiles = getBrowserStudioReactRefreshFilesForBuild();
 	const setupEnvironment = getBrowserStudioSetupEnvironmentForBuild();
+	const workspacePackageExports =
+		getBrowserStudioWorkspacePackageExportsForBuild();
 	const output = await build({
 		entrypoints: ['src/dev/index.tsx', 'src/browser-studio-worker.ts'],
 		define: {
@@ -75,6 +81,9 @@ const buildDevAssets = async () => {
 				JSON.stringify(dependencyVersions),
 			__BROWSER_STUDIO_REACT_REFRESH_FILES__: JSON.stringify(reactRefreshFiles),
 			__BROWSER_STUDIO_SETUP_ENVIRONMENT__: JSON.stringify(setupEnvironment),
+			__BROWSER_STUDIO_WORKSPACE_PACKAGE_EXPORTS__: JSON.stringify(
+				workspacePackageExports,
+			),
 		},
 		format: 'esm',
 		naming: '[name].mjs',
@@ -145,6 +154,32 @@ const start = async () => {
 			if (url.pathname === '/frame.html') {
 				return responseWithHeaders(frameHtml, {
 					headers: {'Content-Type': contentTypes['.html']},
+				});
+			}
+
+			if (url.pathname.startsWith(workspacePackagePath)) {
+				const relativePath = url.pathname.slice(workspacePackagePath.length);
+				const workspaceAssetPath = path.join(
+					repoDir,
+					path.normalize(relativePath),
+				);
+				if (
+					!workspaceAssetPath.startsWith(`${workspacePackagesDir}${path.sep}`)
+				) {
+					return responseWithHeaders('Not found', {status: 404});
+				}
+
+				const workspaceFile = Bun.file(workspaceAssetPath);
+				if (!(await workspaceFile.exists())) {
+					return responseWithHeaders('Not found', {status: 404});
+				}
+
+				const workspaceContentType =
+					contentTypes[path.extname(workspaceAssetPath)];
+				return responseWithHeaders(workspaceFile, {
+					headers: workspaceContentType
+						? {'Content-Type': workspaceContentType}
+						: undefined,
 				});
 			}
 

--- a/packages/browser-studio/src/test/dependency-versions.test.ts
+++ b/packages/browser-studio/src/test/dependency-versions.test.ts
@@ -22,11 +22,19 @@ test('browser studio dependency versions are derived from package metadata', () 
 	const studioPackageJson = readPackageJson(
 		join(repoDir, 'packages', 'studio', 'package.json'),
 	);
+	const transitionsPackageJson = readPackageJson(
+		join(repoDir, 'packages', 'transitions', 'package.json'),
+	);
 	const dependencyVersions = getBrowserStudioDependencyVersionsForBuild();
 	const reactVersion = rootPackageJson.workspaces?.catalog?.react;
 	const reactDomVersion = rootPackageJson.workspaces?.catalog?.['react-dom'];
 
-	if (!studioPackageJson.version || !reactVersion || !reactDomVersion) {
+	if (
+		!studioPackageJson.version ||
+		!transitionsPackageJson.version ||
+		!reactVersion ||
+		!reactDomVersion
+	) {
 		throw new Error(
 			'Could not find package metadata for dependency version test',
 		);
@@ -34,6 +42,9 @@ test('browser studio dependency versions are derived from package metadata', () 
 
 	expect(dependencyVersions['@remotion/studio']).toBe(
 		studioPackageJson.version,
+	);
+	expect(dependencyVersions['@remotion/transitions']).toBe(
+		transitionsPackageJson.version,
 	);
 	expect(dependencyVersions.react).toBe(reactVersion);
 	expect(dependencyVersions['react-dom']).toBe(reactDomVersion);

--- a/packages/browser-studio/src/types.ts
+++ b/packages/browser-studio/src/types.ts
@@ -53,6 +53,7 @@ export type BrowserStudioProps = {
 	project: VirtualProject;
 	readOnly: boolean;
 	iframeSrc?: string;
+	workspacePackageBaseUrl?: string;
 	dependencyResolver?: BrowserStudioDependencyResolver;
 	onCompileStateChange?: (state: CompileState) => void;
 	onProjectChange?: (project: VirtualProject) => void;
@@ -63,6 +64,7 @@ export type BrowserStudioWorkerCompileRequest =
 			type: 'init';
 			project: VirtualProject;
 			dependencyResolutions: Record<string, BrowserStudioDependencyResolution>;
+			workspacePackageBaseUrl: string | null;
 	  }
 	| {
 			type: 'update-project';

--- a/packages/browser-studio/src/workspace-package-exports.ts
+++ b/packages/browser-studio/src/workspace-package-exports.ts
@@ -1,0 +1,82 @@
+export type BrowserStudioWorkspacePackageExports = Record<
+	string,
+	{
+		readonly exports: Record<string, string>;
+		readonly packageRoot: string;
+	}
+>;
+
+declare const __BROWSER_STUDIO_WORKSPACE_PACKAGE_EXPORTS__:
+	| BrowserStudioWorkspacePackageExports
+	| undefined;
+
+export const getBrowserStudioWorkspacePackageExports = () => {
+	if (typeof __BROWSER_STUDIO_WORKSPACE_PACKAGE_EXPORTS__ === 'undefined') {
+		throw new Error(
+			'Browser Studio workspace package exports were not injected',
+		);
+	}
+
+	return __BROWSER_STUDIO_WORKSPACE_PACKAGE_EXPORTS__;
+};
+
+const getPackageName = (request: string) =>
+	request.startsWith('@')
+		? request.split('/').slice(0, 2).join('/')
+		: request.split('/')[0];
+
+export const resolveBrowserStudioWorkspacePackage = ({
+	baseUrl,
+	packages,
+	request,
+}: {
+	baseUrl: string;
+	packages: BrowserStudioWorkspacePackageExports;
+	request: string;
+}) => {
+	const packageName = getPackageName(request);
+	const workspacePackage = packages[packageName];
+	if (!workspacePackage) {
+		return null;
+	}
+
+	const subpath =
+		request === packageName ? '.' : `.${request.slice(packageName.length)}`;
+	let target = workspacePackage.exports[subpath];
+
+	if (!target) {
+		for (const [exportPattern, exportTarget] of Object.entries(
+			workspacePackage.exports,
+		)) {
+			const wildcardIndex = exportPattern.indexOf('*');
+			if (wildcardIndex === -1) {
+				continue;
+			}
+
+			const prefix = exportPattern.slice(0, wildcardIndex);
+			const suffix = exportPattern.slice(wildcardIndex + 1);
+			if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
+				continue;
+			}
+
+			const wildcard = subpath.slice(
+				prefix.length,
+				suffix.length === 0 ? undefined : -suffix.length,
+			);
+			target = exportTarget.replace('*', wildcard);
+			break;
+		}
+	}
+
+	if (!target || !target.startsWith('./')) {
+		throw new Error(
+			`The repository package ${packageName} does not expose ${subpath} to Browser Studio.`,
+		);
+	}
+
+	const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+	return new URL(
+		`${workspacePackage.packageRoot}/${target.slice(2)}`,
+		normalizedBaseUrl,
+	).href;
+};


### PR DESCRIPTION
## Summary

- resolve all Remotion workspace package exports from current repository build artifacts in Browser Studio development and E2E
- derive workspace package versions and browser export paths from package metadata
- keep third-party packages on the existing external resolver and document the intentional production behavior

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testbrowserstudio`
- red/green verified by disabling workspace resolution and observing the expected E2E failure

Closes #10147
