### PR TITLE
`@remotion/studio`: Lazily measure selected outlines

### DIFF
--- a/packages/example/e2e/render-output-drag.test.mts
+++ b/packages/example/e2e/render-output-drag.test.mts
@@ -176,8 +176,15 @@ test.describe('render output dragging', () => {
 					}),
 				);
 			});
-			await expect.poll(() => fs.existsSync(copiedAsset)).toBe(true);
-			expect(fs.readFileSync(copiedAsset)).toEqual(contents);
+			await expect
+				.poll(() => {
+					if (!fs.existsSync(copiedAsset)) {
+						return false;
+					}
+
+					return fs.readFileSync(copiedAsset).equals(contents);
+				})
+				.toBe(true);
 			await expect(
 				page.getByText('render-output-drag-e2e.mp4', {exact: true}),
 			).toBeVisible();

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -253,29 +253,6 @@ test.describe('visual mode', () => {
 				.getByLabel('4 other programmatically duplicated instances are hidden'),
 		).toBeVisible({timeout: 15_000});
 		await expect(page.getByText('25% gridline', {exact: true})).toHaveCount(0);
-		const visibleOutlines = page.locator(
-			'.remotion-studio-composition-container > svg[aria-hidden="true"] > polygon[stroke-opacity="1"]',
-		);
-
-		await firstGridline.hover();
-		await expect(visibleOutlines).toHaveCount(5);
-
-		const northCanvasLabel = page
-			.locator('.remotion-studio-composition-container')
-			.getByText('North', {exact: true});
-		await northCanvasLabel.hover({force: true});
-		await expect(visibleOutlines).toHaveCount(5);
-		const centralCanvasLabel = page
-			.locator('.remotion-studio-composition-container')
-			.getByText('Central', {exact: true});
-		const northLabelTitles = page.getByTitle('North label');
-		const northLabelTitleCountBeforeSelection = await northLabelTitles.count();
-		await centralCanvasLabel.click({force: true});
-		await expect(northLabelTitles).toHaveCount(
-			northLabelTitleCountBeforeSelection + 1,
-		);
-		await page.mouse.move(0, 0);
-		await expect(visibleOutlines).toHaveCount(5);
 
 		await firstGridline.click();
 		const duplicationLabel = page.getByText('5 instances', {

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -7,6 +7,7 @@ import React, {
 	useLayoutEffect,
 	useMemo,
 	useRef,
+	useState,
 } from 'react';
 import type {CanvasContent} from 'remotion';
 import {Internals} from 'remotion';
@@ -147,6 +148,26 @@ const CompWhenItHasDimensions: React.FC<{
 	readonly assetMetadata: AssetMetadata | null;
 }> = ({contentDimensions, canvasSize, canvasContent, assetMetadata}) => {
 	const {size: previewSize} = useContext(Internals.PreviewSizeContext);
+	const [canvasHovered, setCanvasHovered] = useState(false);
+	const compositionContainerRef = useRef<HTMLDivElement>(null);
+	useEffect(() => {
+		const compositionContainer = compositionContainerRef.current;
+		if (compositionContainer === null) {
+			setCanvasHovered(false);
+			return;
+		}
+
+		const onPointerEnter = () => setCanvasHovered(true);
+		const onPointerLeave = () => setCanvasHovered(false);
+		setCanvasHovered(compositionContainer.matches(':hover'));
+		compositionContainer.addEventListener('pointerenter', onPointerEnter);
+		compositionContainer.addEventListener('pointerleave', onPointerLeave);
+
+		return () => {
+			compositionContainer.removeEventListener('pointerenter', onPointerEnter);
+			compositionContainer.removeEventListener('pointerleave', onPointerLeave);
+		};
+	}, [canvasContent.type]);
 
 	const {centerX, centerY, yCorrection, xCorrection, scale} = useMemo(() => {
 		if (contentDimensions === 'none') {
@@ -240,7 +261,11 @@ const CompWhenItHasDimensions: React.FC<{
 	}
 
 	return (
-		<div className="remotion-studio-composition-container" style={outer}>
+		<div
+			ref={compositionContainerRef}
+			className="remotion-studio-composition-container"
+			style={outer}
+		>
 			<PortalContainer
 				contentDimensions={contentDimensions as Dimensions}
 				scale={scale}
@@ -248,6 +273,7 @@ const CompWhenItHasDimensions: React.FC<{
 				yCorrection={yCorrection}
 			/>
 			<SelectedOutlineOverlay
+				canvasHovered={canvasHovered}
 				compositionHeight={(contentDimensions as Dimensions).height}
 				compositionWidth={(contentDimensions as Dimensions).width}
 				scale={scale}

--- a/packages/studio/src/components/SelectedOutlineKeyboardControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineKeyboardControls.tsx
@@ -15,11 +15,11 @@ import {
 	type SelectedOutlineKeyframedDragChange,
 	type SelectedOutlineStaticDragChange,
 } from './selected-outline-drag';
+import type {getSequencesWithSelectableOutlines} from './selected-outline-measurement';
 import {
 	getSelectedSequenceKeys,
 	getSequenceKeysContainingSelection,
 } from './selected-outline-measurement';
-import type {getSequencesWithSelectableOutlines} from './selected-outline-measurement';
 import {
 	translateFieldKey,
 	type SelectedOutlineKeyboardNudgeSession,
@@ -35,10 +35,10 @@ export const SelectedOutlineKeyboardControls: React.FC<{
 	readonly getLatestOutlineTargetByKey: (
 		key: string,
 	) => SelectedOutlineTarget | undefined;
-	readonly selectableOutlines: ReturnType<
+	readonly getSelectableOutlines: () => ReturnType<
 		typeof getSequencesWithSelectableOutlines
 	>;
-}> = ({getLatestOutlineTargetByKey, selectableOutlines}) => {
+}> = ({getLatestOutlineTargetByKey, getSelectableOutlines}) => {
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const {getDragOverrides} = useContext(
 		Internals.VisualModeDragOverridesContext,
@@ -210,6 +210,7 @@ export const SelectedOutlineKeyboardControls: React.FC<{
 			const selectedSequenceKeys = getSelectedSequenceKeys(selectedItems);
 			const sequenceKeysContainingSelection =
 				getSequenceKeysContainingSelection(selectedItems);
+			const selectableOutlines = getSelectableOutlines();
 			const allDragTargets = selectableOutlines.flatMap(({key}) => {
 				if (
 					!selectedSequenceKeys.has(key) &&
@@ -302,8 +303,8 @@ export const SelectedOutlineKeyboardControls: React.FC<{
 			getCurrentFrame,
 			getDragOverrides,
 			getLatestOutlineTargetByKey,
+			getSelectableOutlines,
 			seekWithArrowKey,
-			selectableOutlines,
 			setDragOverrides,
 		],
 	);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -180,6 +180,423 @@ const getCropDragFields = ({
 	return fields as SelectedOutlineCropDragTarget['fields'];
 };
 
+type SelectableOutlines = ReturnType<typeof getSequencesWithSelectableOutlines>;
+
+type CalculateOutlineTargetsOptions = {
+	readonly mode: 'controls' | 'layout';
+	readonly runtimeValuesByStore: ReadonlyMap<
+		RuntimeValueStore,
+		Readonly<Record<string, unknown>>
+	>;
+	readonly selectableOutlines: SelectableOutlines;
+	readonly targetKey: string | null;
+	readonly targetTimelinePosition: number;
+};
+
+type CalculateOutlineTargets = (
+	options: CalculateOutlineTargetsOptions,
+) => SelectedOutlineLayoutTarget[];
+
+const calculateOutlineTargets = ({
+	connectedClientId,
+	editorShowOutlines,
+	getDragOverrides,
+	getScaleLockState,
+	isFullscreen,
+	mode,
+	previewSelectionAvailable,
+	propStatuses,
+	runtimeValuesByStore,
+	selectableOutlines,
+	selectedCropInfo,
+	selectedEffectsBySequenceKey,
+	selectedSequenceKeys,
+	selectedTransformOriginInfo,
+	sequenceKeysContainingSelection,
+	studioInteractivityEnabled,
+	targetKey,
+	targetTimelinePosition,
+}: CalculateOutlineTargetsOptions & {
+	readonly connectedClientId: string | null;
+	readonly editorShowOutlines: boolean;
+	readonly getDragOverrides: React.ContextType<
+		typeof Internals.VisualModeDragOverridesContext
+	>['getDragOverrides'];
+	readonly getScaleLockState: React.ContextType<
+		typeof ScaleLockContext
+	>['getScaleLockState'];
+	readonly isFullscreen: boolean;
+	readonly previewSelectionAvailable: boolean;
+	readonly propStatuses: React.ContextType<
+		typeof Internals.VisualModePropStatusesContext
+	>['propStatuses'];
+	readonly selectedCropInfo: ReturnType<typeof getSelectedCropInfo>;
+	readonly selectedEffectsBySequenceKey: ReturnType<
+		typeof getSelectedEffectFieldsBySequenceKey
+	>;
+	readonly selectedSequenceKeys: ReadonlySet<string>;
+	readonly selectedTransformOriginInfo: ReturnType<
+		typeof getSelectedTransformOriginInfo
+	>;
+	readonly sequenceKeysContainingSelection: ReadonlySet<string>;
+	readonly studioInteractivityEnabled: boolean;
+}): SelectedOutlineLayoutTarget[] => {
+	if (
+		isFullscreen ||
+		!isStudioSelectionEnabled() ||
+		!previewSelectionAvailable ||
+		!editorShowOutlines
+	) {
+		return [];
+	}
+
+	const previewInteractive =
+		connectedClientId !== null && studioInteractivityEnabled;
+
+	const firstNodePathInfoBySourceNode = new Map<string, SequenceNodePathInfo>();
+	const selectedSourceNodeKeys = new Set<string>();
+	for (const {key, nodePathInfo} of selectableOutlines) {
+		const sourceNodeKey = timelineSequenceNodePathToKey(
+			nodePathInfo.sequenceSubscriptionKey,
+		);
+		if (selectedSequenceKeys.has(key)) {
+			selectedSourceNodeKeys.add(sourceNodeKey);
+		}
+
+		const currentFirst = firstNodePathInfoBySourceNode.get(sourceNodeKey);
+		if (currentFirst === undefined || nodePathInfo.index < currentFirst.index) {
+			firstNodePathInfoBySourceNode.set(sourceNodeKey, nodePathInfo);
+		}
+	}
+
+	return selectableOutlines.flatMap((selectableOutline) => {
+		const {key, keyframeDisplayOffset, nodePathInfo, sequence} =
+			selectableOutline;
+		if (targetKey !== null && targetKey !== key) {
+			return [];
+		}
+
+		if (sequence.refForOutline === null) {
+			throw new Error('Expected sequence to have a ref for outline');
+		}
+
+		const selected = selectedSequenceKeys.has(key);
+		const containsSelection = sequenceKeysContainingSelection.has(key);
+		const nodePath = nodePathInfo.sequenceSubscriptionKey;
+		const sourceNodeKey = timelineSequenceNodePathToKey(nodePath);
+		const showSelectedOutline =
+			containsSelection || selectedSourceNodeKeys.has(sourceNodeKey);
+		const selectionNodePathInfo =
+			firstNodePathInfoBySourceNode.get(sourceNodeKey);
+		if (selectionNodePathInfo === undefined) {
+			throw new Error('Expected a first sequence for the source node');
+		}
+
+		const {controls} = sequence;
+		const nodePropStatuses = Internals.getPropStatusesCtx(
+			propStatuses,
+			nodePath,
+		);
+		const sourceFrame = targetTimelinePosition - keyframeDisplayOffset;
+		const dragOverrides = getDragOverrides(nodePath) ?? {};
+		const runtimeValues = controls
+			? (runtimeValuesByStore.get(controls.runtimeValues) ??
+				controls.runtimeValues.getSnapshot())
+			: {};
+		const activeSchema = controls
+			? getSelectedOutlineActiveSchema({
+					schema: controls.schema,
+					currentRuntimeValueDotNotation: runtimeValues,
+					dragOverrides,
+					propStatus: nodePropStatuses,
+					frame: sourceFrame,
+				})
+			: null;
+		const cropValues = {
+			cropLeft: getEffectiveCropValue({
+				activeSchema,
+				dragOverrides,
+				fieldKey: cropFieldKeys.left,
+				frame: sourceFrame,
+				propStatuses: nodePropStatuses,
+				runtimeValues,
+			}),
+			cropRight: getEffectiveCropValue({
+				activeSchema,
+				dragOverrides,
+				fieldKey: cropFieldKeys.right,
+				frame: sourceFrame,
+				propStatuses: nodePropStatuses,
+				runtimeValues,
+			}),
+			cropTop: getEffectiveCropValue({
+				activeSchema,
+				dragOverrides,
+				fieldKey: cropFieldKeys.top,
+				frame: sourceFrame,
+				propStatuses: nodePropStatuses,
+				runtimeValues,
+			}),
+			cropBottom: getEffectiveCropValue({
+				activeSchema,
+				dragOverrides,
+				fieldKey: cropFieldKeys.bottom,
+				frame: sourceFrame,
+				propStatuses: nodePropStatuses,
+				runtimeValues,
+			}),
+		};
+		const crop = Internals.resolveSequenceCrop(cropValues);
+		const selectedForTransformOrigin =
+			selectedTransformOriginInfo?.sequenceKey === key;
+		const selectedForCrop = selectedCropInfo?.sequenceKey === key;
+		const selectedForUvHandles = selectedEffectsBySequenceKey.has(key);
+		const layoutTarget: SelectedOutlineLayoutTarget = {
+			key,
+			containsSelection,
+			crop,
+			keyframeDisplayOffset,
+			nodePathInfo,
+			ref: sequence.refForOutline,
+			selected,
+			selectedForCrop,
+			selectedForTransformOrigin,
+			selectedForUvHandles,
+			showSelectedOutline,
+			selection: {
+				type: 'sequence',
+				nodePathInfo: selectionNodePathInfo,
+			},
+			sequence,
+		};
+		if (mode === 'layout') {
+			return [layoutTarget];
+		}
+
+		const cropFields = getCropDragFields({
+			activeSchema,
+			cropValues,
+			propStatuses: nodePropStatuses,
+		});
+		const fieldSchema = activeSchema?.[translateFieldKey];
+		const propStatus = nodePropStatuses?.[translateFieldKey];
+		const scaleFieldSchema = activeSchema?.[scaleFieldKey];
+		const scalePropStatus = nodePropStatuses?.[scaleFieldKey];
+		const rotationFieldSchema = activeSchema?.[rotateFieldKey];
+		const rotationPropStatus = nodePropStatuses?.[rotateFieldKey];
+		const transformOriginFieldSchema = activeSchema?.[transformOriginFieldKey];
+		const transformOriginPropStatus =
+			nodePropStatuses?.[transformOriginFieldKey];
+		const transformOriginValueForRotation =
+			transformOriginFieldSchema?.type === 'transform-origin' &&
+			(transformOriginPropStatus?.status === 'static' ||
+				transformOriginPropStatus?.status === 'keyframed')
+				? String(
+						Internals.getEffectiveVisualModeValue({
+							propStatus: transformOriginPropStatus,
+							dragOverrideValue: dragOverrides[transformOriginFieldKey],
+							defaultValue: transformOriginFieldSchema.default,
+							frame: sourceFrame,
+							shouldResortToDefaultValueIfUndefined: true,
+						}) ?? transformOriginFieldSchema.default,
+					)
+				: '50% 50%';
+		const canDragStatus =
+			propStatus?.status === 'static' ||
+			(propStatus?.status === 'keyframed' &&
+				propStatus.interpolationFunction === 'interpolate');
+		const canRotationDragStatus =
+			rotationPropStatus?.status === 'static' ||
+			(rotationPropStatus?.status === 'keyframed' &&
+				rotationPropStatus.interpolationFunction === 'interpolate');
+		const canDrag =
+			previewInteractive &&
+			controls !== null &&
+			fieldSchema?.type === 'translate' &&
+			canDragStatus;
+		const canScaleDragStatus =
+			scalePropStatus?.status === 'static' ||
+			(scalePropStatus?.status === 'keyframed' &&
+				scalePropStatus.interpolationFunction === 'interpolate');
+		const canScaleDrag =
+			previewInteractive &&
+			controls !== null &&
+			scaleFieldSchema?.type === 'scale' &&
+			canScaleDragStatus;
+		const canRotationDrag =
+			previewInteractive &&
+			controls !== null &&
+			rotationFieldSchema?.type === 'rotation-css' &&
+			canRotationDragStatus;
+		const transformOriginSourceFrame =
+			selectedTransformOriginInfo?.displayFrame === null ||
+			selectedTransformOriginInfo?.displayFrame === undefined
+				? sourceFrame
+				: selectedTransformOriginInfo.displayFrame - keyframeDisplayOffset;
+		const canTransformOriginStatus =
+			transformOriginPropStatus?.status === 'static' ||
+			(transformOriginPropStatus?.status === 'keyframed' &&
+				transformOriginPropStatus.interpolationFunction === 'interpolate');
+		const canTransformOriginTranslateStatus =
+			propStatus?.status === 'static' ||
+			(propStatus?.status === 'keyframed' &&
+				propStatus.interpolationFunction === 'interpolate');
+		const canTransformOriginDrag =
+			previewInteractive &&
+			selectedForTransformOrigin &&
+			controls !== null &&
+			transformOriginFieldSchema?.type === 'transform-origin' &&
+			fieldSchema?.type === 'translate' &&
+			canTransformOriginStatus &&
+			canTransformOriginTranslateStatus;
+		const cropSourceFrame =
+			selectedCropInfo?.displayFrame === null ||
+			selectedCropInfo?.displayFrame === undefined
+				? sourceFrame
+				: selectedCropInfo.displayFrame - keyframeDisplayOffset;
+		const canCropDrag =
+			previewInteractive &&
+			selectedForCrop &&
+			controls !== null &&
+			cropFields !== null;
+		return [
+			{
+				...layoutTarget,
+				canCrop: previewInteractive && controls !== null && cropFields !== null,
+				cropDrag: canCropDrag
+					? {
+							clientId: connectedClientId,
+							fields: cropFields,
+							nodePath,
+							schema: controls.schema,
+							sourceFrame: cropSourceFrame,
+							transformOrigin:
+								transformOriginFieldSchema?.type === 'transform-origin' &&
+								transformOriginPropStatus !== undefined
+									? {
+											defaultValue: transformOriginFieldSchema.default,
+											propStatus: transformOriginPropStatus,
+											value: transformOriginValueForRotation,
+										}
+									: null,
+						}
+					: null,
+				drag: canDrag
+					? {
+							propStatus,
+							clientId: connectedClientId,
+							fieldDefault: fieldSchema.default,
+							keyframeDisplayOffset,
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
+				scaleDrag: canScaleDrag
+					? {
+							propStatus: scalePropStatus,
+							clientId: connectedClientId,
+							fieldDefault: scaleFieldSchema.default,
+							fieldSchema: scaleFieldSchema,
+							keyframeDisplayOffset,
+							linked: getScaleLockState({
+								nodePath,
+								fieldKey: scaleFieldKey,
+								defaultValue: (() => {
+									const dragOverrideValue = dragOverrides[scaleFieldKey];
+									const effectiveValue = Internals.getEffectiveVisualModeValue({
+										propStatus: scalePropStatus,
+										dragOverrideValue,
+										defaultValue: scaleFieldSchema.default,
+										shouldResortToDefaultValueIfUndefined: true,
+									});
+									const [x, y] =
+										NoReactInternals.parseScaleValue(effectiveValue);
+									return x === y;
+								})(),
+							}),
+							nodePath,
+							schema: controls.schema,
+						}
+					: null,
+				rotationDrag: canRotationDrag
+					? {
+							propStatus: rotationPropStatus,
+							clientId: connectedClientId,
+							fieldDefault: rotationFieldSchema.default,
+							fieldSchema: rotationFieldSchema,
+							keyframeDisplayOffset,
+							nodePath,
+							schema: controls.schema,
+							transformOriginValue: transformOriginValueForRotation,
+						}
+					: null,
+				transformOriginDrag: canTransformOriginDrag
+					? {
+							clientId: connectedClientId,
+							keyframeDisplayOffset,
+							nodePath,
+							originDefault: transformOriginFieldSchema.default,
+							originPropStatus: transformOriginPropStatus,
+							originValue: String(
+								Internals.getEffectiveVisualModeValue({
+									propStatus: transformOriginPropStatus,
+									dragOverrideValue: dragOverrides[transformOriginFieldKey],
+									defaultValue: transformOriginFieldSchema.default,
+									frame: transformOriginSourceFrame,
+									shouldResortToDefaultValueIfUndefined: true,
+								}) ?? transformOriginFieldSchema.default,
+							),
+							rotateValue: String(
+								rotationPropStatus?.status === 'static' ||
+									rotationPropStatus?.status === 'keyframed'
+									? (Internals.getEffectiveVisualModeValue({
+											propStatus: rotationPropStatus,
+											dragOverrideValue: dragOverrides[rotateFieldKey],
+											defaultValue:
+												rotationFieldSchema?.type === 'rotation-css'
+													? rotationFieldSchema.default
+													: '0deg',
+											frame: transformOriginSourceFrame,
+											shouldResortToDefaultValueIfUndefined: true,
+										}) ?? '0deg')
+									: '0deg',
+							),
+							scaleValue:
+								scalePropStatus?.status === 'static' ||
+								scalePropStatus?.status === 'keyframed'
+									? String(
+											Internals.getEffectiveVisualModeValue({
+												propStatus: scalePropStatus,
+												dragOverrideValue: dragOverrides[scaleFieldKey],
+												defaultValue:
+													scaleFieldSchema?.type === 'scale'
+														? scaleFieldSchema.default
+														: 1,
+												frame: transformOriginSourceFrame,
+												shouldResortToDefaultValueIfUndefined: true,
+											}) ?? 1,
+										)
+									: '1',
+							schema: controls.schema,
+							sourceFrame: transformOriginSourceFrame,
+							translateDefault: fieldSchema.default,
+							translatePropStatus: propStatus,
+							translateValue: String(
+								Internals.getEffectiveVisualModeValue({
+									propStatus,
+									dragOverrideValue: dragOverrides[translateFieldKey],
+									defaultValue: fieldSchema.default,
+									frame: transformOriginSourceFrame,
+									shouldResortToDefaultValueIfUndefined: true,
+								}) ?? fieldSchema.default,
+							),
+						}
+					: null,
+			} satisfies SelectedOutlineTarget,
+		];
+	});
+};
+
 export type {
 	SelectedOutlineDragState,
 	SelectedOutlineRotationDragState,
@@ -199,18 +616,7 @@ type ActiveSelectedOutlineOverlayProps = Omit<
 	SelectedOutlineOverlayProps,
 	'canvasHovered'
 > & {
-	readonly calculateOutlineTargets: (options: {
-		readonly mode: 'controls' | 'layout';
-		readonly runtimeValuesByStore: ReadonlyMap<
-			RuntimeValueStore,
-			Readonly<Record<string, unknown>>
-		>;
-		readonly selectableOutlines: ReturnType<
-			typeof getSequencesWithSelectableOutlines
-		>;
-		readonly targetKey: string | null;
-		readonly targetTimelinePosition: number;
-	}) => SelectedOutlineLayoutTarget[];
+	readonly calculateOutlineTargetsForCurrentState: CalculateOutlineTargets;
 	readonly draggingOutline: boolean;
 	readonly getLatestOutlineTargetByKey: (
 		key: string,
@@ -233,7 +639,7 @@ type ActiveSelectedOutlineOverlayProps = Omit<
 const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 	ActiveSelectedOutlineOverlayProps
 > = ({
-	calculateOutlineTargets,
+	calculateOutlineTargetsForCurrentState,
 	compositionHeight,
 	compositionWidth,
 	draggingOutline,
@@ -285,7 +691,7 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 
 	const outlineTargets = useMemo(
 		() =>
-			calculateOutlineTargets({
+			calculateOutlineTargetsForCurrentState({
 				mode: 'layout',
 				runtimeValuesByStore: outlineRuntimeValuesByStore,
 				selectableOutlines,
@@ -293,7 +699,7 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 				targetTimelinePosition: timelinePosition,
 			}),
 		[
-			calculateOutlineTargets,
+			calculateOutlineTargetsForCurrentState,
 			outlineRuntimeValuesByStore,
 			selectableOutlines,
 			timelinePosition,
@@ -355,8 +761,6 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 	const isFullscreen = useIsFullscreen();
 	const {getCurrentFrame} = PlayerInternals.usePlayerMethods();
 	const [draggingOutline, setDraggingOutline] = useState(false);
-	const previewInteractive =
-		previewServerState.type === 'connected' && isStudioInteractivityEnabled();
 	const previewSelectionAvailable =
 		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
 	const selectedSequenceKeys = useMemo(
@@ -407,404 +811,47 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		],
 	);
 
-	const calculateOutlineTargets = useCallback(
-		({
-			mode,
-			runtimeValuesByStore,
-			selectableOutlines,
-			targetKey,
-			targetTimelinePosition,
-		}: {
-			readonly mode: 'controls' | 'layout';
-			readonly runtimeValuesByStore: ReadonlyMap<
-				RuntimeValueStore,
-				Readonly<Record<string, unknown>>
-			>;
-			readonly selectableOutlines: ReturnType<
-				typeof getSequencesWithSelectableOutlines
-			>;
-			readonly targetKey: string | null;
-			readonly targetTimelinePosition: number;
-		}): SelectedOutlineLayoutTarget[] => {
-			if (
-				isFullscreen ||
-				!isStudioSelectionEnabled() ||
-				!previewSelectionAvailable ||
-				!editorShowOutlines
-			) {
-				return [];
-			}
-
-			const firstNodePathInfoBySourceNode = new Map<
-				string,
-				SequenceNodePathInfo
-			>();
-			const selectedSourceNodeKeys = new Set<string>();
-			for (const {key, nodePathInfo} of selectableOutlines) {
-				const sourceNodeKey = timelineSequenceNodePathToKey(
-					nodePathInfo.sequenceSubscriptionKey,
-				);
-				if (selectedSequenceKeys.has(key)) {
-					selectedSourceNodeKeys.add(sourceNodeKey);
-				}
-
-				const currentFirst = firstNodePathInfoBySourceNode.get(sourceNodeKey);
-				if (
-					currentFirst === undefined ||
-					nodePathInfo.index < currentFirst.index
-				) {
-					firstNodePathInfoBySourceNode.set(sourceNodeKey, nodePathInfo);
-				}
-			}
-
-			return selectableOutlines.flatMap((selectableOutline) => {
-				const {key, keyframeDisplayOffset, nodePathInfo, sequence} =
-					selectableOutline;
-				if (targetKey !== null && targetKey !== key) {
-					return [];
-				}
-
-				if (sequence.refForOutline === null) {
-					throw new Error('Expected sequence to have a ref for outline');
-				}
-
-				const selected = selectedSequenceKeys.has(key);
-				const containsSelection = sequenceKeysContainingSelection.has(key);
-				const nodePath = nodePathInfo.sequenceSubscriptionKey;
-				const sourceNodeKey = timelineSequenceNodePathToKey(nodePath);
-				const showSelectedOutline =
-					containsSelection || selectedSourceNodeKeys.has(sourceNodeKey);
-				const selectionNodePathInfo =
-					firstNodePathInfoBySourceNode.get(sourceNodeKey);
-				if (selectionNodePathInfo === undefined) {
-					throw new Error('Expected a first sequence for the source node');
-				}
-
-				const {controls} = sequence;
-				const nodePropStatuses = Internals.getPropStatusesCtx(
+	const calculateOutlineTargetsForCurrentState =
+		useCallback<CalculateOutlineTargets>(
+			(options) =>
+				calculateOutlineTargets({
+					...options,
+					connectedClientId:
+						previewServerState.type === 'connected'
+							? previewServerState.clientId
+							: null,
+					editorShowOutlines,
+					getDragOverrides,
+					getScaleLockState,
+					isFullscreen,
+					previewSelectionAvailable,
 					propStatuses,
-					nodePath,
-				);
-				const sourceFrame = targetTimelinePosition - keyframeDisplayOffset;
-				const dragOverrides = getDragOverrides(nodePath) ?? {};
-				const runtimeValues = controls
-					? (runtimeValuesByStore.get(controls.runtimeValues) ??
-						controls.runtimeValues.getSnapshot())
-					: {};
-				const activeSchema = controls
-					? getSelectedOutlineActiveSchema({
-							schema: controls.schema,
-							currentRuntimeValueDotNotation: runtimeValues,
-							dragOverrides,
-							propStatus: nodePropStatuses,
-							frame: sourceFrame,
-						})
-					: null;
-				const cropValues = {
-					cropLeft: getEffectiveCropValue({
-						activeSchema,
-						dragOverrides,
-						fieldKey: cropFieldKeys.left,
-						frame: sourceFrame,
-						propStatuses: nodePropStatuses,
-						runtimeValues,
-					}),
-					cropRight: getEffectiveCropValue({
-						activeSchema,
-						dragOverrides,
-						fieldKey: cropFieldKeys.right,
-						frame: sourceFrame,
-						propStatuses: nodePropStatuses,
-						runtimeValues,
-					}),
-					cropTop: getEffectiveCropValue({
-						activeSchema,
-						dragOverrides,
-						fieldKey: cropFieldKeys.top,
-						frame: sourceFrame,
-						propStatuses: nodePropStatuses,
-						runtimeValues,
-					}),
-					cropBottom: getEffectiveCropValue({
-						activeSchema,
-						dragOverrides,
-						fieldKey: cropFieldKeys.bottom,
-						frame: sourceFrame,
-						propStatuses: nodePropStatuses,
-						runtimeValues,
-					}),
-				};
-				const crop = Internals.resolveSequenceCrop(cropValues);
-				const selectedForTransformOrigin =
-					selectedTransformOriginInfo?.sequenceKey === key;
-				const selectedForCrop = selectedCropInfo?.sequenceKey === key;
-				const selectedForUvHandles = selectedEffectsBySequenceKey.has(key);
-				const layoutTarget: SelectedOutlineLayoutTarget = {
-					key,
-					containsSelection,
-					crop,
-					keyframeDisplayOffset,
-					nodePathInfo,
-					ref: sequence.refForOutline,
-					selected,
-					selectedForCrop,
-					selectedForTransformOrigin,
-					selectedForUvHandles,
-					showSelectedOutline,
-					selection: {
-						type: 'sequence',
-						nodePathInfo: selectionNodePathInfo,
-					},
-					sequence,
-				};
-				if (mode === 'layout') {
-					return [layoutTarget];
-				}
+					selectedCropInfo,
+					selectedEffectsBySequenceKey,
+					selectedSequenceKeys,
+					selectedTransformOriginInfo,
+					sequenceKeysContainingSelection,
+					studioInteractivityEnabled: isStudioInteractivityEnabled(),
+				}),
+			[
+				editorShowOutlines,
+				getDragOverrides,
+				getScaleLockState,
+				isFullscreen,
+				previewSelectionAvailable,
+				previewServerState,
+				propStatuses,
+				selectedCropInfo,
+				selectedEffectsBySequenceKey,
+				selectedSequenceKeys,
+				selectedTransformOriginInfo,
+				sequenceKeysContainingSelection,
+			],
+		);
 
-				const cropFields = getCropDragFields({
-					activeSchema,
-					cropValues,
-					propStatuses: nodePropStatuses,
-				});
-				const fieldSchema = activeSchema?.[translateFieldKey];
-				const propStatus = nodePropStatuses?.[translateFieldKey];
-				const scaleFieldSchema = activeSchema?.[scaleFieldKey];
-				const scalePropStatus = nodePropStatuses?.[scaleFieldKey];
-				const rotationFieldSchema = activeSchema?.[rotateFieldKey];
-				const rotationPropStatus = nodePropStatuses?.[rotateFieldKey];
-				const transformOriginFieldSchema =
-					activeSchema?.[transformOriginFieldKey];
-				const transformOriginPropStatus =
-					nodePropStatuses?.[transformOriginFieldKey];
-				const transformOriginValueForRotation =
-					transformOriginFieldSchema?.type === 'transform-origin' &&
-					(transformOriginPropStatus?.status === 'static' ||
-						transformOriginPropStatus?.status === 'keyframed')
-						? String(
-								Internals.getEffectiveVisualModeValue({
-									propStatus: transformOriginPropStatus,
-									dragOverrideValue: dragOverrides[transformOriginFieldKey],
-									defaultValue: transformOriginFieldSchema.default,
-									frame: sourceFrame,
-									shouldResortToDefaultValueIfUndefined: true,
-								}) ?? transformOriginFieldSchema.default,
-							)
-						: '50% 50%';
-				const canDragStatus =
-					propStatus?.status === 'static' ||
-					(propStatus?.status === 'keyframed' &&
-						propStatus.interpolationFunction === 'interpolate');
-				const canRotationDragStatus =
-					rotationPropStatus?.status === 'static' ||
-					(rotationPropStatus?.status === 'keyframed' &&
-						rotationPropStatus.interpolationFunction === 'interpolate');
-				const canDrag =
-					previewInteractive &&
-					controls !== null &&
-					fieldSchema?.type === 'translate' &&
-					canDragStatus;
-				const canScaleDragStatus =
-					scalePropStatus?.status === 'static' ||
-					(scalePropStatus?.status === 'keyframed' &&
-						scalePropStatus.interpolationFunction === 'interpolate');
-				const canScaleDrag =
-					previewInteractive &&
-					controls !== null &&
-					scaleFieldSchema?.type === 'scale' &&
-					canScaleDragStatus;
-				const canRotationDrag =
-					previewInteractive &&
-					controls !== null &&
-					rotationFieldSchema?.type === 'rotation-css' &&
-					canRotationDragStatus;
-				const transformOriginSourceFrame =
-					selectedTransformOriginInfo?.displayFrame === null ||
-					selectedTransformOriginInfo?.displayFrame === undefined
-						? sourceFrame
-						: selectedTransformOriginInfo.displayFrame - keyframeDisplayOffset;
-				const canTransformOriginStatus =
-					transformOriginPropStatus?.status === 'static' ||
-					(transformOriginPropStatus?.status === 'keyframed' &&
-						transformOriginPropStatus.interpolationFunction === 'interpolate');
-				const canTransformOriginTranslateStatus =
-					propStatus?.status === 'static' ||
-					(propStatus?.status === 'keyframed' &&
-						propStatus.interpolationFunction === 'interpolate');
-				const canTransformOriginDrag =
-					previewInteractive &&
-					selectedForTransformOrigin &&
-					controls !== null &&
-					transformOriginFieldSchema?.type === 'transform-origin' &&
-					fieldSchema?.type === 'translate' &&
-					canTransformOriginStatus &&
-					canTransformOriginTranslateStatus;
-				const cropSourceFrame =
-					selectedCropInfo?.displayFrame === null ||
-					selectedCropInfo?.displayFrame === undefined
-						? sourceFrame
-						: selectedCropInfo.displayFrame - keyframeDisplayOffset;
-				const canCropDrag =
-					previewInteractive &&
-					selectedForCrop &&
-					controls !== null &&
-					cropFields !== null;
-				return [
-					{
-						...layoutTarget,
-						canCrop:
-							previewInteractive && controls !== null && cropFields !== null,
-						cropDrag: canCropDrag
-							? {
-									clientId: previewServerState.clientId,
-									fields: cropFields,
-									nodePath,
-									schema: controls.schema,
-									sourceFrame: cropSourceFrame,
-									transformOrigin:
-										transformOriginFieldSchema?.type === 'transform-origin' &&
-										transformOriginPropStatus !== undefined
-											? {
-													defaultValue: transformOriginFieldSchema.default,
-													propStatus: transformOriginPropStatus,
-													value: transformOriginValueForRotation,
-												}
-											: null,
-								}
-							: null,
-						drag: canDrag
-							? {
-									propStatus,
-									clientId: previewServerState.clientId,
-									fieldDefault: fieldSchema.default,
-									keyframeDisplayOffset,
-									nodePath,
-									schema: controls.schema,
-								}
-							: null,
-						scaleDrag: canScaleDrag
-							? {
-									propStatus: scalePropStatus,
-									clientId: previewServerState.clientId,
-									fieldDefault: scaleFieldSchema.default,
-									fieldSchema: scaleFieldSchema,
-									keyframeDisplayOffset,
-									linked: getScaleLockState({
-										nodePath,
-										fieldKey: scaleFieldKey,
-										defaultValue: (() => {
-											const dragOverrideValue = dragOverrides[scaleFieldKey];
-											const effectiveValue =
-												Internals.getEffectiveVisualModeValue({
-													propStatus: scalePropStatus,
-													dragOverrideValue,
-													defaultValue: scaleFieldSchema.default,
-													shouldResortToDefaultValueIfUndefined: true,
-												});
-											const [x, y] =
-												NoReactInternals.parseScaleValue(effectiveValue);
-											return x === y;
-										})(),
-									}),
-									nodePath,
-									schema: controls.schema,
-								}
-							: null,
-						rotationDrag: canRotationDrag
-							? {
-									propStatus: rotationPropStatus,
-									clientId: previewServerState.clientId,
-									fieldDefault: rotationFieldSchema.default,
-									fieldSchema: rotationFieldSchema,
-									keyframeDisplayOffset,
-									nodePath,
-									schema: controls.schema,
-									transformOriginValue: transformOriginValueForRotation,
-								}
-							: null,
-						transformOriginDrag: canTransformOriginDrag
-							? {
-									clientId: previewServerState.clientId,
-									keyframeDisplayOffset,
-									nodePath,
-									originDefault: transformOriginFieldSchema.default,
-									originPropStatus: transformOriginPropStatus,
-									originValue: String(
-										Internals.getEffectiveVisualModeValue({
-											propStatus: transformOriginPropStatus,
-											dragOverrideValue: dragOverrides[transformOriginFieldKey],
-											defaultValue: transformOriginFieldSchema.default,
-											frame: transformOriginSourceFrame,
-											shouldResortToDefaultValueIfUndefined: true,
-										}) ?? transformOriginFieldSchema.default,
-									),
-									rotateValue: String(
-										rotationPropStatus?.status === 'static' ||
-											rotationPropStatus?.status === 'keyframed'
-											? (Internals.getEffectiveVisualModeValue({
-													propStatus: rotationPropStatus,
-													dragOverrideValue: dragOverrides[rotateFieldKey],
-													defaultValue:
-														rotationFieldSchema?.type === 'rotation-css'
-															? rotationFieldSchema.default
-															: '0deg',
-													frame: transformOriginSourceFrame,
-													shouldResortToDefaultValueIfUndefined: true,
-												}) ?? '0deg')
-											: '0deg',
-									),
-									scaleValue:
-										scalePropStatus?.status === 'static' ||
-										scalePropStatus?.status === 'keyframed'
-											? String(
-													Internals.getEffectiveVisualModeValue({
-														propStatus: scalePropStatus,
-														dragOverrideValue: dragOverrides[scaleFieldKey],
-														defaultValue:
-															scaleFieldSchema?.type === 'scale'
-																? scaleFieldSchema.default
-																: 1,
-														frame: transformOriginSourceFrame,
-														shouldResortToDefaultValueIfUndefined: true,
-													}) ?? 1,
-												)
-											: '1',
-									schema: controls.schema,
-									sourceFrame: transformOriginSourceFrame,
-									translateDefault: fieldSchema.default,
-									translatePropStatus: propStatus,
-									translateValue: String(
-										Internals.getEffectiveVisualModeValue({
-											propStatus,
-											dragOverrideValue: dragOverrides[translateFieldKey],
-											defaultValue: fieldSchema.default,
-											frame: transformOriginSourceFrame,
-											shouldResortToDefaultValueIfUndefined: true,
-										}) ?? fieldSchema.default,
-									),
-								}
-							: null,
-					} satisfies SelectedOutlineTarget,
-				];
-			});
-		},
-		[
-			propStatuses,
-			getDragOverrides,
-			getScaleLockState,
-			editorShowOutlines,
-			isFullscreen,
-			previewInteractive,
-			previewSelectionAvailable,
-			previewServerState,
-			selectedCropInfo,
-			selectedEffectsBySequenceKey,
-			selectedSequenceKeys,
-			selectedTransformOriginInfo,
-			sequenceKeysContainingSelection,
-		],
+	const calculateOutlineTargetsRef = useRef(
+		calculateOutlineTargetsForCurrentState,
 	);
-
-	const calculateOutlineTargetsRef = useRef(calculateOutlineTargets);
 	const getSelectableOutlinesRef = useRef(getSelectableOutlines);
 	const selectableOutlinesCacheRef = useRef<{
 		readonly getSelectableOutlines: typeof getSelectableOutlines;
@@ -814,9 +861,9 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		readonly timelinePosition: number;
 	} | null>(null);
 	useLayoutEffect(() => {
-		calculateOutlineTargetsRef.current = calculateOutlineTargets;
+		calculateOutlineTargetsRef.current = calculateOutlineTargetsForCurrentState;
 		getSelectableOutlinesRef.current = getSelectableOutlines;
-	}, [calculateOutlineTargets, getSelectableOutlines]);
+	}, [calculateOutlineTargetsForCurrentState, getSelectableOutlines]);
 	const getSelectableOutlinesAtFrame = useCallback(
 		(timelinePosition: number) => {
 			const currentGetSelectableOutlines = getSelectableOutlinesRef.current;
@@ -893,7 +940,9 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 			/>
 			{measurementActive ? (
 				<ActiveSelectedOutlineOverlay
-					calculateOutlineTargets={calculateOutlineTargets}
+					calculateOutlineTargetsForCurrentState={
+						calculateOutlineTargetsForCurrentState
+					}
 					compositionHeight={compositionHeight}
 					compositionWidth={compositionWidth}
 					draggingOutline={draggingOutline}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -25,7 +25,10 @@ import {useIsFullscreen} from '../helpers/use-is-fullscreen';
 import {useRuntimeValueSnapshots} from '../helpers/use-runtime-values';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
 import {ScaleLockContext} from '../state/scale-lock';
-import {useSetTimelineSequenceHover} from '../state/timeline-sequence-hover';
+import {
+	useSetTimelineSequenceHover,
+	useTimelineSequenceHoverState,
+} from '../state/timeline-sequence-hover';
 import {getSelectedOutlineActiveSchema} from './selected-outline-drag';
 import {
 	getSelectedCropInfo,
@@ -184,6 +187,7 @@ export type {
 } from './selected-outline-types';
 
 type SelectedOutlineOverlayProps = {
+	readonly canvasHovered: boolean;
 	readonly compositionHeight: number;
 	readonly compositionWidth: number;
 	readonly scale: number;
@@ -191,127 +195,64 @@ type SelectedOutlineOverlayProps = {
 	readonly translationY: number;
 };
 
-const SelectedOutlineOverlayUnmemoized: React.FC<
-	SelectedOutlineOverlayProps
+type ActiveSelectedOutlineOverlayProps = Omit<
+	SelectedOutlineOverlayProps,
+	'canvasHovered'
+> & {
+	readonly calculateOutlineTargets: (options: {
+		readonly mode: 'controls' | 'layout';
+		readonly runtimeValuesByStore: ReadonlyMap<
+			RuntimeValueStore,
+			Readonly<Record<string, unknown>>
+		>;
+		readonly selectableOutlines: ReturnType<
+			typeof getSequencesWithSelectableOutlines
+		>;
+		readonly targetKey: string | null;
+		readonly targetTimelinePosition: number;
+	}) => SelectedOutlineLayoutTarget[];
+	readonly draggingOutline: boolean;
+	readonly getLatestOutlineTargetByKey: (
+		key: string,
+	) => SelectedOutlineTarget | undefined;
+	readonly getSelectableOutlines: (
+		timelinePosition: number,
+	) => ReturnType<typeof getSequencesWithSelectableOutlines>;
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction?: TimelineSelectionInteraction,
+	) => void;
+	readonly selectedSequenceKeys: ReadonlySet<string>;
+	readonly sequenceKeysContainingSelection: ReadonlySet<string>;
+	readonly sequences: React.ContextType<
+		typeof Internals.SequenceManager
+	>['sequences'];
+};
+
+const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
+	ActiveSelectedOutlineOverlayProps
 > = ({
+	calculateOutlineTargets,
 	compositionHeight,
 	compositionWidth,
+	draggingOutline,
+	getLatestOutlineTargetByKey,
+	getSelectableOutlines,
+	onDraggingChange,
+	onSelect,
 	scale,
+	selectedSequenceKeys,
+	sequenceKeysContainingSelection,
+	sequences,
 	translationX,
 	translationY,
 }) => {
-	const {selectedItems, selectItem} = useTimelineSelection();
-	const {sequences} = useContext(Internals.SequenceManager);
-	const {compositions} = useContext(Internals.CompositionManager);
-	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
-	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {overrideIdToNodePathMappings} = useContext(
-		Internals.OverrideIdsToNodePathsGettersContext,
-	);
-	const {getDragOverrides} = useContext(
-		Internals.VisualModeDragOverridesContext,
-	);
-	const {getScaleLockState} = useContext(ScaleLockContext);
-	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
-	const setHoveredSequence = useSetTimelineSequenceHover();
-	const isFullscreen = useIsFullscreen();
-	const {getCurrentFrame} = PlayerInternals.usePlayerMethods();
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
-	const [draggingOutline, setDraggingOutline] = useState(false);
 	const updateOutlinesRef = useRef<() => void>(() => undefined);
-	const previewInteractive =
-		previewServerState.type === 'connected' && isStudioInteractivityEnabled();
-	const previewSelectionAvailable =
-		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
-
-	const onDraggingChange = React.useCallback(
-		(dragging: boolean) => {
-			setDraggingOutline(dragging);
-			if (dragging) {
-				setHoveredSequence((currentHover) =>
-					currentHover?.source === 'canvas' ? null : currentHover,
-				);
-			}
-		},
-		[setHoveredSequence],
-	);
-	const selectOutlineItem = useCallback(
-		(item: TimelineSelection, interaction?: TimelineSelectionInteraction) => {
-			selectItem(item, interaction, undefined, {reveal: true});
-		},
-		[selectItem],
-	);
 	const selectableOutlines = useMemo(() => {
-		if (
-			isFullscreen ||
-			!isStudioSelectionEnabled() ||
-			!previewSelectionAvailable ||
-			!editorShowOutlines
-		) {
-			return [];
-		}
-
-		return getSequencesWithSelectableOutlines({
-			sequences,
-			overrideIdsToNodePaths: overrideIdToNodePathMappings,
-			compositions,
-			timelinePosition,
-		});
-	}, [
-		compositions,
-		editorShowOutlines,
-		isFullscreen,
-		overrideIdToNodePathMappings,
-		previewSelectionAvailable,
-		sequences,
-		timelinePosition,
-	]);
-	const selectedSequenceKeys = useMemo(
-		() => getSelectedSequenceKeys(selectedItems),
-		[selectedItems],
-	);
-	const sequenceKeysContainingSelection = useMemo(
-		() => getSequenceKeysContainingSelection(selectedItems),
-		[selectedItems],
-	);
-	const selectedEffectsBySequenceKey = useMemo(
-		() => getSelectedEffectFieldsBySequenceKey(selectedItems),
-		[selectedItems],
-	);
-	const selectedTransformOriginInfo = useMemo(
-		() => getSelectedTransformOriginInfo(selectedItems),
-		[selectedItems],
-	);
-	const selectedCropInfo = useMemo(
-		() => getSelectedCropInfo(selectedItems),
-		[selectedItems],
-	);
-	const {firstNodePathInfoBySourceNode, selectedSourceNodeKeys} =
-		useMemo(() => {
-			const firstBySourceNode = new Map<string, SequenceNodePathInfo>();
-			const selectedSourceNodes = new Set<string>();
-			for (const {key, nodePathInfo} of selectableOutlines) {
-				const sourceNodeKey = timelineSequenceNodePathToKey(
-					nodePathInfo.sequenceSubscriptionKey,
-				);
-				if (selectedSequenceKeys.has(key)) {
-					selectedSourceNodes.add(sourceNodeKey);
-				}
-
-				const currentFirst = firstBySourceNode.get(sourceNodeKey);
-				if (
-					currentFirst === undefined ||
-					nodePathInfo.index < currentFirst.index
-				) {
-					firstBySourceNode.set(sourceNodeKey, nodePathInfo);
-				}
-			}
-
-			return {
-				firstNodePathInfoBySourceNode: firstBySourceNode,
-				selectedSourceNodeKeys: selectedSourceNodes,
-			};
-		}, [selectableOutlines, selectedSequenceKeys]);
+		return getSelectableOutlines(timelinePosition);
+	}, [getSelectableOutlines, timelinePosition]);
 	const outlineRuntimeControls = useMemo(() => {
 		return selectableOutlines.flatMap(({key, sequence}) => {
 			if (
@@ -342,10 +283,135 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		[outlineRuntimeControls, outlineRuntimeSnapshots],
 	);
 
+	const outlineTargets = useMemo(
+		() =>
+			calculateOutlineTargets({
+				mode: 'layout',
+				runtimeValuesByStore: outlineRuntimeValuesByStore,
+				selectableOutlines,
+				targetKey: null,
+				targetTimelinePosition: timelinePosition,
+			}),
+		[
+			calculateOutlineTargets,
+			outlineRuntimeValuesByStore,
+			selectableOutlines,
+			timelinePosition,
+		],
+	);
+
+	const outlineTargetsRef =
+		useRef<readonly SelectedOutlineLayoutTarget[]>(outlineTargets);
+	const getOutlineTargets = useCallback(() => outlineTargetsRef.current, []);
+	useLayoutEffect(() => {
+		outlineTargetsRef.current = outlineTargets;
+		updateOutlinesRef.current();
+	}, [outlineTargets, scale, translationX, translationY]);
+	return (
+		<SelectedOutlineRenderer
+			compositionHeight={compositionHeight}
+			compositionWidth={compositionWidth}
+			dragging={draggingOutline}
+			getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
+			getOutlineTargets={getOutlineTargets}
+			onDraggingChange={onDraggingChange}
+			onSelect={onSelect}
+			scale={scale}
+			sequences={sequences}
+			updateOutlinesRef={updateOutlinesRef}
+		/>
+	);
+};
+
+const ActiveSelectedOutlineOverlay = React.memo(
+	ActiveSelectedOutlineOverlayUnmemoized,
+);
+
+const SelectedOutlineOverlayUnmemoized: React.FC<
+	SelectedOutlineOverlayProps
+> = ({
+	canvasHovered,
+	compositionHeight,
+	compositionWidth,
+	scale,
+	translationX,
+	translationY,
+}) => {
+	const {selectedItems, selectItem} = useTimelineSelection();
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {compositions} = useContext(Internals.CompositionManager);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+	const {getScaleLockState} = useContext(ScaleLockContext);
+	const {editorShowOutlines} = useContext(EditorShowOutlinesContext);
+	const setHoveredSequence = useSetTimelineSequenceHover();
+	const hoveredSequence = useTimelineSequenceHoverState();
+	const isFullscreen = useIsFullscreen();
+	const {getCurrentFrame} = PlayerInternals.usePlayerMethods();
+	const [draggingOutline, setDraggingOutline] = useState(false);
+	const previewInteractive =
+		previewServerState.type === 'connected' && isStudioInteractivityEnabled();
+	const previewSelectionAvailable =
+		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
+	const selectedSequenceKeys = useMemo(
+		() => getSelectedSequenceKeys(selectedItems),
+		[selectedItems],
+	);
+	const sequenceKeysContainingSelection = useMemo(
+		() => getSequenceKeysContainingSelection(selectedItems),
+		[selectedItems],
+	);
+	const selectedEffectsBySequenceKey = useMemo(
+		() => getSelectedEffectFieldsBySequenceKey(selectedItems),
+		[selectedItems],
+	);
+	const selectedTransformOriginInfo = useMemo(
+		() => getSelectedTransformOriginInfo(selectedItems),
+		[selectedItems],
+	);
+	const selectedCropInfo = useMemo(
+		() => getSelectedCropInfo(selectedItems),
+		[selectedItems],
+	);
+	const getSelectableOutlines = useCallback(
+		(timelinePosition: number) => {
+			if (
+				isFullscreen ||
+				!isStudioSelectionEnabled() ||
+				!previewSelectionAvailable ||
+				!editorShowOutlines
+			) {
+				return [];
+			}
+
+			return getSequencesWithSelectableOutlines({
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				compositions,
+				timelinePosition,
+			});
+		},
+		[
+			compositions,
+			editorShowOutlines,
+			isFullscreen,
+			overrideIdToNodePathMappings,
+			previewSelectionAvailable,
+			sequences,
+		],
+	);
+
 	const calculateOutlineTargets = useCallback(
 		({
 			mode,
 			runtimeValuesByStore,
+			selectableOutlines,
 			targetKey,
 			targetTimelinePosition,
 		}: {
@@ -353,6 +419,9 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 			readonly runtimeValuesByStore: ReadonlyMap<
 				RuntimeValueStore,
 				Readonly<Record<string, unknown>>
+			>;
+			readonly selectableOutlines: ReturnType<
+				typeof getSequencesWithSelectableOutlines
 			>;
 			readonly targetKey: string | null;
 			readonly targetTimelinePosition: number;
@@ -364,6 +433,28 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 				!editorShowOutlines
 			) {
 				return [];
+			}
+
+			const firstNodePathInfoBySourceNode = new Map<
+				string,
+				SequenceNodePathInfo
+			>();
+			const selectedSourceNodeKeys = new Set<string>();
+			for (const {key, nodePathInfo} of selectableOutlines) {
+				const sourceNodeKey = timelineSequenceNodePathToKey(
+					nodePathInfo.sequenceSubscriptionKey,
+				);
+				if (selectedSequenceKeys.has(key)) {
+					selectedSourceNodeKeys.add(sourceNodeKey);
+				}
+
+				const currentFirst = firstNodePathInfoBySourceNode.get(sourceNodeKey);
+				if (
+					currentFirst === undefined ||
+					nodePathInfo.index < currentFirst.index
+				) {
+					firstNodePathInfoBySourceNode.set(sourceNodeKey, nodePathInfo);
+				}
 			}
 
 			return selectableOutlines.flatMap((selectableOutline) => {
@@ -705,68 +796,119 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 			previewInteractive,
 			previewSelectionAvailable,
 			previewServerState,
-			firstNodePathInfoBySourceNode,
 			selectedCropInfo,
 			selectedEffectsBySequenceKey,
 			selectedSequenceKeys,
-			selectedSourceNodeKeys,
 			selectedTransformOriginInfo,
 			sequenceKeysContainingSelection,
-			selectableOutlines,
 		],
 	);
-	const outlineTargets = useMemo(
-		() =>
-			calculateOutlineTargets({
-				mode: 'layout',
-				runtimeValuesByStore: outlineRuntimeValuesByStore,
-				targetKey: null,
-				targetTimelinePosition: timelinePosition,
-			}),
-		[calculateOutlineTargets, outlineRuntimeValuesByStore, timelinePosition],
-	);
+
 	const calculateOutlineTargetsRef = useRef(calculateOutlineTargets);
+	const getSelectableOutlinesRef = useRef(getSelectableOutlines);
+	const selectableOutlinesCacheRef = useRef<{
+		readonly getSelectableOutlines: typeof getSelectableOutlines;
+		readonly selectableOutlines: ReturnType<
+			typeof getSequencesWithSelectableOutlines
+		>;
+		readonly timelinePosition: number;
+	} | null>(null);
 	useLayoutEffect(() => {
 		calculateOutlineTargetsRef.current = calculateOutlineTargets;
-	}, [calculateOutlineTargets]);
+		getSelectableOutlinesRef.current = getSelectableOutlines;
+	}, [calculateOutlineTargets, getSelectableOutlines]);
+	const getSelectableOutlinesAtFrame = useCallback(
+		(timelinePosition: number) => {
+			const currentGetSelectableOutlines = getSelectableOutlinesRef.current;
+			const cached = selectableOutlinesCacheRef.current;
+			if (
+				cached?.timelinePosition === timelinePosition &&
+				cached.getSelectableOutlines === currentGetSelectableOutlines
+			) {
+				return cached.selectableOutlines;
+			}
+
+			const selectableOutlines = currentGetSelectableOutlines(timelinePosition);
+			selectableOutlinesCacheRef.current = {
+				getSelectableOutlines: currentGetSelectableOutlines,
+				selectableOutlines,
+				timelinePosition,
+			};
+			return selectableOutlines;
+		},
+		[],
+	);
 	const getLatestOutlineTargetByKey = useCallback(
 		(key: string) => {
+			const timelinePosition = getCurrentFrame();
 			const target = calculateOutlineTargetsRef.current({
 				mode: 'controls',
 				runtimeValuesByStore: new Map(),
+				selectableOutlines: getSelectableOutlinesAtFrame(timelinePosition),
 				targetKey: key,
-				targetTimelinePosition: getCurrentFrame(),
+				targetTimelinePosition: timelinePosition,
 			})[0];
 			return target as SelectedOutlineTarget | undefined;
 		},
-		[getCurrentFrame],
+		[getCurrentFrame, getSelectableOutlinesAtFrame],
 	);
-
-	const outlineTargetsRef =
-		useRef<readonly SelectedOutlineLayoutTarget[]>(outlineTargets);
-	const getOutlineTargets = useCallback(() => outlineTargetsRef.current, []);
+	const getCurrentSelectableOutlines = useCallback(
+		() => getSelectableOutlinesAtFrame(getCurrentFrame()),
+		[getCurrentFrame, getSelectableOutlinesAtFrame],
+	);
+	const onDraggingChange = useCallback(
+		(dragging: boolean) => {
+			setDraggingOutline(dragging);
+			if (dragging) {
+				setHoveredSequence((currentHover) =>
+					currentHover?.source === 'canvas' ? null : currentHover,
+				);
+			}
+		},
+		[setHoveredSequence],
+	);
+	const selectOutlineItem = useCallback(
+		(item: TimelineSelection, interaction?: TimelineSelectionInteraction) => {
+			selectItem(item, interaction, undefined, {reveal: true});
+		},
+		[selectItem],
+	);
+	const measurementActive =
+		canvasHovered || draggingOutline || hoveredSequence?.source === 'timeline';
 	useLayoutEffect(() => {
-		outlineTargetsRef.current = outlineTargets;
-		updateOutlinesRef.current();
-	}, [outlineTargets, scale, translationX, translationY]);
+		if (measurementActive) {
+			return;
+		}
+
+		setHoveredSequence((currentHover) =>
+			currentHover?.source === 'canvas' ? null : currentHover,
+		);
+	}, [measurementActive, setHoveredSequence]);
+
 	return (
 		<>
-			<SelectedOutlineRenderer
-				compositionHeight={compositionHeight}
-				compositionWidth={compositionWidth}
-				dragging={draggingOutline}
-				getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
-				getOutlineTargets={getOutlineTargets}
-				onDraggingChange={onDraggingChange}
-				onSelect={selectOutlineItem}
-				scale={scale}
-				sequences={sequences}
-				updateOutlinesRef={updateOutlinesRef}
-			/>
 			<SelectedOutlineKeyboardControls
 				getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
-				selectableOutlines={selectableOutlines}
+				getSelectableOutlines={getCurrentSelectableOutlines}
 			/>
+			{measurementActive ? (
+				<ActiveSelectedOutlineOverlay
+					calculateOutlineTargets={calculateOutlineTargets}
+					compositionHeight={compositionHeight}
+					compositionWidth={compositionWidth}
+					draggingOutline={draggingOutline}
+					getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
+					getSelectableOutlines={getSelectableOutlines}
+					onDraggingChange={onDraggingChange}
+					onSelect={selectOutlineItem}
+					scale={scale}
+					selectedSequenceKeys={selectedSequenceKeys}
+					sequenceKeysContainingSelection={sequenceKeysContainingSelection}
+					sequences={sequences}
+					translationX={translationX}
+					translationY={translationY}
+				/>
+			) : null}
 		</>
 	);
 };


### PR DESCRIPTION
## Summary

- mount the frame-reactive selected-outline measurement only while the canvas or timeline is hovered
- keep outline measurement active when a drag leaves the canvas
- preserve keyboard nudging with imperative, per-frame-cached target lookup
- use native pointer boundary events so canvas hover works across the composition portal

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/timeline-selection.test.ts`
