### PR TITLE
Docs: Clarify rendering-service prohibition applies to all Users

### DIFF
--- a/packages/docs/docs/terms.mdx
+++ b/packages/docs/docs/terms.mdx
@@ -194,6 +194,8 @@ It is not allowed to copy or modify the Remotion Software for the purpose of sel
 
 It is not allowed to reverse-engineer, disassemble, reverse-compile, or otherwise attempt to derive the source code of any part of the Remotion Software or Services that is not provided by Remotion in source code form.
 
+It is not allowed to operate a rendering service that allows end-users to bring or upload their own Remotion code. Offering a rendering service in this way might obscure the fact that Remotion needs to be licensed, and any such rendering service requires prior explicit and written approval from Remotion. The conditions under which a rendering service may be operated, including acceptable configurations, are described in "[Remotion Software used for a rendering service](#RenderingService)".
+
 Unless otherwise expressly agreed, the software license is non-assignable/non-transferable, which means a license holder is not allowed to assign/transfer the license to anyone else.
 
 It is not permissible to indicate or try to imply in any manner, that a User stands in a qualified relationship with Remotion or that Remotion has endorsed the User without any prior written approval, the User's products or services, or any third party's products and services for any purpose.
@@ -325,7 +327,7 @@ It is acceptable to allow third parties to render videos through a service if th
 
 It is also acceptable for services to generate Remotion code through artificial intelligence and render it.
 
-It is not acceptable for services to allow end-users to bring/upload their own Remotion code. Offering a rendering service in this way might obscure the fact that Remotion needs to be licensed. Any such rendering service requires prior explicit and written approval from Remotion.
+It is not acceptable for services to allow end-users to bring/upload their own Remotion code. Offering a rendering service in this way might obscure the fact that Remotion needs to be licensed. Any such rendering service requires prior explicit and written approval from Remotion. This prohibition is also stated among the "[Disallowed use cases](#Disallowed)", which apply to all Users.
 
 Examples:
 


### PR DESCRIPTION
## Summary

- Restates the prohibition on operating a rendering service that lets end-users bring/upload their own Remotion code inside the universal **Disallowed use cases** section (under `## Software license`, which governs all Users).
- Adds a bidirectional cross-reference between the **Disallowed use cases** section and the **Remotion Software used for a rendering service** section so the scope is unambiguous.

## Why

Closes remotion-dev/business#1386

The "Remotion Software used for a rendering service" section is nested under `## Company License`. Because of that heading hierarchy, a reader could reasonably infer its rules only govern Company License Users, leaving Free License Users unaddressed — even though Free License Users may use Remotion under the Remotion for Automators option and are therefore also bound by these rules.

Rather than move the section (which would disturb the detailed acceptable/unacceptable scenarios and examples that belong with the Company License material), this change places the key prohibition in the one section guaranteed to apply to everyone — `### Disallowed use cases`, which sits under `## Software license` — and cross-links the two sections in both directions. This makes the universal applicability explicit without introducing any new prohibition or altering existing anchors.

## Changes

`packages/docs/docs/terms.mdx`:

1. **New paragraph in `### Disallowed use cases`** — states that operating a rendering service allowing end-users to upload their own Remotion code is not allowed, that such services require prior explicit written approval, and links to the rendering-service section for the full conditions and acceptable configurations.
2. **Cross-reference in `### Remotion Software used for a rendering service`** — the "not acceptable" paragraph now notes the prohibition is also stated among the Disallowed use cases, which apply to all Users.

No anchors were changed, so existing inbound links (`#Disallowed`, `#RenderingService`) continue to resolve.

## Test plan

- [ ] Render the docs site locally and verify both sections render correctly.
- [ ] Verify the `#Disallowed` and `#RenderingService` anchor links still resolve.
- [ ] Verify the cross-reference links between the two sections navigate correctly.
- [ ] Review that the wording is consistent with the rest of the Terms and Conditions.

Made with [Cursor](https://cursor.com)