### PR TITLE
Internal skills: Install Canvas Capture browser

### DIFF
--- a/.agents/skills/canvas-capture-extension/SKILL.md
+++ b/.agents/skills/canvas-capture-extension/SKILL.md
@@ -22,14 +22,19 @@ the unpacked copy outside the checkout so deleting a worktree cannot break it.
 
    The script builds with Bun and installs the seven unpacked-extension files in
    `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
+   Before building, it verifies that the pinned Chrome for Testing
+   `150.0.7842.0` (`r1631007`) is installed. If the browser is installed outside
+   the documented location, pass `--browser-executable <path>`. If it is missing
+   or incompatible, use `$install-canvas-capture-browser` to install it.
 
 3. Confirm that the installed directory contains `manifest.json`,
    `background.js`, `content.js`, `popup.css`, `popup.html`, `popup.js`, and
    `receiver.js`.
 
-## Reload in Chrome
+## Reload in Chrome for Testing
 
-- Open `chrome://extensions` manually in Chrome or Chrome Canary.
+- Launch the pinned Chrome for Testing `150.0.7842.0` (`r1631007`) with the
+  dedicated Canvas Capture profile, then open `chrome://extensions` manually.
 - Enable **Developer mode** on `chrome://extensions`.
 - If **Remotion Canvas Capture** already points to the durable directory, click
   **Reload**.

--- a/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
+++ b/.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh
@@ -4,9 +4,13 @@ set -euo pipefail
 
 repo_dir=""
 install_dir="/Users/jonathanburger/Applications/Remotion Canvas Capture Extension"
