### PR TITLE
`@remotion/renderer`: Prioritize Zed, VS Code, Cursor in default editor list

### DIFF
--- a/packages/renderer/src/options/default-editor.tsx
+++ b/packages/renderer/src/options/default-editor.tsx
@@ -1,10 +1,10 @@
 import type {AnyRemotionOption} from './option';
 
 export const defaultEditorIds = [
+	'zed',
 	'vscode',
 	'cursor',
 	'windsurf',
-	'zed',
 	'vscodium',
 	'webstorm',
 	'sublime-text',

--- a/packages/studio-server/src/test/editor-registry.test.ts
+++ b/packages/studio-server/src/test/editor-registry.test.ts
@@ -75,8 +75,8 @@ test('discovers installed Linux editors from known locations and PATH', async ()
 	);
 
 	expect(editors.map(({id, process}) => ({id, process}))).toEqual([
-		{id: 'vscode', process: '/custom/bin/code'},
 		{id: 'zed', process: '/home/test/.local/bin/zed'},
+		{id: 'vscode', process: '/custom/bin/code'},
 	]);
 });
 


### PR DESCRIPTION
Fixes #10076

Authored by @santhiprakash in `santhiprakash/remotion:fix/default-editor-priority-10076`; opened by @garudaccs because the `santhiprakash` account is currently blocked by the `remotion-dev` org.