### PR TITLE
Docs: Reorder the open-source license FAQ

### DIFF
--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -21,12 +21,6 @@ You are eligible to use Remotion for free if you are:
 
 [Contact us](/contact) in case you need confirmation if your use case is acceptable.
 
-### Is Remotion open-source?
-
-No. Remotion is source-available software, but it is not open-source software according to the [Open Source Initiative's Open Source Definition](https://opensource.org/osd).
-
-The Remotion source code is publicly available, but its use is governed by the proprietary [Remotion License](/docs/license/pricing), which includes conditions that are not part of OSI-approved open-source licenses.
-
 ### Why is Remotion free for some and paid for others?
 
 The Remotion project works similarly as many open source projects, in that way, that the code is openly available on GitHub and that individuals use it freely and contribute back. But to pay for the time that it takes to maintain such an ambitious project, we need to generate money. This is also good for you: You get regular updates, good support, motivated maintainers and an overall healthy product. By separating individuals and companies, we are charging those who are most able to afford it.
@@ -36,6 +30,12 @@ The Remotion project works similarly as many open source projects, in that way, 
 There is no difference between the free and paid version.
 
 We discriminate the price of the same software for various users: Remotion is free for individuals and small organizations, but paid for bigger organizations.
+
+### Is Remotion open-source?
+
+No. Remotion is source-available software, but it is not open-source software according to the [Open Source Initiative's Open Source Definition](https://opensource.org/osd).
+
+The Remotion source code is publicly available, but its use is governed by the proprietary [Remotion License](/docs/license/pricing), which includes conditions that are not part of OSI-approved open-source licenses.
 
 ### What does prioritized support mean?
 


### PR DESCRIPTION
## Summary

Move the “Is Remotion open-source?” FAQ item after the free-versus-paid functionality answer so the licensing overview reads in a more logical order.

This editorial change was split out of #10266 so it can be reviewed independently.

## Test plan

- confirm the FAQ order renders correctly
- confirm the existing heading anchors remain unchanged