### PR TITLE
`@remotion/media`: Scope caches to individual renders

### DIFF
--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -132,6 +132,10 @@ import type {RemotionEnvironment} from './remotion-environment-context.js';
 import {RemotionEnvironmentContext} from './remotion-environment-context.js';
 import {RemotionRootContexts} from './RemotionRoot.js';
 import {
+	makeRenderResourceManager,
+	RenderResourceManagerContext,
+} from './render-resource-manager.js';
+import {
 	RenderAssetManager,
 	RenderAssetManagerProvider,
 } from './RenderAssetManager.js';
@@ -286,6 +290,8 @@ const compositionSelectorRef = createRef<{
 // API and are less likely to use it
 export const Internals = {
 	MaxMediaCacheSizeContext,
+	makeRenderResourceManager,
+	RenderResourceManagerContext,
 	useUnsafeVideoConfig,
 	useFrameForVolumeProp,
 	useTimelinePosition: TimelinePosition.useTimelinePosition,

--- a/packages/core/src/render-resource-manager.ts
+++ b/packages/core/src/render-resource-manager.ts
@@ -1,0 +1,70 @@
+import React from 'react';
+
+type RenderResource = {
+	resource: unknown;
+	dispose: () => void;
+};
+
+export type RenderResourceManager = {
+	getOrCreateResource: <T>({
+		key,
+		create,
+	}: {
+		key: string;
+		create: () => {resource: T; dispose: () => void};
+	}) => T;
+	dispose: () => void;
+};
+
+export const makeRenderResourceManager = (): RenderResourceManager => {
+	const resources = new Map<string, RenderResource>();
+	let disposed = false;
+
+	return {
+		getOrCreateResource: <T>({
+			key,
+			create,
+		}: {
+			key: string;
+			create: () => {resource: T; dispose: () => void};
+		}) => {
+			if (disposed) {
+				throw new Error('Render resource manager has already been disposed');
+			}
+
+			const existing = resources.get(key);
+			if (existing) {
+				return existing.resource as T;
+			}
+
+			const created = create();
+			resources.set(key, created);
+			return created.resource;
+		},
+		dispose: () => {
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			const resourcesToDispose = Array.from(resources.values());
+			resources.clear();
+
+			let firstError: unknown = null;
+			for (const resource of resourcesToDispose) {
+				try {
+					resource.dispose();
+				} catch (error) {
+					firstError ??= error;
+				}
+			}
+
+			if (firstError !== null) {
+				throw firstError;
+			}
+		},
+	};
+};
+
+export const RenderResourceManagerContext =
+	React.createContext<RenderResourceManager | null>(null);

--- a/packages/core/src/test/render-resource-manager.test.ts
+++ b/packages/core/src/test/render-resource-manager.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'bun:test';
+import {makeRenderResourceManager} from '../render-resource-manager';
+
+test('render resources are shared within one render and isolated between renders', () => {
+	const firstManager = makeRenderResourceManager();
+	const secondManager = makeRenderResourceManager();
+	const disposeCounts = {first: 0, second: 0};
+
+	const firstResource = firstManager.getOrCreateResource({
+		key: 'resource',
+		create: () => ({
+			resource: {render: 'first'},
+			dispose: () => disposeCounts.first++,
+		}),
+	});
+	const sameFirstResource = firstManager.getOrCreateResource({
+		key: 'resource',
+		create: () => {
+			throw new Error('Resource should only be created once per render');
+		},
+	});
+	const secondResource = secondManager.getOrCreateResource({
+		key: 'resource',
+		create: () => ({
+			resource: {render: 'second'},
+			dispose: () => disposeCounts.second++,
+		}),
+	});
+
+	expect(sameFirstResource).toBe(firstResource);
+	expect(secondResource).not.toBe(firstResource);
+
+	firstManager.dispose();
+	expect(disposeCounts).toEqual({first: 1, second: 0});
+
+	firstManager.dispose();
+	expect(disposeCounts).toEqual({first: 1, second: 0});
+	expect(() =>
+		firstManager.getOrCreateResource({
+			key: 'after-dispose',
+			create: () => ({resource: {}, dispose: () => undefined}),
+		}),
+	).toThrow('Render resource manager has already been disposed');
+
+	secondManager.dispose();
+	expect(disposeCounts).toEqual({first: 1, second: 1});
+});

--- a/packages/media/src/audio-extraction/audio-manager.ts
+++ b/packages/media/src/audio-extraction/audio-manager.ts
@@ -1,12 +1,16 @@
 import type {AudioSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
-import {getTotalCacheStats} from '../caches';
 import type {RememberActualMatroskaTimestamps} from '../video-extraction/remember-actual-matroska-timestamps';
 import type {AudioSampleIterator} from './audio-iterator';
 import {makeAudioIterator} from './audio-iterator';
 
-export const makeAudioManager = () => {
+export const makeAudioManager = ({
+	getTotalCacheStats,
+}: {
+	getTotalCacheStats: () => {count: number; totalSize: number};
+}) => {
 	const iterators: AudioSampleIterator[] = [];
+	let disposed = false;
 
 	const makeIterator = ({
 		timeInSeconds,
@@ -95,6 +99,10 @@ export const makeAudioManager = () => {
 		logLevel: LogLevel;
 		maxCacheSize: number;
 	}) => {
+		if (disposed) {
+			throw new Error('Media cache has already been disposed');
+		}
+
 		let attempts = 0;
 		const maxAttempts = 3;
 		while (
@@ -135,6 +143,9 @@ export const makeAudioManager = () => {
 		}
 
 		deleteDuplicateIterators(logLevel);
+		if (disposed) {
+			throw new Error('Media cache has already been disposed');
+		}
 
 		return makeIterator({
 			src,
@@ -162,6 +173,23 @@ export const makeAudioManager = () => {
 		for (const iterator of iterators) {
 			iterator.logOpenFrames();
 		}
+	};
+
+	const clearAll = () => {
+		for (const iterator of iterators) {
+			iterator.prepareForDeletion();
+		}
+
+		iterators.length = 0;
+	};
+
+	const dispose = () => {
+		if (disposed) {
+			return;
+		}
+
+		disposed = true;
+		clearAll();
 	};
 
 	let queue = Promise.resolve<unknown>(undefined);
@@ -201,5 +229,7 @@ export const makeAudioManager = () => {
 		getIteratorMostInThePast,
 		logOpenFrames,
 		deleteDuplicateIterators,
+		clearAll,
+		dispose,
 	};
 };

--- a/packages/media/src/audio-extraction/extract-audio.ts
+++ b/packages/media/src/audio-extraction/extract-audio.ts
@@ -1,5 +1,5 @@
 import {type LogLevel} from 'remotion';
-import {audioManager} from '../caches';
+import type {MediaCache} from '../caches';
 import {combineAudioDataAndClosePrevious} from '../convert-audiodata/combine-audiodata';
 import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {
@@ -10,7 +10,6 @@ import {
 	TARGET_NUMBER_OF_CHANNELS,
 	getTargetSampleRate,
 } from '../convert-audiodata/resample-audiodata';
-import {getSink} from '../get-sink';
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import {
 	isNetworkError,
@@ -34,6 +33,7 @@ type ExtractAudioParams = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	mediaCache: MediaCache;
 };
 
 const extractAudioInternal = async ({
@@ -50,6 +50,7 @@ const extractAudioInternal = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	mediaCache,
 }: ExtractAudioParams): Promise<
 	| {
 			data: PcmS16AudioData | null;
@@ -60,7 +61,12 @@ const extractAudioInternal = async ({
 	| 'network-error'
 > => {
 	const {getAudio, actualMatroskaTimestamps, isMatroska, getDuration} =
-		await getSink(src, logLevel, credentials, requestInit);
+		await mediaCache.sinkManager.getSink(
+			src,
+			logLevel,
+			credentials,
+			requestInit,
+		);
 
 	let mediaDurationInSeconds: number | null = null;
 	if (loop) {
@@ -101,7 +107,7 @@ const extractAudioInternal = async ({
 	}
 
 	try {
-		const sampleIterator = await audioManager.getIterator({
+		const sampleIterator = await mediaCache.audioManager.getIterator({
 			src,
 			timeInSeconds,
 			audioSampleSink: audio.sampleSink,
@@ -118,7 +124,7 @@ const extractAudioInternal = async ({
 			durationInSeconds,
 		);
 
-		audioManager.logOpenFrames();
+		mediaCache.audioManager.logOpenFrames();
 
 		const audioDataArray: PcmS16AudioData[] = [];
 		for (let i = 0; i < samples.length; i++) {

--- a/packages/media/src/audio-extraction/extract-audio.ts
+++ b/packages/media/src/audio-extraction/extract-audio.ts
@@ -225,12 +225,10 @@ const extractAudioInternal = async ({
 	}
 };
 
-let queue = Promise.resolve<ExtractAudioReturnType | undefined>(undefined);
-
 export const extractAudio = (
 	params: ExtractAudioParams,
 ): Promise<ExtractAudioReturnType> => {
-	queue = queue.then(() => extractAudioInternal(params));
-
-	return queue as Promise<ExtractAudioReturnType>;
+	return params.mediaCache.queueAudioExtraction(() =>
+		extractAudioInternal(params),
+	);
 };

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -9,7 +9,7 @@ import {
 	useDelayRender,
 	useRemotionEnvironment,
 } from 'remotion';
-import {useMaxMediaCacheSize} from '../caches';
+import {useMaxMediaCacheSize, useRenderMediaCache} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
@@ -85,6 +85,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	);
 
 	const maxCacheSize = useMaxMediaCacheSize(logLevel);
+	const mediaCache = useRenderMediaCache(logLevel);
 
 	const audioEnabled = Internals.useAudioEnabled();
 
@@ -134,8 +135,13 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 			maxCacheSize,
 			credentials,
 			requestInit: initialRequestInit,
+			mediaCache,
 		})
 			.then((result) => {
+				if (mediaCache.isDisposed()) {
+					return;
+				}
+
 				const handleError = (
 					error: Error,
 					clientSideError: Error,
@@ -242,6 +248,10 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 				continueRender(newHandle);
 			})
 			.catch((error) => {
+				if (mediaCache.isDisposed()) {
+					return;
+				}
+
 				cancelRender(error);
 			});
 
@@ -280,6 +290,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 		onError,
 		credentials,
 		initialRequestInit,
+		mediaCache,
 	]);
 
 	if (replaceWithHtml5Audio) {

--- a/packages/media/src/caches.ts
+++ b/packages/media/src/caches.ts
@@ -1,23 +1,100 @@
 import React from 'react';
 import {cancelRender, Internals, type LogLevel} from 'remotion';
 import {makeAudioManager} from './audio-extraction/audio-manager';
+import {makeSinkManager} from './get-sink';
 import {makeKeyframeManager} from './video-extraction/keyframe-manager';
 
 // Frames can be out of order, but we don't expect them to be more than 0.2 seconds out of order
 export const getSafeWindowOfMonotonicity = (fps: number) => (0.2 * 30) / fps;
 
-export const keyframeManager = makeKeyframeManager();
-export const audioManager = makeAudioManager();
+export const makeMediaCache = () => {
+	const sinkManager = makeSinkManager();
+	const managerInstances: {
+		keyframe: ReturnType<typeof makeKeyframeManager> | null;
+		audio: ReturnType<typeof makeAudioManager> | null;
+	} = {
+		keyframe: null,
+		audio: null,
+	};
+	const getCacheStats = () => {
+		const {keyframe: currentKeyframeManager, audio: currentAudioManager} =
+			managerInstances;
 
-export const getTotalCacheStats = () => {
-	const keyframeManagerCacheStats = keyframeManager.getCacheStats();
-	const audioManagerCacheStats = audioManager.getCacheStats();
+		if (currentKeyframeManager === null || currentAudioManager === null) {
+			throw new Error('Media cache managers have not been initialized');
+		}
+
+		const keyframeManagerCacheStats = currentKeyframeManager.getCacheStats();
+		const audioManagerCacheStats = currentAudioManager.getCacheStats();
+
+		return {
+			count: keyframeManagerCacheStats.count + audioManagerCacheStats.count,
+			totalSize:
+				keyframeManagerCacheStats.totalSize + audioManagerCacheStats.totalSize,
+		};
+	};
+
+	const keyframeManagerInstance = makeKeyframeManager({
+		getTotalCacheStats: getCacheStats,
+	});
+	const audioManagerInstance = makeAudioManager({
+		getTotalCacheStats: getCacheStats,
+	});
+	managerInstances.keyframe = keyframeManagerInstance;
+	managerInstances.audio = audioManagerInstance;
+	let disposed = false;
 
 	return {
-		count: keyframeManagerCacheStats.count + audioManagerCacheStats.count,
-		totalSize:
-			keyframeManagerCacheStats.totalSize + audioManagerCacheStats.totalSize,
+		sinkManager,
+		keyframeManager: keyframeManagerInstance,
+		audioManager: audioManagerInstance,
+		getTotalCacheStats: getCacheStats,
+		isDisposed: () => disposed,
+		dispose: (logLevel: LogLevel) => {
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			try {
+				keyframeManagerInstance.dispose(logLevel);
+			} finally {
+				try {
+					audioManagerInstance.dispose();
+				} finally {
+					sinkManager.dispose();
+				}
+			}
+		},
 	};
+};
+
+export type MediaCache = ReturnType<typeof makeMediaCache>;
+
+export const globalMediaCache = makeMediaCache();
+export const {keyframeManager, audioManager, getTotalCacheStats} =
+	globalMediaCache;
+
+export const useRenderMediaCache = (logLevel: LogLevel): MediaCache => {
+	const renderResourceManager = React.useContext(
+		Internals.RenderResourceManagerContext,
+	);
+
+	if (renderResourceManager === null) {
+		return globalMediaCache;
+	}
+
+	return renderResourceManager.getOrCreateResource({
+		key: '@remotion/media/cache',
+		create: () => {
+			const resource = makeMediaCache();
+
+			return {
+				resource,
+				dispose: () => resource.dispose(logLevel),
+			};
+		},
+	});
 };
 
 const getUncachedMaxCacheSize = (logLevel: LogLevel) => {

--- a/packages/media/src/caches.ts
+++ b/packages/media/src/caches.ts
@@ -42,6 +42,8 @@ export const makeMediaCache = () => {
 	});
 	managerInstances.keyframe = keyframeManagerInstance;
 	managerInstances.audio = audioManagerInstance;
+	let frameExtractionQueue = Promise.resolve<unknown>(undefined);
+	let audioExtractionQueue = Promise.resolve<unknown>(undefined);
 	let disposed = false;
 
 	return {
@@ -50,6 +52,16 @@ export const makeMediaCache = () => {
 		audioManager: audioManagerInstance,
 		getTotalCacheStats: getCacheStats,
 		isDisposed: () => disposed,
+		queueFrameExtraction: <T>(extract: () => Promise<T>) => {
+			const extraction = frameExtractionQueue.then(extract);
+			frameExtractionQueue = extraction.catch(() => undefined);
+			return extraction;
+		},
+		queueAudioExtraction: <T>(extract: () => Promise<T>) => {
+			const extraction = audioExtractionQueue.then(extract);
+			audioExtractionQueue = extraction.catch(() => undefined);
+			return extraction;
+		},
 		dispose: (logLevel: LogLevel) => {
 			if (disposed) {
 				return;

--- a/packages/media/src/extract-frame-and-audio.ts
+++ b/packages/media/src/extract-frame-and-audio.ts
@@ -1,5 +1,6 @@
 import type {LogLevel} from 'remotion';
 import {extractAudio} from './audio-extraction/extract-audio';
+import type {MediaCache} from './caches';
 import {isNetworkError} from './is-type-of-error';
 import type {MediaRequestInit} from './request-init';
 import {extractFrame} from './video-extraction/extract-frame';
@@ -22,6 +23,7 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	mediaCache,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -38,6 +40,7 @@ export const extractFrameAndAudio = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	mediaCache: MediaCache;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	try {
 		const [video, audio] = await Promise.all([
@@ -54,6 +57,7 @@ export const extractFrameAndAudio = async ({
 						maxCacheSize,
 						credentials,
 						requestInit,
+						mediaCache,
 					})
 				: null,
 			includeAudio
@@ -71,6 +75,7 @@ export const extractFrameAndAudio = async ({
 						maxCacheSize,
 						credentials,
 						requestInit,
+						mediaCache,
 					})
 				: null,
 		]);

--- a/packages/media/src/get-sink.ts
+++ b/packages/media/src/get-sink.ts
@@ -6,9 +6,7 @@ import {
 	type MediaRequestInit,
 } from './request-init';
 import type {GetSink} from './video-extraction/get-frames-since-keyframe';
-import {getSinks} from './video-extraction/get-frames-since-keyframe';
-
-export const sinkPromises: Record<string, Promise<GetSink>> = {};
+import {makeSinks} from './video-extraction/get-frames-since-keyframe';
 
 export const getSinkCacheKey = ({
 	src,
@@ -25,30 +23,75 @@ export const getSinkCacheKey = ({
 		getMediaRequestInitFingerprint(requestInit),
 	]);
 
-export const getSink = (
-	src: string,
-	logLevel: LogLevel,
-	credentials: RequestCredentials | undefined,
-	requestInit: MediaRequestInit | undefined,
-) => {
-	const normalizedRequestInit = normalizeMediaRequestInit(requestInit);
-	const cacheKey = getSinkCacheKey({
-		src,
-		credentials,
-		requestInit: normalizedRequestInit,
-	});
-	let promise = sinkPromises[cacheKey];
-	if (!promise) {
-		Internals.Log.verbose(
-			{
-				logLevel,
-				tag: '@remotion/media',
-			},
-			`Sink for ${src} was not found, creating new sink`,
-		);
-		promise = getSinks(src, logLevel, credentials, normalizedRequestInit);
-		sinkPromises[cacheKey] = promise;
-	}
+export const makeSinkManager = () => {
+	const sinkPromises: Record<string, Promise<GetSink>> = {};
+	const inputDisposers: Record<string, () => void> = {};
+	let disposed = false;
 
-	return promise;
+	return {
+		getSink: (
+			src: string,
+			logLevel: LogLevel,
+			credentials: RequestCredentials | undefined,
+			requestInit: MediaRequestInit | undefined,
+		) => {
+			if (disposed) {
+				return Promise.reject(
+					new Error('Media cache has already been disposed'),
+				);
+			}
+
+			const normalizedRequestInit = normalizeMediaRequestInit(requestInit);
+			const cacheKey = getSinkCacheKey({
+				src,
+				credentials,
+				requestInit: normalizedRequestInit,
+			});
+			let promise = sinkPromises[cacheKey];
+			if (!promise) {
+				Internals.Log.verbose(
+					{
+						logLevel,
+						tag: '@remotion/media',
+					},
+					`Sink for ${src} was not found, creating new sink`,
+				);
+				const sinks = makeSinks(
+					src,
+					logLevel,
+					credentials,
+					normalizedRequestInit,
+				);
+				promise = sinks.promise;
+				sinkPromises[cacheKey] = promise;
+				inputDisposers[cacheKey] = sinks.dispose;
+			}
+
+			return promise;
+		},
+		dispose: () => {
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			let firstError: unknown = null;
+			for (const cacheKey of Object.keys(inputDisposers)) {
+				try {
+					inputDisposers[cacheKey]();
+				} catch (error) {
+					firstError ??= error;
+				} finally {
+					delete inputDisposers[cacheKey];
+					delete sinkPromises[cacheKey];
+				}
+			}
+
+			if (firstError !== null) {
+				throw firstError;
+			}
+		},
+	};
 };
+
+export type SinkManager = ReturnType<typeof makeSinkManager>;

--- a/packages/media/src/test/audio-encoding.test.ts
+++ b/packages/media/src/test/audio-encoding.test.ts
@@ -1,6 +1,6 @@
 import {assert, expect, test} from 'vitest';
 import {extractAudio} from '../audio-extraction/extract-audio';
-import {getMaxVideoCacheSize} from '../caches';
+import {getMaxVideoCacheSize, globalMediaCache} from '../caches';
 
 // prettier-ignore
 const expectedFirst100 = [
@@ -36,6 +36,7 @@ test('Audio samples from MP3 should produce identical s16 output on Chrome and F
 		durationInSeconds: 1 / 30,
 		audioStreamIndex: 0,
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	if (a === 'cannot-decode') {

--- a/packages/media/src/test/browser.test.ts
+++ b/packages/media/src/test/browser.test.ts
@@ -1,5 +1,9 @@
 import {assert, expect, test} from 'vitest';
-import {getMaxVideoCacheSize, keyframeManager} from '../caches';
+import {
+	getMaxVideoCacheSize,
+	globalMediaCache,
+	keyframeManager,
+} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
 import {extractFrameAndAudio} from '../extract-frame-and-audio';
 
@@ -21,6 +25,7 @@ test('Should be able to extract a frame', async () => {
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	if (result.type === 'cannot-decode') {
@@ -77,6 +82,7 @@ test('Should be able to extract the last frame', async () => {
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	if (result.type === 'cannot-decode') {
@@ -132,6 +138,7 @@ test('Should manage the cache', async (t) => {
 			fps: 30,
 			maxCacheSize: getMaxVideoCacheSize('info'),
 			credentials: undefined,
+			mediaCache: globalMediaCache,
 		});
 	}
 
@@ -162,6 +169,7 @@ test('Should be apply volume correctly', async () => {
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	if (result.type === 'cannot-decode') {
@@ -221,6 +229,7 @@ test('Should be able to loop', async () => {
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	if (result.type === 'cannot-decode') {

--- a/packages/media/src/test/editlist-offset.test.ts
+++ b/packages/media/src/test/editlist-offset.test.ts
@@ -1,6 +1,6 @@
 import {assert, expect, test} from 'vitest';
 import {extractAudio} from '../audio-extraction/extract-audio';
-import {getMaxVideoCacheSize} from '../caches';
+import {getMaxVideoCacheSize, globalMediaCache} from '../caches';
 
 test('Audio extraction should be correct if there is edit list offset', async () => {
 	// Time: 0.00sec, should return null
@@ -17,6 +17,7 @@ test('Audio extraction should be correct if there is edit list offset', async ()
 		trimAfter: undefined,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 	assert(audio1 !== 'cannot-decode');
 	assert(audio1 !== 'unknown-container-format');
@@ -38,6 +39,7 @@ test('Audio extraction should be correct if there is edit list offset', async ()
 		trimAfter: undefined,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 	assert(audio2 !== 'cannot-decode');
 	assert(audio2 !== 'unknown-container-format');
@@ -62,6 +64,7 @@ test('Audio extraction should be correct if there is edit list offset', async ()
 		trimAfter: undefined,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 	assert(audio3 !== 'cannot-decode');
 	assert(audio3 !== 'unknown-container-format');

--- a/packages/media/src/test/extract-accuracy-uneven.test.ts
+++ b/packages/media/src/test/extract-accuracy-uneven.test.ts
@@ -1,6 +1,6 @@
 import {assert, expect, test} from 'vitest';
 import {extractAudio} from '../audio-extraction/extract-audio';
-import {getMaxVideoCacheSize} from '../caches';
+import {getMaxVideoCacheSize, globalMediaCache} from '../caches';
 
 test('Extract accuracy over 100 frames with playback rate 1.75', async () => {
 	const FPS = 25;
@@ -22,6 +22,7 @@ test('Extract accuracy over 100 frames with playback rate 1.75', async () => {
 			trimAfter: undefined,
 			maxCacheSize: getMaxVideoCacheSize('info'),
 			credentials: undefined,
+			mediaCache: globalMediaCache,
 		});
 		if (audio === 'cannot-decode') {
 			throw new Error(`Cannot decode at frame ${i}`);

--- a/packages/media/src/test/extract-accuracy.test.ts
+++ b/packages/media/src/test/extract-accuracy.test.ts
@@ -1,6 +1,6 @@
 import {assert, expect, test} from 'vitest';
 import {extractAudio} from '../audio-extraction/extract-audio';
-import {getMaxVideoCacheSize} from '../caches';
+import {getMaxVideoCacheSize, globalMediaCache} from '../caches';
 
 test('Extract accuracy over 100 frames with playback rate 2', async () => {
 	const FPS = 25;
@@ -22,6 +22,7 @@ test('Extract accuracy over 100 frames with playback rate 2', async () => {
 			trimAfter: undefined,
 			maxCacheSize: getMaxVideoCacheSize('info'),
 			credentials: undefined,
+			mediaCache: globalMediaCache,
 		});
 		if (audio === 'cannot-decode') {
 			throw new Error(`Cannot decode at frame ${i}`);

--- a/packages/media/src/test/looping.test.ts
+++ b/packages/media/src/test/looping.test.ts
@@ -1,5 +1,5 @@
 import {assert, expect, test} from 'vitest';
-import {getMaxVideoCacheSize} from '../caches';
+import {getMaxVideoCacheSize, globalMediaCache} from '../caches';
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import {extractFrame} from '../video-extraction/extract-frame';
 
@@ -44,6 +44,7 @@ test(
 				fps,
 				maxCacheSize: getMaxVideoCacheSize('info'),
 				credentials: undefined,
+				mediaCache: globalMediaCache,
 			});
 			expect(result.type).toBe('success');
 			assert(result.type === 'success');

--- a/packages/media/src/test/video-after-end.test.ts
+++ b/packages/media/src/test/video-after-end.test.ts
@@ -1,5 +1,9 @@
 import {assert, expect, test} from 'vitest';
-import {getMaxVideoCacheSize, keyframeManager} from '../caches';
+import {
+	getMaxVideoCacheSize,
+	globalMediaCache,
+	keyframeManager,
+} from '../caches';
 import {extractFrame} from '../video-extraction/extract-frame';
 
 test('Should render last frame for timestamps after video end', async () => {
@@ -16,6 +20,7 @@ test('Should render last frame for timestamps after video end', async () => {
 		fps: 24,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	assert(result.type === 'success');

--- a/packages/media/src/test/video-non-zero-start.test.ts
+++ b/packages/media/src/test/video-non-zero-start.test.ts
@@ -1,5 +1,9 @@
 import {assert, expect, test} from 'vitest';
-import {getMaxVideoCacheSize, keyframeManager} from '../caches';
+import {
+	getMaxVideoCacheSize,
+	globalMediaCache,
+	keyframeManager,
+} from '../caches';
 import {extractFrame} from '../video-extraction/extract-frame';
 
 test('Should render first frame for videos starting after timestamp 0', async () => {
@@ -20,6 +24,7 @@ test('Should render first frame for videos starting after timestamp 0', async ()
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	// Should successfully extract (no error thrown)

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -1,7 +1,11 @@
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
 import {assert, expect, test} from 'vitest';
 import {audioIteratorManager} from '../audio-iterator-manager';
-import {getMaxVideoCacheSize, keyframeManager} from '../caches';
+import {
+	getMaxVideoCacheSize,
+	globalMediaCache,
+	keyframeManager,
+} from '../caches';
 import {makeNonceManager} from '../nonce-manager';
 import {extractFrame} from '../video-extraction/extract-frame';
 import {videoIteratorManager} from '../video-iterator-manager';
@@ -194,6 +198,7 @@ test('in rendering, should also be smart', async (t) => {
 			fps: 30,
 			maxCacheSize: getMaxVideoCacheSize('info'),
 			credentials: undefined,
+			mediaCache: globalMediaCache,
 		});
 		assert(frame.type === 'success');
 		if (lastFrame) {
@@ -217,6 +222,7 @@ test('in rendering, should also be smart', async (t) => {
 		fps: 30,
 		maxCacheSize: getMaxVideoCacheSize('info'),
 		credentials: undefined,
+		mediaCache: globalMediaCache,
 	});
 
 	assert(firstRealFrame.type === 'success');

--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -1,4 +1,5 @@
 import type {LogLevel} from 'remotion';
+import {globalMediaCache} from '../caches';
 import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {extractFrameAndAudio} from '../extract-frame-and-audio';
 import type {MediaRequestInit} from '../request-init';
@@ -112,6 +113,7 @@ export const addBroadcastChannelListener = () => {
 						maxCacheSize: data.maxCacheSize,
 						credentials: data.credentials,
 						requestInit: data.requestInit,
+						mediaCache: globalMediaCache,
 					});
 
 					if (result.type === 'cannot-decode') {

--- a/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
+++ b/packages/media/src/video-extraction/extract-frame-via-broadcast-channel.ts
@@ -1,4 +1,5 @@
 import {type LogLevel} from 'remotion';
+import type {MediaCache} from '../caches';
 import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {extractFrameAndAudio} from '../extract-frame-and-audio';
 import {
@@ -46,6 +47,7 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	mediaCache,
 }: {
 	src: string;
 	timeInSeconds: number;
@@ -63,6 +65,7 @@ export const extractFrameViaBroadcastChannel = async ({
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	mediaCache: MediaCache;
 }): Promise<ExtractFrameViaBroadcastChannelResult> => {
 	if (isClientSideRendering || window.remotion_isMainTab) {
 		return extractFrameAndAudio({
@@ -81,6 +84,7 @@ export const extractFrameViaBroadcastChannel = async ({
 			maxCacheSize,
 			credentials,
 			requestInit,
+			mediaCache,
 		});
 	}
 

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -155,12 +155,10 @@ const extractFrameInternal = async ({
 
 type ExtractFrameReturnType = Awaited<ReturnType<typeof extractFrameInternal>>;
 
-let queue = Promise.resolve<ExtractFrameReturnType | undefined>(undefined);
-
 export const extractFrame = (
 	params: ExtractFrameParams,
 ): Promise<ExtractFrameReturnType> => {
-	queue = queue.then(() => extractFrameInternal(params));
-
-	return queue as Promise<ExtractFrameReturnType>;
+	return params.mediaCache.queueFrameExtraction(() =>
+		extractFrameInternal(params),
+	);
 };

--- a/packages/media/src/video-extraction/extract-frame.ts
+++ b/packages/media/src/video-extraction/extract-frame.ts
@@ -1,6 +1,5 @@
 import {Internals, type LogLevel} from 'remotion';
-import {keyframeManager} from '../caches';
-import {getSink} from '../get-sink';
+import type {MediaCache} from '../caches';
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import type {MediaRequestInit} from '../request-init';
 
@@ -29,6 +28,7 @@ type ExtractFrameParams = {
 	maxCacheSize: number;
 	credentials: RequestCredentials | undefined;
 	requestInit?: MediaRequestInit;
+	mediaCache: MediaCache;
 };
 
 const extractFrameInternal = async ({
@@ -43,8 +43,14 @@ const extractFrameInternal = async ({
 	maxCacheSize,
 	credentials,
 	requestInit,
+	mediaCache,
 }: ExtractFrameParams): Promise<ExtractFrameResult> => {
-	const sink = await getSink(src, logLevel, credentials, requestInit);
+	const sink = await mediaCache.sinkManager.getSink(
+		src,
+		logLevel,
+		credentials,
+		requestInit,
+	);
 
 	const [video, mediaDurationInSecondsRaw] = await Promise.all([
 		sink.getVideo(),
@@ -110,7 +116,7 @@ const extractFrameInternal = async ({
 	// https://discord.com/channels/@me/1127949286789881897/1455728482150518906
 	// Should be able to remove once upgraded to Chrome 145
 	try {
-		const keyframeBank = await keyframeManager.requestKeyframeBank({
+		const keyframeBank = await mediaCache.keyframeManager.requestKeyframeBank({
 			videoSampleSink: video.sampleSink,
 			timestamp: timeInSeconds,
 			src,

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -60,7 +60,7 @@ const getFormatOrNullOrNetworkError = async (
 	}
 };
 
-export const getSinks = async (
+export const makeSinks = (
 	src: string,
 	logLevel: LogLevel,
 	credentials: RequestCredentials | undefined,
@@ -74,143 +74,149 @@ export const getSinks = async (
 			...(resolvedRequestInit ? {requestInit: resolvedRequestInit} : undefined),
 		}),
 	});
+	const getSinks = async () => {
+		const format = await getFormatOrNullOrNetworkError(input);
+		const isMatroska = format === MATROSKA || format === WEBM;
 
-	const format = await getFormatOrNullOrNetworkError(input);
-	const isMatroska = format === MATROSKA || format === WEBM;
-
-	const getVideoSinks = async (): Promise<VideoSinkResult> => {
-		if (format === 'network-error') {
-			return 'network-error';
-		}
-
-		if (format === null) {
-			return 'unknown-container-format';
-		}
-
-		const videoTrack = await input.getPrimaryVideoTrack();
-		if (!videoTrack) {
-			return 'no-video-track';
-		}
-
-		if (await videoTrack.isLive()) {
-			throw new Error(
-				'Live streams are not currently supported by Remotion. Sorry! Source: ' +
-					src,
-			);
-		}
-
-		if (await videoTrack.isRelativeToUnixEpoch()) {
-			throw new Error(
-				'Streams with UNIX timestamps are not currently supported by Remotion. Sorry! Source: ' +
-					src,
-			);
-		}
-
-		const canDecode = await videoTrack.canDecode();
-
-		if (!canDecode) {
-			if (videoTrack.codec === 'prores') {
-				return 'cannot-decode-prores';
+		const getVideoSinks = async (): Promise<VideoSinkResult> => {
+			if (format === 'network-error') {
+				return 'network-error';
 			}
 
-			return 'cannot-decode';
-		}
+			if (format === null) {
+				return 'unknown-container-format';
+			}
 
-		const sampleSink = new VideoSampleSink(videoTrack);
-		const packetSink = new EncodedPacketSink(videoTrack);
+			const videoTrack = await input.getPrimaryVideoTrack();
+			if (!videoTrack) {
+				return 'no-video-track';
+			}
 
-		// Try to get the keypacket at the requested timestamp.
-		// If it returns null (timestamp is before the first keypacket), fall back to the first packet.
-		// This matches mediabunny's internal behavior and handles videos that don't start at timestamp 0.
-		const startPacket = await packetSink.getFirstPacket({
-			verifyKeyPackets: true,
-		});
+			if (await videoTrack.isLive()) {
+				throw new Error(
+					'Live streams are not currently supported by Remotion. Sorry! Source: ' +
+						src,
+				);
+			}
 
-		const hasAlpha = startPacket?.sideData.alpha;
-		if (hasAlpha && !canBrowserUseWebGl2()) {
-			Internals.Log.warn(
-				{logLevel, tag: '@remotion/media'},
-				`WebGL2 is not available, using the non-fast CPU path to decode alpha for ${src}.`,
-			);
-		}
+			if (await videoTrack.isRelativeToUnixEpoch()) {
+				throw new Error(
+					'Streams with UNIX timestamps are not currently supported by Remotion. Sorry! Source: ' +
+						src,
+				);
+			}
 
-		return {
-			sampleSink,
+			const canDecode = await videoTrack.canDecode();
+
+			if (!canDecode) {
+				if (videoTrack.codec === 'prores') {
+					return 'cannot-decode-prores';
+				}
+
+				return 'cannot-decode';
+			}
+
+			const sampleSink = new VideoSampleSink(videoTrack);
+			const packetSink = new EncodedPacketSink(videoTrack);
+
+			// Try to get the keypacket at the requested timestamp.
+			// If it returns null (timestamp is before the first keypacket), fall back to the first packet.
+			// This matches mediabunny's internal behavior and handles videos that don't start at timestamp 0.
+			const startPacket = await packetSink.getFirstPacket({
+				verifyKeyPackets: true,
+			});
+
+			const hasAlpha = startPacket?.sideData.alpha;
+			if (hasAlpha && !canBrowserUseWebGl2()) {
+				Internals.Log.warn(
+					{logLevel, tag: '@remotion/media'},
+					`WebGL2 is not available, using the non-fast CPU path to decode alpha for ${src}.`,
+				);
+			}
+
+			return {
+				sampleSink,
+			};
 		};
-	};
 
-	let videoSinksPromise: Promise<VideoSinkResult> | null = null;
-	const getVideoSinksPromise = () => {
-		if (videoSinksPromise) {
+		let videoSinksPromise: Promise<VideoSinkResult> | null = null;
+		const getVideoSinksPromise = () => {
+			if (videoSinksPromise) {
+				return videoSinksPromise;
+			}
+
+			videoSinksPromise = getVideoSinks();
 			return videoSinksPromise;
-		}
+		};
 
-		videoSinksPromise = getVideoSinks();
-		return videoSinksPromise;
-	};
+		// audioSinksPromise is now a record indexed by audio track index
+		const audioSinksPromise: Record<
+			number,
+			Promise<AudioSinkResult> | undefined
+		> = {};
 
-	// audioSinksPromise is now a record indexed by audio track index
-	const audioSinksPromise: Record<
-		number,
-		Promise<AudioSinkResult> | undefined
-	> = {};
+		const getAudioSinks = async (
+			index: number | null,
+		): Promise<AudioSinkResult> => {
+			if (format === null) {
+				return 'unknown-container-format';
+			}
 
-	const getAudioSinks = async (
-		index: number | null,
-	): Promise<AudioSinkResult> => {
-		if (format === null) {
-			return 'unknown-container-format';
-		}
+			if (format === 'network-error') {
+				return 'network-error';
+			}
 
-		if (format === 'network-error') {
-			return 'network-error';
-		}
+			const [videoTrack, audioTracks] = await Promise.all([
+				input.getPrimaryVideoTrack(),
+				input.getAudioTracks(),
+			]);
 
-		const [videoTrack, audioTracks] = await Promise.all([
-			input.getPrimaryVideoTrack(),
-			input.getAudioTracks(),
-		]);
+			const audioTrack = await resolveAudioTrack({
+				videoTrack,
+				audioTracks,
+				audioStreamIndex: index,
+			});
 
-		const audioTrack = await resolveAudioTrack({
-			videoTrack,
-			audioTracks,
-			audioStreamIndex: index,
-		});
+			if (!audioTrack) {
+				return 'no-audio-track';
+			}
 
-		if (!audioTrack) {
-			return 'no-audio-track';
-		}
+			const canDecode = await audioTrack.canDecode();
 
-		const canDecode = await audioTrack.canDecode();
+			if (!canDecode) {
+				return 'cannot-decode-audio';
+			}
 
-		if (!canDecode) {
-			return 'cannot-decode-audio';
-		}
+			return {
+				sampleSink: new AudioSampleSink(audioTrack),
+			};
+		};
+
+		const getAudioSinksPromise = (index: number | null) => {
+			const keyIndex = index === null ? -1 : index;
+			if (audioSinksPromise[keyIndex]) {
+				return audioSinksPromise[keyIndex];
+			}
+
+			audioSinksPromise[keyIndex] = getAudioSinks(index);
+			return audioSinksPromise[keyIndex];
+		};
 
 		return {
-			sampleSink: new AudioSampleSink(audioTrack),
+			getVideo: () => getVideoSinksPromise(),
+			getAudio: (index: number | null) => getAudioSinksPromise(index),
+			actualMatroskaTimestamps: rememberActualMatroskaTimestamps(isMatroska),
+			isMatroska,
+			getDuration: () => {
+				return getDurationOrCompute(input);
+			},
 		};
-	};
-
-	const getAudioSinksPromise = (index: number | null) => {
-		const keyIndex = index === null ? -1 : index;
-		if (audioSinksPromise[keyIndex]) {
-			return audioSinksPromise[keyIndex];
-		}
-
-		audioSinksPromise[keyIndex] = getAudioSinks(index);
-		return audioSinksPromise[keyIndex];
 	};
 
 	return {
-		getVideo: () => getVideoSinksPromise(),
-		getAudio: (index: number | null) => getAudioSinksPromise(index),
-		actualMatroskaTimestamps: rememberActualMatroskaTimestamps(isMatroska),
-		isMatroska,
-		getDuration: () => {
-			return getDurationOrCompute(input);
-		},
+		promise: getSinks(),
+		dispose: () => input.dispose(),
 	};
 };
 
-export type GetSink = Awaited<ReturnType<typeof getSinks>>;
+export type GetSink = Awaited<ReturnType<typeof makeSinks>['promise']>;

--- a/packages/media/src/video-extraction/keyframe-manager.ts
+++ b/packages/media/src/video-extraction/keyframe-manager.ts
@@ -1,15 +1,34 @@
 import type {VideoSampleSink} from 'mediabunny';
 import {Internals, type LogLevel} from 'remotion';
-import {getSafeWindowOfMonotonicity, getTotalCacheStats} from '../caches';
+import {getSafeWindowOfMonotonicity} from '../caches';
 import {renderTimestampRange} from '../render-timestamp-range';
 import {type KeyframeBank, makeKeyframeBank} from './keyframe-bank';
 
-export const makeKeyframeManager = () => {
+export const makeKeyframeManager = ({
+	getTotalCacheStats,
+}: {
+	getTotalCacheStats: () => {count: number; totalSize: number};
+}) => {
 	let sources: Record<string, KeyframeBank[]> = {};
+	let disposed = false;
 
-	const addKeyframeBank = ({src, bank}: {src: string; bank: KeyframeBank}) => {
+	const addKeyframeBank = ({
+		src,
+		bank,
+		logLevel,
+	}: {
+		src: string;
+		bank: KeyframeBank;
+		logLevel: LogLevel;
+	}) => {
+		if (disposed) {
+			bank.prepareForDeletion(logLevel, 'media cache was disposed');
+			return false;
+		}
+
 		sources[src] = sources[src] ?? [];
 		sources[src].push(bank);
+		return true;
 	};
 
 	const logCacheStats = (logLevel: LogLevel) => {
@@ -230,7 +249,9 @@ export const makeKeyframeManager = () => {
 				initialTimestampRequest: timestamp,
 			});
 
-			addKeyframeBank({src, bank: newKeyframeBank});
+			if (!addKeyframeBank({src, bank: newKeyframeBank, logLevel})) {
+				return null;
+			}
 
 			return newKeyframeBank;
 		}
@@ -262,7 +283,9 @@ export const makeKeyframeManager = () => {
 			src,
 		});
 
-		addKeyframeBank({src, bank: replacementKeybank});
+		if (!addKeyframeBank({src, bank: replacementKeybank, logLevel})) {
+			return null;
+		}
 
 		return replacementKeybank;
 	};
@@ -282,6 +305,10 @@ export const makeKeyframeManager = () => {
 		maxCacheSize: number;
 		fps: number;
 	}) => {
+		if (disposed) {
+			return null;
+		}
+
 		ensureToStayUnderMaxCacheSize(logLevel, maxCacheSize);
 
 		clearKeyframeBanksBeforeTime({
@@ -316,6 +343,15 @@ export const makeKeyframeManager = () => {
 		sources = {};
 	};
 
+	const dispose = (logLevel: LogLevel) => {
+		if (disposed) {
+			return;
+		}
+
+		disposed = true;
+		clearAll(logLevel);
+	};
+
 	let queue = Promise.resolve<unknown>(undefined);
 
 	return {
@@ -344,10 +380,11 @@ export const makeKeyframeManager = () => {
 					fps,
 				}),
 			);
-			return queue as Promise<KeyframeBank>;
+			return queue as Promise<KeyframeBank | null>;
 		},
 		getCacheStats,
 		clearAll,
+		dispose,
 	};
 };
 

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -21,7 +21,7 @@ import {
 	useRemotionEnvironment,
 	useVideoConfig,
 } from 'remotion';
-import {useMaxMediaCacheSize} from '../caches';
+import {useMaxMediaCacheSize, useRenderMediaCache} from '../caches';
 import {applyVolume} from '../convert-audiodata/apply-volume';
 import {getTargetSampleRate} from '../convert-audiodata/resample-audiodata';
 import {frameForVolumeProp} from '../looped-frame';
@@ -138,6 +138,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 	const videoEnabled = Internals.useVideoEnabled();
 
 	const maxCacheSize = useMaxMediaCacheSize(logLevel);
+	const mediaCache = useRenderMediaCache(logLevel);
 	const effectChainState = Internals.useEffectChainState();
 
 	const [error, setError] = useState<Error | null>(null);
@@ -203,8 +204,17 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 			maxCacheSize,
 			credentials,
 			requestInit: initialRequestInit,
+			mediaCache,
 		})
 			.then(async (result) => {
+				if (mediaCache.isDisposed()) {
+					if (result.type === 'success') {
+						result.frame?.close();
+					}
+
+					return;
+				}
+
 				const handleError = (
 					err: Error,
 					clientSideError: Error,
@@ -393,6 +403,10 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 				continueRender(newHandle);
 			})
 			.catch((err) => {
+				if (mediaCache.isDisposed()) {
+					return;
+				}
+
 				cancelRender(err);
 			});
 
@@ -437,6 +451,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 		effectChainState,
 		effects,
 		initialRequestInit,
+		mediaCache,
 	]);
 
 	warnAboutObjectFitInStyleOrClassName({style, className, logLevel});

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -343,7 +343,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 								height: imageBitmap.height,
 							});
 
-							if (!completed) {
+							if (!completed || mediaCache.isDisposed()) {
 								imageBitmap.close();
 								return;
 							}

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -252,85 +252,90 @@ export function createScaffold<Props extends Record<string, unknown>>({
 	const collectAssets = createRef<{
 		collectAssets: () => TRenderAsset[];
 	}>();
+	const renderResourceManager = Internals.makeRenderResourceManager();
 
 	flushSync(() => {
 		root.render(
-			<Internals.MaxMediaCacheSizeContext.Provider
-				value={mediaCacheSizeInBytes}
+			<Internals.RenderResourceManagerContext.Provider
+				value={renderResourceManager}
 			>
-				<Internals.RemotionEnvironmentContext.Provider
-					value={{
-						isStudio: false,
-						isRendering: true,
-						isPlayer: false,
-						isReadOnlyStudio: false,
-						isClientSideRendering: true,
-					}}
+				<Internals.MaxMediaCacheSizeContext.Provider
+					value={mediaCacheSizeInBytes}
 				>
-					<Internals.DelayRenderContextType.Provider value={delayRenderScope}>
-						<Internals.CompositionManager.Provider
-							value={{
-								compositions: [
-									{
-										id,
-										// @ts-expect-error
-										component: Component,
-										nonce: [[0, 0]],
-										defaultProps: {},
-										folderName: null,
-										parentFolderName: null,
-										schema: schema ?? null,
-										calculateMetadata: null,
+					<Internals.RemotionEnvironmentContext.Provider
+						value={{
+							isStudio: false,
+							isRendering: true,
+							isPlayer: false,
+							isReadOnlyStudio: false,
+							isClientSideRendering: true,
+						}}
+					>
+						<Internals.DelayRenderContextType.Provider value={delayRenderScope}>
+							<Internals.CompositionManager.Provider
+								value={{
+									compositions: [
+										{
+											id,
+											// @ts-expect-error
+											component: Component,
+											nonce: [[0, 0]],
+											defaultProps: {},
+											folderName: null,
+											parentFolderName: null,
+											schema: schema ?? null,
+											calculateMetadata: null,
+											durationInFrames,
+											fps,
+											height,
+											width,
+										},
+									],
+									canvasContent: {
+										type: 'composition',
+										compositionId: id,
+									},
+									currentCompositionMetadata: {
+										props: resolvedProps,
 										durationInFrames,
 										fps,
 										height,
 										width,
+										defaultCodec: defaultCodec ?? null,
+										defaultOutName: defaultOutName ?? null,
+										defaultVideoImageFormat: null,
+										defaultPixelFormat: null,
+										defaultProResProfile: null,
+										defaultSampleRate: null,
 									},
-								],
-								canvasContent: {
-									type: 'composition',
-									compositionId: id,
-								},
-								currentCompositionMetadata: {
-									props: resolvedProps,
-									durationInFrames,
-									fps,
-									height,
-									width,
-									defaultCodec: defaultCodec ?? null,
-									defaultOutName: defaultOutName ?? null,
-									defaultVideoImageFormat: null,
-									defaultPixelFormat: null,
-									defaultProResProfile: null,
-									defaultSampleRate: null,
-								},
-								folders: [],
-							}}
-						>
-							<Internals.PixelDensityContext.Provider value={pixelDensity}>
-								<Internals.RenderAssetManagerProvider
-									collectAssets={collectAssets}
-								>
-									<UpdateTime
-										audioEnabled={audioEnabled}
-										videoEnabled={videoEnabled}
-										logLevel={logLevel}
-										compId={id}
-										initialFrame={initialFrame}
-										timeUpdater={timeUpdater}
+									folders: [],
+								}}
+							>
+								<Internals.PixelDensityContext.Provider value={pixelDensity}>
+									<Internals.RenderAssetManagerProvider
+										collectAssets={collectAssets}
 									>
-										<Internals.CanUseRemotionHooks.Provider value>
-											{/**
-											 * @ts-expect-error	*/}
-											<Component {...resolvedProps} />
-										</Internals.CanUseRemotionHooks.Provider>
-									</UpdateTime>
-								</Internals.RenderAssetManagerProvider>
-							</Internals.PixelDensityContext.Provider>
-						</Internals.CompositionManager.Provider>
-					</Internals.DelayRenderContextType.Provider>
-				</Internals.RemotionEnvironmentContext.Provider>
-			</Internals.MaxMediaCacheSizeContext.Provider>,
+										<UpdateTime
+											audioEnabled={audioEnabled}
+											videoEnabled={videoEnabled}
+											logLevel={logLevel}
+											compId={id}
+											initialFrame={initialFrame}
+											timeUpdater={timeUpdater}
+										>
+											<Internals.CanUseRemotionHooks.Provider value>
+												{/**
+												 * @ts-expect-error	*/}
+												<Component {...resolvedProps} />
+											</Internals.CanUseRemotionHooks.Provider>
+										</UpdateTime>
+									</Internals.RenderAssetManagerProvider>
+								</Internals.PixelDensityContext.Provider>
+							</Internals.CompositionManager.Provider>
+						</Internals.DelayRenderContextType.Provider>
+					</Internals.RemotionEnvironmentContext.Provider>
+				</Internals.MaxMediaCacheSizeContext.Provider>
+			</Internals.RenderResourceManagerContext.Provider>,
 		);
 	});
 	updateFallbackScaffoldVisibility();
@@ -342,14 +347,21 @@ export function createScaffold<Props extends Record<string, unknown>>({
 		htmlInCanvasContext,
 		[Symbol.dispose]: () => {
 			fallbackScaffoldObserver?.disconnect();
-			root.unmount();
-			if (htmlInCanvasContext) {
-				teardownHtmlInCanvas({htmlInCanvasContext, wrapper, div});
-			}
+			try {
+				root.unmount();
+			} finally {
+				try {
+					renderResourceManager.dispose();
+				} finally {
+					if (htmlInCanvasContext) {
+						teardownHtmlInCanvas({htmlInCanvasContext, wrapper, div});
+					}
 
-			div.remove();
-			wrapper.remove();
-			cleanupCSS();
+					div.remove();
+					wrapper.remove();
+					cleanupCSS();
+				}
+			}
 		},
 		timeUpdater,
 		collectAssets,

--- a/packages/web-renderer/src/test/abort-render.test.tsx
+++ b/packages/web-renderer/src/test/abort-render.test.tsx
@@ -1,3 +1,6 @@
+import {Video} from '@remotion/media';
+import {Input} from 'mediabunny';
+import {staticFile} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
@@ -13,9 +16,10 @@ test('should be able to cancel renderMediaOnWeb()', async (t) => {
 	}
 
 	const Component: React.FC = () => {
-		return null;
+		return <Video src={staticFile('video.mp4')} />;
 	};
 
+	const disposeSpy = vi.spyOn(Input.prototype, 'dispose');
 	const controller = new AbortController();
 
 	const prom = renderMediaOnWeb({
@@ -30,14 +34,19 @@ test('should be able to cancel renderMediaOnWeb()', async (t) => {
 		},
 		signal: controller.signal,
 		inputProps: {},
+		onProgress: ({renderedFrames}) => {
+			if (renderedFrames === 1) {
+				controller.abort();
+			}
+		},
 	});
 
-	await new Promise((resolve) => {
-		setTimeout(resolve, 200);
-	});
-
-	controller.abort();
-	await expect(prom).rejects.toThrow('renderMediaOnWeb() was cancelled');
+	try {
+		await expect(prom).rejects.toThrow('renderMediaOnWeb() was cancelled');
+		expect(disposeSpy).toHaveBeenCalled();
+	} finally {
+		disposeSpy.mockRestore();
+	}
 });
 
 test('should be able to cancel renderStillOnWeb()', async () => {

--- a/packages/web-renderer/src/test/abort-render.test.tsx
+++ b/packages/web-renderer/src/test/abort-render.test.tsx
@@ -1,5 +1,6 @@
-import {Video} from '@remotion/media';
+import {Audio, Video} from '@remotion/media';
 import {Input} from 'mediabunny';
+import {useEffect} from 'react';
 import {staticFile} from 'remotion';
 import {expect, test, vi} from 'vitest';
 import {renderMediaOnWeb} from '../render-media-on-web';
@@ -47,6 +48,76 @@ test('should be able to cancel renderMediaOnWeb()', async (t) => {
 	} finally {
 		disposeSpy.mockRestore();
 	}
+});
+
+test('should render successfully after aborting during media extraction', async (t) => {
+	if (t.task.file.projectName !== 'firefox') {
+		t.skip();
+		return;
+	}
+
+	const controller = new AbortController();
+	const AbortingComponent: React.FC = () => {
+		useEffect(() => {
+			const timeout = setTimeout(() => controller.abort(), 0);
+
+			return () => clearTimeout(timeout);
+		}, []);
+
+		return (
+			<>
+				<Video src={staticFile('video.mp4')} />
+				<Audio src={staticFile('dialogue.wav')} />
+			</>
+		);
+	};
+
+	await expect(
+		renderMediaOnWeb({
+			licenseKey: 'free-license',
+			composition: {
+				component: AbortingComponent,
+				id: 'abort-during-media-extraction',
+				width: 100,
+				height: 100,
+				fps: 30,
+				durationInFrames: 10,
+			},
+			signal: controller.signal,
+			container: 'webm',
+			videoCodec: 'vp8',
+			outputTarget: 'arraybuffer',
+			inputProps: {},
+		}),
+	).rejects.toThrow('renderMediaOnWeb() was cancelled');
+
+	const SuccessfulComponent: React.FC = () => {
+		return (
+			<>
+				<Video src={staticFile('video.mp4')} />
+				<Audio src={staticFile('dialogue.wav')} />
+			</>
+		);
+	};
+
+	const result = await renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition: {
+			component: SuccessfulComponent,
+			id: 'render-after-abort',
+			width: 100,
+			height: 100,
+			fps: 30,
+			durationInFrames: 1,
+		},
+		frameRange: [0, 0],
+		container: 'webm',
+		videoCodec: 'vp8',
+		outputTarget: 'arraybuffer',
+		inputProps: {},
+	});
+
+	expect((await result.getBlob()).size).toBeGreaterThan(0);
 });
 
 test('should be able to cancel renderStillOnWeb()', async () => {

--- a/packages/web-renderer/src/test/video.test.tsx
+++ b/packages/web-renderer/src/test/video.test.tsx
@@ -1,6 +1,7 @@
 import {Video} from '@remotion/media';
+import {Input} from 'mediabunny';
 import {AbsoluteFill, staticFile} from 'remotion';
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {testImage} from './utils';
@@ -20,8 +21,9 @@ test('can extract a video frame', async (t) => {
 		);
 	};
 
-	const blob = await (
-		await renderStillOnWeb({
+	const disposeSpy = vi.spyOn(Input.prototype, 'dispose');
+	const render = () =>
+		renderStillOnWeb({
 			licenseKey: 'free-license',
 			composition: {
 				component: Component,
@@ -35,14 +37,27 @@ test('can extract a video frame', async (t) => {
 			frame: 20,
 			inputProps: {},
 			delayRenderTimeoutInMilliseconds: 5000,
-		})
-	).blob({format: 'png'});
+		});
 
-	await testImage({
-		blob,
-		testId: 'video-tag',
-		allowedMismatchedPixelRatio: 0.01,
-	});
+	try {
+		const blob = await (await render()).blob({format: 'png'});
+
+		await testImage({
+			blob,
+			testId: 'video-tag',
+			allowedMismatchedPixelRatio: 0.01,
+		});
+
+		expect(disposeSpy).toHaveBeenCalled();
+		const disposedInputsAfterFirstRender = disposeSpy.mock.calls.length;
+
+		await render();
+		expect(disposeSpy.mock.calls.length).toBeGreaterThan(
+			disposedInputsAfterFirstRender,
+		);
+	} finally {
+		disposeSpy.mockRestore();
+	}
 });
 
 test('cannot render inside an svg tag', async () => {


### PR DESCRIPTION
## Summary

- scope sink, keyframe, and audio extraction caches to each client-side render
- dispose decoded media samples and Mediabunny inputs when a render succeeds, fails, or is aborted
- leave the preview media lifecycle unchanged

Alternative implementation to #10208.

## Tests

- `bun test src/test/render-resource-manager.test.ts`
- `bunx vitest src/test --browser --run` in `packages/media` (95 passed)
- `bunx vitest src/test/video.test.tsx src/test/abort-render.test.tsx --browser --run`
- `bun run build`
- `bun run stylecheck`

The success-path cleanup regression was also verified red/green by temporarily removing render-resource disposal: Firefox and WebKit failed until the disposal path was restored.
