### PR TITLE
Internal: Stabilize Studio visual mode E2E tests

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -21,22 +21,40 @@ const dropAssetOnCanvas = async ({
 		height: null,
 		width: null,
 	});
-	await page
-		.locator('.remotion-studio-composition-container')
-		.evaluate((element, data) => {
-			const rect = element.getBoundingClientRect();
-			const dataTransfer = new DataTransfer();
-			dataTransfer.setData(data.mimeType, data.payload);
-			element.dispatchEvent(
-				new DragEvent('drop', {
+	const canvas = page.locator('.remotion-studio-composition-container');
+	await expect
+		.poll(() =>
+			canvas.evaluate((element, data) => {
+				const rect = element.getBoundingClientRect();
+				const dataTransfer = new DataTransfer();
+				dataTransfer.setData(data.mimeType, data.payload);
+				const event = new DragEvent('dragover', {
 					bubbles: true,
 					cancelable: true,
 					clientX: rect.left + rect.width / 2,
 					clientY: rect.top + rect.height / 2,
 					dataTransfer,
-				}),
-			);
-		}, dragData);
+				});
+				element.dispatchEvent(event);
+
+				return event.defaultPrevented;
+			}, dragData),
+		)
+		.toBe(true);
+	await canvas.evaluate((element, data) => {
+		const rect = element.getBoundingClientRect();
+		const dataTransfer = new DataTransfer();
+		dataTransfer.setData(data.mimeType, data.payload);
+		element.dispatchEvent(
+			new DragEvent('drop', {
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + rect.width / 2,
+				clientY: rect.top + rect.height / 2,
+				dataTransfer,
+			}),
+		);
+	}, dragData);
 };
 
 const getVideoTag = (source: string, assetPath: string) => {
@@ -290,12 +308,13 @@ test.describe('visual mode', () => {
 		await expect(
 			page.getByRole('button', {name: '0', exact: true}),
 		).toBeVisible({timeout: 15_000});
+		const currentTime = page
+			.getByRole('button')
+			.filter({hasText: /^\d\d:\d\d\.\d\d/});
 
 		await page.locator('[data-timeline-scrubber]').click();
 
-		await expect(
-			page.getByRole('button', {name: '75', exact: true}),
-		).toBeVisible();
+		await expect(currentTime).not.toHaveAttribute('aria-label', '0');
 	});
 
 	test('should place Canvas drops where they are visible at the playhead', async ({


### PR DESCRIPTION
## Summary

- wait for the Canvas drag-over handler to accept asset drops before dispatching the drop
- verify read-only timeline seeking without relying on an exact geometry-dependent frame

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should seek in read-only Studio|should place Canvas drops" --repeat-each=5`
