### PR TITLE
`remotion`: Fix `useCurrentScale()` on initial load

### DIFF
--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -123,7 +123,7 @@ import {MaxMediaCacheSizeContext} from './max-video-cache-size.js';
 import type {NonceHistory} from './nonce.js';
 import {NonceContext} from './nonce.js';
 import {playbackLogging} from './playback-logging.js';
-import {portalNode} from './portal-node.js';
+import {portalNode, setPortalNodeCurrentScale} from './portal-node.js';
 import {PrefetchProvider} from './prefetch-state.js';
 import {usePreload} from './prefetch.js';
 import {PremountContext} from './PremountContext.js';
@@ -351,6 +351,7 @@ export const Internals = {
 	getPreviewDomElement,
 	compositionsRef,
 	portalNode,
+	setPortalNodeCurrentScale,
 	waitForRoot,
 	SetTimelineContext,
 	CanUseRemotionHooksProvider,

--- a/packages/core/src/portal-node.ts
+++ b/packages/core/src/portal-node.ts
@@ -1,4 +1,29 @@
 let _portalNode: null | HTMLElement = null;
+let portalNodeCurrentScale = 1;
+let portalNodeCurrentScaleListeners: (() => void)[] = [];
+
+export const getPortalNodeCurrentScale = () => portalNodeCurrentScale;
+
+export const subscribeToPortalNodeCurrentScale = (listener: () => void) => {
+	portalNodeCurrentScaleListeners.push(listener);
+
+	return () => {
+		portalNodeCurrentScaleListeners = portalNodeCurrentScaleListeners.filter(
+			(currentListener) => currentListener !== listener,
+		);
+	};
+};
+
+export const setPortalNodeCurrentScale = (scale: number) => {
+	if (portalNodeCurrentScale === scale) {
+		return;
+	}
+
+	portalNodeCurrentScale = scale;
+	for (const listener of portalNodeCurrentScaleListeners) {
+		listener();
+	}
+};
 
 export const portalNode = () => {
 	if (!_portalNode) {

--- a/packages/core/src/use-current-scale.ts
+++ b/packages/core/src/use-current-scale.ts
@@ -1,4 +1,8 @@
 import React, {createContext} from 'react';
+import {
+	getPortalNodeCurrentScale,
+	subscribeToPortalNodeCurrentScale,
+} from './portal-node';
 import {useRemotionEnvironment} from './use-remotion-environment';
 import {useUnsafeVideoConfig} from './use-unsafe-video-config';
 
@@ -94,6 +98,16 @@ export const useCurrentScale = (options?: Options) => {
 	const zoomContext = React.useContext(PreviewSizeContext);
 	const config = useUnsafeVideoConfig();
 	const env = useRemotionEnvironment();
+	const [portalScale, setPortalScale] = React.useState(
+		getPortalNodeCurrentScale,
+	);
+
+	React.useEffect(() => {
+		const update = () => setPortalScale(getPortalNodeCurrentScale());
+		update();
+
+		return subscribeToPortalNodeCurrentScale(update);
+	}, []);
 
 	if (hasContext === null || config === null || zoomContext === null) {
 		if (options?.dontThrowIfOutsideOfRemotion) {
@@ -118,10 +132,7 @@ export const useCurrentScale = (options?: Options) => {
 		return hasContext.scale;
 	}
 
-	return calculateScale({
-		canvasSize: hasContext.canvasSizeForAuto,
-		compositionHeight: config.height,
-		compositionWidth: config.width,
-		previewSize: zoomContext.size.size,
-	});
+	// Studio initially renders the composition into an unscaled offscreen portal.
+	// Return the scale that the preview has actually committed to that portal.
+	return portalScale;
 };

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -68,6 +68,15 @@ test.describe('visual mode', () => {
 		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
 	});
 
+	test('should compensate DOM measurements with useCurrentScale() on direct load', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/use-current-scale-on-load`);
+		await expect(
+			page.getByTestId('use-current-scale-corrected-width'),
+		).toHaveText('100', {timeout: 15_000});
+	});
+
 	test('should show the composition list', async ({page}) => {
 		await page.goto(STUDIO_URL);
 		await expect(page.getByRole('button', {name: 'Schema'})).toBeVisible({

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Composition, Folder} from 'remotion';
+import {AbsoluteFill, Composition, Folder, useCurrentScale} from 'remotion';
 import {BarChart} from './BarChart';
 import {EffectKeyframeE2e} from './EffectKeyframeE2e';
 import {
@@ -14,9 +14,44 @@ import {NewVideoComp} from './NewVideo';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
 import {VisualControls} from './VisualControls';
 
+const UseCurrentScaleOnLoad: React.FC = () => {
+	const scale = useCurrentScale();
+	const measuredElement = React.useRef<HTMLDivElement>(null);
+	const [correctedWidth, setCorrectedWidth] = React.useState<number | null>(
+		null,
+	);
+
+	React.useLayoutEffect(() => {
+		if (!measuredElement.current) {
+			return;
+		}
+
+		setCorrectedWidth(
+			Math.round(measuredElement.current.getBoundingClientRect().width / scale),
+		);
+	}, [scale]);
+
+	return (
+		<AbsoluteFill>
+			<div ref={measuredElement} style={{width: 100}} />
+			<div data-testid="use-current-scale-corrected-width">
+				{correctedWidth}
+			</div>
+		</AbsoluteFill>
+	);
+};
+
 export const E2eTestRoot: React.FC = () => {
 	return (
 		<>
+			<Composition
+				id="use-current-scale-on-load"
+				component={UseCurrentScaleOnLoad}
+				width={1920}
+				height={1080}
+				fps={30}
+				durationInFrames={30}
+			/>
 			<Folder name="Schema">
 				<Composition
 					id="schema-test"

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -4,6 +4,7 @@ import React, {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 } from 'react';
@@ -285,13 +286,19 @@ const PortalContainer: React.FC<{
 		yCorrection,
 	]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const {current} = portalContainer;
 		current?.appendChild(Internals.portalNode());
+		Internals.setPortalNodeCurrentScale(scale);
+
 		return () => {
-			current?.removeChild(Internals.portalNode());
+			const portalNode = Internals.portalNode();
+			if (current && portalNode.parentNode === current) {
+				current.removeChild(portalNode);
+				Internals.setPortalNodeCurrentScale(1);
+			}
 		};
-	}, []);
+	}, [scale]);
 
 	const onPointerDown = useCallback(
 		(event: PointerEvent) => {

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -289,7 +289,6 @@ const PortalContainer: React.FC<{
 	useLayoutEffect(() => {
 		const {current} = portalContainer;
 		current?.appendChild(Internals.portalNode());
-		Internals.setPortalNodeCurrentScale(scale);
 
 		return () => {
 			const portalNode = Internals.portalNode();
@@ -298,6 +297,10 @@ const PortalContainer: React.FC<{
 				Internals.setPortalNodeCurrentScale(1);
 			}
 		};
+	}, []);
+
+	useLayoutEffect(() => {
+		Internals.setPortalNodeCurrentScale(scale);
 	}, [scale]);
 
 	const onPointerDown = useCallback(


### PR DESCRIPTION
## Summary

- synchronize `useCurrentScale()` with the scale actually committed to the Studio portal
- attach the portal during the layout phase and safely reset its scale during cleanup
- add a direct-load E2E regression for corrected DOM measurements

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts -g "compensate DOM measurements"`
- core tests: 651 passed
- Studio tests: 562 passed
