### PR TITLE
Docs: Add VideoEncoder visibleRect issue

### DIFF
--- a/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
+++ b/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
@@ -10,6 +10,7 @@ It serves as a tracker for overall progress and known issues.
 
 | Issue                                                                                                                                                     | Product | Filed by     | Status    |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------ | --------- |
+| [VideoEncoder does not respect visibleRect of VideoFrame, crops incorrectly](https://issues.chromium.org/issues/543284189)                                | Chrome  | @Vanilagy    | Open      |
 | [AudioData.copyTo with interleaved f32 handles frameOffset incorrectly](https://bugzilla.mozilla.org/show_bug.cgi?id=2017589)                             | Firefox | @JonnyBurger | Open      |
 | [H.264 packet with "Unspecified" NALU (24..31) trips up key frame validation, erroring VideoDecoder](https://issues.chromium.org/issues/470109459)        | Chrome  | @Vanilagy    | Fixed     |
 | [H.264 VideoDecoder key frame detection fails for packets with an AUD not at the start](https://issues.chromium.org/issues/519012430)                     | Chrome  | @Vanilagy    | Fixed     |


### PR DESCRIPTION
## Summary

- Add Chromium issue 543284189 to the WebCodecs bugs tracker
- Attribute the report to @Vanilagy and mark its current status as open

Tracker: https://issues.chromium.org/issues/543284189

## Testing

- `bunx oxfmt packages/docs/docs/mediabunny/webcodecs-bugs.mdx --write`
- `bun run build`
- `bun run stylecheck`

## Preview

- [WebCodecs Bugs](https://remotion-git-codex-add-videoencoder-visible-rect-bug-remotion.vercel.app/docs/mediabunny/webcodecs-bugs)
