### PR TITLE
Docs: Clarify that Automators applies only to Company License users

### DIFF
--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -19,8 +19,6 @@ You are eligible to use Remotion for free if you are:
 - a non-profit or not-for-profit organisation
 - evaluating whether Remotion is a good fit, and are not yet using it in a commercial way
 
-Remotion for Creators and Remotion for Automators are Company License options. They apply only if you do not qualify for the Free License. Free License users may also create automated pipelines and render programmatically.
-
 [Contact us](/contact) in case you need confirmation if your use case is acceptable.
 
 ### Is Remotion open-source?

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -93,7 +93,7 @@ Previews in the [Remotion Studio](/docs/studio) or [Remotion Player](/docs/playe
 
 ### When do I need to purchase Renders?
 
-If you do not qualify for the Free License, building an automation makes your use case fall under Remotion for Automators. Setting up an automation to render videos programmatically requires you to purchase Renders.
+If you do not qualify for the Free License, building an automation makes your use case fall under Remotion for Automators and requires you to purchase Renders.
 
 Low-volume video production, such as rendering locally or one-off renders on a server, fall under the Remotion for Creators option and do not require purchasing Renders.
 

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -19,6 +19,8 @@ You are eligible to use Remotion for free if you are:
 - a non-profit or not-for-profit organisation
 - evaluating whether Remotion is a good fit, and are not yet using it in a commercial way
 
+Remotion for Creators and Remotion for Automators are Company License options. They apply only if you do not qualify for the Free License. Free License users may also create automated pipelines and render programmatically.
+
 [Contact us](/contact) in case you need confirmation if your use case is acceptable.
 
 ### Is Remotion open-source?
@@ -85,8 +87,6 @@ An automation is defined as owning code that programmatically calls one of the f
 - [`npx remotion cloudrun still`](/docs/cloudrun/cli/still)
 - [`<Player>`](/docs/player/player)
 
-Building an automation makes the use case fall under the Remotion for Automators option.
-
 ### How is 1 Render defined?
 
 1 Render is the successful generation of a video, audio, GIF, PDF or still image.
@@ -95,7 +95,7 @@ Previews in the [Remotion Studio](/docs/studio) or [Remotion Player](/docs/playe
 
 ### When do I need to purchase Renders?
 
-If you don't qualify for the Free License and are setting up an automation to render videos programmatically, you need to purchase Renders.
+If you do not qualify for the Free License, building an automation makes your use case fall under Remotion for Automators. Setting up an automation to render videos programmatically requires you to purchase Renders.
 
 Low-volume video production, such as rendering locally or one-off renders on a server, fall under the Remotion for Creators option and do not require purchasing Renders.
 


### PR DESCRIPTION
## Summary

Clarify that Remotion for Creators and Remotion for Automators are Company License options that apply only after determining that a user does not qualify for the Free License.

Changes to `packages/docs/docs/license/faq.mdx`:

- state that Free License users may create automated pipelines and render programmatically
- move the unqualified automation statement into “When do I need to purchase Renders?” and add the Free License condition

Closes remotion-dev/business#1426.

## Split PRs

- #10276 aligns the Free License eligibility wording with the Terms
- #10277 reorders the open-source FAQ item

## Test plan

- confirm the Free License clarification renders in the eligibility answer
- confirm the automation statement appears only under “When do I need to purchase Renders?”
- review the wording against remotion-dev/business#1426