### PR TITLE
`remotion-monorepo`: Fix pre-commit hook on Linux

### DIFF
--- a/pre-commit.ts
+++ b/pre-commit.ts
@@ -13,7 +13,7 @@ if (changedFiles.length === 0) {
 	process.exit(0);
 }
 
-const formatPackageNames = new Set<string>();
+const formatPackageDirs = new Set<string>();
 const lintPackageNames = new Set<string>();
 
 for (const file of changedFiles) {
@@ -32,7 +32,7 @@ for (const file of changedFiles) {
 	const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
 
 	if (pkgJson.scripts?.format) {
-		formatPackageNames.add(pkgJson.name);
+		formatPackageDirs.add(path.resolve('packages', dir));
 	}
 
 	if (pkgJson.scripts?.lint) {
@@ -40,12 +40,10 @@ for (const file of changedFiles) {
 	}
 }
 
-if (formatPackageNames.size > 0) {
-	const formatFilters = [...formatPackageNames].flatMap((name) => [
-		'--filter',
-		name,
-	]);
-	await $`bun run ${formatFilters} format`;
+if (formatPackageDirs.size > 0) {
+	for (const dir of formatPackageDirs) {
+		await $`bun run --cwd ${dir} format`;
+	}
 
 	// Re-stage originally staged files so formatting changes are included in this commit
 	if (stagedFiles.length > 0) {


### PR DESCRIPTION
The pre-commit hook currently uses `bun run --filter` to format changed packages. On Linux, this fails immediately with:

```text
  error: ENOENT
```

This is caused by a known Bun bug when resolving recursive workspace patterns containing mixed-case directory names:

- https://github.com/oven-sh/bun/issues/21670
- https://github.com/oven-sh/bun/pull/29941

This PR avoids workspace resolution in the hook. It tracks the directories of changed packages and runs each formatter directly using bun run --cwd.

Validation

- Reproduced the failure on Linux with a change in packages/docs.
- Ran bun pre-commit.ts after the fix; oxfmt src completed successfully.
- Verified --cwd using the repository's pinned Bun 1.3.3.
- Ran bunx oxfmt pre-commit.ts --check.

Tradeoff

Formatters now run sequentially when multiple packages are changed. In practice, pre-commit changes usually affect only a small number of packages, and this avoids relying on Bun's currently broken workspace filtering on Linux.