+browser_executable="/Users/jonathanburger/Applications/Recorder Chrome.app/Contents/MacOS/Google Chrome for Testing"
+expected_browser_version="150.0.7842.0"
+expected_browser_revision="r1631007"
+browser_download_url="https://storage.googleapis.com/chrome-for-testing-per-commit-public/mac-arm64/r1631007/chrome-mac-arm64.zip"
 
 usage() {
-	printf '%s\n' "Usage: rebuild-extension.sh [--repo PATH] [--install-dir PATH]"
+	printf '%s\n' "Usage: rebuild-extension.sh [--repo PATH] [--install-dir PATH] [--browser-executable PATH]"
 }
 
 while (($# > 0)); do
@@ -17,6 +21,10 @@ while (($# > 0)); do
 		;;
 	--install-dir)
 		install_dir="${2:?--install-dir requires a path}"
+		shift 2
+		;;
+	--browser-executable)
+		browser_executable="${2:?--browser-executable requires a path}"
 		shift 2
 		;;
 	--help | -h)
@@ -48,6 +56,26 @@ dist_dir="$package_dir/dist"
 
 if [[ ! -f "$package_dir/package.json" || ! -f "$package_dir/manifest.json" ]]; then
 	printf 'Not a canvas capture extension source directory: %s\n' "$package_dir" >&2
+	exit 1
+fi
+
+if [[ ! -x "$browser_executable" ]]; then
+	printf 'Chrome for Testing was not found at: %s\n' "$browser_executable" >&2
+	printf 'Canvas Capture requires Chrome for Testing %s (revision %s).\n' "$expected_browser_version" "$expected_browser_revision" >&2
+	printf 'Download it from: %s\n' "$browser_download_url" >&2
+	printf '%s\n' 'After installing it, rerun this command. For a different location, pass --browser-executable PATH.' >&2
+	exit 1
+fi
+
+browser_version="$("$browser_executable" --version 2>&1 || true)"
+browser_version="${browser_version%"${browser_version##*[![:space:]]}"}"
+expected_browser_description="Google Chrome for Testing $expected_browser_version"
+if [[ "$browser_version" != "$expected_browser_description" ]]; then
+	printf '%s\n' 'The installed browser is incompatible with Canvas Capture.' >&2
+	printf 'Expected: %s (revision %s)\n' "$expected_browser_description" "$expected_browser_revision" >&2
+	printf 'Found: %s\n' "${browser_version:-unknown browser or version}" >&2
+	printf 'Download the required browser from: %s\n' "$browser_download_url" >&2
+	printf '%s\n' 'Then rerun this command, passing --browser-executable PATH if it is installed in a different location.' >&2
 	exit 1
 fi
 

--- a/.agents/skills/install-canvas-capture-browser/SKILL.md
+++ b/.agents/skills/install-canvas-capture-browser/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: install-canvas-capture-browser
+description: Install and verify the pinned Chrome for Testing build used by the private Remotion Canvas Capture extension on Apple Silicon macOS. Use when setting up Canvas Capture, when Recorder Chrome is missing or has the wrong version, or when the canvas-capture-extension installer reports that Chrome for Testing 150.0.7842.0 (r1631007) is unavailable.
+---
+
+# Install Canvas Capture Browser
+
+Install the exact Chrome for Testing build known to support Canvas Draw Element
+and proprietary H.264 codecs. Keep it pinned because other Chrome builds may
+remove or change the experimental API.
+
+## Install
+
+1. Run the bundled installer:
+
+   ```bash
+   .agents/skills/install-canvas-capture-browser/scripts/install-browser.sh
+   ```
+
+   The script only supports Apple Silicon macOS. It downloads revision
+   `r1631007`, verifies the archive checksum and version `150.0.7842.0`, and
+   installs the app at `/Users/jonathanburger/Applications/Recorder Chrome.app`.
+   It exits successfully without downloading when the correct version is
+   already installed. It does not overwrite an incompatible existing app.
+
+2. Confirm the script reports the expected installed path and version.
+
+3. Launch it for Canvas Capture with:
+
+   ```bash
+   '/Users/jonathanburger/Applications/Recorder Chrome.app/Contents/MacOS/Google Chrome for Testing' \
+     --user-data-dir='/Users/jonathanburger/Library/Application Support/Chrome for Testing Canvas Capture r1631007' \
+     --enable-features=CanvasDrawElement \
+     --enable-blink-features=CanvasDrawElement \
+     --disable-component-update \
+     --no-first-run \
+     --no-default-browser-check
+   ```
+
+Use this browser only with trusted websites because the pinned build does not
+receive security updates.

--- a/.agents/skills/install-canvas-capture-browser/agents/openai.yaml
+++ b/.agents/skills/install-canvas-capture-browser/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Install Canvas Capture Browser'
+  short_description: 'Install the pinned Canvas Capture browser'
+  default_prompt: 'Use $install-canvas-capture-browser to install the pinned Chrome for Testing build for Canvas Capture.'

--- a/.agents/skills/install-canvas-capture-browser/scripts/install-browser.sh
+++ b/.agents/skills/install-canvas-capture-browser/scripts/install-browser.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+expected_version="150.0.7842.0"
+expected_revision="r1631007"
+expected_sha256="86de7ffdb70d3f41714bf5b2b6fe3ef23cbf6c924eb407343418f31b9c721f7f"
+download_url="https://storage.googleapis.com/chrome-for-testing-per-commit-public/mac-arm64/r1631007/chrome-mac-arm64.zip"
+install_app="/Users/jonathanburger/Applications/Recorder Chrome.app"
+
+usage() {
+	printf '%s\n' 'Usage: install-browser.sh [--install-app PATH]'
+}
+
+while (($# > 0)); do
+	case "$1" in
+	--install-app)
+		install_app="${2:?--install-app requires a path}"
+		shift 2
+		;;
+	--help | -h)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		printf 'Unknown argument: %s\n' "$1" >&2
+		exit 1
+		;;
+	esac
+done
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+	printf '%s\n' 'Canvas Capture requires Apple Silicon macOS for this pinned browser build.' >&2
+	exit 1
+fi
+
+installed_plist="$install_app/Contents/Info.plist"
+installed_executable="$install_app/Contents/MacOS/Google Chrome for Testing"
+if [[ -e "$install_app" ]]; then
+	installed_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$installed_plist" 2>/dev/null || true)"
+	if [[ "$installed_version" == "$expected_version" && -x "$installed_executable" ]]; then
+		printf 'Chrome for Testing %s (%s) is already installed at %s\n' "$expected_version" "$expected_revision" "$install_app"
+		exit 0
+	fi
+
+	printf 'Cannot install because an incompatible app already exists at: %s\n' "$install_app" >&2
+	printf 'Expected Chrome for Testing %s (%s), found version: %s\n' "$expected_version" "$expected_revision" "${installed_version:-unknown}" >&2
+	printf '%s\n' 'Move or remove that app after confirming it is safe to do so, then rerun this installer.' >&2
+	exit 1
+fi
+
+temporary_dir="$(mktemp -d)"
+cleanup() {
+	if [[ -d "$temporary_dir" ]]; then
+		rm -rf -- "$temporary_dir"
+	fi
+}
+trap cleanup EXIT
+
+archive_path="$temporary_dir/chrome-mac-arm64.zip"
+extracted_dir="$temporary_dir/extracted"
+source_app="$extracted_dir/chrome-mac-arm64/Google Chrome for Testing.app"
+
+printf 'Downloading Chrome for Testing %s (%s)…\n' "$expected_version" "$expected_revision"
+curl --fail --location --progress-bar "$download_url" --output "$archive_path"
+
+actual_sha256="$(shasum -a 256 "$archive_path" | cut -d ' ' -f 1)"
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+	printf '%s\n' 'The downloaded Chrome for Testing archive failed checksum verification.' >&2
+	printf 'Expected SHA-256: %s\n' "$expected_sha256" >&2
+	printf 'Found SHA-256:    %s\n' "$actual_sha256" >&2
+	exit 1
+fi
+
+mkdir -p "$extracted_dir"
+ditto -x -k "$archive_path" "$extracted_dir"
+
+source_plist="$source_app/Contents/Info.plist"
+source_executable="$source_app/Contents/MacOS/Google Chrome for Testing"
+downloaded_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$source_plist" 2>/dev/null || true)"
+if [[ "$downloaded_version" != "$expected_version" || ! -x "$source_executable" ]]; then
+	printf '%s\n' 'The verified archive did not contain the required Chrome for Testing app.' >&2
+	printf 'Expected version: %s\n' "$expected_version" >&2
+	printf 'Found version:    %s\n' "${downloaded_version:-unknown}" >&2
+	exit 1
+fi
+
+mkdir -p "$(dirname "$install_app")"
+mv "$source_app" "$install_app"
+
+installed_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$installed_plist")"
+if [[ "$installed_version" != "$expected_version" || ! -x "$installed_executable" ]]; then
+	printf 'Chrome for Testing could not be verified after installation at: %s\n' "$install_app" >&2
+	exit 1
+fi
+
+printf 'Installed Chrome for Testing %s (%s) at %s\n' "$expected_version" "$expected_revision" "$install_app"

--- a/packages/canvas-capture-extension/README.md
+++ b/packages/canvas-capture-extension/README.md
@@ -4,7 +4,7 @@ Record an element—or a whole webpage—as a high-resolution H.264 MP4 or VP9 W
 
 ## Pinned browser setup on macOS
 
-Use [Chrome for Testing at revision `r1631007`](https://storage.googleapis.com/chrome-for-testing-per-commit-public/mac-arm64/r1631007/chrome-mac-arm64.zip) on Apple Silicon. This is the exact Chromium revision where the required HTML-in-canvas implementation is known to work. Chrome for Testing does not auto-update, and unlike an open-source Chromium build, it is built with proprietary codec support so the browser can both encode and play the H.264 MP4 produced by this extension.
+Use [Chrome for Testing `150.0.7842.0` at revision `r1631007`](https://storage.googleapis.com/chrome-for-testing-per-commit-public/mac-arm64/r1631007/chrome-mac-arm64.zip) on Apple Silicon. This is the exact Chromium revision where the required HTML-in-canvas implementation is known to work. Chrome for Testing does not auto-update, and unlike an open-source Chromium build, it is built with proprietary codec support so the browser can both encode and play the H.264 MP4 produced by this extension.
 
 After extracting the archive, move and rename the app to a durable location such as:
 
@@ -34,7 +34,7 @@ Do not replace this browser with Chrome Canary or a normal Chrome installation: 
 
 ## Build and install
 
-1. From the repository root, run `.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh --repo "$PWD"`. This builds the package and installs the unpacked extension outside the worktree.
+1. From the repository root, run `.agents/skills/canvas-capture-extension/scripts/rebuild-extension.sh --repo "$PWD"`. This verifies the pinned Chrome for Testing version, builds the package, and installs the unpacked extension outside the worktree. If the browser is not at the path shown above, also pass `--browser-executable <path>`.
 2. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**.
 3. Select `/Users/jonathanburger/Applications/Remotion Canvas Capture Extension`.
 4. Enable `chrome://flags/#canvas-draw-element` and restart Chrome if HTML-in-canvas is not already enabled.


### PR DESCRIPTION
## Summary

- add an internal skill that installs the pinned Chrome for Testing build for Canvas Capture
- verify the downloaded archive checksum and embedded browser version before installation
- validate the pinned browser before rebuilding the Canvas Capture extension and provide actionable errors
- document the exact Chrome version and connect the extension workflow to the browser installer skill

## Test plan

- `bun run build`
- `bun run stylecheck`
- validate the new skill with `quick_validate.py`
- run the browser installer against the real pinned browser and verify its idempotent path
- rebuild the Canvas Capture extension using the installed browser and verify all seven artifacts
