### PR TITLE
Docs: Mark renderMedia() licenseKey as required in v5

### DIFF
--- a/packages/docs/docs/5-0-migration.mdx
+++ b/packages/docs/docs/5-0-migration.mdx
@@ -189,6 +189,13 @@ This prevents the Player from continuing while media or images are still loading
 
 **Required action**: If you want to keep the old behavior, set `pauseWhenBuffering={false}` on video and audio components and `pauseWhenLoading={false}` on `<Img>` explicitly.
 
+## `licenseKey` is now required in `renderMedia()`
+
+`licenseKey` is now a required option in [`renderMedia()`](/docs/renderer/render-media#licensekey).  
+Previously, it was optional and defaulted to `null`.
+
+**Required action**: Pass a license key string, or explicitly set `licenseKey: null`.
+
 ## License changes
 
 Remotion 5.0 has an updated license. View the [license](https://github.com/remotion-dev/remotion/blob/5-0-license/LICENSE.md) here or compare the [changes](https://github.com/remotion-dev/remotion/pull/3750).

--- a/packages/docs/docs/renderer/render-media.mdx
+++ b/packages/docs/docs/renderer/render-media.mdx
@@ -34,6 +34,7 @@ await renderMedia({
   codec: 'h264',
   outputLocation,
   inputProps,
+  licenseKey: null,
 });
 ```
 
@@ -508,7 +509,11 @@ An option to be used only if implementing a distributed renderer, see [Distribut
 
 <Options id="on-browser-download" />
 
-### `licenseKey?`<AvailableFrom v="4.0.409"/>
+### `licenseKey`<AvailableFrom v="4.0.409"/>
+
+_string | null_
+
+Optional in v4.x, required from v5.0.
 
 <Options id="license-key" />
 


### PR DESCRIPTION
Fixes the v5 documentation drift for `renderMedia()`.

- Updates the `licenseKey` option in the [`renderMedia()`](/docs/renderer/render-media#licensekey) docs from `licenseKey?` to `licenseKey`, noting it is a required `string | null` from v5.0.
- Adds `licenseKey: null` to the top-level code example.
- Adds a migration entry to [v5.0 migration guide](/docs/5-0-migration) explaining the breaking change.

Closes https://github.com/remotion-dev/remotion/issues/9539

## Preview

- https://remotion-git-fork-garudaccs-fix-9539-v5-license-fb2b96-remotion.vercel.app/docs/renderer/render-media#licensekey
- https://remotion-git-fork-garudaccs-fix-9539-v5-license-fb2b96-remotion.vercel.app/docs/5-0-migration
