### PR TITLE
remotion.dev/convert: Allow renaming converted files

### DIFF
--- a/packages/convert/app/components/ConvertProgress.tsx
+++ b/packages/convert/app/components/ConvertProgress.tsx
@@ -1,4 +1,10 @@
-import React, {createRef} from 'react';
+import React, {
+	createRef,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
 import {formatBytes} from '~/lib/format-bytes';
 import {formatElapsedTime} from '~/lib/format-elapsed-time';
 import {formatSeconds} from '~/lib/format-seconds';
@@ -8,6 +14,7 @@ import {
 	useAddProgressToTitle,
 } from '~/lib/title-context';
 import {AudioWaveForm, AudioWaveformContainer} from './AudioWaveform';
+import {PenIcon} from './icons/pen';
 import {Card} from './ui/card';
 import {Skeleton} from './ui/skeleton';
 import type {VideoThumbnailRef} from './VideoThumbnail';
@@ -25,6 +32,7 @@ export const ConvertProgress: React.FC<{
 	readonly startTime?: number;
 	readonly completedTime?: number;
 	readonly draggableFile: File | null;
+	readonly onNameChange: ((name: string) => void) | null;
 }> = ({
 	state,
 	newName,
@@ -35,11 +43,49 @@ export const ConvertProgress: React.FC<{
 	startTime,
 	completedTime,
 	draggableFile,
+	onNameChange,
 }) => {
 	const progress = done ? 1 : state.overallProgress;
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [draftName, setDraftName] = useState(newName ?? '');
+	const nameInputRef = useRef<HTMLInputElement>(null);
 
 	useAddProgressToTitle(progress);
 	useAddOutputFilenameToTitle(newName);
+
+	useEffect(() => {
+		if (!isRenaming) {
+			setDraftName(newName ?? '');
+		}
+	}, [isRenaming, newName]);
+
+	useEffect(() => {
+		if (isRenaming) {
+			nameInputRef.current?.focus();
+			nameInputRef.current?.select();
+		}
+	}, [isRenaming]);
+
+	const commitName = useCallback(() => {
+		if (!newName || !onNameChange) {
+			setIsRenaming(false);
+			return;
+		}
+
+		const trimmedName = draftName.trim();
+		if (trimmedName) {
+			onNameChange(trimmedName);
+		} else {
+			setDraftName(newName);
+		}
+
+		setIsRenaming(false);
+	}, [draftName, newName, onNameChange]);
+
+	const cancelRenaming = useCallback(() => {
+		setDraftName(newName ?? '');
+		setIsRenaming(false);
+	}, [newName]);
 
 	return (
 		<Card className="overflow-hidden">
@@ -54,6 +100,7 @@ export const ConvertProgress: React.FC<{
 						mirrorHorizontal={false}
 						mirrorVertical={false}
 						draggableFile={done ? draggableFile : null}
+						draggableFileName={done ? newName : null}
 					/>
 					{duration ? (
 						<>
@@ -81,8 +128,47 @@ export const ConvertProgress: React.FC<{
 			) : null}
 			<div className="p-2">
 				<div>
-					{newName ? (
-						<strong className="font-brand ">{newName}</strong>
+					{newName && isRenaming ? (
+						<input
+							ref={nameInputRef}
+							aria-label="File name"
+							className="h-6 w-full rounded-sm border border-input bg-background px-1 font-brand font-bold focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+							value={draftName}
+							onChange={(event) => setDraftName(event.target.value)}
+							onBlur={commitName}
+							onKeyDown={(event) => {
+								if (event.key === 'Enter') {
+									event.preventDefault();
+									commitName();
+								}
+
+								if (event.key === 'Escape') {
+									event.preventDefault();
+									cancelRenaming();
+								}
+							}}
+						/>
+					) : newName ? (
+						<div className="flex min-w-0 items-center">
+							<strong className="min-w-0 break-all font-brand">
+								{newName}
+							</strong>
+							{done && onNameChange ? (
+								<button
+									type="button"
+									aria-label="Rename file"
+									title="Rename file"
+									className="ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+									onClick={() => setIsRenaming(true)}
+								>
+									<PenIcon
+										aria-hidden="true"
+										color="currentColor"
+										className="size-3.5"
+									/>
+								</button>
+							) : null}
+						</div>
 					) : (
 						<Skeleton className="h-4 w-[200px]" />
 					)}

--- a/packages/convert/app/components/ConvertProgress.tsx
+++ b/packages/convert/app/components/ConvertProgress.tsx
@@ -126,7 +126,7 @@ export const ConvertProgress: React.FC<{
 					<div className="border-b-2 border-black" />
 				</>
 			) : null}
-			<div className="p-2">
+			<div className="group/output-details p-2">
 				<div>
 					{newName && isRenaming ? (
 						<input
@@ -158,13 +158,13 @@ export const ConvertProgress: React.FC<{
 									type="button"
 									aria-label="Rename file"
 									title="Rename file"
-									className="ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+									className="pointer-events-none ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-sm opacity-0 transition-opacity group-hover/output-details:pointer-events-auto group-hover/output-details:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
 									onClick={() => setIsRenaming(true)}
 								>
 									<PenIcon
 										aria-hidden="true"
-										color="currentColor"
-										className="size-3.5"
+										color="#000000"
+										className="size-[18px]"
 									/>
 								</button>
 							) : null}

--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -529,6 +529,16 @@ const ConvertUI = ({
 		setState({type: 'idle'});
 	}, []);
 
+	const onOutputNameChange = useCallback((newName: string) => {
+		setState((currentState) => {
+			if (currentState.type !== 'done') {
+				return currentState;
+			}
+
+			return {...currentState, newName};
+		});
+	}, []);
+
 	const onMirrorClick = useCallback(() => {
 		setVideoEditState((editState) => ({
 			...editState,
@@ -589,6 +599,7 @@ const ConvertUI = ({
 					state={state.state}
 					newName={state.newName}
 					draggableFile={null}
+					onNameChange={null}
 					done={false}
 					duration={durationInSeconds}
 					isReencoding={
@@ -618,6 +629,7 @@ const ConvertUI = ({
 					state={state.state}
 					newName={state.newName}
 					draggableFile={state.draggableFile}
+					onNameChange={onOutputNameChange}
 					duration={durationInSeconds}
 					isReencoding={
 						supportedConfigs !== null &&

--- a/packages/convert/app/components/VideoThumbnail.tsx
+++ b/packages/convert/app/components/VideoThumbnail.tsx
@@ -20,6 +20,7 @@ type Props = {
 	readonly mirrorVertical: boolean;
 	readonly initialReveal: boolean;
 	readonly draggableFile?: File | null;
+	readonly draggableFileName?: string | null;
 };
 
 export type VideoThumbnailRef = {
@@ -43,6 +44,7 @@ const VideoThumbnailRefForward: React.ForwardRefRenderFunction<
 		mirrorVertical,
 		initialReveal,
 		draggableFile = null,
+		draggableFileName = null,
 	},
 	forwardedRef,
 ) => {
@@ -150,13 +152,14 @@ const VideoThumbnailRefForward: React.ForwardRefRenderFunction<
 				!setFileDragData({
 					dataTransfer: event.dataTransfer,
 					file: draggableFile,
+					fileName: draggableFileName ?? draggableFile.name,
 					objectUrl: dragObjectUrl,
 				})
 			) {
 				event.preventDefault();
 			}
 		},
-		[dragObjectUrl, draggableFile],
+		[dragObjectUrl, draggableFile, draggableFileName],
 	);
 
 	return (

--- a/packages/convert/app/components/icons/pen.tsx
+++ b/packages/convert/app/components/icons/pen.tsx
@@ -1,0 +1,18 @@
+import type {SVGProps} from 'react';
+import React from 'react';
+
+// Keep this in sync with the pen icon used by Studio's src inspector.
+export const PenIcon: React.FC<
+	SVGProps<SVGSVGElement> & {
+		readonly color: string;
+	}
+> = ({color, ...props}) => {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+			<path
+				fill={color}
+				d="M18.7 2.3a1 1 0 0 0-1.4 0L5.2 14.4a1 1 0 0 0-.26.46l-1.4 4.95a.5.5 0 0 0 .62.62l4.95-1.4a1 1 0 0 0 .46-.26L21.7 6.7a1 1 0 0 0 0-1.4l-3-3Zm-10.33 14.9-2.4.68.68-2.4L15.5 6.62l1.73 1.73-8.86 8.85Zm10.28-10.27L16.92 5.2 18 4.12l1.73 1.73-1.08 1.08Z"
+			/>
+		</svg>
+	);
+};

--- a/packages/convert/app/lib/file-drag.ts
+++ b/packages/convert/app/lib/file-drag.ts
@@ -55,16 +55,25 @@ export const canOfferFileDrag = ({
 export const setFileDragData = ({
 	dataTransfer,
 	file,
+	fileName,
 	objectUrl,
 }: {
 	readonly dataTransfer: DataTransfer;
 	readonly file: File;
+	readonly fileName: string;
 	readonly objectUrl: string;
 }) => {
 	try {
 		dataTransfer.clearData();
 		dataTransfer.effectAllowed = 'copy';
-		const item = dataTransfer.items.add(file);
+		const fileForDrag =
+			file.name === fileName
+				? file
+				: new File([file], fileName, {
+						lastModified: file.lastModified,
+						type: file.type,
+					});
+		const item = dataTransfer.items.add(fileForDrag);
 		if (item === null) {
 			return false;
 		}
@@ -74,7 +83,7 @@ export const setFileDragData = ({
 		// the standards-based File item above.
 		dataTransfer.setData(
 			'DownloadURL',
-			`${file.type || 'application/octet-stream'}:${file.name}:${objectUrl}`,
+			`${fileForDrag.type || 'application/octet-stream'}:${fileForDrag.name}:${objectUrl}`,
 		);
 		dataTransfer.setData(CONVERTED_OUTPUT_DRAG_TYPE, '1');
 		return true;

--- a/packages/convert/test/file-drag.test.tsx
+++ b/packages/convert/test/file-drag.test.tsx
@@ -82,7 +82,16 @@ test('uses the editable output name when dragging the completed thumbnail', asyn
 		});
 
 		expect(thumbnail.textContent).toBe('');
-		fireEvent.click(rendered.getByRole('button', {name: 'Rename file'}));
+		const renameButton = rendered.getByRole('button', {name: 'Rename file'});
+		expect(renameButton.classList.contains('opacity-0')).toBe(true);
+		expect(
+			renameButton.classList.contains('group-hover/output-details:opacity-100'),
+		).toBe(true);
+		const pen = renameButton.querySelector('svg');
+		expect(pen?.classList.contains('size-[18px]')).toBe(true);
+		expect(pen?.querySelector('path')?.getAttribute('fill')).toBe('#000000');
+
+		fireEvent.click(renameButton);
 		const nameInput = rendered.getByRole('textbox', {name: 'File name'});
 		fireEvent.change(nameInput, {target: {value: 'renamed.mp4'}});
 		fireEvent.keyDown(nameInput, {key: 'Enter'});

--- a/packages/convert/test/file-drag.test.tsx
+++ b/packages/convert/test/file-drag.test.tsx
@@ -1,5 +1,6 @@
 import {afterEach, expect, test} from 'bun:test';
 import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import {useState} from 'react';
 import {ConvertProgress} from '../app/components/ConvertProgress';
 import {ReplaceVideo} from '../app/components/ReplaceVideo';
 import {
@@ -14,7 +15,7 @@ afterEach(() => {
 	cleanup();
 });
 
-test('offers the completed thumbnail as a file drag without adding UI', async () => {
+test('uses the editable output name when dragging the completed thumbnail', async () => {
 	const originalCreateObjectUrl = URL.createObjectURL;
 	const originalRevokeObjectUrl = URL.revokeObjectURL;
 	const revokedUrls: string[] = [];
@@ -45,15 +46,18 @@ test('offers the completed thumbnail as a file drag without adding UI', async ()
 	} as unknown as DataTransfer;
 
 	try {
-		const rendered = render(
-			<TitleProvider routeAction={{type: 'generic-convert'}}>
+		const ConvertProgressWithEditableName = () => {
+			const [name, setName] = useState(file.name);
+
+			return (
 				<ConvertProgress
 					bars={[]}
 					done
 					draggableFile={file}
 					duration={1}
 					isReencoding
-					newName={file.name}
+					newName={name}
+					onNameChange={setName}
 					state={{
 						bytesWritten: file.size,
 						hasVideo: true,
@@ -61,6 +65,12 @@ test('offers the completed thumbnail as a file drag without adding UI', async ()
 						overallProgress: 1,
 					}}
 				/>
+			);
+		};
+
+		const rendered = render(
+			<TitleProvider routeAction={{type: 'generic-convert'}}>
+				<ConvertProgressWithEditableName />
 				<ReplaceVideo src={{type: 'file', file}} setSrc={() => undefined} />
 			</TitleProvider>,
 		);
@@ -72,11 +82,20 @@ test('offers the completed thumbnail as a file drag without adding UI', async ()
 		});
 
 		expect(thumbnail.textContent).toBe('');
+		fireEvent.click(rendered.getByRole('button', {name: 'Rename file'}));
+		const nameInput = rendered.getByRole('textbox', {name: 'File name'});
+		fireEvent.change(nameInput, {target: {value: 'renamed.mp4'}});
+		fireEvent.keyDown(nameInput, {key: 'Enter'});
+		expect(rendered.getByText('renamed.mp4')).not.toBeNull();
+
 		fireEvent.dragStart(thumbnail, {dataTransfer});
 
-		expect(addedFiles).toEqual([file]);
+		expect(addedFiles).toHaveLength(1);
+		expect(addedFiles[0]?.name).toBe('renamed.mp4');
+		expect(addedFiles[0]?.type).toBe(file.type);
+		expect(addedFiles[0]?.size).toBe(file.size);
 		expect(dragData.get('DownloadURL')).toBe(
-			'video/mp4:converted.mp4:blob:converted-output',
+			'video/mp4:renamed.mp4:blob:converted-output',
 		);
 		expect(dragData.get(CONVERTED_OUTPUT_DRAG_TYPE)).toBe('1');
 
@@ -134,6 +153,7 @@ test('does not advertise unsafe outputs as file drags', () => {
 				duration={1}
 				isReencoding
 				newName="converted.mp4"
+				onNameChange={null}
 				state={{
 					bytesWritten: 1,
 					hasVideo: true,


### PR DESCRIPTION
## Summary

- add an inline filename editor after conversion using the pen icon from Studio's `src` inspector
- keep the edited filename in the completed conversion state so downloads use it
- apply the edited filename to both the standard dragged `File` and Chromium's `DownloadURL` metadata

Follow-up to #10221.

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/convert && bun test test`
- `cd packages/convert && bun run lint`
- `cd packages/convert && bun run build-page`
