### PR TITLE
`@remotion/studio`: Remove noisy success notifications

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -188,9 +188,7 @@ export const TimelineEffectItem: React.FC<{
 					effectIndex,
 				},
 			]);
-			if (result.success) {
-				showNotification('Removed effect from source file', 2000);
-			} else {
+			if (!result.success) {
 				showNotification(result.reason, 4000);
 			}
 		} catch (err) {

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -118,15 +118,6 @@ const deleteEffects = (
 	)
 		.then((result) => {
 			if (result.success) {
-				const singleEffect = effects[0];
-				showNotification(
-					effects.length === 1 && singleEffect?.type === 'single-effect'
-						? 'Removed effect from source file'
-						: effects.length === 1
-							? 'Removed effects from source file'
-							: 'Removed effects from source files',
-					2000,
-				);
 				return true;
 			}
 

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -196,17 +196,12 @@ export const getSequenceContextMenuItems = ({
 					return;
 				}
 
-				navigator.clipboard
-					.writeText(contextForAgents)
-					.then(() => {
-						showNotification('Copied context for agents', 1000);
-					})
-					.catch((err) => {
-						showNotification(
-							`Could not copy to clipboard: ${(err as Error).message}`,
-							1000,
-						);
-					});
+				navigator.clipboard.writeText(contextForAgents).catch((err) => {
+					showNotification(
+						`Could not copy to clipboard: ${(err as Error).message}`,
+						1000,
+					);
+				});
 			},
 			quickSwitcherLabel: null,
 			subMenu: null,


### PR DESCRIPTION
## Summary

- remove success notifications after deleting timeline effects from source files
- remove the success notification after copying agent context
- retain error notifications for failed deletion and clipboard operations

## Testing

- `bun run build`
- `bun run stylecheck`
