### PR TITLE
Internal tests: Fix SSR test timeout cascade

### DIFF
--- a/packages/it-tests/package.json
+++ b/packages/it-tests/package.json
@@ -7,7 +7,7 @@
 	"license": "SEE LICENSE IN LICENSE.md",
 	"scripts": {
 		"test": " node --test src/node-version/media-parser.mjs && bun test src/rendering --run --timeout 60000",
-		"testssr": "bun test src/ssr src/bundle src/webcodecs --timeout 40000",
+		"testssr": "bun src/run-ssr-tests.ts",
 		"testmonorepo": "bun test src/monorepo --run --timeout 40000",
 		"testtemplates": "bun test src/templates --timeout 400000",
 		"testlambda": "exit 0",

--- a/packages/it-tests/src/run-ssr-tests.ts
+++ b/packages/it-tests/src/run-ssr-tests.ts
@@ -1,0 +1,70 @@
+import {readdirSync} from 'node:fs';
+import path from 'node:path';
+
+const packageRoot = path.join(import.meta.dir, '..');
+const requestedFiles = Bun.argv.slice(2);
+const testFiles = requestedFiles.length
+	? requestedFiles
+	: ['ssr', 'bundle', 'webcodecs'].flatMap((directory) =>
+			readdirSync(path.join(import.meta.dir, directory))
+				.filter((file) => file.endsWith('.test.ts'))
+				.sort()
+				.map((file) => `./src/${directory}/${file}`),
+		);
+
+for (const testFile of testFiles) {
+	for (let attempt = 1; attempt <= 2; attempt++) {
+		const subprocess = Bun.spawn(
+			[process.execPath, 'test', testFile, '--timeout', '40000'],
+			{
+				cwd: packageRoot,
+				detached: process.platform !== 'win32',
+				env: process.env,
+				stdin: 'ignore',
+				stdout: 'inherit',
+				stderr: 'inherit',
+			},
+		);
+		let timedOut = false;
+		let forceKillTimeout: ReturnType<typeof setTimeout> | null = null;
+		const killSubprocess = (signal: 'SIGKILL' | 'SIGTERM') => {
+			try {
+				if (process.platform !== 'win32') {
+					process.kill(-subprocess.pid, signal);
+					return;
+				}
+			} catch {
+				// Fall back to killing the direct child if its process group is gone.
+			}
+
+			subprocess.kill(signal);
+		};
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			killSubprocess('SIGTERM');
+			forceKillTimeout = setTimeout(() => {
+				killSubprocess('SIGKILL');
+			}, 2_000);
+		}, 90_000);
+		const exitCode = await subprocess.exited;
+		clearTimeout(timeout);
+		if (forceKillTimeout !== null) {
+			clearTimeout(forceKillTimeout);
+		}
+
+		if (timedOut && attempt === 1) {
+			console.error(`${testFile} timed out. Retrying in a clean process.`);
+			continue;
+		}
+
+		if (timedOut) {
+			throw new Error(`${testFile} timed out twice.`);
+		}
+
+		if (exitCode !== 0) {
+			process.exit(exitCode);
+		}
+
+		break;
+	}
+}

--- a/packages/it-tests/src/ssr/render-frames.test.ts
+++ b/packages/it-tests/src/ssr/render-frames.test.ts
@@ -4,129 +4,110 @@ import os from 'os';
 import path from 'path';
 import {
 	RenderInternals,
-	getCompositions,
 	openBrowser,
 	renderFrames,
+	selectComposition,
 	stitchFramesToVideo,
 } from '@remotion/renderer';
 
 const exampleBuild = path.join(__dirname, '..', '..', '..', 'example', 'build');
 
