### PR TITLE
`@remotion/canvas-capture-extension`: Fix Convert handoff hostname

### DIFF
--- a/packages/canvas-capture-extension/manifest.json
+++ b/packages/canvas-capture-extension/manifest.json
@@ -12,7 +12,10 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["https://remotion.dev/convert*"],
+			"matches": [
+				"https://remotion.dev/convert*",
+				"https://www.remotion.dev/convert*"
+			],
 			"js": ["receiver.js"],
 			"run_at": "document_start"
 		}

--- a/packages/canvas-capture-extension/src/background.ts
+++ b/packages/canvas-capture-extension/src/background.ts
@@ -69,7 +69,7 @@ chrome.runtime.onMessage.addListener((message) => {
 		return;
 	}
 
-	const url = new URL('https://remotion.dev/convert');
+	const url = new URL('https://www.remotion.dev/convert');
 	url.searchParams.set('canvas-capture', message.captureId);
 	return chrome.tabs.create({url: url.toString()});
 });


### PR DESCRIPTION
## Summary

- open Remotion Convert on its canonical `www.remotion.dev` hostname
- allow the canvas capture receiver on both the canonical and redirecting hostnames

## Testing

- `bun run build`
- `bun run stylecheck`
- rebuilt the unpacked Canvas Capture extension and verified its installed manifest and background bundle
