### PR TITLE
`@remotion/studio`: Respect disconnected state in composition controls

### DIFF
--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -6,6 +6,7 @@ import React, {
 	useState,
 } from 'react';
 import type {_InternalTypes} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {BrowseElementsIcon} from '../../icons/browse-elements';
 import {PicIcon} from '../../icons/frame';
@@ -297,6 +298,8 @@ export const CompositionInspector: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly setDefaultProps: UpdaterFunction<Record<string, unknown>>;
 }> = ({composition, currentDefaultProps, readOnlyStudio, setDefaultProps}) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+
 	return (
 		<div style={scrollableContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<div style={inspectorOverviewSection}>
@@ -304,7 +307,7 @@ export const CompositionInspector: React.FC<{
 				<InspectorSectionDivider />
 				<CompositionMetadata
 					compositionId={composition.id}
-					disabled={readOnlyStudio}
+					disabled={readOnlyStudio || previewServerState.type !== 'connected'}
 					stack={composition.stack}
 				/>
 			</div>

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -444,17 +444,21 @@ const RenderButtonInner: React.FC<{
 		}
 
 		return [
-			{
-				type: 'item' as const,
-				id: 'server-render',
-				label: 'Server-side render',
-				value: 'server-render',
-				onClick: () => handleRenderTypeChange('server-render'),
-				keyHint: null,
-				leftItem: null,
-				subMenu: null,
-				quickSwitcherLabel: null,
-			},
+			...(canServerRender
+				? [
+						{
+							type: 'item' as const,
+							id: 'server-render',
+							label: 'Server-side render',
+							value: 'server-render',
+							onClick: () => handleRenderTypeChange('server-render'),
+							keyHint: null,
+							leftItem: null,
+							subMenu: null,
+							quickSwitcherLabel: null,
+						},
+					]
+				: []),
 			{
 				type: 'item' as const,
 				id: 'client-render',
@@ -467,7 +471,7 @@ const RenderButtonInner: React.FC<{
 				quickSwitcherLabel: null,
 			},
 		];
-	}, [handleRenderTypeChange, readOnlyStudio]);
+	}, [canServerRender, handleRenderTypeChange, readOnlyStudio]);
 
 	const spaceToBottom = useMemo(() => {
 		const margin = 10;


### PR DESCRIPTION
## Summary

- show composition metadata values as read-only while the Studio server is unavailable
- hide the server-side render menu item unless the Studio server is connected

## Checks

- `bun run build`
- `bun run stylecheck`
