### PR TITLE
`@remotion/studio`: Avoid expanded track rerenders on every frame

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -1,5 +1,5 @@
-import {stringifySequenceSubscriptionKey} from '@remotion/studio-shared';
 import React, {useContext} from 'react';
+import {areSequenceNodePathInfosEqual} from '../../helpers/are-sequence-node-path-infos-equal';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	TIMELINE_ITEM_BORDER_BOTTOM,
@@ -96,46 +96,16 @@ const areTimelineExpandedKeyframeRowPropsEqual = (
 		prevProps.canEditEasing !== nextProps.canEditEasing ||
 		prevProps.showSeparator !== nextProps.showSeparator ||
 		prevProps.keyframes.length !== nextProps.keyframes.length ||
-		prevProps.nodePathInfo.index !== nextProps.nodePathInfo.index ||
-		prevProps.nodePathInfo.numberOfSequencesWithThisNodePath !==
-			nextProps.nodePathInfo.numberOfSequencesWithThisNodePath ||
-		prevProps.nodePathInfo.supportsEffects !==
-			nextProps.nodePathInfo.supportsEffects ||
-		stringifySequenceSubscriptionKey(
-			prevProps.nodePathInfo.sequenceSubscriptionKey,
-		) !==
-			stringifySequenceSubscriptionKey(
-				nextProps.nodePathInfo.sequenceSubscriptionKey,
-			) ||
-		prevProps.nodePathInfo.auxiliaryKeys.length !==
-			nextProps.nodePathInfo.auxiliaryKeys.length
-	) {
-		return false;
-	}
-
-	const prevVideoConfig =
-		prevProps.nodePathInfo.sequenceSubscriptionKey.videoConfigValues;
-	const nextVideoConfig =
-		nextProps.nodePathInfo.sequenceSubscriptionKey.videoConfigValues;
-	if (
-		prevVideoConfig !== nextVideoConfig &&
-		(prevVideoConfig === null ||
-			nextVideoConfig === null ||
-			prevVideoConfig.durationInFrames !== nextVideoConfig.durationInFrames ||
-			prevVideoConfig.fps !== nextVideoConfig.fps ||
-			prevVideoConfig.height !== nextVideoConfig.height ||
-			prevVideoConfig.width !== nextVideoConfig.width)
-	) {
-		return false;
-	}
-
-	return (
-		prevProps.keyframes.every(
-			(keyframe, index) => keyframe.frame === nextProps.keyframes[index].frame,
-		) &&
-		prevProps.nodePathInfo.auxiliaryKeys.every(
-			(key, index) => key === nextProps.nodePathInfo.auxiliaryKeys[index],
+		!areSequenceNodePathInfosEqual(
+			prevProps.nodePathInfo,
+			nextProps.nodePathInfo,
 		)
+	) {
+		return false;
+	}
+
+	return prevProps.keyframes.every(
+		(keyframe, index) => keyframe.frame === nextProps.keyframes[index].frame,
 	);
 };
 

--- a/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedTrackKeyframes.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import type {TSequence} from 'remotion';
+import {areSequenceNodePathInfosEqual} from '../../helpers/are-sequence-node-path-infos-equal';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TimelineExpandedKeyframeRow} from './TimelineExpandedKeyframeRow';
 import {useExpandedTrackKeyframeRows} from './use-expanded-track-keyframe-rows';
 
