### PR TITLE
`remotion`: Prevent missed buffering resume events

### DIFF
--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -43,12 +43,14 @@ const useBufferManager = (
 	mountTime: number | null,
 ): BufferManager => {
 	const [blocks, setBlocks] = useState<Block[]>([]);
-	const [onBufferingCallbacks, setOnBufferingCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
-	const [onResumeCallbacks, setOnResumeCallbacks] = useState<
-		OnBufferingCallback[]
-	>([]);
+	// Listener registries are refs, not state: `usePlayback` parks its loop
+	// during buffering and registers its resume listener from a rAF callback.
+	// With state, that registration only lands after the next React commit -
+	// if the last block unblocks before then, the resume dispatch reads the
+	// previous array, the listener is never called, and the playback loop
+	// stays parked forever (frame clock frozen while isPlaying() is true).
+	const onBufferingCallbacks = useRef<OnBufferingCallback[]>([]);
+	const onResumeCallbacks = useRef<OnResumeCallback[]>([]);
 
 	const env = useRemotionEnvironment();
 	const rendering = env.isRendering;
@@ -89,11 +91,16 @@ const useBufferManager = (
 
 	const listenForBuffering: ListenForBuffering = useCallback(
 		(callback: OnBufferingCallback) => {
-			setOnBufferingCallbacks((c) => [...c, callback]);
+			onBufferingCallbacks.current = [
+				...onBufferingCallbacks.current,
+				callback,
+			];
 
 			return {
 				remove: () => {
-					setOnBufferingCallbacks((c) => c.filter((cb) => cb !== callback));
+					onBufferingCallbacks.current = onBufferingCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
@@ -102,11 +109,13 @@ const useBufferManager = (
 
 	const listenForResume: ListenForResume = useCallback(
 		(callback: OnResumeCallback) => {
-			setOnResumeCallbacks((c) => [...c, callback]);
+			onResumeCallbacks.current = [...onResumeCallbacks.current, callback];
 
 			return {
 				remove: () => {
-					setOnResumeCallbacks((c) => c.filter((cb) => cb !== callback));
+					onResumeCallbacks.current = onResumeCallbacks.current.filter(
+						(cb) => cb !== callback,
+					);
 				},
 			};
 		},
@@ -123,7 +132,7 @@ const useBufferManager = (
 		// not re-dispatch `waiting` to listeners.
 		if (blocks.length > 0 && !buffering.current) {
 			buffering.current = true;
-			onBufferingCallbacks.forEach((c) => c());
+			[...onBufferingCallbacks.current].forEach((c) => c());
 			playbackLogging({
 				logLevel,
 				message: 'Player is entering buffer state',
@@ -151,7 +160,7 @@ const useBufferManager = (
 			// dispatch `resume` to listeners.
 			if (blocks.length === 0 && buffering.current) {
 				buffering.current = false;
-				onResumeCallbacks.forEach((c) => c());
+				[...onResumeCallbacks.current].forEach((c) => c());
 				playbackLogging({
 					logLevel,
 					message: 'Player is exiting buffer state',

--- a/packages/core/src/test/buffering.test.tsx
+++ b/packages/core/src/test/buffering.test.tsx
@@ -103,3 +103,67 @@ test('a block added and removed within the same commit emits no events', () => {
 	expect(events).toEqual([]);
 	expect(manager!.buffering.current).toBe(false);
 });
+
+test('a listener registered while buffering ends still receives "resume"', () => {
+	// usePlayback() parks its loop during buffering and registers its resume
+	// listener from outside the React render cycle (a rAF callback). The
+	// registration must be visible to the resume dispatch of the very next
+	// commit - if it only lands one commit later, the resume is missed and the
+	// playback loop stays parked forever.
+	let registerOnNextCommit = false;
+	let resumed = false;
+
+	const LateRegistrar: React.FC<{readonly generation: number}> = ({
+		generation,
+	}) => {
+		const context = useContext(BufferingContextReact);
+
+		useLayoutEffect(() => {
+			if (registerOnNextCommit) {
+				registerOnNextCommit = false;
+				context!.listenForResume(() => {
+					resumed = true;
+				});
+			}
+		}, [context, generation]);
+
+		return null;
+	};
+
+	const renderWithGeneration = (generation: number) =>
+		render(
+			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+				<BufferingProvider>
+					<Harness />
+					<LateRegistrar generation={generation} />
+				</BufferingProvider>
+			</RemotionEnvironmentContext.Provider>,
+		);
+
+	const {rerender} = renderWithGeneration(1);
+
+	let block: {unblock: () => void} | null = null;
+	act(() => {
+		block = manager!.addBlock({id: 'scrub'});
+	});
+	expect(manager!.buffering.current).toBe(true);
+
+	// Register inside the same commit that empties the block list - the child's
+	// layout effect runs before the provider's dispatch effect, like the
+	// playback loop registering mid-transition.
+	registerOnNextCommit = true;
+	act(() => {
+		rerender(
+			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+				<BufferingProvider>
+					<Harness />
+					<LateRegistrar generation={2} />
+				</BufferingProvider>
+			</RemotionEnvironmentContext.Provider>,
+		);
+		block!.unblock();
+	});
+
+	expect(manager!.buffering.current).toBe(false);
+	expect(resumed).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Make buffering and resume listener registration and removal synchronous
- Dispatch listener snapshots so callbacks can safely remove themselves
- Cover resume registration during the same commit that ends buffering

Closes #10170

## Testing

- `bun test src/test/buffering.test.tsx` in `packages/core`
- `bun run build`
- `bun run stylecheck`
