### PR TITLE
Docs: Recommend <Video> for Lambda performance

### DIFF
--- a/packages/docs/docs/lambda/cost.mdx
+++ b/packages/docs/docs/lambda/cost.mdx
@@ -16,6 +16,11 @@ Reducing the memory will linearly decrease the cost. Try out different values fo
 
 A lot of compute time is spent on warming up the Lambda function, opening browsers, uploading and downloading assets. By using less Lambda functions, less overhead is being produced which will ultimately result in lower cost, however also in slower render speeds. See the [Lambda Concurrency](/docs/lambda/concurrency) page for more information.
 
+## Use `<Video>` from `@remotion/media`
+
+We made a new [`<Video>`](/docs/media/video) that we now generally recommend.  
+It can start decoding before the full video is downloaded and avoids full asset downloads too, speeding up the render.
+
 ## Using cheaper regions
 
 Not all AWS regions have the same cost. See the [AWS Lambda](https://aws.amazon.com/lambda/pricing/) pricing chart to see if you are using a region that is more expensive.

--- a/packages/docs/docs/lambda/speed.mdx
+++ b/packages/docs/docs/lambda/speed.mdx
@@ -21,6 +21,16 @@ Adding more memory on Lambda will also scale up the CPU power on Lambda proporti
 
 The [`concurrencyPerLambda`](/docs/lambda/rendermediaonlambda#concurrencyperlambda) property in [`renderMediaOnLambda()`](/docs/lambda/rendermediaonlambda) allows you to open multiple browser tabs in a single Lambda function, therefore opening an opportunity to do more work at once. If the Lambda function is too busy, increasing the concurrency might also be counterproductive.
 
+## Use `<Video>` from `@remotion/media`
+
+We made a new [`<Video>`](/docs/media/video) that we now generally recommend.  
+It can start decoding before the full video is downloaded and avoids full asset downloads too, speeding up the render.
+
+## Enable `overwrite` in `renderMediaOnLambda()`
+
+The [`overwrite`](/docs/lambda/rendermediaonlambda#overwrite) options skips a check and overwrites any existing files in the S3 bucket.  
+If you are not concerned, enable this option and save some time.
+
 ## Use `speculateFunctionName()`
 
 Instead of calling [`getFunctions()`](/docs/lambda/getfunctions), you can call [`speculateFunctionName()`](/docs/lambda/speculatefunctionname) to calculate the name of the function you are about to call to save an API call and save up to 1 second.


### PR DESCRIPTION
## Summary

- Recommend `@remotion/media`'s `<Video>` for faster and cheaper Lambda renders
- Document the `renderMediaOnLambda()` `overwrite` optimization

## Testing

- `bunx oxfmt packages/docs/docs/lambda/cost.mdx packages/docs/docs/lambda/speed.mdx --write`
- `bun run build`
- `bun run stylecheck`

Closes #10250

## Preview

- [Optimizing for cost](https://remotion-git-codex-docs-lambda-video-cost-remotion.vercel.app/docs/lambda/optimizing-cost)
- [Optimizing for speed](https://remotion-git-codex-docs-lambda-video-cost-remotion.vercel.app/docs/lambda/optimizing-speed)
