### PR TITLE
`@remotion/studio`: Prevent stale node paths during Fast Refresh

### DIFF
--- a/packages/studio-server/src/preview-server/live-events.ts
+++ b/packages/studio-server/src/preview-server/live-events.ts
@@ -145,6 +145,13 @@ let liveEventsListener: LiveEventsServer | null = null;
 
 const waiters: Waiter[] = [];
 
+export const notifyClientsAboutHmrStart = () => {
+	liveEventsListener?.sendEventToClient({
+		type: 'hmr',
+		hmrEvent: {action: 'building'},
+	});
+};
+
 export const waitForLiveEventsListener = (): Promise<LiveEventsServer> => {
 	if (liveEventsListener) {
 		return Promise.resolve(liveEventsListener);

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -8,7 +8,10 @@ import {
 	writeFileAndNotifyFileWatchers,
 } from '../file-watcher';
 import {formatLogFileLocation} from './format-log-file-location';
-import {waitForLiveEventsListener} from './live-events';
+import {
+	notifyClientsAboutHmrStart,
+	waitForLiveEventsListener,
+} from './live-events';
 import {suppressBundlerUpdateForFile} from './watch-ignore-next-change';
 
 export interface UndoEntryDescription {
@@ -448,6 +451,10 @@ export function popUndo(): {success: true} | {success: false; reason: string} {
 		redoStack.shift();
 	}
 
+	if (!entry.suppressHmrOnFileRestore) {
+		notifyClientsAboutHmrStart();
+	}
+
 	for (const snapshot of entry.snapshots) {
 		suppressUndoStackInvalidation(snapshot.filePath);
 		if (entry.suppressHmrOnFileRestore) {
@@ -519,6 +526,10 @@ export function popRedo(): {success: true} | {success: false; reason: string} {
 	);
 	if (undoStack.length > MAX_ENTRIES) {
 		undoStack.shift();
+	}
+
+	if (!entry.suppressHmrOnFileRestore) {
+		notifyClientsAboutHmrStart();
 	}
 
 	for (const snapshot of snapshotsWithNewContents) {

--- a/packages/studio/src/FastRefreshProvider.tsx
+++ b/packages/studio/src/FastRefreshProvider.tsx
@@ -1,5 +1,10 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {flushSync} from 'react-dom';
 import {FastRefreshContext} from './fast-refresh-context';
+import {
+	FAST_REFRESH_COMPLETE_EVENT,
+	FAST_REFRESH_START_EVENT,
+} from './hot-middleware-client/fast-refresh-events';
 
 declare const __webpack_module__: {
 	hot: {
@@ -11,6 +16,8 @@ export const FastRefreshProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const [fastRefreshes, setFastRefreshes] = useState(0);
+	const [fastRefreshGeneration, setFastRefreshGeneration] = useState(0);
+	const [isFastRefreshing, setIsFastRefreshing] = useState(false);
 	const [manualRefreshes, setManualRefreshes] = useState(0);
 
 	const increaseManualRefreshes = useCallback(() => {
@@ -18,6 +25,20 @@ export const FastRefreshProvider: React.FC<{
 	}, []);
 
 	useEffect(() => {
+		const onFastRefreshStart = () => {
+			flushSync(() => {
+				setIsFastRefreshing(true);
+				setFastRefreshGeneration((generation) => generation + 1);
+			});
+		};
+
+		const onFastRefreshComplete = () => {
+			setIsFastRefreshing(false);
+		};
+
+		window.addEventListener(FAST_REFRESH_START_EVENT, onFastRefreshStart);
+		window.addEventListener(FAST_REFRESH_COMPLETE_EVENT, onFastRefreshComplete);
+
 		if (typeof __webpack_module__ !== 'undefined') {
 			if (__webpack_module__.hot) {
 				__webpack_module__.hot.addStatusHandler((status) => {
@@ -27,11 +48,31 @@ export const FastRefreshProvider: React.FC<{
 				});
 			}
 		}
+
+		return () => {
+			window.removeEventListener(FAST_REFRESH_START_EVENT, onFastRefreshStart);
+			window.removeEventListener(
+				FAST_REFRESH_COMPLETE_EVENT,
+				onFastRefreshComplete,
+			);
+		};
 	}, []);
 
 	const value = useMemo(
-		() => ({fastRefreshes, manualRefreshes, increaseManualRefreshes}),
-		[fastRefreshes, manualRefreshes, increaseManualRefreshes],
+		() => ({
+			fastRefreshes,
+			fastRefreshGeneration,
+			isFastRefreshing,
+			manualRefreshes,
+			increaseManualRefreshes,
+		}),
+		[
+			fastRefreshes,
+			fastRefreshGeneration,
+			isFastRefreshing,
+			manualRefreshes,
+			increaseManualRefreshes,
+		],
 	);
 
 	return (

--- a/packages/studio/src/components/SequencePropsSubscriptionProvider.tsx
+++ b/packages/studio/src/components/SequencePropsSubscriptionProvider.tsx
@@ -7,6 +7,15 @@ import type {
 	SequencePropsSubscriptionKey,
 	TSequence,
 } from 'remotion';
+import {FastRefreshContext} from '../fast-refresh-context';
+
+type OverrideToNodePathMapWithGeneration = Record<
+	string,
+	{
+		generation: number;
+		nodePath: SequencePropsSubscriptionKey;
+	}
+>;
 
 export const getReadOnlyOverrideIdToNodePathMappings = (
 	sequences: readonly TSequence[],
@@ -38,8 +47,10 @@ export const SequencePropsSubscriptionProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {sequences} = useContext(Internals.SequenceManager);
+	const {fastRefreshGeneration, isFastRefreshing} =
+		useContext(FastRefreshContext);
 	const [overrideToNodePathMap, setOverrideIdToNodePathMap] =
-		useState<OverrideIdToNodePaths>({});
+		useState<OverrideToNodePathMapWithGeneration>({});
 	const readOnlyOverrideToNodePathMap = useMemo(
 		() =>
 			window.remotion_isReadOnlyStudio
@@ -52,22 +63,42 @@ export const SequencePropsSubscriptionProvider: React.FC<{
 		(overrideId: string, state: SequencePropsSubscriptionKey) => {
 			setOverrideIdToNodePathMap((prev) => {
 				const existing = prev[overrideId];
-				if (existing && existing === state) {
+				if (
+					existing?.generation === fastRefreshGeneration &&
+					existing.nodePath === state
+				) {
 					return prev;
 				}
 
-				return {...prev, [overrideId]: state};
+				return {
+					...prev,
+					[overrideId]: {generation: fastRefreshGeneration, nodePath: state},
+				};
 			});
 		},
-		[],
+		[fastRefreshGeneration],
 	);
+
+	const activeOverrideToNodePathMap = useMemo((): OverrideIdToNodePaths => {
+		if (isFastRefreshing) {
+			return {};
+		}
+
+		return Object.fromEntries(
+			Object.entries(overrideToNodePathMap).flatMap(([overrideId, mapping]) =>
+				mapping.generation === fastRefreshGeneration
+					? [[overrideId, mapping.nodePath]]
+					: [],
+			),
+		);
+	}, [fastRefreshGeneration, isFastRefreshing, overrideToNodePathMap]);
 
 	const getters = useMemo((): OverrideToNodePathGetters => {
 		return {
 			overrideIdToNodePathMappings:
-				readOnlyOverrideToNodePathMap ?? overrideToNodePathMap,
+				readOnlyOverrideToNodePathMap ?? activeOverrideToNodePathMap,
 		};
-	}, [overrideToNodePathMap, readOnlyOverrideToNodePathMap]);
+	}, [activeOverrideToNodePathMap, readOnlyOverrideToNodePathMap]);
 
 	const setters = useMemo((): OverrideToNodeSetters => {
 		return {setOverrideIdToNodePath};

--- a/packages/studio/src/components/Timeline/sequence-props-subscription-store.ts
+++ b/packages/studio/src/components/Timeline/sequence-props-subscription-store.ts
@@ -22,6 +22,7 @@ const makeKey = ({
 	assetKeys,
 	effectKeys,
 	videoConfigValues,
+	generation,
 }: {
 	fileName: string;
 	line: number;
@@ -31,8 +32,9 @@ const makeKey = ({
 	assetKeys: string[];
 	effectKeys: string[][];
 	videoConfigValues: VideoConfigValues;
+	generation: number;
 }): Key =>
-	`${fileName}\0${line}\0${column}\0${componentIdentity ?? ''}\0${sequenceKeys.join('\0')}\0${assetKeys.join('\0')}\0${effectKeys.map((keys) => keys.join('\0')).join('\0\0')}\0${JSON.stringify(videoConfigValues)}`;
+	`${fileName}\0${line}\0${column}\0${componentIdentity ?? ''}\0${sequenceKeys.join('\0')}\0${assetKeys.join('\0')}\0${effectKeys.map((keys) => keys.join('\0')).join('\0\0')}\0${JSON.stringify(videoConfigValues)}\0${generation}`;
 
 type SubscribeResult = Awaited<ReturnType<typeof subscribeToSequenceProps>>;
 
@@ -60,6 +62,7 @@ export const acquireSequencePropsSubscription = ({
 	applyOnce,
 	applyEach,
 	videoConfigValues,
+	generation,
 }: {
 	fileName: string;
 	line: number;
@@ -72,6 +75,7 @@ export const acquireSequencePropsSubscription = ({
 	applyOnce: ApplyResult;
 	applyEach: ApplyResult;
 	videoConfigValues: VideoConfigValues;
+	generation: number;
 }): {release: () => void} => {
 	const sequenceKeys = getAllSchemaKeys(schema);
 	const assetKeys = getAssetSchemaKeys(schema);
@@ -85,6 +89,7 @@ export const acquireSequencePropsSubscription = ({
 		assetKeys,
 		effectKeys,
 		videoConfigValues,
+		generation,
 	});
 	let entry = entries.get(key);
 

--- a/packages/studio/src/components/Timeline/use-resolved-stack-react-to-change.ts
+++ b/packages/studio/src/components/Timeline/use-resolved-stack-react-to-change.ts
@@ -1,6 +1,7 @@
 import type {EventSourceEvent} from '@remotion/studio-shared';
 import {useContext, useEffect, useRef, useState} from 'react';
 import type {ResolvedStackLocation} from 'remotion';
+import {FastRefreshContext} from '../../fast-refresh-context';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useResolvedStack} from './use-resolved-stack';
 
@@ -27,10 +28,37 @@ export const useResolveStackAndReactToChange = (
 	getStack: () => string | null,
 ) => {
 	const {subscribeToEvent} = useContext(StudioServerConnectionCtx);
-	const [stack, setStack] = useState<string | null>(() => getStack());
+	const {fastRefreshGeneration, isFastRefreshing} =
+		useContext(FastRefreshContext);
+	const [stackState, setStackState] = useState<{
+		generation: number;
+		stack: string | null;
+	}>(() => ({generation: fastRefreshGeneration, stack: getStack()}));
+	const stack =
+		stackState.generation === fastRefreshGeneration && !isFastRefreshing
+			? stackState.stack
+			: null;
 	const resolvedLocation = useResolvedStack(stack);
 	const resolvedLocationRef = useRef(resolvedLocation);
 	resolvedLocationRef.current = resolvedLocation;
+
+	useEffect(() => {
+		if (isFastRefreshing) {
+			return;
+		}
+
+		const currentStack = getStack();
+		setStackState((previous) => {
+			if (
+				previous.generation === fastRefreshGeneration &&
+				previous.stack === currentStack
+			) {
+				return previous;
+			}
+
+			return {generation: fastRefreshGeneration, stack: currentStack};
+		});
+	}, [fastRefreshGeneration, getStack, isFastRefreshing]);
 
 	useEffect(() => {
 		let interval: Timer | null = null;
@@ -58,7 +86,10 @@ export const useResolveStackAndReactToChange = (
 						interval = null;
 					}
 
-					setStack(newStack);
+					setStackState({
+						generation: fastRefreshGeneration,
+						stack: newStack,
+					});
 				}
 			}, 10);
 		};
@@ -71,7 +102,7 @@ export const useResolveStackAndReactToChange = (
 				clearInterval(interval);
 			}
 		};
-	}, [subscribeToEvent, getStack]);
+	}, [fastRefreshGeneration, subscribeToEvent, getStack]);
 
 	return resolvedLocation;
 };

--- a/packages/studio/src/components/Timeline/use-resolved-stack.ts
+++ b/packages/studio/src/components/Timeline/use-resolved-stack.ts
@@ -26,13 +26,13 @@ export const useResolvedStack = (
 		Internals.SequenceStackTracesUpdateContext,
 	);
 
-	const [value, setValue] = useState<ResolvedStackLocation | null>(() => {
-		if (!stack) {
-			return null;
-		}
-
-		return resolvedCache.get(stack) ?? null;
-	});
+	const [resolved, setResolved] = useState<{
+		stack: string | null;
+		value: ResolvedStackLocation | null;
+	}>(() => ({
+		stack,
+		value: stack ? (resolvedCache.get(stack) ?? null) : null,
+	}));
 
 	useEffect(() => {
 		if (!stack) {
@@ -40,7 +40,7 @@ export const useResolvedStack = (
 		}
 
 		if (resolvedCache.has(stack)) {
-			setValue(resolvedCache.get(stack)!);
+			setResolved({stack, value: resolvedCache.get(stack)!});
 			return;
 		}
 
@@ -49,6 +49,10 @@ export const useResolvedStack = (
 		}
 
 		const subs = subscribers.get(stack)!;
+		const setValue = (value: ResolvedStackLocation | null) => {
+			setResolved({stack, value});
+		};
+
 		subs.add(setValue);
 
 		if (!inFlight.has(stack)) {
@@ -76,5 +80,5 @@ export const useResolvedStack = (
 		};
 	}, [stack, updateResolvedStackTrace]);
 
-	return value;
+	return resolved.stack === stack ? resolved.value : null;
 };

--- a/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
@@ -10,6 +10,7 @@ import type {
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {FastRefreshContext} from '../../fast-refresh-context';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {ExpandedTracksSetterContext} from '../ExpandedTracksProvider';
 import {acquireSequencePropsSubscription} from './sequence-props-subscription-store';
@@ -40,6 +41,13 @@ export const useSequencePropsSubscription = ({
 	);
 
 	const {previewServerState: state} = useContext(StudioServerConnectionCtx);
+	const {fastRefreshGeneration, isFastRefreshing} =
+		useContext(FastRefreshContext);
+	const fastRefreshStateRef = useRef({
+		fastRefreshGeneration,
+		isFastRefreshing,
+	});
+	fastRefreshStateRef.current = {fastRefreshGeneration, isFastRefreshing};
 	const previousNodePathRef = useRef<SequencePropsSubscriptionKey | null>(null);
 	const overrideIdToNodePathMappingsRef = useRef(overrideIdToNodePathMappings);
 	overrideIdToNodePathMappingsRef.current = overrideIdToNodePathMappings;
@@ -74,6 +82,7 @@ export const useSequencePropsSubscription = ({
 
 	useEffect(() => {
 		if (
+			isFastRefreshing ||
 			!clientId ||
 			!locationSource ||
 			!shouldSubscribeToSourceFile(locationSource) ||
@@ -87,6 +96,7 @@ export const useSequencePropsSubscription = ({
 
 		const nodePathAtResubscribe =
 			overrideIdToNodePathMappingsRef.current[overrideId] ?? null;
+		const subscriptionGeneration = fastRefreshGeneration;
 
 		const {release} = acquireSequencePropsSubscription({
 			fileName: locationSource,
@@ -103,15 +113,26 @@ export const useSequencePropsSubscription = ({
 				height: videoConfig.height,
 				width: videoConfig.width,
 			},
+			generation: subscriptionGeneration,
 			applyOnce: (result) => {
-				if (!result.success) {
+				if (
+					!result.success ||
+					fastRefreshStateRef.current.isFastRefreshing ||
+					fastRefreshStateRef.current.fastRefreshGeneration !==
+						subscriptionGeneration
+				) {
 					return;
 				}
 
 				setPropStatuses(result.nodePath, () => result.status);
 			},
 			applyEach: (result) => {
-				if (!result.success) {
+				if (
+					!result.success ||
+					fastRefreshStateRef.current.isFastRefreshing ||
+					fastRefreshStateRef.current.fastRefreshGeneration !==
+						subscriptionGeneration
+				) {
 					return;
 				}
 
@@ -123,11 +144,7 @@ export const useSequencePropsSubscription = ({
 					? stringifySequenceSubscriptionKey(previousNodePath)
 					: null;
 
-				if (previousNodePathKey === newNodePathKey) {
-					return;
-				}
-
-				if (previousNodePath) {
+				if (previousNodePath && previousNodePathKey !== newNodePathKey) {
 					migrateExpandedTracksForSubscriptionKey(
 						previousNodePath,
 						newNodePath,
@@ -147,6 +164,8 @@ export const useSequencePropsSubscription = ({
 		componentIdentity,
 		effects,
 		effectsSignature,
+		fastRefreshGeneration,
+		isFastRefreshing,
 		locationColumn,
 		locationLine,
 		locationSource,

--- a/packages/studio/src/fast-refresh-context.ts
+++ b/packages/studio/src/fast-refresh-context.ts
@@ -2,12 +2,16 @@ import {createContext} from 'react';
 
 export type FastRefreshContextType = {
 	fastRefreshes: number;
+	fastRefreshGeneration: number;
+	isFastRefreshing: boolean;
 	manualRefreshes: number;
 	increaseManualRefreshes: () => void;
 };
 
 export const FastRefreshContext = createContext<FastRefreshContextType>({
 	fastRefreshes: 0,
+	fastRefreshGeneration: 0,
+	isFastRefreshing: false,
 	manualRefreshes: 0,
 	increaseManualRefreshes: () => {},
 });

--- a/packages/studio/src/hot-middleware-client/client.ts
+++ b/packages/studio/src/hot-middleware-client/client.ts
@@ -15,6 +15,7 @@ import {
 	HOT_MIDDLEWARE_WARNING_STYLE,
 } from '../helpers/colors';
 import {subscribeToPreviewServerEvents} from '../helpers/preview-server-events';
+import {notifyFastRefreshStart} from './fast-refresh-events';
 import {processUpdate} from './process-update';
 
 declare global {
@@ -87,6 +88,7 @@ function createReporter() {
 function processMessage(obj: HotMiddlewareMessage) {
 	switch (obj.action) {
 		case 'building':
+			notifyFastRefreshStart();
 			window.remotion_isBuilding?.();
 
 			break;

--- a/packages/studio/src/hot-middleware-client/fast-refresh-events.ts
+++ b/packages/studio/src/hot-middleware-client/fast-refresh-events.ts
@@ -1,0 +1,10 @@
+export const FAST_REFRESH_START_EVENT = 'remotion-fast-refresh-start';
+export const FAST_REFRESH_COMPLETE_EVENT = 'remotion-fast-refresh-complete';
+
+export const notifyFastRefreshStart = () => {
+	window.dispatchEvent(new Event(FAST_REFRESH_START_EVENT));
+};
+
+export const notifyFastRefreshComplete = () => {
+	window.dispatchEvent(new Event(FAST_REFRESH_COMPLETE_EVENT));
+};

--- a/packages/studio/src/hot-middleware-client/process-update.ts
+++ b/packages/studio/src/hot-middleware-client/process-update.ts
@@ -13,6 +13,7 @@
 
 import type {HotMiddlewareOptions, ModuleMap} from '@remotion/studio-shared';
 import {reloadUrl} from '../helpers/url-state';
+import {notifyFastRefreshComplete} from './fast-refresh-events';
 
 if (!__webpack_module__.hot) {
 	throw new Error('[Fast refresh] Hot Module Replacement is disabled.');
@@ -90,11 +91,15 @@ export const processUpdate = function (
 			) {
 				if (applyErr) return handleError(applyErr);
 
-				if (!upToDate()) {
+				const isUpToDate = upToDate();
+				if (!isUpToDate) {
 					check();
 				}
 
 				logUpdates(updatedModules, renewedModules);
+				if (isUpToDate) {
+					notifyFastRefreshComplete();
+				}
 			};
 
 			const applyResult = __webpack_module__.hot?.apply(applyOptions);
@@ -105,6 +110,8 @@ export const processUpdate = function (
 						applyCallback(null, outdatedModules);
 					})
 					.catch((_err: Error) => applyCallback(_err, []));
+			} else {
+				notifyFastRefreshComplete();
 			}
 		};
 
@@ -189,5 +196,7 @@ export const processUpdate = function (
 	const {reload} = options;
 	if (!upToDate(hash) && __webpack_module__.hot?.status() === 'idle') {
 		check();
+	} else {
+		notifyFastRefreshComplete();
 	}
 };


### PR DESCRIPTION
## Summary

- invalidate Visual Mode node-path mappings as soon as Fast Refresh compilation starts
- keep stack resolution and sequence subscriptions isolated to the current refresh generation
- announce HMR before undo and redo restore files so stale subscriptions cannot resubscribe

## Testing

- `bun run build`
- `bun run stylecheck`
- manually verified the `Eyebrow` deletion scenario in Studio

Closes https://github.com/remotion-dev/remotion/issues/10115
