### PR TITLE
`remotion`: Re-check audio resume success before reporting failure

### DIFF
--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -39,12 +39,14 @@ export const waitUntilActuallyResumed = (
 
 		onAbort = () => finish('cancelled');
 
-		const hasAudiblyStarted = () => {
+		const hasAudiblyStarted = (
+			startPerformanceTime: number | undefined,
+		): startPerformanceTime is number => {
 			const outputTimestamp = audioContext.getOutputTimestamp();
 			return (
-				startOutputPerformanceTime !== undefined &&
+				startPerformanceTime !== undefined &&
 				outputTimestamp.performanceTime !== undefined &&
-				outputTimestamp.performanceTime > startOutputPerformanceTime &&
+				outputTimestamp.performanceTime > startPerformanceTime &&
 				outputTimestamp.contextTime !== undefined &&
 				outputTimestamp.contextTime > startCurrentTime
 			);
@@ -56,10 +58,10 @@ export const waitUntilActuallyResumed = (
 			const outputTimestamp = audioContext.getOutputTimestamp();
 			const elapsedWallClock = performance.now() - startWallClock;
 
-			if (hasAudiblyStarted()) {
+			if (hasAudiblyStarted(startOutputPerformanceTime)) {
 				Log.verbose(
 					{logLevel, tag: 'audio'},
-					`waitUntilActuallyResumed: getOutputTimestamp.performanceTime advanced from ${startOutputPerformanceTime?.toFixed(
+					`waitUntilActuallyResumed: getOutputTimestamp.performanceTime advanced from ${startOutputPerformanceTime.toFixed(
 						6,
 					)} to ${outputTimestamp.performanceTime?.toFixed(
 						6,
@@ -90,7 +92,7 @@ export const waitUntilActuallyResumed = (
 			// declaring failure so a resume that actually completed is not
 			// reported as failed - the Player would otherwise mute itself even
 			// though playback was started by a user gesture and audio is running.
-			if (hasAudiblyStarted()) {
+			if (hasAudiblyStarted(startOutputPerformanceTime)) {
 				finish('resumed');
 				return;
 			}

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -39,24 +39,29 @@ export const waitUntilActuallyResumed = (
 
 		onAbort = () => finish('cancelled');
 
+		const hasAudiblyStarted = () => {
+			const outputTimestamp = audioContext.getOutputTimestamp();
+			return (
+				startOutputPerformanceTime !== undefined &&
+				outputTimestamp.performanceTime !== undefined &&
+				outputTimestamp.performanceTime > startOutputPerformanceTime &&
+				outputTimestamp.contextTime !== undefined &&
+				outputTimestamp.contextTime > startCurrentTime
+			);
+		};
+
 		const check = () => {
 			animationFrame = null;
 			const {currentTime} = audioContext;
 			const outputTimestamp = audioContext.getOutputTimestamp();
 			const elapsedWallClock = performance.now() - startWallClock;
 
-			if (
-				startOutputPerformanceTime !== undefined &&
-				outputTimestamp.performanceTime !== undefined &&
-				outputTimestamp.performanceTime > startOutputPerformanceTime &&
-				outputTimestamp.contextTime !== undefined &&
-				outputTimestamp.contextTime > startCurrentTime
-			) {
+			if (hasAudiblyStarted()) {
 				Log.verbose(
 					{logLevel, tag: 'audio'},
-					`waitUntilActuallyResumed: getOutputTimestamp.performanceTime advanced from ${startOutputPerformanceTime.toFixed(
+					`waitUntilActuallyResumed: getOutputTimestamp.performanceTime advanced from ${startOutputPerformanceTime?.toFixed(
 						6,
-					)} to ${outputTimestamp.performanceTime.toFixed(
+					)} to ${outputTimestamp.performanceTime?.toFixed(
 						6,
 					)} after ${elapsedWallClock.toFixed(
 						1,
@@ -80,6 +85,16 @@ export const waitUntilActuallyResumed = (
 
 		signal.addEventListener('abort', onAbort, {once: true});
 		timeout = setTimeout(() => {
+			// The success check is scheduled with requestAnimationFrame, which can
+			// be starved while the main thread is busy. Re-check once before
+			// declaring failure so a resume that actually completed is not
+			// reported as failed - the Player would otherwise mute itself even
+			// though playback was started by a user gesture and audio is running.
+			if (hasAudiblyStarted()) {
+				finish('resumed');
+				return;
+			}
+
 			Log.warn(
 				{logLevel, tag: 'audio'},
 				'WARNING: You enabled autoPlay on an unmuted <Player /> and the browser did not allow the video to be started. Remotion muted the <Player /> so it can play. To properly handle this, either set the `muted` prop or remove the `autoPlay` prop',


### PR DESCRIPTION
`waitUntilActuallyResumed()` polls for output-clock progress with `requestAnimationFrame`, but declares failure with a wall-clock `setTimeout`. When the main thread is busy for around a second (heavy rendering, or a bundler rebuild during development), the timeout can fire before the rAF callback ever gets to run. A resume that actually completed is then reported as `'failed'`, and `use-playback.ts` responds by muting the Player - even though playback was started by a user gesture and audio is audibly running. Nothing unmutes it afterwards, so one busy second silences the Player for its whole lifetime.

This change re-checks the output timestamp once inside the timeout callback before finishing with `'failed'`. If the context did audibly start, the wait resolves `'resumed'` as it would have if the rAF loop had been scheduled in time. Genuine autoplay blocks still time out and report failure exactly as before.

Repro: start playback from a click, then keep the main thread busy past the 1000ms window (e.g. a large synchronous task right after `play()`). Without this change the Player logs the autoplay warning and mutes despite the gesture; with it, playback continues unmuted.