### PR TITLE
`@remotion/lambda-go`: Omit GIF loop count from non-GIF renders

### DIFF
--- a/packages/lambda-go/internalops.go
+++ b/packages/lambda-go/internalops.go
@@ -132,7 +132,9 @@ func constructRenderInternals(options *RemotionOptions) (*renderInternalOptions,
 	} else {
 		internalParams.TimeoutInMilliseconds = options.TimeoutInMilliseconds
 	}
-	internalParams.NumberOfGifLoops = options.NumberOfGifLoops
+	if internalParams.Codec == "gif" {
+		internalParams.NumberOfGifLoops = &options.NumberOfGifLoops
+	}
 
 	if options.DownloadBehavior == nil {
 		internalParams.DownloadBehavior = map[string]interface{}{

--- a/packages/lambda-go/lambda_go_sdk_test.go
+++ b/packages/lambda-go/lambda_go_sdk_test.go
@@ -66,6 +66,61 @@ func TestPrintVersion(t *testing.T) {
 	println(string(jsonData))
 }
 
+func TestRenderPayloadNumberOfGifLoops(t *testing.T) {
+	tests := []struct {
+		name                 string
+		codec                string
+		numberOfGifLoops     int
+		wantNumberOfGifLoops *int
+	}{
+		{name: "default codec omits GIF loops"},
+		{name: "non-GIF codec omits GIF loops", codec: "h264", numberOfGifLoops: 2},
+		{name: "GIF codec includes zero loops", codec: "gif", numberOfGifLoops: 0, wantNumberOfGifLoops: new(0)},
+		{name: "GIF codec includes positive loops", codec: "gif", numberOfGifLoops: 2, wantNumberOfGifLoops: new(2)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload, err := constructRenderInternals(&RemotionOptions{
+				Region:           "us-east-1",
+				Composition:      "react-svg",
+				FunctionName:     "remotion-render",
+				ServeUrl:         "testbed",
+				Codec:            test.codec,
+				NumberOfGifLoops: test.numberOfGifLoops,
+			})
+			if err != nil {
+				t.Fatalf("could not construct render payload: %v", err)
+			}
+
+			jsonData, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("could not marshal render payload: %v", err)
+			}
+
+			var serializedPayload map[string]interface{}
+			if err := json.Unmarshal(jsonData, &serializedPayload); err != nil {
+				t.Fatalf("could not unmarshal render payload: %v", err)
+			}
+
+			serializedLoops, hasNumberOfGifLoops := serializedPayload["numberOfGifLoops"]
+			if test.wantNumberOfGifLoops == nil {
+				if hasNumberOfGifLoops {
+					t.Fatalf("numberOfGifLoops should be omitted, got %v", serializedLoops)
+				}
+				return
+			}
+
+			if !hasNumberOfGifLoops {
+				t.Fatalf("numberOfGifLoops should be %d, but was omitted", *test.wantNumberOfGifLoops)
+			}
+			if serializedLoops != float64(*test.wantNumberOfGifLoops) {
+				t.Fatalf("numberOfGifLoops = %v, want %d", serializedLoops, *test.wantNumberOfGifLoops)
+			}
+		})
+	}
+}
+
 func TestSerializeNilInputProps(t *testing.T) {
 	result, err := serializeInputProps(nil, "us-east-1", "video-or-audio", "", false)
 	if err != nil {

--- a/packages/lambda-go/models.go
+++ b/packages/lambda-go/models.go
@@ -82,7 +82,7 @@ type renderInternalOptions struct {
 	ChromiumOptions                interface{}            `json:"chromiumOptions"`
 	Scale                          int                    `json:"scale"`
 	EveryNthFrame                  int                    `json:"everyNthFrame"`
-	NumberOfGifLoops               int                    `json:"numberOfGifLoops"`
+	NumberOfGifLoops               *int                   `json:"numberOfGifLoops,omitempty"`
 	ConcurrencyPerLambda           int                    `json:"concurrencyPerLambda"`
 	Concurrency                    *int                   `json:"concurrency"`
 	DownloadBehavior               map[string]interface{} `json:"downloadBehavior"`


### PR DESCRIPTION
## Summary

- omit `numberOfGifLoops` from Go Lambda SDK render payloads unless the codec is GIF
- preserve meaningful zero and positive loop counts for GIF renders
- cover the serialized request contract with a regression test

## Testing

- `go test ./...`
- `bun run build`
- `bun run stylecheck`

Closes #10218
