### PR TITLE
Studio: show zod .describe() text as tooltip in the props editor

### DIFF
--- a/packages/example/src/SchemaTest/index.tsx
+++ b/packages/example/src/SchemaTest/index.tsx
@@ -115,7 +115,10 @@ export const schemaTestSchema = z.object({
 	description: zTextarea().nullable(),
 	country: z.enum(COUNTRY_NAMES),
 	dropdown: z.enum(['a', 'b', 'c']),
-	optionalEnum: z.enum(['vert', 'jaune', 'orange', 'rouge']).optional(),
+	optionalEnum: z
+		.enum(['vert', 'jaune', 'orange', 'rouge'])
+		.optional()
+		.describe('The background color of the video'),
 	superSchema: z.array(
 		z.discriminatedUnion('type', [
 			z.object({

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -19,7 +19,7 @@ test('resolves a statically imported composition component', async () => {
 	});
 
 	expect(location.source).toBe(path.join('src', 'SchemaTest', 'index.tsx'));
-	expect(location.line).toBe(143);
+	expect(location.line).toBe(146);
 	expect(location.canAddSequence).toBe(true);
 });
 

--- a/packages/studio/src/components/RenderModal/InfoBubble.tsx
+++ b/packages/studio/src/components/RenderModal/InfoBubble.tsx
@@ -22,7 +22,8 @@ const container: React.CSSProperties = {
 export const InfoBubble: React.FC<{
 	readonly title: string;
 	readonly children: React.ReactNode;
-}> = ({title, children}) => {
+	readonly horizontalAlignment?: 'left' | 'right';
+}> = ({title, children, horizontalAlignment = 'left'}) => {
 	const [hovered, setIsHovered] = useState(false);
 	const [opened, setOpened] = useState(false);
 	const ref = useRef<HTMLButtonElement>(null);
@@ -108,9 +109,11 @@ export const InfoBubble: React.FC<{
 						position: 'fixed',
 						bottom: size.windowSize.height - size.top,
 					}),
-			left: size.left,
+			...(horizontalAlignment === 'left'
+				? {left: size.left}
+				: {right: size.windowSize.width - (size.left + size.width)}),
 		};
-	}, [layout, opened, size]);
+	}, [horizontalAlignment, layout, opened, size]);
 
 	const style = useMemo((): React.CSSProperties => {
 		return {
@@ -149,6 +152,7 @@ export const InfoBubble: React.FC<{
 									<InfoTooltip
 										backgroundColor={INPUT_BACKGROUND}
 										arrowDirection={layout}
+										horizontalAlignment={horizontalAlignment}
 									>
 										{children}
 									</InfoTooltip>

--- a/packages/studio/src/components/RenderModal/InfoTooltip.tsx
+++ b/packages/studio/src/components/RenderModal/InfoTooltip.tsx
@@ -7,24 +7,14 @@ const arrow: React.CSSProperties = {
 	height: 7,
 	display: 'block',
 	overflow: 'visible',
-	marginLeft: 7,
-};
-
-const arrowUp: React.CSSProperties = {
-	...arrow,
-	transform: `translateY(1px)`,
-};
-
-const arrowDown: React.CSSProperties = {
-	...arrow,
-	marginTop: -1,
 };
 
 export const InfoTooltip: React.FC<{
 	readonly children: React.ReactNode;
 	readonly arrowDirection: 'up' | 'down';
 	readonly backgroundColor: string;
-}> = ({children, arrowDirection, backgroundColor}) => {
+	readonly horizontalAlignment: 'left' | 'right';
+}> = ({children, arrowDirection, backgroundColor, horizontalAlignment}) => {
 	const container: React.CSSProperties = useMemo(() => {
 		return {
 			boxShadow:
@@ -37,19 +27,29 @@ export const InfoTooltip: React.FC<{
 			borderRadius: '4px',
 		};
 	}, [arrowDirection, backgroundColor]);
+	const arrowStyle: React.CSSProperties = useMemo(() => {
+		return {
+			...arrow,
+			...(horizontalAlignment === 'left' ? {marginLeft: 7} : {marginRight: 7}),
+			...(arrowDirection === 'up'
+				? {transform: `translateY(1px)`}
+				: {marginTop: -1}),
+		};
+	}, [arrowDirection, horizontalAlignment]);
+
 	return (
 		<div
 			style={{
 				display: 'flex',
 				flexDirection: arrowDirection === 'up' ? 'column-reverse' : 'column',
-				alignItems: 'flex-start',
+				alignItems: horizontalAlignment === 'left' ? 'flex-start' : 'flex-end',
 			}}
 		>
 			<div style={container} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 				{children}
 			</div>
 			{arrowDirection === 'down' ? (
-				<svg viewBox="0 0 14 7" style={arrowDown}>
+				<svg viewBox="0 0 14 7" style={arrowStyle}>
 					<path
 						d={`M 14 0 L 7 7 L 0 0`}
 						fill={backgroundColor}
@@ -60,7 +60,7 @@ export const InfoTooltip: React.FC<{
 				</svg>
 			) : null}
 			{arrowDirection === 'up' ? (
-				<svg viewBox="0 0 14 7" style={arrowUp}>
+				<svg viewBox="0 0 14 7" style={arrowStyle}>
 					<path
 						d={`M 0 7 L 7 0 L 14 7`}
 						fill={backgroundColor}

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
@@ -1,10 +1,21 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from 'react';
 import {FAIL_COLOR, LIGHT_TEXT, WHITE} from '../../../helpers/colors';
 import {Flex} from '../../layout';
 import {InlineRemoveButton} from '../InlineRemoveButton';
 import {getSchemaLabel} from './get-schema-label';
 import {DEFAULT_PROPS_PATH_CLASSNAME} from './scroll-to-default-props-path';
 import type {JSONPath} from './zod-types';
+
+export const SchemaDescriptionOverrideContext = createContext<{
+	readonly jsonPath: JSONPath;
+	readonly description: string;
+} | null>(null);
 
 const compactStyles: React.CSSProperties = {
 	fontSize: 12,
@@ -25,6 +36,14 @@ export const SchemaLabel: React.FC<{
 	readonly description: string | null;
 }> = ({jsonPath, onRemove, valid, suffix, handleClick, description}) => {
 	const [clickableButtonHovered, setClickableButtonHovered] = useState(false);
+	const descriptionOverride = useContext(SchemaDescriptionOverrideContext);
+	const displayedDescription =
+		descriptionOverride?.jsonPath.length === jsonPath.length &&
+		descriptionOverride.jsonPath.every(
+			(part, index) => part === jsonPath[index],
+		)
+			? descriptionOverride.description
+			: description;
 
 	const labelStyle: React.CSSProperties = useMemo(() => {
 		return {
@@ -44,7 +63,7 @@ export const SchemaLabel: React.FC<{
 	}, []);
 
 	const labelContent = (
-		<span style={labelStyle} title={description ?? undefined}>
+		<span style={labelStyle} title={displayedDescription ?? undefined}>
 			{getSchemaLabel(jsonPath)} {suffix ? suffix : null}
 		</span>
 	);

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
@@ -95,7 +95,7 @@ export const SchemaLabel: React.FC<{
 				labelContent
 			)}
 			{displayedDescription ? (
-				<InfoBubble title="Field description">
+				<InfoBubble title="Field description" horizontalAlignment="right">
 					<div style={descriptionStyle}>{displayedDescription}</div>
 				</InfoBubble>
 			) : null}

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
@@ -22,7 +22,8 @@ export const SchemaLabel: React.FC<{
 	readonly valid: boolean;
 	readonly suffix: string | null;
 	readonly handleClick: null | (() => void);
-}> = ({jsonPath, onRemove, valid, suffix, handleClick}) => {
+	readonly description: string | null;
+}> = ({jsonPath, onRemove, valid, suffix, handleClick, description}) => {
 	const [clickableButtonHovered, setClickableButtonHovered] = useState(false);
 
 	const labelStyle: React.CSSProperties = useMemo(() => {
@@ -43,7 +44,7 @@ export const SchemaLabel: React.FC<{
 	}, []);
 
 	const labelContent = (
-		<span style={labelStyle}>
+		<span style={labelStyle} title={description ?? undefined}>
 			{getSchemaLabel(jsonPath)} {suffix ? suffix : null}
 		</span>
 	);

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
@@ -30,6 +30,8 @@ const compactStyles: React.CSSProperties = {
 
 const descriptionStyle: React.CSSProperties = {
 	fontSize: 12,
+	maxWidth: 360,
+	overflowWrap: 'anywhere',
 	padding: 10,
 };
 

--- a/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/SchemaLabel.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import {FAIL_COLOR, LIGHT_TEXT, WHITE} from '../../../helpers/colors';
 import {Flex} from '../../layout';
+import {InfoBubble} from '../InfoBubble';
 import {InlineRemoveButton} from '../InlineRemoveButton';
 import {getSchemaLabel} from './get-schema-label';
 import {DEFAULT_PROPS_PATH_CLASSNAME} from './scroll-to-default-props-path';
@@ -25,6 +26,11 @@ const compactStyles: React.CSSProperties = {
 	flexDirection: 'row',
 	alignItems: 'center',
 	flex: 1,
+};
+
+const descriptionStyle: React.CSSProperties = {
+	fontSize: 12,
+	padding: 10,
 };
 
 export const SchemaLabel: React.FC<{
@@ -63,7 +69,7 @@ export const SchemaLabel: React.FC<{
 	}, []);
 
 	const labelContent = (
-		<span style={labelStyle} title={displayedDescription ?? undefined}>
+		<span style={labelStyle}>
 			{getSchemaLabel(jsonPath)} {suffix ? suffix : null}
 		</span>
 	);
@@ -88,6 +94,11 @@ export const SchemaLabel: React.FC<{
 			) : (
 				labelContent
 			)}
+			{displayedDescription ? (
+				<InfoBubble title="Field description">
+					<div style={descriptionStyle}>{displayedDescription}</div>
+				</InfoBubble>
+			) : null}
 			<Flex />
 			{onRemove ? <InlineRemoveButton onClick={onRemove} /> : null}
 		</div>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodArrayEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodArrayEditor.tsx
@@ -4,7 +4,11 @@ import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
 import {SchemaArrayItemSeparationLine} from './SchemaSeparationLine';
 import {SchemaVerticalGuide} from './SchemaVerticalGuide';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {getArrayElement} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodArrayItemEditor} from './ZodArrayItemEditor';
@@ -58,6 +62,7 @@ export const ZodArrayEditor: React.FC<{
 					jsonPath={jsonPath}
 					onRemove={onRemove}
 					suffix={suffix}
+					description={getUserFacingDescription(schema)}
 					valid={zodValidation.success}
 					handleClick={() => setExpanded(!expanded)}
 				/>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodBooleanEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodBooleanEditor.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react';
 import {Checkbox} from '../../Checkbox';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
+import {getUserFacingDescription, type AnyZodSchema} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import type {UpdaterFunction} from './ZodSwitch';
 
@@ -15,7 +16,8 @@ export const ZodBooleanEditor: React.FC<{
 	readonly setValue: UpdaterFunction<boolean>;
 	readonly onRemove: null | (() => void);
 	readonly mayPad: boolean;
-}> = ({jsonPath, value, setValue, onRemove, mayPad}) => {
+	readonly schema: AnyZodSchema;
+}> = ({jsonPath, value, setValue, onRemove, mayPad, schema}) => {
 	const onToggle: React.ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
 			setValue(() => e.target.checked, {shouldSave: true});
@@ -31,6 +33,7 @@ export const ZodBooleanEditor: React.FC<{
 				onRemove={onRemove}
 				valid
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<Checkbox

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodColorEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodColorEditor.tsx
@@ -4,7 +4,11 @@ import {Row, Spacing} from '../../layout';
 import {RemotionInput} from '../../NewComposition/RemInput';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -63,6 +67,7 @@ export const ZodColorEditor: React.FC<{
 				onRemove={onRemove}
 				valid={localValue.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<Row align="center">

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodDateEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodDateEditor.tsx
@@ -5,7 +5,11 @@ import {Spacing} from '../../layout';
 import {RemotionInput} from '../../NewComposition/RemInput';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -82,6 +86,7 @@ export const ZodDateEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<RemotionInput

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodDiscriminatedUnionEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodDiscriminatedUnionEditor.tsx
@@ -9,7 +9,11 @@ import {Combobox} from '../../NewComposition/ComboBox';
 import {createZodValues} from './create-zod-values';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {
 	getDiscriminatedOption,
 	getDiscriminatedOptionKeys,
@@ -86,6 +90,7 @@ export const ZodDiscriminatedUnionEditor: React.FC<{
 							jsonPath={[...jsonPath, discriminator]}
 							onRemove={onRemove}
 							suffix={null}
+							description={getUserFacingDescription(schema)}
 							valid={zodValidation.success}
 						/>
 						<Combobox
@@ -103,6 +108,7 @@ export const ZodDiscriminatedUnionEditor: React.FC<{
 			mayPad,
 			onRemove,
 			discriminator,
+			schema,
 			value,
 			zodValidation.success,
 		]);

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodEnumEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodEnumEditor.tsx
@@ -5,7 +5,11 @@ import type {ComboboxValue} from '../../NewComposition/ComboBox';
 import {Combobox} from '../../NewComposition/ComboBox';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {getEnumValues} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
@@ -68,6 +72,7 @@ export const ZodEnumEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 
 			<div style={isRoot ? undefined : container}>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodMatrixEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodMatrixEditor.tsx
@@ -5,7 +5,11 @@ import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
 import {SchemaArrayItemSeparationLine} from './SchemaSeparationLine';
 import {SchemaVerticalGuide} from './SchemaVerticalGuide';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {getArrayElement} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodArrayItemEditor} from './ZodArrayItemEditor';
@@ -74,6 +78,7 @@ export const ZodMatrixEditor: React.FC<{
 				jsonPath={jsonPath}
 				onRemove={onRemove}
 				suffix={suffix}
+				description={getUserFacingDescription(schema)}
 				valid={zodValidation.success}
 				handleClick={() => setExpanded(!expanded)}
 			/>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodNonEditableValue.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodNonEditableValue.tsx
@@ -34,6 +34,7 @@ export const ZonNonEditableValue: React.FC<{
 				onRemove={null}
 				valid
 				suffix={null}
+				description={null}
 			/>
 			<div style={fullWidth}>
 				<em style={wideEmptyLabel}>{label}</em>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodNumberEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodNumberEditor.tsx
@@ -8,7 +8,11 @@ import {
 	getZodNumberMinimum,
 	getZodNumberStep,
 } from './zod-number-constraints';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -59,6 +63,7 @@ export const ZodNumberEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<InputDragger

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodObjectEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodObjectEditor.tsx
@@ -4,7 +4,11 @@ import {fieldsetLabel} from '../layout';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
 import {SchemaVerticalGuide} from './SchemaVerticalGuide';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {getObjectShape, getZodSchemaType} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -69,6 +73,7 @@ export const ZodObjectEditor: React.FC<{
 					jsonPath={jsonPath}
 					onRemove={onRemove}
 					suffix={suffix}
+					description={getUserFacingDescription(schema)}
 					valid={zodValidation.success}
 					handleClick={() => setExpanded(!expanded)}
 				/>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
@@ -9,7 +9,7 @@ import {
 import {Spacing} from '../../layout';
 import {createZodValues} from './create-zod-values';
 import {Fieldset} from './Fieldset';
-import {SchemaLabel} from './SchemaLabel';
+import {SchemaDescriptionOverrideContext, SchemaLabel} from './SchemaLabel';
 import {
 	getUserFacingDescription,
 	zodSafeParse,
@@ -64,6 +64,10 @@ export const ZodOrNullishEditor: React.FC<{
 		() => zodSafeParse(schema, value),
 		[schema, value],
 	);
+	const description = getUserFacingDescription(schema);
+	const descriptionOverride = useMemo(() => {
+		return description ? {jsonPath, description} : null;
+	}, [description, jsonPath]);
 
 	const onCheckBoxChange: React.ChangeEventHandler<HTMLInputElement> =
 		useCallback(
@@ -90,6 +94,17 @@ export const ZodOrNullishEditor: React.FC<{
 						getUserFacingDescription(innerSchema)
 					}
 				/>
+			) : descriptionOverride ? (
+				<SchemaDescriptionOverrideContext.Provider value={descriptionOverride}>
+					<ZodSwitch
+						value={value}
+						setValue={setValue}
+						jsonPath={jsonPath}
+						schema={innerSchema}
+						onRemove={onRemove}
+						mayPad={false}
+					/>
+				</SchemaDescriptionOverrideContext.Provider>
 			) : (
 				<ZodSwitch
 					value={value}

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodOrNullishEditor.tsx
@@ -10,7 +10,11 @@ import {Spacing} from '../../layout';
 import {createZodValues} from './create-zod-values';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	getUserFacingDescription,
+	zodSafeParse,
+	type AnyZodSchema,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import type {UpdaterFunction} from './ZodSwitch';
 import {ZodSwitch} from './ZodSwitch';
@@ -81,6 +85,10 @@ export const ZodOrNullishEditor: React.FC<{
 					onRemove={onRemove}
 					valid={zodValidation.success}
 					suffix={null}
+					description={
+						getUserFacingDescription(schema) ??
+						getUserFacingDescription(innerSchema)
+					}
 				/>
 			) : (
 				<ZodSwitch

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodStaticFileEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodStaticFileEditor.tsx
@@ -5,7 +5,11 @@ import {Combobox} from '../../NewComposition/ComboBox';
 import {useStaticFiles} from '../../use-static-files';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -66,6 +70,7 @@ export const ZodStaticFileEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 
 			<div style={isRoot ? undefined : container}>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodStringEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodStringEditor.tsx
@@ -4,7 +4,11 @@ import {useZodIfPossible} from '../../get-zod-if-possible';
 import {RemotionInput} from '../../NewComposition/RemInput';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -50,6 +54,7 @@ export const ZodStringEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<RemotionInput

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodSwitch.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodSwitch.tsx
@@ -151,6 +151,7 @@ export const ZodSwitch: React.FC<{
 				jsonPath={jsonPath}
 				onRemove={onRemove}
 				mayPad={mayPad}
+				schema={schema}
 			/>
 		);
 	}

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodTextareaEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodTextareaEditor.tsx
@@ -7,7 +7,7 @@ import {RemTextarea} from '../../NewComposition/RemTextarea';
 import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
 import type {AnyZodSchema} from './zod-schema-type';
-import {zodSafeParse} from './zod-schema-type';
+import {zodSafeParse, getUserFacingDescription} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
 import type {UpdaterFunction} from './ZodSwitch';
@@ -64,6 +64,7 @@ export const ZodTextareaEditor: React.FC<{
 				onRemove={onRemove}
 				valid={zodValidation.success}
 				suffix={null}
+				description={getUserFacingDescription(schema)}
 			/>
 			<div style={fullWidth}>
 				<RemTextarea

--- a/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleEditor.tsx
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/ZodTupleEditor.tsx
@@ -4,7 +4,11 @@ import {Fieldset} from './Fieldset';
 import {SchemaLabel} from './SchemaLabel';
 import {SchemaArrayItemSeparationLine} from './SchemaSeparationLine';
 import {SchemaVerticalGuide} from './SchemaVerticalGuide';
-import {zodSafeParse, type AnyZodSchema} from './zod-schema-type';
+import {
+	zodSafeParse,
+	type AnyZodSchema,
+	getUserFacingDescription,
+} from './zod-schema-type';
 import {getTupleItems} from './zod-schema-type';
 import type {JSONPath} from './zod-types';
 import {ZodFieldValidation} from './ZodFieldValidation';
@@ -58,6 +62,7 @@ export const ZodTupleEditor: React.FC<{
 					jsonPath={jsonPath}
 					onRemove={onRemove}
 					suffix={suffix}
+					description={getUserFacingDescription(schema)}
 					valid={zodValidation.success}
 					handleClick={() => setExpanded(!expanded)}
 				/>

--- a/packages/studio/src/components/RenderModal/SchemaEditor/zod-schema-type.ts
+++ b/packages/studio/src/components/RenderModal/SchemaEditor/zod-schema-type.ts
@@ -166,6 +166,21 @@ export const getZodSchemaDescription = (
 	return schema.description;
 };
 
+// Branded types (zColor(), zTextarea(), zMatrix()) store their marker in the
+// description, so those must not surface as user-facing text.
+const REMOTION_BRAND_PREFIX = '__remotion-';
+
+export const getUserFacingDescription = (
+	schema: AnyZodSchema,
+): string | null => {
+	const description = getZodSchemaDescription(schema);
+	if (!description || description.startsWith(REMOTION_BRAND_PREFIX)) {
+		return null;
+	}
+
+	return description;
+};
+
 /**
  * Get the shape of an object schema.
  * v3: _def.shape() (function)


### PR DESCRIPTION
Closes #10227

## Problem

When using `.describe()` on a zod schema field, the description is not surfaced anywhere in the Studio props editor. In the linked issue, the reporter tried to change the label of an optional enum's checkbox via `.describe()` and found no way to attach human-readable context to a field. (The `<undefined>` checkbox label itself is intentional — it toggles the field to `undefined` — and is left unchanged.)

## Solution

Show non-branded zod descriptions as a native `title` tooltip on the field label in the schema editor:

- New helper `getUserFacingDescription()` in `zod-schema-type.ts`: returns the schema description via the existing v3/v4-aware `getZodSchemaDescription()`, filtering out internal branded markers (descriptions starting with `__remotion-`, used by `zColor()`, `zTextarea()`, `zMatrix()`).
- `SchemaLabel` accepts a `description: string | null` prop and renders it as `title` on the label span.
- All schema editors pass their field's description. `ZodOptionalEditor`/`ZodNullableEditor` (via `ZodOrNullishEditor`) check the outer schema first and fall back to the inner one, so both `.describe().optional()` and `.optional().describe()` work.
- `ZodBooleanEditor` now receives the `schema` prop (it previously didn't), so boolean fields get tooltips too.
- The `schema-test` example composition's `optionalEnum` field (same shape as the issue's repro) now carries a `.describe()` for manual testing.

## Test Plan

- `packages/studio`: `bun run lint` (0 errors), `bun run formatting`, `bun test src` (564 pass), and `turbo run make` (tsgo typecheck + bundle) all green.
- Ran the Studio against `packages/example`, composition `schema-test`: the `optionalEnum` label carries the tooltip, and it is the only field affected. DOM verification across all 32 fields of the props panel:

```js
[...document.querySelectorAll('[data-json-path]')]
  .filter((el) => el.querySelector('span')?.title)
  .map((el) => ({path: el.dataset.jsonPath, title: el.querySelector('span').title}))
// → [{path: "optionalEnum", title: "The background color of the video"}]
```

- Branded types (`zColor()` etc.) verified unaffected — their `__remotion-*` marker descriptions are filtered out and never shown.