-test(
-	'Legacy SSR way of rendering videos should still work',
-	async () => {
-		const puppeteerInstance = await openBrowser('chrome');
-		let framesDir: string | null = null;
-		try {
-			const compositions = await getCompositions({
-				serveUrl: exampleBuild,
-				puppeteerInstance,
-				inputProps: {},
-			});
+test('Legacy SSR way of rendering videos should still work', async () => {
+	const puppeteerInstance = await openBrowser('chrome');
+	let framesDir: string | null = null;
+	try {
+		const reactSvg = await selectComposition({
+			id: '22khz',
+			serveUrl: exampleBuild,
+			puppeteerInstance,
+			inputProps: {},
+		});
 
-			const reactSvg = compositions.find((c) => c.id === '22khz');
+		const tmpDir = os.tmpdir();
 
-			if (!reactSvg) {
-				throw new Error('not found');
-			}
-
-			const tmpDir = os.tmpdir();
-
-			// We create a temporary directory for storing the frames
-			const createdFramesDir = await fs.promises.mkdtemp(
-				path.join(os.tmpdir(), 'remotion-'),
-			);
-			framesDir = createdFramesDir;
-
-			const outPath = path.join(tmpDir, 'out.mp4');
-
-			const {assetsInfo} = await renderFrames({
-				composition: reactSvg,
-				imageFormat: 'jpeg',
-				inputProps: {},
-				onFrameUpdate: () => undefined,
-				serveUrl: exampleBuild,
-				concurrency: null,
-				frameRange: [0, 10],
-				outputDir: createdFramesDir,
-				onStart: () => undefined,
-			});
-			await stitchFramesToVideo({
-				assetsInfo,
-				force: true,
-				fps: reactSvg.fps,
-				height: reactSvg.height,
-				outputLocation: outPath,
-				width: reactSvg.width,
-				codec: 'h264',
-				metadata: {Author: 'Lunar'},
-			});
-			expect(fs.existsSync(outPath)).toBe(true);
-			const probe = await RenderInternals.callFf({
-				bin: 'ffprobe',
-				args: [outPath],
-				indent: false,
-				logLevel: 'info',
-				binariesDirectory: null,
-				cancelSignal: undefined,
-			});
-			expect(probe.stderr).toMatch(/Video: h264/);
-		} finally {
-			if (framesDir !== null) {
-				RenderInternals.deleteDirectory(framesDir);
-			}
-
-			await puppeteerInstance.close({silent: false});
-		}
-	},
-	{retry: 3},
-);
-
-test(
-	'renderFrames() should render selected frames',
-	async () => {
-		const puppeteerInstance = await openBrowser('chrome');
-		const selectedFramesDir = await fs.promises.mkdtemp(
-			path.join(os.tmpdir(), 'remotion-selected-frames-'),
+		// We create a temporary directory for storing the frames
+		const createdFramesDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'remotion-'),
 		);
+		framesDir = createdFramesDir;
 
-		try {
-			const compositions = await getCompositions({
-				serveUrl: exampleBuild,
-				puppeteerInstance,
-				inputProps: {},
-			});
-			const tenFrameTester = compositions.find(
-				(c) => c.id === 'ten-frame-tester',
-			);
+		const outPath = path.join(tmpDir, 'out.mp4');
 
-			if (!tenFrameTester) {
-				throw new Error('not found');
-			}
-
-			const selectedFramesRender = await renderFrames({
-				composition: tenFrameTester,
-				frames: [5, 0, 2],
-				imageFormat: 'jpeg',
-				inputProps: {},
-				onFrameUpdate: () => undefined,
-				serveUrl: exampleBuild,
-				concurrency: null,
-				outputDir: selectedFramesDir,
-				onStart: () => undefined,
-				puppeteerInstance,
-			});
-
-			expect(selectedFramesRender.frameCount).toBe(3);
-			expect((await fs.promises.readdir(selectedFramesDir)).sort()).toEqual([
-				'element-0.jpeg',
-				'element-2.jpeg',
-				'element-5.jpeg',
-			]);
-		} finally {
-			RenderInternals.deleteDirectory(selectedFramesDir);
-			await puppeteerInstance.close({silent: false});
+		const {assetsInfo} = await renderFrames({
+			composition: reactSvg,
+			imageFormat: 'jpeg',
+			inputProps: {},
+			onFrameUpdate: () => undefined,
+			serveUrl: exampleBuild,
+			concurrency: null,
+			frameRange: [0, 10],
+			outputDir: createdFramesDir,
+			onStart: () => undefined,
+		});
+		await stitchFramesToVideo({
+			assetsInfo,
+			force: true,
+			fps: reactSvg.fps,
+			height: reactSvg.height,
+			outputLocation: outPath,
+			width: reactSvg.width,
+			codec: 'h264',
+			metadata: {Author: 'Lunar'},
+		});
+		expect(fs.existsSync(outPath)).toBe(true);
+		const probe = await RenderInternals.callFf({
+			bin: 'ffprobe',
+			args: [outPath],
+			indent: false,
+			logLevel: 'info',
+			binariesDirectory: null,
+			cancelSignal: undefined,
+		});
+		expect(probe.stderr).toMatch(/Video: h264/);
+	} finally {
+		if (framesDir !== null) {
+			RenderInternals.deleteDirectory(framesDir);
 		}
-	},
-	{retry: 3},
-);
+
+		await puppeteerInstance.close({silent: false});
+	}
+});
+
+test('renderFrames() should render selected frames', async () => {
+	const puppeteerInstance = await openBrowser('chrome');
+	const selectedFramesDir = await fs.promises.mkdtemp(
+		path.join(os.tmpdir(), 'remotion-selected-frames-'),
+	);
+
+	try {
+		const tenFrameTester = await selectComposition({
+			id: 'ten-frame-tester',
+			serveUrl: exampleBuild,
+			puppeteerInstance,
+			inputProps: {},
+		});
+
+		const selectedFramesRender = await renderFrames({
+			composition: tenFrameTester,
+			frames: [5, 0, 2],
+			imageFormat: 'jpeg',
+			inputProps: {},
+			onFrameUpdate: () => undefined,
+			serveUrl: exampleBuild,
+			concurrency: null,
+			outputDir: selectedFramesDir,
+			onStart: () => undefined,
+			puppeteerInstance,
+		});
+
+		expect(selectedFramesRender.frameCount).toBe(3);
+		expect((await fs.promises.readdir(selectedFramesDir)).sort()).toEqual([
+			'element-0.jpeg',
+			'element-2.jpeg',
+			'element-5.jpeg',
+		]);
+	} finally {
+		RenderInternals.deleteDirectory(selectedFramesDir);
+		await puppeteerInstance.close({silent: false});
+	}
+});

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -2,9 +2,9 @@ import {expect, test} from 'bun:test';
 import os from 'os';
 import path from 'path';
 import {
-	getCompositions,
 	renderMedia,
 	RenderInternals,
+	selectComposition,
 } from '@remotion/renderer';
 
 const exampleBuild = path.join(__dirname, '..', '..', '..', 'example', 'build');
