### PR TITLE
`@remotion/studio-server`: Insert elements beside composition roots

### DIFF
--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -982,31 +982,42 @@ const replaceNullRoot = ({
 	};
 };
 
-const replaceSelfClosingRoot = ({
+const replaceJsxElementRoot = ({
 	element,
 	root,
 	sequenceLocalName,
 	source,
 	unit,
+	wrapRootInSequence,
 }: {
 	element: string;
 	root: AstNode;
-	sequenceLocalName: string;
+	sequenceLocalName: string | null;
 	source: string;
 	unit: string;
+	wrapRootInSequence: boolean;
 }): TextEdit => {
 	const start = getPosition(root, 'start');
 	const indent = lineIndentAt(source, start);
 	const original = source.slice(start, getPosition(root, 'end'));
+	if (wrapRootInSequence && sequenceLocalName === null) {
+		throw new Error('Expected a Sequence import for a self-closing root');
+	}
+
+	const existingRoot = wrapRootInSequence
+		? [
+				`${indent}${unit}<${sequenceLocalName}>`,
+				`${indent}${unit}${unit}${original}`,
+				`${indent}${unit}</${sequenceLocalName}>`,
+			]
+		: [`${indent}${unit}${original}`];
 
 	return {
 		start,
 		end: getPosition(root, 'end'),
 		text: [
 			'<>',
-			`${indent}${unit}<${sequenceLocalName}>`,
-			`${indent}${unit}${unit}${original}`,
-			`${indent}${unit}</${sequenceLocalName}>`,
+			...existingRoot,
 			`${indent}${unit}${element}`,
 			`${indent}</>`,
 		].join('\n'),
@@ -1102,13 +1113,14 @@ export const insertSolidIntoSource = ({
 					source,
 					unit,
 				})
-			: isSelfClosing && sequenceImport
-				? replaceSelfClosingRoot({
+			: root.type === 'JSXElement'
+				? replaceJsxElementRoot({
 						element,
 						root,
-						sequenceLocalName: sequenceImport.localName,
+						sequenceLocalName: sequenceImport?.localName ?? null,
 						source,
 						unit,
+						wrapRootInSequence: isSelfClosing,
 					})
 				: appendToJsxRoot({
 						element,

--- a/packages/studio-codemods/src/test/insert-solid.test.ts
+++ b/packages/studio-codemods/src/test/insert-solid.test.ts
@@ -37,3 +37,24 @@ test('inserts a timeline Solid in a positioned Sequence', () => {
 	expect(result.output).toContain("translate: '120.3px 80px'");
 	expect(result.output).toContain('<Solid width={1280} height={720}');
 });
+
+test('inserts a Solid as a sibling of a component root', () => {
+	const result = insertSolidIntoSource({
+		exportName: 'MyComposition',
+		height: 720,
+		position: null,
+		source: `export const MyComposition = () => (
+	<MapViewport>
+		<MapRegion />
+	</MapViewport>
+);
+`,
+		width: 1280,
+	});
+
+	const rootEnd = result.output.indexOf('</MapViewport>');
+	const solidStart = result.output.indexOf('<Solid');
+	expect(result.output).toContain('<>');
+	expect(rootEnd).toBeGreaterThan(-1);
+	expect(solidStart).toBeGreaterThan(rootEnd);
+});

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -1866,17 +1866,17 @@ const addElementToComponentRoot = ({
 		);
 	}
 
-	if (rootNode.type === 'JSXElement' && rootNode.openingElement.selfClosing) {
+	if (rootNode.type === 'JSXElement') {
+		const existingRoot = rootNode.openingElement.selfClosing
+			? createSequenceWithChild({
+					child: stripParenthesizedExtra(rootNode),
+					sequenceLocalName: ensureSequenceImport(ast),
+				})
+			: stripParenthesizedExtra(rootNode);
 		const fragment = recast.types.builders.jsxFragment(
 			recast.types.builders.jsxOpeningFragment(),
 			recast.types.builders.jsxClosingFragment(),
-			[
-				createSequenceWithChild({
-					child: stripParenthesizedExtra(rootNode),
-					sequenceLocalName: ensureSequenceImport(ast),
-				}),
-				element,
-			],
+			[existingRoot, element],
 		);
 		let replaced = false;
 		recast.types.visit(ast, {

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -479,6 +479,64 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 	}
 });
 
+test('inserts an asset as a sibling of a connected composition', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {MyComp} from './MyComp';",
+				'export const RemotionRoot = () => {',
+				'\treturn <Composition id="test" component={MyComp} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'MyComp.tsx'),
+			[
+				"import {Sequence} from 'remotion';",
+				"import {Skills2Announcement} from './Skills2Announcement';",
+				'',
+				'export const MyComp: React.FC = () => {',
+				'\treturn (',
+				'\t\t<Sequence name="Skills2Announcement">',
+				'\t\t\t<Skills2Announcement />',
+				'\t\t</Sequence>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+
+		const result = await insertJsxElementIntoComposition({
+			remotionRoot: tempDir,
+			compositionFile: 'Root.tsx',
+			compositionId: 'test',
+			element: {
+				type: 'asset',
+				assetType: 'video',
+				src: 'clip.mp4',
+				srcType: 'static',
+				dimensions: {width: 1920, height: 1080},
+				durationInFrames: 90,
+				position: null,
+			},
+			from: 42,
+			prettierConfigOverride: {singleQuote: true, useTabs: true},
+		});
+
+		const connectedCompositionEnd = result.output.indexOf('</Sequence>');
+		const videoStart = result.output.indexOf('<Video');
+		expect(result.output).toContain('<>');
+		expect(connectedCompositionEnd).toBeGreaterThan(-1);
+		expect(videoStart).toBeGreaterThan(connectedCompositionEnd);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('removes parentheses when wrapping a self-closing root in a Sequence', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
## Summary

- insert new assets, Solids, components, and compositions beside a JSX composition root instead of inside it
- preserve connected-composition and custom-component child boundaries
- retain the existing Sequence wrapper for self-closing roots

## Testing

- `bun test packages/studio-codemods/src/test/insert-solid.test.ts packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9764
Closes #9869
