### PR TITLE
Docs: Align Free License eligibility with Terms

### DIFF
--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -14,7 +14,7 @@ Remotion is a React-based technology for programmatic video creation. It lets yo
 
 You are eligible to use Remotion for free if you are:
 
-- an individual using the Remotion Software for personal use
+- an individual
 - an organization or team of individuals with up to 3 people
 - a non-profit or not-for-profit organization
 - evaluating whether the Remotion Software is a good fit, and are not yet using it in a commercial way

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -10,14 +10,14 @@ description: Frequently asked questions about Remotion licensing, pricing, rende
 
 Remotion is a React-based technology for programmatic video creation. It lets you build videos with code, AI agents, or manual edits; preview and refine them in the browser; and render them locally, client-side, or in the cloud. If you want to learn about Remotion itself first, start with [The Fundamentals](/docs/the-fundamentals).
 
-### Who is eligible for the free license?
+### Who is eligible for the Free License?
 
 You are eligible to use Remotion for free if you are:
 
-- an individual
-- a for-profit organisation with up to 3 employees
-- a non-profit or not-for-profit organisation
-- evaluating whether Remotion is a good fit, and are not yet using it in a commercial way
+- an individual using the Remotion Software for personal use
+- an organization or team of individuals with up to 3 people
+- a non-profit or not-for-profit organization
+- evaluating whether the Remotion Software is a good fit, and are not yet using it in a commercial way
 
 [Contact us](/contact) in case you need confirmation if your use case is acceptable.
 


### PR DESCRIPTION
## Summary

- capitalize Free License as a defined term in the eligibility heading
- align the FAQ eligibility bullets with the Terms definition of a Free License User

This change was split out of #10266 so the wording alignment can be reviewed independently.

## Test plan

- confirm the FAQ eligibility bullets match the Terms definition
- confirm the existing heading anchor remains unchanged