### PR TITLE
Internal: Include `build` tasks in affected CI

### DIFF
--- a/.github/scripts/ci.test.ts
+++ b/.github/scripts/ci.test.ts
@@ -76,11 +76,16 @@ describe('CI plan generation', () => {
 		expect(plan.build_matrix).toEqual(MINIMAL_BUILD_MATRIX);
 	});
 
-	test('uses the full build matrix for a package source change', () => {
-		const plan = planFor({tasks: [{name: 'make'}, {name: 'test'}]});
-		expect(plan.build).toBe(true);
-		expect(plan.build_matrix).toEqual(FULL_BUILD_MATRIX);
-	});
+	test.each(['build', 'make', 'test'])(
+		'uses the full build matrix when a non-docs %s task is affected',
+		(task) => {
+			const plan = planFor({
+				tasks: [{name: task, packageName: 'template-electron'}],
+			});
+			expect(plan.build).toBe(true);
+			expect(plan.build_matrix).toEqual(FULL_BUILD_MATRIX);
+		},
+	);
 
 	test.each([
 		['lambda', 'testlambda'],

--- a/.github/scripts/ci.ts
+++ b/.github/scripts/ci.ts
@@ -29,7 +29,7 @@ const TASKS_BY_SUITE = {
 	webrenderer: ['testwebrenderer', 'testbrowserstudio'],
 	ssr: ['testssr'],
 	templates: ['testtemplates'],
-	build: ['make', 'test'],
+	build: ['build', 'make', 'test'],
 	bundle_example: ['bundle-testbed'],
 } as const;
 
@@ -211,7 +211,9 @@ export const createCiPlan = (input: PlannerInput): CiPlan => {
 		const bundleExample = selected('bundle_example');
 		const hasNonDocsBuild = tasks.some(
 			(task) =>
-				(task.name === 'make' || task.name === 'test') &&
+				(task.name === 'build' ||
+					task.name === 'make' ||
+					task.name === 'test') &&
 				task.package.name !== 'docs',
 		);
 


### PR DESCRIPTION
## Summary

- Treat affected Turborepo `build` tasks as part of the CI build suite, alongside `make` and `test`.
- Use the full build matrix when a non-docs `build` task is affected.
- Extend the CI planner tests to cover all three build task names.

## Context

PR #10195 exposed the gap: Turborepo reported `template-electron#build`, but the planner did not select the build matrix. As a result, the Node 16 installation checks that later failed on `main` did not run on the pull request.

## Verification

- `bun test ./.github/scripts/ci.test.ts`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`

The new `build` task regression case was also verified red/green.
