### PR TITLE
`@remotion/studio`: Make timeline hover subscriptions selective

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -27,7 +27,10 @@ import {useRuntimeValueSnapshots} from '../helpers/use-runtime-values';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
-import {TimelineSequenceHoverContext} from '../state/timeline-sequence-hover';
+import {
+	useSetTimelineSequenceHover,
+	useTimelineSequenceHoverState,
+} from '../state/timeline-sequence-hover';
 import {showNotification} from './Notifications/NotificationCenter';
 import {
 	clearSelectedOutlineDragOverrides,
@@ -668,9 +671,8 @@ export const SelectedOutlineOverlay: React.FC<{
 	);
 	const {getScaleLockState} = useContext(ScaleLockContext);
 	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
-	const {hoveredSequence, setHoveredSequence} = useContext(
-		TimelineSequenceHoverContext,
-	);
+	const hoveredSequence = useTimelineSequenceHoverState();
+	const setHoveredSequence = useSetTimelineSequenceHover();
 	const {editorShowGuides, guidesList} = useContext(EditorShowGuidesContext);
 	const isFullscreen = useIsFullscreen();
 	const {frameBack, frameForward, getCurrentFrame, seek} =

--- a/packages/studio/src/components/ShowOutlinesProvider.tsx
+++ b/packages/studio/src/components/ShowOutlinesProvider.tsx
@@ -5,8 +5,8 @@ import {
 	persistEditorShowOutlinesOption,
 } from '../state/editor-outlines';
 import {
+	createTimelineSequenceHoverStore,
 	TimelineSequenceHoverContext,
-	type TimelineSequenceHover,
 } from '../state/timeline-sequence-hover';
 
 export const ShowOutlinesProvider: React.FC<{
@@ -15,8 +15,10 @@ export const ShowOutlinesProvider: React.FC<{
 	const [editorShowOutlines, setEditorShowOutlinesState] = useState(() =>
 		loadEditorShowOutlinesOption(),
 	);
-	const [hoveredSequence, setHoveredSequence] =
-		useState<TimelineSequenceHover | null>(null);
+	const timelineSequenceHoverStore = useMemo(
+		() => createTimelineSequenceHoverStore(),
+		[],
+	);
 
 	const setEditorShowOutlines = useCallback(
 		(newValue: (prevState: boolean) => boolean) => {
@@ -35,14 +37,9 @@ export const ShowOutlinesProvider: React.FC<{
 			setEditorShowOutlines,
 		};
 	}, [editorShowOutlines, setEditorShowOutlines]);
-	const timelineSequenceHoverCtx = useMemo(
-		() => ({hoveredSequence, setHoveredSequence}),
-		[hoveredSequence],
-	);
-
 	return (
 		<EditorShowOutlinesContext.Provider value={editorShowOutlinesCtx}>
-			<TimelineSequenceHoverContext.Provider value={timelineSequenceHoverCtx}>
+			<TimelineSequenceHoverContext.Provider value={timelineSequenceHoverStore}>
 				{children}
 			</TimelineSequenceHoverContext.Provider>
 		</EditorShowOutlinesContext.Provider>

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -95,7 +95,7 @@ const TimelineSequenceFn: React.FC<{
 	);
 };
 
-const TimelineSequenceCurrentFrame: React.FC<{
+const TimelineSequenceCurrentFrameFn: React.FC<{
 	readonly s: TSequence;
 	readonly displayDurationInFrames: number;
 	readonly premountWidth: number | null;
@@ -250,6 +250,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		</div>
 	);
 };
+
+const TimelineSequenceCurrentFrame = React.memo(TimelineSequenceCurrentFrameFn);
 
 const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -95,7 +95,7 @@ const TimelineSequenceFn: React.FC<{
 	);
 };
 
-const TimelineSequenceCurrentFrameFn: React.FC<{
+const TimelineSequenceCurrentFrame: React.FC<{
 	readonly s: TSequence;
 	readonly displayDurationInFrames: number;
 	readonly premountWidth: number | null;
@@ -250,8 +250,6 @@ const TimelineSequenceCurrentFrameFn: React.FC<{
 		</div>
 	);
 };
-
-const TimelineSequenceCurrentFrame = React.memo(TimelineSequenceCurrentFrameFn);
 
 const TimelineSequenceInner: React.FC<{
 	readonly s: TSequence;

--- a/packages/studio/src/components/Timeline/TimelineTrack.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTrack.tsx
@@ -15,6 +15,8 @@ import {
 import {TimelineSequence} from './TimelineSequence';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
+const emptyConnectedCompositions = [] as const;
+
 const TimelineTrackUnmemoized: React.FC<{
 	readonly track: TimelineTrackData;
 }> = ({track}) => {
@@ -57,7 +59,9 @@ const TimelineTrackUnmemoized: React.FC<{
 				) : null}
 				<TimelineSequence
 					s={track.sequence}
-					connectedCompositions={track.connectedCompositions ?? []}
+					connectedCompositions={
+						track.connectedCompositions ?? emptyConnectedCompositions
+					}
 					nodePathInfo={track.nodePathInfo}
 					sequenceFrameOffset={track.sequenceFrameOffset}
 				/>

--- a/packages/studio/src/state/timeline-sequence-hover.ts
+++ b/packages/studio/src/state/timeline-sequence-hover.ts
@@ -1,5 +1,11 @@
 import type {Dispatch, SetStateAction} from 'react';
-import {createContext, useCallback, useContext, useMemo} from 'react';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useSyncExternalStore,
+} from 'react';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {
 	timelineNodePathInfoToKey,
@@ -12,25 +18,60 @@ export type TimelineSequenceHover = {
 	readonly source: 'canvas' | 'timeline';
 };
 
-type TimelineSequenceHoverState = {
-	readonly hoveredSequence: TimelineSequenceHover | null;
+type TimelineSequenceHoverStore = {
+	readonly getSnapshot: () => TimelineSequenceHover | null;
+	readonly subscribe: (listener: () => void) => () => void;
 	readonly setHoveredSequence: Dispatch<
 		SetStateAction<TimelineSequenceHover | null>
 	>;
 };
 
+export const createTimelineSequenceHoverStore =
+	(): TimelineSequenceHoverStore => {
+		let hoveredSequence: TimelineSequenceHover | null = null;
+		const listeners = new Set<() => void>();
+
+		return {
+			getSnapshot: () => hoveredSequence,
+			subscribe: (listener) => {
+				listeners.add(listener);
+				return () => listeners.delete(listener);
+			},
+			setHoveredSequence: (action) => {
+				const nextHoveredSequence =
+					typeof action === 'function' ? action(hoveredSequence) : action;
+				if (nextHoveredSequence === hoveredSequence) {
+					return;
+				}
+
+				hoveredSequence = nextHoveredSequence;
+				for (const listener of listeners) {
+					listener();
+				}
+			},
+		};
+	};
+
 export const TimelineSequenceHoverContext =
-	createContext<TimelineSequenceHoverState>({
-		hoveredSequence: null,
-		setHoveredSequence: () => undefined,
-	});
+	createContext<TimelineSequenceHoverStore>(createTimelineSequenceHoverStore());
+
+export const useTimelineSequenceHoverState = () => {
+	const store = useContext(TimelineSequenceHoverContext);
+	return useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getSnapshot,
+	);
+};
+
+export const useSetTimelineSequenceHover = () => {
+	return useContext(TimelineSequenceHoverContext).setHoveredSequence;
+};
 
 export const useTimelineSequenceHover = (
 	nodePathInfo: SequenceNodePathInfo | null,
 ) => {
-	const {hoveredSequence, setHoveredSequence} = useContext(
-		TimelineSequenceHoverContext,
-	);
+	const store = useContext(TimelineSequenceHoverContext);
 	const sequenceKey = useMemo(
 		() =>
 			nodePathInfo === null
@@ -45,21 +86,41 @@ export const useTimelineSequenceHover = (
 				: timelineSequenceNodePathToKey(nodePathInfo.sequenceSubscriptionKey),
 		[nodePathInfo],
 	);
+	const getSnapshot = useCallback(
+		() =>
+			nodePathKey !== null && store.getSnapshot()?.nodePathKey === nodePathKey,
+		[nodePathKey, store],
+	);
+	const hovered = useSyncExternalStore(
+		store.subscribe,
+		getSnapshot,
+		getSnapshot,
+	);
 
 	const onPointerEnter = useCallback(() => {
 		if (sequenceKey === null || nodePathKey === null) {
 			return;
 		}
 
-		setHoveredSequence({
-			key: sequenceKey,
-			nodePathKey,
-			source: 'timeline',
+		store.setHoveredSequence((currentHover) => {
+			if (
+				currentHover?.key === sequenceKey &&
+				currentHover.nodePathKey === nodePathKey &&
+				currentHover.source === 'timeline'
+			) {
+				return currentHover;
+			}
+
+			return {
+				key: sequenceKey,
+				nodePathKey,
+				source: 'timeline',
+			};
 		});
-	}, [nodePathKey, sequenceKey, setHoveredSequence]);
+	}, [nodePathKey, sequenceKey, store]);
 
 	const onPointerLeave = useCallback(() => {
-		setHoveredSequence((currentHover) => {
+		store.setHoveredSequence((currentHover) => {
 			if (
 				currentHover?.source !== 'timeline' ||
 				currentHover.key !== sequenceKey
@@ -69,10 +130,7 @@ export const useTimelineSequenceHover = (
 
 			return null;
 		});
-	}, [sequenceKey, setHoveredSequence]);
-
-	const hovered =
-		nodePathKey !== null && hoveredSequence?.nodePathKey === nodePathKey;
+	}, [sequenceKey, store]);
 
 	return useMemo(
 		() => ({hovered, onPointerEnter, onPointerLeave}),


### PR DESCRIPTION
## Summary

- move timeline sequence hover state into a stable external store
- select each timeline item's derived hover boolean with `useSyncExternalStore`
- keep the canvas overlay subscribed to the complete hover state
- avoid notifying React when pointer entry produces the existing hover value

Stacked on #10179.

## Testing

- `bun run build`
- `bun run stylecheck`
