### PR TITLE
Docs: Mention @remotion/media tags on the Lambda cost page

### DIFF
--- a/packages/docs/docs/lambda/cost.mdx
+++ b/packages/docs/docs/lambda/cost.mdx
@@ -8,6 +8,15 @@ crumb: 'Lambda'
 
 On this page, a few strategies for optimizing the cost of using Remotion Lambda are presented.
 
+## Use the `@remotion/media` tags
+
+Use [`<Video />`](/docs/media/video) and [`<Audio />`](/docs/media/audio) from [`@remotion/media`](/docs/media) instead of [`<OffthreadVideo />`](/docs/offthreadvideo) or [`<Html5Video />`](/docs/html5-video). On Lambda, this reduces the bill in two ways:
+
+- **Less compute time**: The `@remotion/media` tags are the fastest way to render video. Since Lambda is billed per GB-second, a faster render is directly a cheaper render.
+- **Less data transfer**: They fetch media using byte range requests, so a Lambda function only downloads the part of the file it actually renders. [`<OffthreadVideo />`](/docs/offthreadvideo) downloads the entire file into every function. See [Data transfer cost](/docs/lambda/data-transfer-cost#option-2-use-remotionmedia-tags).
+
+See the [comparison of video tags](/docs/video-tags) for the tradeoffs. Note that some media falls back to [`<OffthreadVideo />`](/docs/offthreadvideo) during rendering, which forgoes these savings — see [Fallback behavior](/docs/media/fallback) for when this happens and how to observe it on Lambda.
+
 ## Less memory
 
 Reducing the memory will linearly decrease the cost. Try out different values for the memory when deploying a Lambda function and see how low you can set it without experiencing a crash.
@@ -35,5 +44,7 @@ See [this video](https://www.youtube.com/watch?v=GUsjj1jsLhw) of how we optimize
 ## See also
 
 - [How much does Remotion Lambda cost?](/docs/lambda/cost-example)
+- [Data transfer cost](/docs/lambda/data-transfer-cost)
+- [Comparison of video tags](/docs/video-tags)
 - [Optimizing for speed](/docs/lambda/optimizing-speed)
 - [Performance](/docs/performance)


### PR DESCRIPTION
Fixes #10250.

The [Optimizing for cost](https://www.remotion.dev/docs/lambda/optimizing-cost) page did not mention the `@remotion/media` tags, even though they are the biggest cost lever for many Lambda users.

Adds a section covering the two ways they lower the bill:

- **Less compute time** — they render fastest, and Lambda is billed per GB-second.
- **Less data transfer** — byte range requests mean a function only downloads the part of the file it renders, instead of pulling the whole file into every function.

Both points link to pages that already document them ([Data transfer cost](https://www.remotion.dev/docs/lambda/data-transfer-cost#option-2-use-remotionmedia-tags), [Comparison of video tags](https://www.remotion.dev/docs/video-tags)) rather than restating the detail here. I also noted that a fallback to `<OffthreadVideo>` forgoes the savings, linking to [Fallback behavior](https://www.remotion.dev/docs/media/fallback), and added the two pages to "See also".

The section is placed first on the page to match "many customers can benefit" from the issue.

Docs-only change (one `.mdx` file). I verified every link target resolves to an existing page and that the `#option-2-use-remotionmedia-tags` anchor matches the heading on the data transfer page, but I did not run a full `docusaurus build` locally.