### PR TITLE
`@remotion/studio`: Fix fast menu dismissal

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -434,10 +434,17 @@ test.describe('visual mode', () => {
 			timeout: 15_000,
 		});
 
+		await page.evaluate(() => {
+			// Keep the menu tree in the interval before the next animation frame to
+			// exercise a fast user's outside click deterministically.
+			window.requestAnimationFrame = () => 0;
+		});
 		await page.getByRole('button', {name: 'More actions'}).click();
-		await page
-			.getByRole('button', {name: 'Playback Rate', exact: true})
-			.click();
+		const playbackRate = page.getByRole('button', {
+			name: 'Playback Rate',
+			exact: true,
+		});
+		await playbackRate.click();
 		await expect(
 			page.getByRole('button', {name: '1x', exact: true}),
 		).toBeVisible();

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -130,14 +130,11 @@ export const HigherZIndex: React.FC<{
 			});
 		};
 
-		// If a menu is opened, then this component will also still receive the pointerdown event.
-		// However we may not interpret it as a outside click, so we need to wait for the next tick
-		requestAnimationFrame(() => {
-			// The third argument `true` registers a capture-phase listener. Some Studio
-			// elements stop pointerdown propagation while still being outside the menu,
-			// so bubbling listeners would miss those clicks and keep the menu open.
-			window.addEventListener('pointerdown', listener, true);
-		});
+		// The capture phase for the pointerdown that opened this layer has already
+		// passed, so installing the listener immediately cannot dismiss the new layer.
+		// Waiting for the next animation frame would leave a window in which a fast
+		// outside click is missed.
+		window.addEventListener('pointerdown', listener, true);
 		return () => {
 			endPointerSession?.();
 			endPointerSession = null;


### PR DESCRIPTION
## Summary

- install the Studio outside-pointer listener immediately once a menu layer mounts
- keep capture-phase dismissal safe from the pointer event that opened the layer
- make the overflow-menu E2E test reproduce a click before the next animation frame

## Diagnosis

The 12-occurrence overflow-menu flake had a one-frame race: the menu was visible before `HigherZIndex` attached its outside-click listener. A fast click in that interval was lost, leaving the full menu tree open. Since the listener now runs in the window capture phase, the opening pointer event has already passed it by the time the new layer mounts, so the extra frame delay is unnecessary.

## Testing

- red/green verified: the deterministic browser regression fails with the delayed listener and passes with the immediate listener
- `bunx playwright test e2e/studio.test.mts --grep "should dismiss an overflow menu tree with one outside click"`
- `bun run build`
- `bun run stylecheck`

Closes the `Playback Rate` overflow-menu flake tracked in #8375.
