### PR TITLE
`@remotion/studio`: Collapse timeline tracks by default

### DIFF
--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -145,4 +145,44 @@ test.describe('effect keyframes', () => {
 			)
 			.toBe(true);
 	});
+
+	test('collapses timeline tracks until a property or effect is selected', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		const opacityRow = page.getByText('Opacity', {exact: true});
+		await expect(async () => {
+			await page
+				.getByTitle('Timeline expansion', {exact: true})
+				.first()
+				.click();
+			await expect(opacityRow).toHaveCount(1, {timeout: 1_000});
+		}).toPass({timeout: 15_000});
+		await expect(
+			page.locator('button[aria-label="Expand track properties"]'),
+		).toBeVisible();
+
+		await opacityRow.click();
+
+		await expect(
+			page.locator('button[aria-label="Collapse track properties"]'),
+		).toBeVisible();
+		await expect(opacityRow).toHaveCount(2);
+
+		const waveRow = page.getByText('wave()', {exact: true});
+		await expect(async () => {
+			await page.getByTitle('Scale precision', {exact: true}).first().click();
+			await expect(waveRow).toHaveCount(1, {timeout: 1_000});
+		}).toPass({timeout: 15_000});
+
+		await waveRow.click();
+
+		await expect(waveRow).toHaveCount(2);
+	});
 });

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -1,8 +1,10 @@
 import {wave} from '@remotion/effects/wave';
 import React from 'react';
-import {AbsoluteFill, Solid} from 'remotion';
+import {AbsoluteFill, interpolate, Solid, useCurrentFrame} from 'remotion';
 
 export const EffectKeyframeE2e: React.FC = () => {
+	const frame = useCurrentFrame();
+
 	return (
 		<AbsoluteFill>
 			<Solid
@@ -12,6 +14,13 @@ export const EffectKeyframeE2e: React.FC = () => {
 				color="#1f2429"
 				style={{scale: 1}}
 				effects={[wave({})]}
+			/>
+			<Solid
+				name="Timeline expansion"
+				width={540}
+				height={540}
+				color="#1f2429"
+				style={{opacity: interpolate(frame, [0, 30], [0, 1])}}
 			/>
 		</AbsoluteFill>
 	);

--- a/packages/studio/src/components/ExpandedTracksProvider.tsx
+++ b/packages/studio/src/components/ExpandedTracksProvider.tsx
@@ -2,59 +2,17 @@ import React, {createContext, useCallback, useMemo, useState} from 'react';
 import type {SequencePropsSubscriptionKey} from 'remotion';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {migrateExpandedTracksForSubscriptionKey} from '../helpers/migrate-expanded-tracks-for-subscription-key';
+import {
+	loadPersistedBooleanMap,
+	persistBooleanMap,
+	toggleBooleanMapKey,
+} from '../helpers/persist-boolean-map';
 import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 
-const SESSION_STORAGE_KEY = 'remotion.editor.expandedTracks';
-
-const onlyCollapsedTrackValues = (
-	state: Record<string, boolean>,
-): Record<string, boolean> => {
-	const result: Record<string, boolean> = {};
-
-	for (const [key, value] of Object.entries(state)) {
-		if (value === false) {
-			result[key] = false;
-		}
-	}
-
-	return result;
-};
+const SESSION_STORAGE_KEY = 'remotion.editor.expandedTracks.v2';
 
 const loadExpandedTracks = () => {
-	if (typeof window === 'undefined') {
-		return {};
-	}
-
-	try {
-		const raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
-		if (raw === null) {
-			return {};
-		}
-
-		const parsed: unknown = JSON.parse(raw);
-		if (!parsed || typeof parsed !== 'object') {
-			return {};
-		}
-
-		return onlyCollapsedTrackValues(parsed as Record<string, boolean>);
-	} catch {
-		return {};
-	}
-};
-
-const persistExpandedTracks = (state: Record<string, boolean>): void => {
-	if (typeof window === 'undefined') {
-		return;
-	}
-
-	try {
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEY,
-			JSON.stringify(onlyCollapsedTrackValues(state)),
-		);
-	} catch {
-		// Ignore quota errors or disabled storage.
-	}
+	return loadPersistedBooleanMap(SESSION_STORAGE_KEY);
 };
 
 export type GetIsExpanded = (nodePathInfo: SequenceNodePathInfo) => boolean;
@@ -120,8 +78,8 @@ export const ExpandedTracksProvider: React.FC<{
 				const next = {...prev};
 
 				for (const key of keysToExpand) {
-					if (next[key] === false) {
-						delete next[key];
+					if (!next[key]) {
+						next[key] = true;
 						changed = true;
 					}
 				}
@@ -130,7 +88,7 @@ export const ExpandedTracksProvider: React.FC<{
 					return prev;
 				}
 
-				persistExpandedTracks(next);
+				persistBooleanMap(SESSION_STORAGE_KEY, next);
 				return next;
 			});
 		},
