### PR TITLE
`@remotion/studio`: Fix canvas snapping flicker

### DIFF
--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -179,6 +179,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				getDragOverrides,
 				timelinePosition: getCurrentFrame(),
 			});
+			const dragOutlines = selected ? getAllDragOutlines() : [outline];
 			let lastValues = new Map<string, string>();
 			let currentPointerX = startPointerX;
 			let currentPointerY = startPointerY;
@@ -235,7 +236,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 						allowY: axisLockedDirection !== 'horizontal',
 						deltaX,
 						deltaY,
-						outlines: selected ? getAllDragOutlines() : [outline],
+						outlines: dragOutlines,
 						scale,
 						targets: snapTargets,
 					});


### PR DESCRIPTION
## Summary

- Freeze selected-outline geometry for the duration of a canvas drag
- Prevent drag overrides from feeding back into the next snap calculation
- Stop center snapping from flickering between positive and negative offsets

## Testing

- `bun test packages/studio/src/test/selected-outline-snap.test.ts`
- `bun run build`
- `bun run stylecheck`