-const TimelineExpandedTrackKeyframesInner: React.FC<{
+type TimelineExpandedTrackKeyframesProps = {
 	readonly sequence: TSequence;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly keyframeDisplayOffset: number;
-}> = ({nodePathInfo, sequence, keyframeDisplayOffset}) => {
+};
+
+const TimelineExpandedTrackKeyframesInner: React.FC<
+	TimelineExpandedTrackKeyframesProps
+> = ({nodePathInfo, sequence, keyframeDisplayOffset}) => {
 	const {rows, expandedHeight} = useExpandedTrackKeyframeRows({
 		sequence,
 		nodePathInfo,
@@ -31,6 +36,21 @@ const TimelineExpandedTrackKeyframesInner: React.FC<{
 	);
 };
 
+const areTimelineExpandedTrackKeyframesPropsEqual = (
+	first: TimelineExpandedTrackKeyframesProps,
+	second: TimelineExpandedTrackKeyframesProps,
+) => {
+	return (
+		first.keyframeDisplayOffset === second.keyframeDisplayOffset &&
+		first.sequence.controls?.schema === second.sequence.controls?.schema &&
+		first.sequence.controls?.runtimeValues ===
+			second.sequence.controls?.runtimeValues &&
+		first.sequence.effects === second.sequence.effects &&
+		areSequenceNodePathInfosEqual(first.nodePathInfo, second.nodePathInfo)
+	);
+};
+
 export const TimelineExpandedTrackKeyframes = React.memo(
 	TimelineExpandedTrackKeyframesInner,
+	areTimelineExpandedTrackKeyframesPropsEqual,
 );

--- a/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
+++ b/packages/studio/src/components/Timeline/use-expanded-track-keyframe-rows.ts
@@ -1,14 +1,15 @@
 import {canEditEasingForInterpolationFunction} from '@remotion/studio-shared';
-import {useContext, useMemo} from 'react';
+import {useCallback, useContext, useMemo} from 'react';
 import {Internals, type TSequence} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
 	getTreeRowHeight,
+	type TimelineTreeNode,
 } from '../../helpers/timeline-layout';
 import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
-import {useRuntimeValues} from '../../helpers/use-runtime-values';
+import {useRuntimeValueSelector} from '../../helpers/use-runtime-values';
 import {ExpandedTracksGetterContext} from '../ExpandedTracksProvider';
 import {getNodeHasKeyframes, getNodeKeyframes} from './get-node-keyframes';
 import type {getTimelineKeyframes} from './get-timeline-keyframes';
@@ -26,6 +27,51 @@ export type ExpandedTrackKeyframeRow = {
 	readonly canEditEasing: boolean;
 	readonly nodePathInfo: SequenceNodePathInfo;
 	readonly rowKey: string;
+};
+
+const areTimelineTreeLayoutsEqual = (
+	first: TimelineTreeNode[],
+	second: TimelineTreeNode[],
+): boolean => {
+	if (first.length !== second.length) {
+		return false;
+	}
+
+	return first.every((firstNode, index) => {
+		const secondNode = second[index];
+		if (
+			firstNode.kind !== secondNode.kind ||
+			timelineNodePathInfoToKey(firstNode.nodePathInfo) !==
+				timelineNodePathInfoToKey(secondNode.nodePathInfo)
+		) {
+			return false;
+		}
+
+		if (firstNode.kind === 'group' && secondNode.kind === 'group') {
+			return areTimelineTreeLayoutsEqual(
+				firstNode.children,
+				secondNode.children,
+			);
+		}
+
+		if (firstNode.kind !== 'field' || secondNode.kind !== 'field') {
+			return false;
+		}
+
+		if (firstNode.field === null || secondNode.field === null) {
+			return firstNode.field === secondNode.field;
+		}
+
+		return (
+			firstNode.field.kind === secondNode.field.kind &&
+			firstNode.field.key === secondNode.field.key &&
+			firstNode.field.typeName === secondNode.field.typeName &&
+			firstNode.field.rowHeight === secondNode.field.rowHeight &&
+			(firstNode.field.kind !== 'effect-field' ||
+				(secondNode.field.kind === 'effect-field' &&
+					firstNode.field.effectIndex === secondNode.field.effectIndex))
+		);
+	});
 };
 
 const getNodeCanEditEasing = ({
@@ -89,10 +135,8 @@ export const useExpandedTrackKeyframeRows = ({
 		Internals.VisualModeDragOverridesContext,
 	);
 	const {selectedItems} = useTimelineSelection();
-	const runtimeValues = useRuntimeValues(sequence.controls);
-
-	const tree = useMemo(
-		() =>
+	const selectTree = useCallback(
+		(runtimeValues: Readonly<Record<string, unknown>>) =>
 			buildTimelineTree({
 				sequence,
 				nodePathInfo,
@@ -104,14 +148,18 @@ export const useExpandedTrackKeyframeRows = ({
 				runtimeValues,
 			}),
 		[
+			sequence,
 			propStatuses,
 			getDragOverrides,
 			getEffectDragOverrides,
 			nodePathInfo,
-			sequence,
-			runtimeValues,
 		],
 	);
+	const tree = useRuntimeValueSelector({
+		controls: sequence.controls,
+		selector: selectTree,
+		isEqual: areTimelineTreeLayoutsEqual,
+	});
 
 	const selectedRowKeys = useMemo(
 		() => getSelectedTimelineExpandedRowKeys(selectedItems),

--- a/packages/studio/src/helpers/are-sequence-node-path-infos-equal.ts
+++ b/packages/studio/src/helpers/are-sequence-node-path-infos-equal.ts
@@ -1,0 +1,35 @@
+import {stringifySequenceSubscriptionKey} from '@remotion/studio-shared';
+import type {SequenceNodePathInfo} from './get-timeline-sequence-sort-key';
+
+export const areSequenceNodePathInfosEqual = (
+	first: SequenceNodePathInfo,
+	second: SequenceNodePathInfo,
+) => {
+	if (
+		first.index !== second.index ||
+		first.numberOfSequencesWithThisNodePath !==
+			second.numberOfSequencesWithThisNodePath ||
+		first.supportsEffects !== second.supportsEffects ||
+		stringifySequenceSubscriptionKey(first.sequenceSubscriptionKey) !==
+			stringifySequenceSubscriptionKey(second.sequenceSubscriptionKey) ||
+		first.auxiliaryKeys.length !== second.auxiliaryKeys.length ||
+		!first.auxiliaryKeys.every(
+			(key, index) => key === second.auxiliaryKeys[index],
+		)
+	) {
+		return false;
+	}
+
+	const firstVideoConfig = first.sequenceSubscriptionKey.videoConfigValues;
+	const secondVideoConfig = second.sequenceSubscriptionKey.videoConfigValues;
+	return (
+		firstVideoConfig === secondVideoConfig ||
+		(firstVideoConfig !== null &&
+			secondVideoConfig !== null &&
+			firstVideoConfig.durationInFrames ===
+				secondVideoConfig.durationInFrames &&
+			firstVideoConfig.fps === secondVideoConfig.fps &&
+			firstVideoConfig.height === secondVideoConfig.height &&
+			firstVideoConfig.width === secondVideoConfig.width)
+	);
+};

--- a/packages/studio/src/helpers/use-runtime-values.ts
+++ b/packages/studio/src/helpers/use-runtime-values.ts
@@ -7,15 +7,6 @@ const EMPTY_RUNTIME_VALUE_STORE = {
 	subscribe: () => () => undefined,
 };
 
-type RuntimeValueSelectorResult =
-	| string
-	| number
-	| boolean
-	| bigint
-	| symbol
-	| null
-	| undefined;
-
 export const useRuntimeValues = (
 	controls: SequenceRegistrationControls | null,
 ): Readonly<Record<string, unknown>> => {
@@ -37,7 +28,7 @@ export const useRuntimeValue = (
 	return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 };
 
-export const useRuntimeValueSelector = <T extends RuntimeValueSelectorResult>({
+export const useRuntimeValueSelector = <T>({
 	controls,
 	selector,
 	isEqual = Object.is,


### PR DESCRIPTION
## Summary

- select the expanded-track tree layout from runtime values
- skip runtime updates when the visible rows and row heights are unchanged
- compare expanded-track props using the stable values consumed by the layout
- share semantic node-path equality between memoized keyframe components

Stacked on #10181.

## Testing

- `bun run build`
- `bun run stylecheck`
