### PR TITLE
`remotion`: Add color control to SVG schemas

### DIFF
--- a/packages/core/src/interactivity-schema.ts
+++ b/packages/core/src/interactivity-schema.ts
@@ -437,7 +437,16 @@ export const backgroundSchema = {
 	},
 } as const satisfies InteractivitySchema;
 
+const svgColorSchema = {
+	color: {
+		type: 'color',
+		default: undefined,
+		description: 'Current color',
+	},
+} as const satisfies InteractivitySchema;
+
 export const svgStrokeSchema = {
+	...svgColorSchema,
 	stroke: {
 		type: 'color',
 		// `none` is the SVG initial value of stroke.

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1379,6 +1379,19 @@ test('Interactive elements register their rendered element for Studio outlines',
 		'<Interactive.Circle>',
 		'<Interactive.Ellipse>',
 		'<Interactive.G>',
+		'<Interactive.Line>',
+		'<Interactive.Path>',
+		'<Interactive.Rect>',
+		'<Interactive.Svg>',
+		'<Interactive.Text>',
+	]) {
+		expect(getByName(displayName)?.controls?.schema).toHaveProperty('color');
+	}
+
+	for (const displayName of [
+		'<Interactive.Circle>',
+		'<Interactive.Ellipse>',
+		'<Interactive.G>',
 		'<Interactive.Path>',
 		'<Interactive.Rect>',
 		'<Interactive.Svg>',

--- a/packages/core/src/test/with-interactivity-schema-helpers.test.ts
+++ b/packages/core/src/test/with-interactivity-schema-helpers.test.ts
@@ -465,7 +465,16 @@ test('backgroundSchema exposes the background color style field', () => {
 });
 
 test('svgStrokeSchema exposes SVG stroke controls', () => {
-	expect(Object.keys(svgStrokeSchema)).toEqual(['stroke', 'strokeWidth']);
+	expect(Object.keys(svgStrokeSchema)).toEqual([
+		'color',
+		'stroke',
+		'strokeWidth',
+	]);
+	expect(svgStrokeSchema.color).toMatchObject({
+		type: 'color',
+		default: undefined,
+		description: 'Current color',
+	});
 	expect(svgStrokeSchema.stroke).toMatchObject({
 		type: 'color',
 		default: 'none',
@@ -485,6 +494,7 @@ test('svgStrokeSchema exposes SVG stroke controls', () => {
 test('svgPaintSchema exposes SVG fill and stroke fields', () => {
 	expect(Object.keys(svgPaintSchema)).toEqual([
 		'fill',
+		'color',
 		'stroke',
 		'strokeWidth',
 	]);
@@ -493,6 +503,7 @@ test('svgPaintSchema exposes SVG fill and stroke fields', () => {
 		default: undefined,
 		description: 'Fill',
 	});
+	expect(svgPaintSchema.color).toBe(svgStrokeSchema.color);
 	expect(svgPaintSchema.stroke).toMatchObject({
 		type: 'color',
 		default: 'none',

--- a/packages/docs/docs/interactive.mdx
+++ b/packages/docs/docs/interactive.mdx
@@ -147,13 +147,13 @@ Use it for components that accept a `style` prop and render rounded corners.
 
 ### `Interactive.svgPaintSchema`<AvailableFrom v="4.0.499" />
 
-Controls for the SVG `fill`, `stroke` and `strokeWidth` props.
+Controls for the SVG `fill`, `stroke` and `strokeWidth` props. The `color` prop is available from <AvailableFrom v="4.0.507" inline /> and controls paint values that use `currentColor`.
 
 Use it for custom components that accept SVG paint props.
 
 ### `Interactive.svgStrokeSchema`<AvailableFrom v="4.0.499" />
 
-Controls for the SVG `stroke` and `strokeWidth` props.
+Controls for the SVG `stroke` and `strokeWidth` props. The `color` prop is available from <AvailableFrom v="4.0.507" inline /> and controls paint values that use `currentColor`.
 
 Use it for custom components such as lines that do not have a paintable interior.
 


### PR DESCRIPTION
## Summary

- Add an SVG `color` control for `currentColor` paint values
- Expose it through both `Interactive.svgPaintSchema` and `Interactive.svgStrokeSchema`
- Document and test the control across all interactive SVG elements

## Validation

- `bun test src/test/with-interactivity-schema-helpers.test.ts src/test/sequence-register-once.test.tsx` from `packages/core`
- `bun run build`
- `bun run stylecheck`

Closes #10203

## Preview

- [Interactive documentation](https://remotion-git-codex-add-svg-current-color-control-remotion.vercel.app/docs/interactive)
