### PR TITLE
`@remotion/studio-server`: Reuse AST across sequence prop subscriptions

### DIFF
--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -64,7 +64,8 @@ type PropOutput = KeyframedPropStatus['output'];
 type PropInterpolationFunction = KeyframedPropStatus['interpolationFunction'];
 
 // A file write synchronously notifies every sequence subscription. Status
-// computation is read-only, so all subscribers can share one parsed snapshot.
+// computation is read-only, so all subscribers can share one parsed snapshot
+// until the notification burst has finished.
 let cachedSequencePropsStatusAst: {
 	fileContents: string;
 	ast: File;
@@ -1354,11 +1355,21 @@ export const computeSequencePropsStatusFromContent = ({
 	videoConfigValues: VideoConfigValues | null;
 }): CanUpdateSequencePropsResponseTrue => {
 	if (cachedSequencePropsStatusAst?.fileContents !== fileContents) {
-		cachedSequencePropsStatusAst = {
+		cachedSequencePropsStatusAst = null;
+		const snapshot = {
 			fileContents,
 			ast: parseAst(fileContents),
-			videoConfigIdentifierValues: new Map(),
+			videoConfigIdentifierValues: new Map<
+				string,
+				VideoConfigIdentifierValues
+			>(),
 		};
+		cachedSequencePropsStatusAst = snapshot;
+		queueMicrotask(() => {
+			if (cachedSequencePropsStatusAst === snapshot) {
+				cachedSequencePropsStatusAst = null;
+			}
+		});
 	}
 
 	const {ast} = cachedSequencePropsStatusAst;

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -63,6 +63,14 @@ type PropPosterize = KeyframedPropStatus['posterize'];
 type PropOutput = KeyframedPropStatus['output'];
 type PropInterpolationFunction = KeyframedPropStatus['interpolationFunction'];
 
+// A file write synchronously notifies every sequence subscription. Status
+// computation is read-only, so all subscribers can share one parsed snapshot.
+let cachedSequencePropsStatusAst: {
+	fileContents: string;
+	ast: File;
+	videoConfigIdentifierValues: Map<string, VideoConfigIdentifierValues>;
+} | null = null;
+
 const staticStatus = (
 	codeValue: unknown,
 	numericExpression: VideoConfigNumericExpression | null,
@@ -1345,11 +1353,30 @@ export const computeSequencePropsStatusFromContent = ({
 	effects: string[][];
 	videoConfigValues: VideoConfigValues | null;
 }): CanUpdateSequencePropsResponseTrue => {
-	const ast = parseAst(fileContents);
-	const videoConfigIdentifierValues = getVideoConfigIdentifierValues({
-		ast,
-		videoConfigValues,
-	});
+	if (cachedSequencePropsStatusAst?.fileContents !== fileContents) {
+		cachedSequencePropsStatusAst = {
+			fileContents,
+			ast: parseAst(fileContents),
+			videoConfigIdentifierValues: new Map(),
+		};
+	}
+
+	const {ast} = cachedSequencePropsStatusAst;
+	const videoConfigCacheKey = JSON.stringify(videoConfigValues);
+	let videoConfigIdentifierValues =
+		cachedSequencePropsStatusAst.videoConfigIdentifierValues.get(
+			videoConfigCacheKey,
+		);
+	if (videoConfigIdentifierValues === undefined) {
+		videoConfigIdentifierValues = getVideoConfigIdentifierValues({
+			ast,
+			videoConfigValues,
+		});
+		cachedSequencePropsStatusAst.videoConfigIdentifierValues.set(
+			videoConfigCacheKey,
+			videoConfigIdentifierValues,
+		);
+	}
 
 	const jsxElementNode = findJsxElementNodeAtNodePath(ast, nodePath);
 	const jsxElement = jsxElementNode?.openingElement ?? null;


### PR DESCRIPTION
## Summary

- reuse the parsed source AST across sequence prop subscribers handling the same file snapshot
- cache derived video config identifier values per source snapshot and video configuration
- avoid repeated full-file parsing during Visual Mode saves, undo, and redo

## Benchmark

Measured against the 161 KB `Skills2Gesture.tsx` composition:

| Request | Before median | After median | Improvement |
| --- | ---: | ---: | ---: |
| Save sequence props | 2,121.7 ms | 355.8 ms | 6.0x / 83.2% |
| Undo | 2,277.0 ms | 85.8 ms | 26.5x / 96.2% |

The baseline used six live requests against the unoptimized server. The optimized result used ten requests with 30 active sequence subscriptions.

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/studio-server && bun test src/test/compute-sequence-props-status.test.ts src/test/save-sequence-props.test.ts` (61 tests passed)
