### PR TITLE
Studio: show Chrome Headless Shell download progress

### DIFF
--- a/packages/cli/src/browser-download-bar.ts
+++ b/packages/cli/src/browser-download-bar.ts
@@ -69,11 +69,33 @@ export const defaultBrowserDownloadProgress = ({
 				? 'Chrome for Testing'
 				: 'Headless Shell';
 
+		const startedAt = Date.now();
+		let doneIn: number | null = null;
+
+		// Must fire in both logger modes - the Studio UI relies on it to display
+		// the download progress (https://github.com/remotion-dev/remotion/issues/10228).
+		const updateDownloadState = (progress: {
+			alreadyAvailable: boolean;
+			percent: number;
+		}) => {
+			if (progress.percent === 1) {
+				doneIn = Date.now() - startedAt;
+			}
+
+			onProgress({
+				alreadyAvailable: progress.alreadyAvailable,
+				progress: progress.percent,
+				doneIn,
+			});
+		};
+
 		if (updatesDontOverwrite) {
 			let lastProgress = 0;
 			return {
 				version: null,
 				onProgress: (progress) => {
+					updateDownloadState(progress);
+
 					if (progress.downloadedBytes > lastProgress + 10_000_000) {
 						lastProgress = progress.downloadedBytes;
 
@@ -102,21 +124,10 @@ export const defaultBrowserDownloadProgress = ({
 			logLevel,
 		});
 
-		const startedAt = Date.now();
-		let doneIn: number | null = null;
-
 		return {
 			version: null,
 			onProgress: (progress) => {
-				if (progress.percent === 1) {
-					doneIn = Date.now() - startedAt;
-				}
-
-				onProgress({
-					alreadyAvailable: progress.alreadyAvailable,
-					progress: progress.percent,
-					doneIn,
-				});
+				updateDownloadState(progress);
 
 				cliOutput.update(
 					makeDownloadProgress({

--- a/packages/cli/src/progress-bar.ts
+++ b/packages/cli/src/progress-bar.ts
@@ -342,7 +342,17 @@ export const makeRenderingAndStitchingProgress = ({
 	return {output, progress, message: getGuiProgressSubtitle(prog)};
 };
 
-const getGuiProgressSubtitle = (progress: AggregateRenderProgress): string => {
+export const getGuiProgressSubtitle = (
+	progress: AggregateRenderProgress,
+): string => {
+	if (progress.browser.error) {
+		return 'Failed to download browser';
+	}
+
+	if (!progress.browser.alreadyAvailable && progress.browser.doneIn === null) {
+		return `Downloading browser ${Math.round(progress.browser.progress * 100)}%`;
+	}
+
 	// Handle floating point inaccuracies
 	const bundlingProgress = progress.bundling?.progress || 0;
 	if (bundlingProgress < 0.99999) {

--- a/packages/cli/src/render-flows/render.ts
+++ b/packages/cli/src/render-flows/render.ts
@@ -255,13 +255,23 @@ export const renderVideoFlow = async ({
 		logLevel,
 		quiet: quietFlagProvided(),
 	});
-	await RenderInternals.internalEnsureBrowser({
-		browserExecutable,
-		indent,
-		logLevel,
-		onBrowserDownload,
-		chromeMode,
-	});
+	try {
+		await RenderInternals.internalEnsureBrowser({
+			browserExecutable,
+			indent,
+			logLevel,
+			onBrowserDownload,
+			chromeMode,
+		});
+	} catch (err) {
+		updateBrowserProgress({
+			progress: browserState.progress,
+			doneIn: null,
+			alreadyAvailable: false,
+			error: true,
+		});
+		throw err;
+	}
 
 	const browserInstance = RenderInternals.internalOpenBrowser({
 		browser,
@@ -300,7 +310,9 @@ export const renderVideoFlow = async ({
 		};
 
 		onProgress({
-			message: `Downloading ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'} ${Math.round(progress.progress * 100)}%`,
+			message: progress.error
+				? `Failed to download ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'}`
+				: `Downloading ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'} ${Math.round(progress.progress * 100)}%`,
 			value: 0,
 			...aggregateRenderProgress,
 		});

--- a/packages/cli/src/render-flows/still.ts
+++ b/packages/cli/src/render-flows/still.ts
@@ -180,7 +180,9 @@ export const renderStillFlow = async ({
 	function updateBrowserProgress(progress: BrowserDownloadState) {
 		aggregate.browser = progress;
 		onProgress({
-			message: `Downloading ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'} ${Math.round(progress.progress * 100)}%`,
+			message: progress.error
+				? `Failed to download ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'}`
+				: `Downloading ${chromeMode === 'chrome-for-testing' ? 'Chrome for Testing' : 'Headless Shell'} ${Math.round(progress.progress * 100)}%`,
 			value: 0,
 			...aggregate,
 		});
@@ -193,13 +195,23 @@ export const renderStillFlow = async ({
 		onProgress: updateBrowserProgress,
 	});
 
-	await RenderInternals.internalEnsureBrowser({
-		browserExecutable,
-		indent,
-		logLevel,
-		onBrowserDownload,
-		chromeMode,
-	});
+	try {
+		await RenderInternals.internalEnsureBrowser({
+			browserExecutable,
+			indent,
+			logLevel,
+			onBrowserDownload,
+			chromeMode,
+		});
+	} catch (err) {
+		updateBrowserProgress({
+			progress: aggregate.browser.progress,
+			doneIn: null,
+			alreadyAvailable: false,
+			error: true,
+		});
+		throw err;
+	}
 
 	const browserInstance = RenderInternals.internalOpenBrowser({
 		browser,

--- a/packages/cli/src/test/browser-download-progress.test.ts
+++ b/packages/cli/src/test/browser-download-progress.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'bun:test';
+import type {BrowserDownloadState} from '@remotion/studio-shared';
+import {defaultBrowserDownloadProgress} from '../browser-download-bar';
+import {getGuiProgressSubtitle} from '../progress-bar';
+import {initialAggregateRenderProgress} from '../progress-types';
+
+test('forwards download progress to the UI callback when updates do not overwrite', () => {
+	const states: BrowserDownloadState[] = [];
+
+	// 'verbose' forces the non-overwriting logger branch, which previously
+	// never called `onProgress` (https://github.com/remotion-dev/remotion/issues/10228)
+	const {onProgress} = defaultBrowserDownloadProgress({
+		indent: false,
+		logLevel: 'verbose',
+		quiet: true,
+		onProgress: (state) => states.push(state),
+	})({chromeMode: 'headless-shell'});
+
+	onProgress({
+		alreadyAvailable: false,
+		percent: 0.5,
+		downloadedBytes: 100_000_000,
+		totalSizeInBytes: 200_000_000,
+	});
+
+	expect(states).toEqual([
+		{alreadyAvailable: false, progress: 0.5, doneIn: null},
+	]);
+
+	onProgress({
+		alreadyAvailable: false,
+		percent: 1,
+		downloadedBytes: 200_000_000,
+		totalSizeInBytes: 200_000_000,
+	});
+
+	expect(states.length).toBe(2);
+	expect(states[1]?.progress).toBe(1);
+	expect(typeof states[1]?.doneIn).toBe('number');
+});
+
+test('GUI subtitle reflects the browser download', () => {
+	const progress = initialAggregateRenderProgress();
+
+	progress.browser = {progress: 0.42, doneIn: null, alreadyAvailable: false};
+	expect(getGuiProgressSubtitle(progress)).toBe('Downloading browser 42%');
+
+	progress.browser = {
+		progress: 0.42,
+		doneIn: null,
+		alreadyAvailable: false,
+		error: true,
+	};
+	expect(getGuiProgressSubtitle(progress)).toBe('Failed to download browser');
+
+	progress.browser = {progress: 1, doneIn: 5000, alreadyAvailable: false};
+	expect(getGuiProgressSubtitle(progress)).toBe('Bundling 0%');
+});

--- a/packages/studio-shared/src/render-job.ts
+++ b/packages/studio-shared/src/render-job.ts
@@ -54,6 +54,7 @@ export type BrowserDownloadState = {
 	progress: number;
 	doneIn: number | null;
 	alreadyAvailable: boolean;
+	error?: boolean;
 };
 
 export type BrowserProgressLog = {

--- a/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
+++ b/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
@@ -5,7 +5,7 @@ import type {
 	StitchingProgressInput,
 } from '@remotion/studio-shared';
 import React, {useCallback, useMemo} from 'react';
-import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
+import {FAIL_COLOR, LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {Spacing} from '../layout';
 import {openInFileExplorer} from '../RenderQueue/actions';
 import {CircularProgress} from '../RenderQueue/CircularProgress';
@@ -52,27 +52,62 @@ const BundlingProgress: React.FC<{
 	);
 };
 
+const failIconStyle: React.CSSProperties = {
+	width: 16,
+	height: 16,
+};
+
+const FailIcon: React.FC = () => {
+	return (
+		<svg style={failIconStyle} viewBox="0 0 512 512">
+			<path
+				fill={FAIL_COLOR}
+				d="M0 160V352L160 512H352L512 352V160L352 0H160L0 160zm353.9 32l-17 17-47 47 47 47 17 17L320 353.9l-17-17-47-47-47 47-17 17L158.1 320l17-17 47-47-47-47-17-17L192 158.1l17 17 47 47 47-47 17-17L353.9 192z"
+			/>
+		</svg>
+	);
+};
+
 const BrowserSetupProgress: React.FC<{
 	readonly progress: number;
 	readonly doneIn: number | null;
 	readonly alreadyAvailable: boolean;
+	readonly error?: boolean;
 	readonly startedBundling: boolean;
 	//	to ensure it only shows already available if we have moved to the next step
-}> = ({progress, doneIn, startedBundling, alreadyAvailable}) => {
+}> = ({progress, doneIn, startedBundling, alreadyAvailable, error}) => {
+	if (error) {
+		return (
+			<div style={progressItem}>
+				<FailIcon />
+				<Spacing x={1} />
+				<div style={label}>Failed to download Headless Shell</div>
+			</div>
+		);
+	}
+
+	// Before the first download callback or the bundling phase, we don't know
+	// yet whether the browser is available - don't show a success state.
+	const stillChecking = alreadyAvailable && progress === 0 && !startedBundling;
+
 	return (
 		<div style={progressItem}>
-			{progress === 1 || alreadyAvailable ? (
+			{stillChecking ? (
+				<CircularProgress progress={0} />
+			) : progress === 1 || alreadyAvailable ? (
 				<SuccessIcon />
 			) : (
 				<CircularProgress progress={progress} />
 			)}
 			<Spacing x={1} />
 			<div style={label}>
-				{alreadyAvailable && startedBundling
-					? 'Headless browser already available'
-					: progress === 1
-						? 'Downloaded Headless Shell'
-						: `Downloading Headless Shell ${Math.round(progress * 100)}%`}
+				{stillChecking
+					? 'Checking for Headless Shell'
+					: alreadyAvailable && startedBundling
+						? 'Headless browser already available'
+						: progress === 1
+							? 'Downloaded Headless Shell'
+							: `Downloading Headless Shell ${Math.round(progress * 100)}%`}
 			</div>
 			{doneIn ? <div style={right}>{doneIn}ms</div> : null}
 		</div>


### PR DESCRIPTION
Closes #10228

## Problem

When Remotion Studio triggers the Chrome Headless Shell download (first render), the download progress often never reaches the Studio UI, making it look stuck.

Root cause: `defaultBrowserDownloadProgress()` has two logger branches, and the non-overwriting one (used whenever `stdout` is not a TTY — Studio launched from a VS Code task, Docker, piped output — or the log level is `verbose`) only logged to the terminal and **never called the `onProgress` callback that feeds the render job state**. The UI received zero updates for the entire download. Additionally, the render-queue subtitle had no browser-download case (any interleaved progress event reset it to `Bundling 0%`), the initial state pretended the browser was `alreadyAvailable` before any check, and a failed download surfaced only as a generic job error.

## Solution

- `browser-download-bar.ts`: the state update is extracted and now fires in **both** logger branches; terminal logging behavior is unchanged.
- `progress-bar.ts` (`getGuiProgressSubtitle`): new browser cases — `Downloading browser X%` while downloading, `Failed to download browser` on failure.
- `GuiRenderStatus.tsx` (`BrowserSetupProgress`): shows `Checking for Headless Shell` with a spinner before the first callback (instead of a success icon based on the optimistic initial state), and a distinct red failure state.
- `BrowserDownloadState` gains an optional `error` flag; the render/still flows set it when `internalEnsureBrowser()` throws (and rethrow), so the failure is clearly indicated per the issue's task list.

## Test Plan

- New unit tests (`packages/cli/src/test/browser-download-progress.test.ts`): the non-overwriting branch forwards progress to the UI callback (regression test for the root cause), and the GUI subtitle covers downloading/failure/done states. `bun test src`: cli 191 pass, studio 564 pass.
- `turbo run make` (typecheck + bundle) green for `@remotion/cli`, `@remotion/studio`, `@remotion/studio-shared`; `lint` and `formatting` clean.
- **Real end-to-end**: removed `node_modules/.remotion`, launched the Studio from `packages/example` with piped stdout (non-TTY — the previously broken branch), and triggered a render from the UI. The render queue showed live updates, sampled from the DOM every 250ms:

```
48.887s: Downloading Headless Shell 0%
49.886s: Downloading Headless Shell 16%
50.871s: Downloading Headless Shell 50%
51.872s: Downloading Headless Shell 84%
52.871s: Downloading Headless Shell 100%
```

  followed by the render completing normally (93.5 MB download, real network).

## Notes / possible follow-ups (out of scope here)

- The zip extraction after the download (~200 MB) still has no progress reporting (`extractZipArchive`), so there is a short silent gap after 100%.
- `downloadedBytes`/`totalSizeInBytes` are available in the callback but not yet surfaced in the UI (only the percentage).
- Waiting on the inter-process download lock is not reported.
