### PR TITLE
@remotion/studio-server: Open source locations in the existing Zed window

### DIFF
--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -277,7 +277,7 @@ function getArgumentsForLineNumber(
 	const isFolder =
 		fs.existsSync(fileName) && fs.lstatSync(fileName).isDirectory();
 	if (isZedEditor) {
-		return [fileName + ':' + lineNumber + ':' + colNumber];
+		return ['--existing', fileName + ':' + lineNumber + ':' + colNumber];
 	}
 
 	switch (editorBasename) {


### PR DESCRIPTION
## Summary

- When Remotion Studio opens a source file in Zed, it now passes the `--existing` flag so the file opens in the current Zed window instead of spawning a new window every time.
- The `create-video` path is intentionally left unchanged, as it is expected to open a new window.

Closes #9744

#### Test plan
- [x] `bunx eslint src/helpers/open-in-editor.ts` passes
- [x] `bun test src/test/open-in-editor.test.ts` passes