@@ -42,15 +42,11 @@ const getSampleRateFromFile = async (filePath: string): Promise<number> => {
 test(
 	'Render video with sampleRate 44100 should produce 44100 Hz audio',
 	async () => {
-		const compositions = await getCompositions({
+		const comp = await selectComposition({
+			id: 'audio-testing',
 			serveUrl: exampleBuild,
 			inputProps: {},
 		});
-		const comp = compositions.find((c) => c.id === 'audio-testing');
-
-		if (!comp) {
-			throw new Error('audio-testing composition not found');
-		}
 
 		const tmpDir = os.tmpdir();
 		const outPath = path.join(tmpDir, 'sample-rate-44100.mp4');
@@ -74,15 +70,11 @@ test(
 test(
 	'Render video with default sampleRate should produce 48000 Hz audio',
 	async () => {
-		const compositions = await getCompositions({
+		const comp = await selectComposition({
+			id: 'audio-testing',
 			serveUrl: exampleBuild,
 			inputProps: {},
 		});
-		const comp = compositions.find((c) => c.id === 'audio-testing');
-
-		if (!comp) {
-			throw new Error('audio-testing composition not found');
-		}
 
 		const tmpDir = os.tmpdir();
 		const outPath = path.join(tmpDir, 'sample-rate-default.mp4');
@@ -99,5 +91,5 @@ test(
 		const sampleRate = await getSampleRateFromFile(outPath);
 		expect(sampleRate).toBe(48000);
 	},
-	{timeout: 30000, retry: 3},
+	{timeout: 30000},
 );

--- a/packages/it-tests/src/ssr/render-media.test.ts
+++ b/packages/it-tests/src/ssr/render-media.test.ts
@@ -4,104 +4,90 @@ import os from 'os';
 import path from 'path';
 import {
 	RenderInternals,
-	getCompositions,
 	openBrowser,
 	renderMedia,
+	selectComposition,
 } from '@remotion/renderer';
 import {NoReactInternals} from 'remotion/no-react';
 
 const exampleBuild = path.join(__dirname, '..', '..', '..', 'example', 'build');
 
-test(
-	'Render video with browser instance open',
-	async () => {
-		const puppeteerInstance = await openBrowser('chrome');
-		const compositions = await getCompositions({
-			serveUrl: exampleBuild,
-			puppeteerInstance,
-			inputProps: {},
-		});
-
-		const reactSvg = compositions.find((c) => c.id === 'react-svg');
-
-		if (!reactSvg) {
-			throw new Error('not found');
-		}
-
-		const tmpDir = os.tmpdir();
-
-		const outPath = path.join(tmpDir, 'out.mp4');
-		const originalFetch = globalThis.fetch;
-		const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
-			input,
-			init,
-		) => {
-			if (String(input).startsWith('https://www.remotion.pro/api/track/')) {
-				return Promise.resolve(
-					new Response(
-						JSON.stringify({
-							success: true,
-							billable: false,
-							classification: 'development',
-						}),
-					),
-				);
-			}
-
-			return originalFetch(input, init);
-		}) as typeof fetch);
-		const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
-
-		try {
-			await renderMedia({
-				outputLocation: outPath,
-				codec: 'h264',
-				serveUrl: exampleBuild,
-				composition: reactSvg,
-				frameRange: [0, 2],
-				puppeteerInstance,
-				metadata: {Author: 'Lunar'},
-				licenseKey: 'free-license',
-				logLevel: 'warn',
-			});
-
-			expect(existsSync(outPath)).toBe(true);
-			const licensingCall = fetchSpy.mock.calls.find(([input]) =>
-				String(input).startsWith('https://www.remotion.pro/api/track/'),
-			);
-			expect(licensingCall).toBeDefined();
-			expect(JSON.parse(String(licensingCall?.[1]?.body))).toMatchObject({
-				apiKey: null,
-				event: 'cloud-render',
-				host: null,
-				isStill: false,
-			});
-			expect(
-				warnSpy.mock.calls.some((args) =>
-					args.join(' ').includes('Pass "licenseKey" to renderMedia()'),
-				),
-			).toBe(false);
-		} finally {
-			fetchSpy.mockRestore();
-			warnSpy.mockRestore();
-			await puppeteerInstance.close({silent: false});
-		}
-	},
-	{retry: 2},
-);
-
-test('Render video with browser instance not open', async () => {
-	const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
-	const compositions = await getCompositions({
+test('Render video with browser instance open', async () => {
+	const puppeteerInstance = await openBrowser('chrome');
+	const reactSvg = await selectComposition({
+		id: 'react-svg',
 		serveUrl: exampleBuild,
+		puppeteerInstance,
 		inputProps: {},
 	});
 
-	const reactSvg = compositions.find((c) => c.id === 'react-svg');
+	const tmpDir = os.tmpdir();
 
-	if (!reactSvg) {
-		throw new Error('not found');
+	const outPath = path.join(tmpDir, 'out.mp4');
+	const originalFetch = globalThis.fetch;
+	const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
+		input,
+		init,
+	) => {
+		if (String(input).startsWith('https://www.remotion.pro/api/track/')) {
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						success: true,
+						billable: false,
+						classification: 'development',
+					}),
+				),
+			);
+		}
+
+		return originalFetch(input, init);
+	}) as typeof fetch);
+	const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
+
+	try {
+		await renderMedia({
+			outputLocation: outPath,
+			codec: 'h264',
+			serveUrl: exampleBuild,
+			composition: reactSvg,
+			frameRange: [0, 2],
+			puppeteerInstance,
+			metadata: {Author: 'Lunar'},
+			licenseKey: 'free-license',
+			logLevel: 'warn',
+		});
+
+		expect(existsSync(outPath)).toBe(true);
+		const licensingCall = fetchSpy.mock.calls.find(([input]) =>
+			String(input).startsWith('https://www.remotion.pro/api/track/'),
+		);
+		expect(licensingCall).toBeDefined();
+		expect(JSON.parse(String(licensingCall?.[1]?.body))).toMatchObject({
+			apiKey: null,
+			event: 'cloud-render',
+			host: null,
+			isStill: false,
+		});
+		expect(
+			warnSpy.mock.calls.some((args) =>
+				args.join(' ').includes('Pass "licenseKey" to renderMedia()'),
+			),
+		).toBe(false);
+	} finally {
+		fetchSpy.mockRestore();
+		warnSpy.mockRestore();
+		await puppeteerInstance.close({silent: false});
 	}
+});
+
+test('Render video with browser instance not open', async () => {
+	const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
+	const reactSvg = await selectComposition({
+		id: 'react-svg',
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
 
 	const tmpDir = os.tmpdir();
 
@@ -171,16 +157,11 @@ test('should fail on invalid CRF', async () => {
 });
 
 test('Render video to a buffer', async () => {
-	const compositions = await getCompositions({
+	const reactSvg = await selectComposition({
+		id: 'react-svg',
 		serveUrl: exampleBuild,
 		inputProps: {},
 	});
-
-	const reactSvg = compositions.find((c) => c.id === 'react-svg');
-
-	if (!reactSvg) {
-		throw new Error('not found');
-	}
 
 	const {buffer, contentType} = await renderMedia({
 		codec: 'h264',
@@ -195,14 +176,11 @@ test('Render video to a buffer', async () => {
 });
 
 test('Render multiple frame ranges to one video', async () => {
-	const compositions = await getCompositions({
+	const composition = await selectComposition({
+		id: 'ten-frame-tester',
 		serveUrl: exampleBuild,
 		inputProps: {},
 	});
-	const composition = compositions.find((c) => c.id === 'ten-frame-tester');
-	if (!composition) {
-		throw new Error('not found');
-	}
 
 	const outputLocation = path.join(os.tmpdir(), 'multiple-frame-ranges.mp4');
 	try {

--- a/packages/it-tests/src/ssr/render-still.test.ts
+++ b/packages/it-tests/src/ssr/render-still.test.ts
@@ -4,9 +4,9 @@ import os from 'os';
 import path from 'path';
 import {
 	ensureBrowser,
-	getCompositions,
 	openBrowser,
 	renderStill,
+	selectComposition,
 } from '@remotion/renderer';
 import {NoReactInternals} from 'remotion/no-react';
 
@@ -16,120 +16,100 @@ beforeAll(async () => {
 	await ensureBrowser();
 });
 
-test(
-	'Render video with browser instance open',
-	async () => {
-		const puppeteerInstance = await openBrowser('chrome');
-		try {
-			const compositions = await getCompositions({
-				serveUrl: exampleBuild,
-				puppeteerInstance,
-				inputProps: {},
-			});
-
-			const reactSvg = compositions.find((c) => c.id === 'react-svg');
-
-			if (!reactSvg) {
-				throw new Error('not found');
-			}
-
-			const tmpDir = os.tmpdir();
-
-			const outPath = path.join(tmpDir, 'out.mp4');
-			const originalFetch = globalThis.fetch;
-			const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
-				input,
-				init,
-			) => {
-				if (String(input).startsWith('https://www.remotion.pro/api/track/')) {
-					return Promise.resolve(
-						new Response(
-							JSON.stringify({
-								success: true,
-								billable: false,
-								classification: 'development',
-							}),
-						),
-					);
-				}
-
-				return originalFetch(input, init);
-			}) as typeof fetch);
-			const warnSpy = spyOn(console, 'warn').mockImplementation(
-				() => undefined,
-			);
-
-			try {
-				const {buffer} = await renderStill({
-					output: outPath,
-					serveUrl: exampleBuild,
-					composition: reactSvg,
-					puppeteerInstance,
-					licenseKey: 'free-license',
-					logLevel: 'warn',
-				});
-				expect(buffer).toBe(null);
-				const licensingCall = fetchSpy.mock.calls.find(([input]) =>
-					String(input).startsWith('https://www.remotion.pro/api/track/'),
-				);
-				expect(licensingCall).toBeDefined();
-				expect(JSON.parse(String(licensingCall?.[1]?.body))).toMatchObject({
-					apiKey: null,
-					event: 'cloud-render',
-					host: null,
-					isStill: true,
-				});
-				expect(
-					warnSpy.mock.calls.some((args) =>
-						args.join(' ').includes('Pass "licenseKey" to renderStill()'),
-					),
-				).toBe(false);
-			} finally {
-				fetchSpy.mockRestore();
-				warnSpy.mockRestore();
-			}
-		} finally {
-			await puppeteerInstance.close({silent: false});
-		}
-	},
-	{retry: 3},
-);
-
-test(
-	'Render still with browser instance not open and legacy webpack config',
-	async () => {
-		const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
-		const compositions = await getCompositions({
+test('Render video with browser instance open', async () => {
+	const puppeteerInstance = await openBrowser('chrome');
+	try {
+		const reactSvg = await selectComposition({
+			id: 'react-svg',
 			serveUrl: exampleBuild,
+			puppeteerInstance,
 			inputProps: {},
 		});
 
-		const reactSvg = compositions.find((c) => c.id === 'react-svg');
-
-		if (!reactSvg) {
-			throw new Error('not found');
-		}
-
 		const tmpDir = os.tmpdir();
 
-		const outPath = path.join(tmpDir, 'subdir', 'out.jpg');
+		const outPath = path.join(tmpDir, 'out.mp4');
+		const originalFetch = globalThis.fetch;
+		const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
+			input,
+			init,
+		) => {
+			if (String(input).startsWith('https://www.remotion.pro/api/track/')) {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							success: true,
+							billable: false,
+							classification: 'development',
+						}),
+					),
+				);
+			}
+
+			return originalFetch(input, init);
+		}) as typeof fetch);
+		const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
 
 		try {
-			await renderStill({
+			const {buffer} = await renderStill({
 				output: outPath,
 				serveUrl: exampleBuild,
 				composition: reactSvg,
+				puppeteerInstance,
+				licenseKey: 'free-license',
 				logLevel: 'warn',
 			});
-			expect(existsSync(outPath)).toBe(true);
+			expect(buffer).toBe(null);
+			const licensingCall = fetchSpy.mock.calls.find(([input]) =>
+				String(input).startsWith('https://www.remotion.pro/api/track/'),
+			);
+			expect(licensingCall).toBeDefined();
+			expect(JSON.parse(String(licensingCall?.[1]?.body))).toMatchObject({
+				apiKey: null,
+				event: 'cloud-render',
+				host: null,
+				isStill: true,
+			});
 			expect(
 				warnSpy.mock.calls.some((args) =>
 					args.join(' ').includes('Pass "licenseKey" to renderStill()'),
 				),
-			).toBe(NoReactInternals.ENABLE_V5_BREAKING_CHANGES);
+			).toBe(false);
 		} finally {
+			fetchSpy.mockRestore();
 			warnSpy.mockRestore();
 		}
-	},
-	{retry: 3},
-);
+	} finally {
+		await puppeteerInstance.close({silent: false});
+	}
+});
+
+test('Render still with browser instance not open and legacy webpack config', async () => {
+	const warnSpy = spyOn(console, 'warn').mockImplementation(() => undefined);
+	const reactSvg = await selectComposition({
+		id: 'react-svg',
+		serveUrl: exampleBuild,
+		inputProps: {},
+	});
+
+	const tmpDir = os.tmpdir();
+
+	const outPath = path.join(tmpDir, 'subdir', 'out.jpg');
+
+	try {
+		await renderStill({
+			output: outPath,
+			serveUrl: exampleBuild,
+			composition: reactSvg,
+			logLevel: 'warn',
+		});
+		expect(existsSync(outPath)).toBe(true);
+		expect(
+			warnSpy.mock.calls.some((args) =>
+				args.join(' ').includes('Pass "licenseKey" to renderStill()'),
+			),
+		).toBe(NoReactInternals.ENABLE_V5_BREAKING_CHANGES);
+	} finally {
+		warnSpy.mockRestore();
+	}
+});


### PR DESCRIPTION
## Summary

- select only the compositions each SSR test needs, avoiding unrelated remote media metadata
- remove in-process retries that could leave renderer resources alive after a timeout
- run every SSR, bundle, and WebCodecs test file in an isolated process with a 90-second watchdog
- terminate the complete process group on a watchdog timeout and retry once in a clean process

## Root cause

The SSR suite ran all test files in one Bun process. Several tests cross native and subprocess boundaries (Chromium, Studio, Rspack, and filesystem watchers). If one of those calls blocked the process, Bun's in-process test timeout could not advance and the entire Turbo task remained silent until GitHub Actions killed it.

The cleanup diagnostics show more than one way to reach this state: an early timeout retained the Studio/esbuild subprocess tree, while the latest timeout retained only the Bun/Turbo process chain. This explains why removing renderer retries improved one trigger but did not eliminate the recurring job timeout.

The new runner confines each file and its descendants to a process group. A blocked file is killed externally, retried once in a fresh process, and identified in the streamed log instead of consuming the 15-minute job timeout.

## Validation

- red/green watchdog check with a synchronously blocked Bun test: the old command exceeded an external timeout; the new runner killed both attempts and exited in 1.88 seconds using a temporarily shortened watchdog
- `cd packages/it-tests && bun run lint`
- `cd packages/it-tests && bun run testssr` (28/28 test files passed)
- `bun run testssr` (70/70 Turbo tasks passed)
- `bun run build` (74/74 Turbo tasks passed)
- `bun run stylecheck` (245/245 Turbo tasks passed)
