### PR TITLE
Internal: Cache Twoslash by workspace dependency

### DIFF
--- a/packages/docusaurus-plugin/src/twoslash-cache.test.ts
+++ b/packages/docusaurus-plugin/src/twoslash-cache.test.ts
@@ -14,6 +14,7 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import {pathToFileURL} from 'url';
 import {
+	createTwoslashCacheContext,
 	garbageCollectSharedTwoslashCache,
 	getSharedTwoslashCacheRoot,
 	getTwoslashCacheKey,
@@ -39,6 +40,7 @@ const makeContext = (
 		typescript: '1.0.0',
 		shikiTwoslash: '1.0.0',
 	},
+	workspacePackages: {},
 });
 
 const makeTemporaryDirectory = () => {
@@ -47,33 +49,64 @@ const makeTemporaryDirectory = () => {
 	return directory;
 };
 
-const makeEnvironmentRepository = (
-	root: string,
-	name: string,
-	declaration: string,
-): string => {
+const versions = {
+	twoslash: '1.0.0',
+	shiki: '1.0.0',
+	typescript: '1.0.0',
+	shikiTwoslash: '1.0.0',
+};
+
+const makeEnvironmentRepository = ({
+	lockfile = 'lockfile',
+	name,
+	packages,
+	root,
+}: {
+	lockfile?: string;
+	name: string;
+	packages: Record<
+		string,
+		{declaration: string; dependencies?: Record<string, string>}
+	>;
+	root: string;
+}): string => {
 	const repository = join(root, name);
 	const docsRoot = join(repository, 'packages', 'docs');
-	const packageRoot = join(repository, 'packages', 'example');
 	mkdirSync(docsRoot, {recursive: true});
-	mkdirSync(join(packageRoot, 'dist'), {recursive: true});
-	writeFileSync(join(repository, 'bun.lock'), 'lockfile', 'utf8');
+	writeFileSync(join(repository, 'bun.lock'), lockfile, 'utf8');
 	writeFileSync(join(repository, 'package.json'), '{}', 'utf8');
-	writeFileSync(join(docsRoot, 'package.json'), '{}', 'utf8');
-	writeFileSync(join(packageRoot, 'package.json'), '{}', 'utf8');
-	writeFileSync(join(packageRoot, 'dist', 'index.d.ts'), declaration, 'utf8');
+	writeFileSync(
+		join(docsRoot, 'package.json'),
+		JSON.stringify({name: 'docs'}),
+		'utf8',
+	);
+
+	for (const [packageName, definition] of Object.entries(packages)) {
+		const directoryName = packageName.replace('@remotion/', '');
+		const packageRoot = join(repository, 'packages', directoryName);
+		mkdirSync(join(packageRoot, 'dist'), {recursive: true});
+		writeFileSync(
+			join(packageRoot, 'package.json'),
+			JSON.stringify({
+				name: packageName,
+				dependencies: definition.dependencies,
+			}),
+			'utf8',
+		);
+		writeFileSync(
+			join(packageRoot, 'dist', 'index.d.ts'),
+			definition.declaration,
+			'utf8',
+		);
+	}
+
 	execFileSync('git', ['init', '--quiet', repository]);
-	execFileSync('git', [
-		'-C',
-		repository,
-		'add',
-		'bun.lock',
-		'package.json',
-		'packages/docs/package.json',
-		'packages/example/package.json',
-	]);
+	execFileSync('git', ['-C', repository, 'add', '.']);
 	return docsRoot;
 };
+
+const makeRepositoryContext = (docsRoot: string) =>
+	createTwoslashCacheContext({docsRoot, versions});
 
 afterEach(() => {
 	for (const directory of temporaryDirectories.splice(0)) {
@@ -85,28 +118,155 @@ afterEach(() => {
 });
 
 describe('Twoslash cache keys', () => {
-	test('fingerprint generated workspace declarations', () => {
+	test('invalidate only snippets affected by workspace declarations', () => {
 		const root = makeTemporaryDirectory();
-		const first = makeEnvironmentRepository(
-			root,
-			'first',
-			'export declare const value: string;',
+		const makePackages = ({
+			alpha = 'export declare const alpha: string;',
+			beta = 'export declare const beta: string;',
+			shared = 'export declare const shared: string;',
+		} = {}) => ({
+			'@remotion/alpha': {
+				declaration: alpha,
+				dependencies: {'@remotion/shared': 'workspace:*'},
+			},
+			'@remotion/beta': {declaration: beta},
+			'@remotion/shared': {declaration: shared},
+		});
+		const baseline = makeRepositoryContext(
+			makeEnvironmentRepository({
+				name: 'baseline',
+				packages: makePackages(),
+				root,
+			}),
 		);
-		const second = makeEnvironmentRepository(
-			root,
-			'second',
-			'export declare const value: number;',
+		const unrelatedChange = makeRepositoryContext(
+			makeEnvironmentRepository({
+				name: 'unrelated',
+				packages: makePackages({
+					beta: 'export declare const beta: number;',
+				}),
+				root,
+			}),
 		);
-		const sameAsFirst = makeEnvironmentRepository(
-			root,
-			'third',
-			'export declare const value: string;',
+		const directChange = makeRepositoryContext(
+			makeEnvironmentRepository({
+				name: 'direct',
+				packages: makePackages({
+					alpha: 'export declare const alpha: number;',
+				}),
+				root,
+			}),
 		);
+		const transitiveChange = makeRepositoryContext(
+			makeEnvironmentRepository({
+				name: 'transitive',
+				packages: makePackages({
+					shared: 'export declare const shared: number;',
+				}),
+				root,
+			}),
+		);
+		const alphaCode = "import {alpha} from '@remotion/alpha';\nalpha;";
+		const alphaKey = getTwoslashCacheKey({
+			code: alphaCode,
+			context: baseline,
+			lang: 'ts',
+		});
+		const getAlphaKey = (context: TwoslashCacheContext) =>
+			getTwoslashCacheKey({code: alphaCode, context, lang: 'ts'});
+
+		expect(getAlphaKey(unrelatedChange)).toBe(alphaKey);
+		expect(getAlphaKey(directChange)).not.toBe(alphaKey);
+		expect(getAlphaKey(transitiveChange)).not.toBe(alphaKey);
+
+		const sharedRoot = join(root, 'selective-shared-cache');
+		const baselineCache = {
+			...baseline,
+			localRoot: join(root, 'baseline-cache'),
+			sharedRoot,
+		};
+		writeTwoslashCacheEntry({
+			context: baselineCache,
+			html: '<pre>alpha</pre>',
+			key: alphaKey,
+		});
+		expect(
+			readTwoslashCacheEntry({
+				context: {
+					...unrelatedChange,
+					localRoot: join(root, 'unrelated-cache'),
+					sharedRoot,
+				},
+				key: getAlphaKey(unrelatedChange),
+			}),
+		).toBe('<pre>alpha</pre>');
+		expect(
+			readTwoslashCacheEntry({
+				context: {
+					...directChange,
+					localRoot: join(root, 'direct-cache'),
+					sharedRoot,
+				},
+				key: getAlphaKey(directChange),
+			}),
+		).toBeNull();
+
+		for (const code of [
+			"import type {Alpha} from '@remotion/alpha/subpath';",
+			"import '@remotion/alpha';",
+			"export {alpha} from '@remotion/alpha';",
+			"import('@remotion/alpha');",
+			"require('@remotion/alpha');",
+			'/// <reference types="@remotion/alpha" />',
+		]) {
+			expect(
+				getTwoslashCacheKey({code, context: directChange, lang: 'ts'}),
+			).not.toBe(getTwoslashCacheKey({code, context: baseline, lang: 'ts'}));
+		}
+
+		expect(
+			getTwoslashCacheKey({
+				code: "import {beta} from '@remotion/beta';\nbeta;",
+				context: unrelatedChange,
+				lang: 'ts',
+			}),
+		).not.toBe(
+			getTwoslashCacheKey({
+				code: "import {beta} from '@remotion/beta';\nbeta;",
+				context: baseline,
+				lang: 'ts',
+			}),
+		);
+		expect(
+			getTwoslashCacheKey({
+				code: 'const local = 1;',
+				context: directChange,
+				lang: 'ts',
+			}),
+		).toBe(
+			getTwoslashCacheKey({
+				code: 'const local = 1;',
+				context: baseline,
+				lang: 'ts',
+			}),
+		);
+	});
+
+	test('fingerprint external dependency resolutions globally', () => {
+		const root = makeTemporaryDirectory();
+		const first = makeEnvironmentRepository({
+			name: 'first',
+			packages: {},
+			root,
+		});
+		const second = makeEnvironmentRepository({
+			lockfile: 'updated lockfile',
+			name: 'second',
+			packages: {},
+			root,
+		});
 
 		expect(getTwoslashEnvironmentHash(second)).not.toBe(
-			getTwoslashEnvironmentHash(first),
-		);
-		expect(getTwoslashEnvironmentHash(sameAsFirst)).toBe(
 			getTwoslashEnvironmentHash(first),
 		);
 	});

--- a/packages/docusaurus-plugin/src/twoslash-cache.ts
+++ b/packages/docusaurus-plugin/src/twoslash-cache.ts
@@ -41,11 +41,17 @@ export interface TwoslashVersions {
 	shikiTwoslash: string;
 }
 
+interface TwoslashWorkspacePackage {
+	dependencies: string[];
+	declarationHash: string;
+}
+
 export interface TwoslashCacheContext {
 	localRoot: string;
 	sharedRoot: string | null;
 	environmentHash: string;
 	versions: TwoslashVersions;
+	workspacePackages: Record<string, TwoslashWorkspacePackage>;
 }
 
 interface SharedCacheHeader {
@@ -170,7 +176,7 @@ const getRepositoryRoot = (docsRoot: string): string => {
 	);
 };
 
-const getTrackedEnvironmentFiles = (repositoryRoot: string): string[] => {
+const getTrackedPackageJsonFiles = (repositoryRoot: string): string[] => {
 	try {
 		const output = execFileSync(
 			'git',
@@ -180,19 +186,14 @@ const getTrackedEnvironmentFiles = (repositoryRoot: string): string[] => {
 				'ls-files',
 				'-z',
 				'--',
-				'bun.lock',
-				'package.json',
 				':(glob)packages/**/package.json',
-				':(glob)packages/**/*.d.ts',
-				':(glob)packages/**/*.d.mts',
-				':(glob)packages/**/*.d.cts',
 			],
 			{encoding: 'buffer', maxBuffer: 10 * 1024 * 1024},
 		);
 
 		return output.toString('utf8').split('\0').filter(Boolean).sort();
 	} catch {
-		return ['bun.lock', 'package.json'];
+		return [];
 	}
 };
 
@@ -235,30 +236,58 @@ export const getTwoslashEnvironmentHash = (docsRoot: string): string => {
 		return cached;
 	}
 
+	// External package versions, TypeScript's ambient types and package-manager
+	// resolutions can affect any snippet. Workspace declarations are fingerprinted
+	// separately so a change to one package does not invalidate every snippet.
 	const hash = createHash('sha256');
-	const trackedFiles = getTrackedEnvironmentFiles(repositoryRoot);
-	const packageDirectories = new Set<string>();
-
-	for (const relativePath of trackedFiles) {
-		const absolutePath = join(repositoryRoot, relativePath);
-		hashFile(hash, repositoryRoot, absolutePath);
-		if (relativePath.endsWith('package.json')) {
-			packageDirectories.add(dirname(absolutePath));
-		}
-	}
-
-	const declarationFiles: string[] = [];
-	for (const packageDirectory of packageDirectories) {
-		collectDeclarationFiles(join(packageDirectory, 'dist'), declarationFiles);
-	}
-
-	for (const declarationFile of declarationFiles.sort()) {
-		hashFile(hash, repositoryRoot, declarationFile);
-	}
-
+	hashFile(hash, repositoryRoot, join(repositoryRoot, 'bun.lock'));
 	const digest = hash.digest('hex');
 	environmentHashCache.set(repositoryRoot, digest);
 	return digest;
+};
+
+const getTwoslashWorkspacePackages = (
+	docsRoot: string,
+): Record<string, TwoslashWorkspacePackage> => {
+	const repositoryRoot = getRepositoryRoot(docsRoot);
+	const packages: Record<string, TwoslashWorkspacePackage> = {};
+
+	for (const relativePackageJsonPath of getTrackedPackageJsonFiles(
+		repositoryRoot,
+	)) {
+		const packageJsonPath = join(repositoryRoot, relativePackageJsonPath);
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+			name?: string;
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+			optionalDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+		};
+		if (!packageJson.name) {
+			continue;
+		}
+
+		const packageDirectory = dirname(packageJsonPath);
+		const declarationFiles: string[] = [];
+		collectDeclarationFiles(join(packageDirectory, 'dist'), declarationFiles);
+		const hash = createHash('sha256');
+		hashFile(hash, repositoryRoot, packageJsonPath);
+		for (const declarationFile of declarationFiles.sort()) {
+			hashFile(hash, repositoryRoot, declarationFile);
+		}
+
+		packages[packageJson.name] = {
+			declarationHash: hash.digest('hex'),
+			dependencies: [
+				...Object.keys(packageJson.dependencies ?? {}),
+				...Object.keys(packageJson.devDependencies ?? {}),
+				...Object.keys(packageJson.optionalDependencies ?? {}),
+				...Object.keys(packageJson.peerDependencies ?? {}),
+			].sort(),
+		};
+	}
+
+	return packages;
 };
 
 export const createTwoslashCacheContext = ({
@@ -273,7 +302,61 @@ export const createTwoslashCacheContext = ({
 		sharedRoot: getSharedTwoslashCacheRoot(docsRoot),
 		environmentHash: getTwoslashEnvironmentHash(docsRoot),
 		versions,
+		workspacePackages: getTwoslashWorkspacePackages(docsRoot),
 	};
+};
+
+const getWorkspacePackageName = (specifier: string): string => {
+	const parts = specifier.split('/');
+	return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+};
+
+const getImportedWorkspacePackageHashes = (
+	code: string,
+	workspacePackages: Record<string, TwoslashWorkspacePackage>,
+): string[] => {
+	const importedPackages = new Set<string>();
+	const importRegex =
+		/(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s*)?['"]([^'"]+)['"]|(?:import|require)\(\s*['"]([^'"]+)['"]\s*\)|\/\/\/\s*<reference\s+types=['"]([^'"]+)['"]/g;
+	for (const match of code.matchAll(importRegex)) {
+		const specifier = match[1] ?? match[2] ?? match[3];
+		if (specifier.startsWith('.') || specifier.startsWith('/')) {
+			continue;
+		}
+
+		const packageName = getWorkspacePackageName(specifier);
+		if (workspacePackages[packageName]) {
+			importedPackages.add(packageName);
+		}
+	}
+
+	const packageClosure = new Set<string>();
+	const visitPackage = (packageName: string) => {
+		if (packageClosure.has(packageName)) {
+			return;
+		}
+
+		const workspacePackage = workspacePackages[packageName];
+		if (!workspacePackage) {
+			return;
+		}
+
+		packageClosure.add(packageName);
+		for (const dependency of workspacePackage.dependencies) {
+			visitPackage(dependency);
+		}
+	};
+
+	for (const packageName of importedPackages) {
+		visitPackage(packageName);
+	}
+
+	return [...packageClosure]
+		.sort()
+		.map(
+			(packageName) =>
+				`${packageName}:${workspacePackages[packageName].declarationHash}`,
+		);
 };
 
 export const getTwoslashCacheKey = ({
@@ -299,6 +382,10 @@ export const getTwoslashCacheKey = ({
 				},
 				versions: context.versions,
 				environmentHash: context.environmentHash,
+				workspacePackages: getImportedWorkspacePackageHashes(
+					code,
+					context.workspacePackages,
+				),
 			}),
 		)
 		.digest('hex');


### PR DESCRIPTION
## Summary

- fingerprint generated declarations per workspace package instead of as one repository-wide hash
- include only directly imported workspace packages and their transitive workspace dependency closure in each Twoslash cache key
- preserve global invalidation for external dependency resolution changes via `bun.lock`
- cover selective shared-cache reuse, direct and transitive invalidation, and supported import forms

This prevents an unrelated declaration change, such as a Browser Studio prop update, from forcing all documentation Twoslash blocks to be recomputed.

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/docusaurus-plugin/src/twoslash-cache.test.ts`
- `bunx oxfmt --check packages/docusaurus-plugin/src/twoslash-cache.ts packages/docusaurus-plugin/src/twoslash-cache.test.ts`