@@ -140,15 +98,8 @@ export const ExpandedTracksProvider: React.FC<{
 	const toggleTrack = useCallback((nodePathInfo: SequenceNodePathInfo) => {
 		setExpandedTracks((prev) => {
 			const key = timelineNodePathInfoToKey(nodePathInfo);
-			const next = {...prev};
-			const isExpanded = next[key] ?? true;
-			if (isExpanded) {
-				next[key] = false;
-			} else {
-				delete next[key];
-			}
-
-			persistExpandedTracks(next);
+			const next = toggleBooleanMapKey(prev, key);
+			persistBooleanMap(SESSION_STORAGE_KEY, next);
 			return next;
 		});
 	}, []);
@@ -168,7 +119,7 @@ export const ExpandedTracksProvider: React.FC<{
 					return prev;
 				}
 
-				persistExpandedTracks(next);
+				persistBooleanMap(SESSION_STORAGE_KEY, next);
 				return next;
 			});
 		},
@@ -178,7 +129,7 @@ export const ExpandedTracksProvider: React.FC<{
 	const getterValue = useMemo(
 		(): ExpandedTracksGetterContextValue => ({
 			getIsExpanded: (nodePathInfo) =>
-				expandedTracks[timelineNodePathInfoToKey(nodePathInfo)] ?? true,
+				expandedTracks[timelineNodePathInfoToKey(nodePathInfo)] ?? false,
 		}),
 		[expandedTracks],
 	);

--- a/packages/studio/src/helpers/migrate-expanded-tracks-for-subscription-key.ts
+++ b/packages/studio/src/helpers/migrate-expanded-tracks-for-subscription-key.ts
@@ -18,13 +18,13 @@ export const migrateExpandedTracksForSubscriptionKey = (
 	const next: BooleanMap = {...prev};
 
 	for (const [key, value] of Object.entries(prev)) {
-		if (value !== false || !key.startsWith(oldPrefix + '.')) {
+		if (!value || !key.startsWith(oldPrefix + '.')) {
 			continue;
 		}
 
 		const migratedKey = newPrefix + key.slice(oldPrefix.length);
-		if (next[migratedKey] === undefined) {
-			next[migratedKey] = false;
+		if (!next[migratedKey]) {
+			next[migratedKey] = true;
 		}
 
 		delete next[key];

--- a/packages/studio/src/test/migrate-expanded-tracks-for-subscription-key.test.ts
+++ b/packages/studio/src/test/migrate-expanded-tracks-for-subscription-key.test.ts
@@ -22,32 +22,32 @@ const expandedKey = (
 		index,
 	].join('.');
 
-test('migrates collapsed keys when subscription node path changes', () => {
+test('migrates expanded keys when subscription node path changes', () => {
 	const oldKey = makeKey(['body', 0, 'children', 1]);
 	const newKey = makeKey(['body', 0, 'children', 2]);
 	const unrelatedKey = makeKey(['body', 0, 'children', 3]);
 
 	const prev = {
-		[expandedKey(oldKey, [], 0)]: false,
-		[expandedKey(oldKey, ['controls', 'from'], 0)]: false,
-		[expandedKey(unrelatedKey, [], 0)]: false,
+		[expandedKey(oldKey, [], 0)]: true,
+		[expandedKey(oldKey, ['controls', 'from'], 0)]: true,
+		[expandedKey(unrelatedKey, [], 0)]: true,
 	};
 
 	const next = migrateExpandedTracksForSubscriptionKey(prev, oldKey, newKey);
 
 	expect(next).toEqual({
-		[expandedKey(newKey, [], 0)]: false,
-		[expandedKey(newKey, ['controls', 'from'], 0)]: false,
-		[expandedKey(unrelatedKey, [], 0)]: false,
+		[expandedKey(newKey, [], 0)]: true,
+		[expandedKey(newKey, ['controls', 'from'], 0)]: true,
+		[expandedKey(unrelatedKey, [], 0)]: true,
 	});
 });
 
-test('ignores expanded keys when subscription node path changes', () => {
+test('ignores collapsed keys when subscription node path changes', () => {
 	const oldKey = makeKey(['body', 0, 'children', 1]);
 	const newKey = makeKey(['body', 0, 'children', 2]);
 
 	const prev = {
-		[expandedKey(oldKey, [], 0)]: true,
+		[expandedKey(oldKey, [], 0)]: false,
 	};
 
 	expect(migrateExpandedTracksForSubscriptionKey(prev, oldKey, newKey)).toBe(
@@ -58,7 +58,7 @@ test('ignores expanded keys when subscription node path changes', () => {
 test('returns null when subscription key is unchanged', () => {
 	const key = makeKey(['body', 0]);
 	const prev = {
-		[expandedKey(key, [], 0)]: true,
+		[expandedKey(key, [], 0)]: false,
 	};
 
 	expect(migrateExpandedTracksForSubscriptionKey(prev, key, key)).toBe(null);


### PR DESCRIPTION
## Summary

- collapse timeline tracks by default and persist only explicit expansions under a fresh session-storage key
- expand the ancestor path when a sequence property or effect is selected
- cover the collapsed default and selection reveal behavior in the Studio E2E workflow

## Testing

- `bun test src/test/migrate-expanded-tracks-for-subscription-key.test.ts` in `packages/studio`
- `bunx playwright test e2e/effect-keyframes.test.mts` in `packages/example`
- `bun run build`
- `bun run stylecheck`

Red/green verified: the new Playwright assertion failed against the previous expanded-by-default Studio bundle and passed after rebuilding with this change.
