### PR TITLE
`@remotion/canvas-capture-extension`: Improve browser setup

### DIFF
--- a/packages/canvas-capture-extension/README.md
+++ b/packages/canvas-capture-extension/README.md
@@ -2,11 +2,41 @@
 
 Record an element—or a whole webpage—as a high-resolution H.264 MP4 or VP9 WebM using Chromium's experimental HTML-in-canvas implementation.
 
+## Pinned browser setup on macOS
+
+Use [Chrome for Testing at revision `r1631007`](https://storage.googleapis.com/chrome-for-testing-per-commit-public/mac-arm64/r1631007/chrome-mac-arm64.zip) on Apple Silicon. This is the exact Chromium revision where the required HTML-in-canvas implementation is known to work. Chrome for Testing does not auto-update, and unlike an open-source Chromium build, it is built with proprietary codec support so the browser can both encode and play the H.264 MP4 produced by this extension.
+
+After extracting the archive, move and rename the app to a durable location such as:
+
+```text
+/Users/jonathanburger/Applications/Recorder Chrome.app
+```
+
+Launch it with a dedicated profile and the HTML-in-canvas feature enabled:
+
+```bash
+'/Users/jonathanburger/Applications/Recorder Chrome.app/Contents/MacOS/Google Chrome for Testing' \
+  --user-data-dir='/Users/jonathanburger/Library/Application Support/Chrome for Testing Canvas Capture r1631007' \
+  --enable-features=CanvasDrawElement \
+  --enable-blink-features=CanvasDrawElement \
+  --disable-component-update \
+  --no-first-run \
+  --no-default-browser-check
+```
+
+Load the unpacked extension from the durable installation directory:
+
+```text
+/Users/jonathanburger/Applications/Remotion Canvas Capture Extension
+```
+
+Do not replace this browser with Chrome Canary or a normal Chrome installation: those update automatically and may remove or change the experimental API. Because this browser is intentionally pinned and will not receive security updates, only use it with trusted websites.
+
 ## Build and install
 
-1. Run `bun run make` in this directory.
+1. From the repository root, run `.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh --repo "$PWD"`. This builds the package and installs the unpacked extension outside the worktree.
 2. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**.
-3. Select `packages/canvas-capture-extension/dist`.
+3. Select `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
 4. Enable `chrome://flags/#canvas-draw-element` and restart Chrome if HTML-in-canvas is not already enabled.
 
 Click the extension icon on a webpage to open the recorder window. Choose H.264 MP4 or VP9 WebM, set the output scale, select an area (the page is focused while you drag, but the recorder window remains open, and the extension picks the deepest DOM element containing the selection) or choose **Whole page**, then press **Record**. The recorder displays the rounded output dimensions and only enables **Record** after the browser confirms that Mediabunny's exact high-quality, realtime configuration is supported. The selected element is drawn at the display's native pixel density, then the crop is copied into a reusable, correctly sized `OffscreenCanvas`. Enable **Include page background** to render the whole page subtree and crop it to the selected area instead of isolating the selected element. Recording continues if the recorder window closes; click the extension icon to reopen it, then press **Stop and open in Convert** to load the recording in [remotion.dev/convert](https://remotion.dev/convert) without downloading it first, or **Stop and download** to save it directly.

--- a/packages/canvas-capture-extension/src/capture.ts
+++ b/packages/canvas-capture-extension/src/capture.ts
@@ -376,7 +376,7 @@ export class ElementCapture {
 		) {
 			this.#wrapped.restore();
 			throw new Error(
-				'The HTML-in-canvas capture APIs are not available in this Chrome build.',
+				'The required HTML-in-canvas APIs are unavailable. Open chrome://flags/#canvas-draw-element, set Canvas Draw Element to Enabled, then fully quit and reopen the browser.',
 			);
 		}
 

--- a/packages/canvas-capture-extension/src/content.ts
+++ b/packages/canvas-capture-extension/src/content.ts
@@ -132,7 +132,7 @@ const createController = (): ExtensionController => {
 	const supported = isHtmlInCanvasAvailable();
 	let status = supported
 		? 'Choose an area or the whole page.'
-		: 'Enable chrome://flags/#canvas-draw-element, then reload.';
+		: 'Canvas capture is unavailable because the experimental HTML-in-canvas API is disabled. Open chrome://flags/#canvas-draw-element, set Canvas Draw Element to Enabled, then fully quit and reopen the browser.';
 	let statusIsError = !supported;
 	let selectionStart: {readonly x: number; readonly y: number} | null = null;
 


### PR DESCRIPTION
## Summary

- document the pinned Chrome for Testing build that supports CanvasDrawElement and H.264 playback
- use durable browser, profile, and unpacked-extension paths in the setup instructions
- explain exactly how to enable the experimental API and fully restart the browser when capture is unavailable

## Validation

- `bun run build`
- `bun run stylecheck`
