### PR TITLE
`@remotion/studio`: Fix stale open-in-editor hover state

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -442,8 +442,7 @@ test.describe('visual mode', () => {
 			page.getByRole('button', {name: '1x', exact: true}),
 		).toBeVisible();
 
-		await page.mouse.move(10, 100);
-		await page.keyboard.press('Escape');
+		await page.mouse.click(10, 100);
 		await expect(
 			page.getByRole('button', {name: 'Playback Rate', exact: true}),
 		).toBeHidden();
@@ -539,7 +538,8 @@ test.describe('visual mode', () => {
 		await expect(
 			page.getByRole('button', {name: 'Change default apps...'}),
 		).toBeVisible();
-		await page.mouse.click(10, 100);
+		await page.mouse.move(10, 100);
+		await page.keyboard.press('Escape');
 
 		await expect(
 			page.getByRole('button', {name: 'Change default apps...'}),

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -526,6 +526,29 @@ test.describe('visual mode', () => {
 		});
 	});
 
+	test('should clear the open-in-editor hover state when closing the menu', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/schema-test`);
+		const openInAnotherApp = page
+			.getByTitle(exampleDir)
+			.getByRole('button', {name: 'Open in another app'});
+
+		await openInAnotherApp.click();
+		await expect(
+			page.getByRole('button', {name: 'Change default apps...'}),
+		).toBeVisible();
+		await page.mouse.click(10, 100);
+
+		await expect(
+			page.getByRole('button', {name: 'Change default apps...'}),
+		).toBeHidden();
+		await expect(openInAnotherApp).toHaveCSS(
+			'background-color',
+			'rgba(0, 0, 0, 0)',
+		);
+	});
+
 	test('should open submenus toward the side with more space', async ({
 		page,
 	}) => {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -538,6 +538,7 @@ test.describe('visual mode', () => {
 		await expect(
 			page.getByRole('button', {name: 'Change default apps...'}),
 		).toBeVisible();
+		// The menu overlay intercepts pointerleave; Escape closes it deterministically.
 		await page.mouse.move(10, 100);
 		await page.keyboard.press('Escape');
 

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -442,7 +442,8 @@ test.describe('visual mode', () => {
 			page.getByRole('button', {name: '1x', exact: true}),
 		).toBeVisible();
 
-		await page.mouse.click(10, 100);
+		await page.mouse.move(10, 100);
+		await page.keyboard.press('Escape');
 		await expect(
 			page.getByRole('button', {name: 'Playback Rate', exact: true}),
 		).toBeHidden();

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -116,6 +116,12 @@ export const InspectorOpenInEditor: React.FC<{
 		},
 		[openWithEditor],
 	);
+	const onDropdownOpenChange = useCallback((open: boolean) => {
+		setDropdownOpened(open);
+		if (!open) {
+			setHovered(false);
+		}
+	}, []);
 	const mainHovered = hovered && !dropdownOpened;
 	const mainButtonStyle = useMemo((): React.CSSProperties => {
 		return {
@@ -201,7 +207,7 @@ export const InspectorOpenInEditor: React.FC<{
 				<EditorIcon editorId={preferredEditorId} size={editorButtonIconSize} />
 			</button>
 			<InlineDropdown
-				onOpenChange={setDropdownOpened}
+				onOpenChange={onDropdownOpenChange}
 				renderAction={renderDropdownAction}
 				style={dropdownStyle}
 				title="Open in another app"


### PR DESCRIPTION
## What changed

Closing the **Open in another app** menu could leave the split button looking hovered even after the pointer had moved away. The menu overlay intercepted the pointer transition, so the component kept stale hover state after the dropdown closed.

The dropdown close callback now clears that stale state together with the open state. Normal hover behavior is preserved: if the pointer is still over the trigger after an Escape close, the browser restores hover through `pointerenter`.

Fixes #10150.

## Implementation

- Wrap `onOpenChange` in `InspectorOpenInEditor` so every close path clears stale hover state.
- Add a focused Studio E2E regression that moves the pointer away while the menu is open, closes it with Escape, and asserts that the trigger background is transparent.
- Scope the regression locator to `MenuBuildIndicator` so Inspector instances with the same accessible button name cannot collide.

## Validation

- `bun run build`
- `bun run test` in `packages/studio` — 564 passing
- focused Playwright regression — passing in Chromium
- repository ESLint 9.19.0 on both changed files
- Oxfmt check on both changed files
- real Studio verification for outside click and Escape close paths
- two independent reviews covering state behavior/testing and UI/accessibility/scope
