### PR TITLE
`@remotion/studio`: Fix menu Escape race

### DIFF
--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -2,6 +2,7 @@ import React, {
 	createContext,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 } from 'react';
@@ -27,7 +28,7 @@ const EscapeHook: React.FC<{
 }> = ({onEscape}) => {
 	const keybindings = useKeybinding();
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const escape = keybindings.registerKeybinding({
 			event: 'keydown',
 			key: 'Escape',
@@ -78,7 +79,7 @@ export const HigherZIndex: React.FC<{
 		? context.currentIndex
 		: (stackedIndex.current ?? context.currentIndex + 1);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (disabled) {
 			return;
 		}

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -65,6 +65,7 @@ export const HigherZIndex: React.FC<{
 }) => {
 	const context = useContext(ZIndexContext);
 	const highestContext = useContext(HighestZIndexContext);
+	const {registerZIndex, unregisterZIndex} = highestContext;
 	const containerRef = useRef<HTMLDivElement>(null);
 	const stackedIndex = useRef<number | null>(null);
 
@@ -84,9 +85,9 @@ export const HigherZIndex: React.FC<{
 			return;
 		}
 
-		highestContext.registerZIndex(currentIndex);
-		return () => highestContext.unregisterZIndex(currentIndex);
-	}, [currentIndex, highestContext, disabled]);
+		registerZIndex(currentIndex);
+		return () => unregisterZIndex(currentIndex);
+	}, [currentIndex, disabled, registerZIndex, unregisterZIndex]);
 
 	useEffect(() => {
 		if (disabled) {


### PR DESCRIPTION
## Summary

- register overlay z-index state before the browser paints the menu
- register the Escape keybinding in the same layout phase
- prevent a visible menu from briefly missing its Escape handler

## Testing

- `bunx playwright test e2e/studio.test.mts --grep "should clear the open-in-editor hover state" --repeat-each=30`
- `bun run build`
- `bun run stylecheck`
