### PR TITLE
@remotion/cli: Add shell option to npx spawn in skills command

### DIFF
--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -69,6 +69,7 @@ export const skillsCommand = (
 		cwd,
 		env: environment,
 		stdio: 'inherit',
+		shell: process.platform === 'win32',
 	});
 
 	return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Problem

`npx remotion skills add` / `update` spawn `npx` (or `npx.cmd` on Windows) without `shell: true`. On Windows with Node 20+, spawning a `.cmd` shim without a shell raises `EINVAL` (CVE-2024-27980 behavior change), so the command fails.

## Fix

Add `shell: process.platform === 'win32'` to the `spawn` options in `packages/cli/src/skills.ts`, matching the existing `getPackageManagerSpawnOptions()` helper in `packages/studio-server/src/helpers/package-manager-spawn-options.ts`.

## Verification

- `bun run formatting` in `packages/cli` passes.
- `bun run lint` in `packages/cli` passes (no new errors).
- Preflight against `remotion-dev/remotion` main is clear; the bug marker is still present and `shell:` is absent from upstream.

Fixes #9758