### PR TITLE
`@remotion/studio`: Avoid timeline sequence rerenders on hover

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -95,7 +95,7 @@ const TimelineSequenceFn: React.FC<{
 	);
 };
 
-const TimelineSequenceCurrentFrame: React.FC<{
+const TimelineSequenceCurrentFrameFn: React.FC<{
 	readonly s: TSequence;
 	readonly displayDurationInFrames: number;
 	readonly premountWidth: number | null;
@@ -250,6 +250,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		</div>
 	);
 };
+
+const TimelineSequenceCurrentFrame = React.memo(TimelineSequenceCurrentFrameFn);
 
 const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -95,7 +95,7 @@ const TimelineSequenceFn: React.FC<{
 	);
 };
 
-const TimelineSequenceCurrentFrameFn: React.FC<{
+const TimelineSequenceCurrentFrame: React.FC<{
 	readonly s: TSequence;
 	readonly displayDurationInFrames: number;
 	readonly premountWidth: number | null;
@@ -250,8 +250,6 @@ const TimelineSequenceCurrentFrameFn: React.FC<{
 		</div>
 	);
 };
-
-const TimelineSequenceCurrentFrame = React.memo(TimelineSequenceCurrentFrameFn);
 
 const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -15,6 +15,8 @@ import {
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
+const emptyConnectedCompositions = [] as const;
+
 const TimelineTrackUnmemoized: React.FC<{
 	readonly track: TimelineTrackData;
 }> = ({track}) => {
@@ -57,7 +59,9 @@ const TimelineTrackUnmemoized: React.FC<{
 				) : null}
 				<TimelineSequence
 					s={track.sequence}
-					connectedCompositions={track.connectedCompositions ?? []}
+					connectedCompositions={
+						track.connectedCompositions ?? emptyConnectedCompositions
+					}
 					nodePathInfo={track.nodePathInfo}
 					sequenceFrameOffset={track.sequenceFrameOffset}
 				/>


### PR DESCRIPTION
## Summary

- memoize `TimelineSequenceCurrentFrame`
- keep the empty connected-compositions fallback referentially stable
- prevent timeline hover state changes from rerendering the sequence frame subtree

## Testing

- `bun run build`
- `bun run stylecheck`
