### PR TITLE
remotion.dev/convert: Support pasting files

### DIFF
--- a/packages/convert/app/components/ReplaceVideo.tsx
+++ b/packages/convert/app/components/ReplaceVideo.tsx
@@ -60,14 +60,30 @@ export const ReplaceVideo: React.FC<{
 			}
 		};
 
+		const onPaste = (e: ClipboardEvent) => {
+			const file = e.clipboardData?.files[0];
+			if (!file) {
+				return;
+			}
+
+			e.preventDefault();
+			if (src === null) {
+				setSrc({type: 'file', file});
+			} else {
+				setFileToReplace(file);
+			}
+		};
+
 		document.addEventListener('dragover', onDragOver, {capture: true});
 		document.addEventListener('dragleave', onDragEnd, {capture: true});
 		document.addEventListener('drop', onDrop, {capture: true});
+		document.addEventListener('paste', onPaste, {capture: true});
 
 		return () => {
 			document.removeEventListener('dragleave', onDragEnd, {capture: true});
 			document.removeEventListener('dragover', onDragOver, {capture: true});
 			document.removeEventListener('drop', onDrop, {capture: true});
+			document.removeEventListener('paste', onPaste, {capture: true});
 		};
 	}, [fileToReplace, setSrc, src]);
 

--- a/packages/convert/test/file-paste.test.tsx
+++ b/packages/convert/test/file-paste.test.tsx
@@ -1,0 +1,39 @@
+import {afterEach, expect, test} from 'bun:test';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import {useState} from 'react';
+import {ReplaceVideo} from '../app/components/ReplaceVideo';
+import type {Source} from '../app/lib/convert-state';
+
+afterEach(() => {
+	cleanup();
+});
+
+test('pastes files and asks before replacing the current file', () => {
+	const firstFile = new File(['first'], 'first.mp4', {type: 'video/mp4'});
+	const secondFile = new File(['second'], 'second.mov', {
+		type: 'video/quicktime',
+	});
+
+	const ConvertWithPaste = () => {
+		const [src, setSrc] = useState<Source | null>(null);
+
+		return (
+			<>
+				<div>{src?.type === 'file' ? src.file.name : 'No file selected'}</div>
+				<ReplaceVideo src={src} setSrc={setSrc} />
+			</>
+		);
+	};
+
+	const rendered = render(<ConvertWithPaste />);
+
+	fireEvent.paste(document, {clipboardData: {files: [firstFile]}});
+	expect(rendered.getByText('first.mp4')).not.toBeNull();
+
+	fireEvent.paste(document, {clipboardData: {files: [secondFile]}});
+	expect(rendered.getByText('Replace video?')).not.toBeNull();
+	expect(rendered.getByText('first.mp4')).not.toBeNull();
+
+	fireEvent.click(rendered.getByRole('button', {name: 'Replace video'}));
+	expect(rendered.getByText('second.mov')).not.toBeNull();
+});


### PR DESCRIPTION
## Summary

- import files pasted from the operating system clipboard into Remotion Convert
- keep the existing confirmation flow when a pasted file would replace the current source
- cover initial paste and confirmed replacement in an integration test

## Testing

- `bun test test` in `packages/convert`
- `bun run build`
- `bun run stylecheck`
