### PR TITLE
`@remotion/studio`: Keep canvas context menus open

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -87,6 +87,44 @@ test.describe('visual mode', () => {
 		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
 	});
 
+	test('should keep canvas item context menus open', async ({page}) => {
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+		await expect(
+			page.getByRole('button', {name: '0', exact: true}),
+		).toBeVisible({timeout: 15_000});
+		await page.locator('[data-timeline-scrubber]').click();
+		await expect(
+			page.getByRole('button', {name: '90', exact: true}),
+		).toBeVisible();
+
+		const canvasItem = page.getByText('Performance overview', {exact: true});
+		const canvasItemBox = await canvasItem.boundingBox();
+		if (canvasItemBox === null) {
+			throw new Error('Canvas item has no bounding box');
+		}
+
+		const canvasItemCenter = {
+			x: canvasItemBox.x + canvasItemBox.width / 2,
+			y: canvasItemBox.y + canvasItemBox.height / 2,
+		};
+		await page.mouse.move(canvasItemCenter.x, canvasItemCenter.y);
+		await page.waitForTimeout(100);
+		await page.mouse.click(canvasItemCenter.x, canvasItemCenter.y, {
+			button: 'right',
+		});
+		await page.mouse.move(10, 10);
+		// Portals do not reliably trigger pointerleave in headless Chromium.
+		await page
+			.locator('.remotion-studio-composition-container')
+			.dispatchEvent('pointerleave');
+
+		const duplicateButton = page.getByRole('button', {
+			name: 'Duplicate',
+			exact: true,
+		});
+		await expect(duplicateButton).toBeVisible();
+	});
+
 	test('should compensate DOM measurements with useCurrentScale() on direct load', async ({
 		page,
 	}) => {

--- a/packages/studio/src/components/ContextMenu.tsx
+++ b/packages/studio/src/components/ContextMenu.tsx
@@ -374,15 +374,27 @@ ContextMenu.displayName = 'ContextMenu';
 export const ContextMenuForTarget: React.FC<{
 	readonly triggerRef: React.RefObject<HTMLElement | SVGElement | null>;
 	readonly getItems: ContextMenuItemsFactory;
-}> = ({triggerRef, getItems}) => {
+	readonly onOpenChange?: (open: boolean) => void;
+}> = ({triggerRef, getItems, onOpenChange = undefined}) => {
 	const idRef = useRef(nextContextMenuId++);
 	const menuTreeIdRef = useRef(getNextMenuTreeId());
 	const invocationRef = useRef(0);
+	const isOpenRef = useRef(false);
 	const getItemsRef = useRef(getItems);
+	const onOpenChangeRef = useRef(onOpenChange);
 	getItemsRef.current = getItems;
+	onOpenChangeRef.current = onOpenChange;
 	const [opened, setOpened] = useState<OpenState>({type: 'not-open'});
 	const [body, setBody] = useState<HTMLElement | null>(null);
 	const {currentZIndex} = useZIndex();
+	const setOpenLifecycleState = useCallback((open: boolean) => {
+		if (isOpenRef.current === open) {
+			return;
+		}
+
+		isOpenRef.current = open;
+		onOpenChangeRef.current?.(open);
+	}, []);
 
 	useEffect(() => {
 		// Access document.body after mount so importing this component stays safe
@@ -402,8 +414,23 @@ export const ContextMenuForTarget: React.FC<{
 			e.stopPropagation();
 
 			const currentInvocation = ++invocationRef.current;
-			const values = await resolveContextMenuItems(getItemsRef.current, e);
+			setOpenLifecycleState(true);
+			let values: readonly ComboboxValue[] | null;
+			try {
+				values = await resolveContextMenuItems(getItemsRef.current, e);
+			} catch (err) {
+				if (currentInvocation === invocationRef.current) {
+					setOpenLifecycleState(false);
+				}
+
+				throw err;
+			}
+
 			if (currentInvocation !== invocationRef.current || values === null) {
+				if (currentInvocation === invocationRef.current) {
+					setOpenLifecycleState(false);
+				}
+
 				return false;
 			}
 
@@ -423,18 +450,21 @@ export const ContextMenuForTarget: React.FC<{
 		return () => {
 			current.removeEventListener('contextmenu', onClick);
 		};
-	}, [triggerRef]);
+	}, [setOpenLifecycleState, triggerRef]);
 
 	useEffect(() => {
 		const invocation = invocationRef;
 		return () => {
 			invocation.current++;
+			setOpenLifecycleState(false);
 		};
-	}, []);
+	}, [setOpenLifecycleState]);
 
 	const onHide = useCallback(() => {
+		invocationRef.current++;
+		setOpenLifecycleState(false);
 		setOpened({type: 'not-open'});
-	}, []);
+	}, [setOpenLifecycleState]);
 
 	useEffect(() => {
 		const onOtherContextMenuOpened = (event: Event) => {

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -62,6 +62,7 @@ type SelectedOutlineElementProps = {
 	readonly layoutTarget: SelectedOutlineLayoutTarget | undefined;
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onSnapPointsChange: (
 		snapPoints: readonly SelectedOutlineSnapPoint[],
 	) => void;
@@ -86,6 +87,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	layoutTarget,
 	outline,
 	onDraggingChange,
+	onContextMenuOpenChange,
 	onSnapPointsChange,
 	onSelect,
 	scale,
@@ -470,6 +472,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				hovered={hovered}
 				outline={outline}
 				onContextMenuOpen={onContextMenuOpen}
+				onContextMenuOpenChange={onContextMenuOpenChange}
 				onDraggingChange={onDraggingChange}
 				onHoverChange={onHoverChange}
 				onSnapPointsChange={onSnapPointsChange}
@@ -493,6 +496,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 							edge={edge}
 							outline={outline}
 							onContextMenuOpen={onContextMenuOpen}
+							onContextMenuOpenChange={onContextMenuOpenChange}
 							onDraggingChange={onDraggingChange}
 							onHoverChange={onHoverChange}
 							onSelect={onSelect}
@@ -512,6 +516,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 							dragging={dragging}
 							outline={outline}
 							onContextMenuOpen={onContextMenuOpen}
+							onContextMenuOpenChange={onContextMenuOpenChange}
 							onDraggingChange={onDraggingChange}
 							onHoverChange={onHoverChange}
 							onSelect={onSelect}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -625,6 +625,7 @@ type ActiveSelectedOutlineOverlayProps = Omit<
 		timelinePosition: number,
 	) => ReturnType<typeof getSequencesWithSelectableOutlines>;
 	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
 		interaction?: TimelineSelectionInteraction,
@@ -646,6 +647,7 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 	getLatestOutlineTargetByKey,
 	getSelectableOutlines,
 	onDraggingChange,
+	onContextMenuOpenChange,
 	onSelect,
 	scale,
 	selectedSequenceKeys,
@@ -721,6 +723,7 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 			getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
 			getOutlineTargets={getOutlineTargets}
 			onDraggingChange={onDraggingChange}
+			onContextMenuOpenChange={onContextMenuOpenChange}
 			onSelect={onSelect}
 			scale={scale}
 			sequences={sequences}
@@ -761,6 +764,7 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 	const isFullscreen = useIsFullscreen();
 	const {getCurrentFrame} = PlayerInternals.usePlayerMethods();
 	const [draggingOutline, setDraggingOutline] = useState(false);
+	const [canvasContextMenuOpen, setCanvasContextMenuOpen] = useState(false);
 	const previewSelectionAvailable =
 		previewServerState.type === 'connected' || window.remotion_isReadOnlyStudio;
 	const selectedSequenceKeys = useMemo(
@@ -921,7 +925,10 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		[selectItem],
 	);
 	const measurementActive =
-		canvasHovered || draggingOutline || hoveredSequence?.source === 'timeline';
+		canvasHovered ||
+		draggingOutline ||
+		canvasContextMenuOpen ||
+		hoveredSequence?.source === 'timeline';
 	useLayoutEffect(() => {
 		if (measurementActive) {
 			return;
@@ -949,6 +956,7 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 					getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
 					getSelectableOutlines={getSelectableOutlines}
 					onDraggingChange={onDraggingChange}
+					onContextMenuOpenChange={setCanvasContextMenuOpen}
 					onSelect={selectOutlineItem}
 					scale={scale}
 					selectedSequenceKeys={selectedSequenceKeys}

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -69,6 +69,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	readonly hasTarget: boolean;
 	readonly hovered: boolean;
 	readonly onContextMenuOpen: SelectedOutlineContextMenuOpenHandler;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
@@ -96,6 +97,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	hasTarget,
 	hovered,
 	onContextMenuOpen,
+	onContextMenuOpenChange,
 	outline,
 	onDraggingChange,
 	onHoverChange,
@@ -516,6 +518,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			<ContextMenuForTarget
 				triggerRef={polygonRef}
 				getItems={onContextMenuOpen}
+				onOpenChange={onContextMenuOpenChange}
 			/>
 		</>
 	);

--- a/packages/studio/src/components/SelectedOutlineRenderer.tsx
+++ b/packages/studio/src/components/SelectedOutlineRenderer.tsx
@@ -81,6 +81,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	) => SelectedOutlineTarget | undefined;
 	readonly getOutlineTargets: () => readonly SelectedOutlineLayoutTarget[];
 	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
 		interaction?: TimelineSelectionInteraction,
@@ -97,6 +98,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	getLatestOutlineTargetByKey,
 	getOutlineTargets,
 	onDraggingChange,
+	onContextMenuOpenChange,
 	onSelect,
 	scale,
 	sequences,
@@ -306,6 +308,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 					getLatestTargetByKey={getLatestOutlineTargetByKey}
 					outline={outline}
 					onDraggingChange={onDraggingChange}
+					onContextMenuOpenChange={onContextMenuOpenChange}
 					onSnapPointsChange={onSnapPointsChange}
 					onSelect={onSelect}
 					scale={scale}

--- a/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
+++ b/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
@@ -52,6 +52,7 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpen: SelectedOutlineContextMenuOpenHandler;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -65,6 +66,7 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 	outline,
 	onDraggingChange,
 	onContextMenuOpen,
+	onContextMenuOpenChange,
 	onHoverChange,
 	onSelect,
 	target,
@@ -358,6 +360,7 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 			<ContextMenuForTarget
 				triggerRef={circleRef}
 				getItems={onContextMenuOpen}
+				onOpenChange={onContextMenuOpenChange}
 			/>
 		</>
 	);

--- a/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
+++ b/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
@@ -46,6 +46,7 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpen: SelectedOutlineContextMenuOpenHandler;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onHoverChange: (key: string | null) => void;
 	readonly onSelect: (
 		item: TimelineSelection,
@@ -59,6 +60,7 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 	outline,
 	onDraggingChange,
 	onContextMenuOpen,
+	onContextMenuOpenChange,
 	onHoverChange,
 	onSelect,
 	target,
@@ -290,7 +292,11 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 				}}
 				onPointerDown={onPointerDown}
 			/>
-			<ContextMenuForTarget triggerRef={lineRef} getItems={onContextMenuOpen} />
+			<ContextMenuForTarget
+				triggerRef={lineRef}
+				getItems={onContextMenuOpen}
+				onOpenChange={onContextMenuOpenChange}
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
## Summary

- keep the canvas selected-outline layer mounted while its context menu is resolving or open
- cancel stale menu item resolutions when the menu closes
- add an end-to-end regression test for leaving the canvas after right-clicking an item

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run test:e2e studio.test.mts --grep "should keep canvas item context menus open"`
