### PR TITLE
`@remotion/studio`: Preserve 3D rotation cursor while dragging

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -565,8 +565,22 @@ test.describe('inspector section collapse', () => {
 			threeDRotationSurfaceBox.y + threeDRotationSurfaceBox.height * 0.25;
 		await page.mouse.move(threeDStartX, threeDStartY);
 		await page.mouse.down();
+		expect(
+			await canvasRotationSurface.evaluate((surface) =>
+				surface.ownerSVGElement === null
+					? null
+					: getComputedStyle(surface.ownerSVGElement).cursor,
+			),
+		).toContain('data:image/svg+xml');
 		await page.mouse.move(threeDStartX + 80, threeDStartY + 60, {steps: 5});
 		await page.mouse.up();
+		expect(
+			await canvasRotationSurface.evaluate((surface) =>
+				surface.ownerSVGElement === null
+					? null
+					: getComputedStyle(surface.ownerSVGElement).cursor,
+			),
+		).not.toContain('data:image/svg+xml');
 		await expect
 			.poll(() => read2DTransformRotation()?.split(' ').length)
 			.toBe(4);

--- a/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
+++ b/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
@@ -78,6 +78,9 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 				return;
 			}
 
+			const previousSvgCursor = svg.style.cursor;
+			svg.style.cursor = canvasRotationCursor;
+
 			const startPointer = {x: event.clientX, y: event.clientY};
 			const center = svgPointToClientPoint(
 				getSelectedOutlineRotationPivot({
@@ -112,6 +115,7 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 					}
 
 					dragStarted = true;
+					forceSpecificCursor(canvasRotationCursor);
 					onDraggingChange(true);
 				}
 
@@ -133,7 +137,6 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 						rotationXDeltaDegrees,
 						rotationYDeltaDegrees,
 					});
-					forceSpecificCursor(canvasRotationCursor);
 				} else {
 					const nextAngle = getAngleDegrees(center, {
 						x: moveEvent.clientX,
@@ -155,7 +158,6 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 						dragStates,
 						rotationDeltaDegrees,
 					});
-					forceSpecificCursor(canvasRotationCursor);
 				}
 
 				for (const dragState of dragStates) {
@@ -185,6 +187,7 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 			};
 
 			const onPointerUp = () => {
+				svg.style.cursor = previousSvgCursor;
 				if (dragStarted) {
 					stopForcingSpecificCursor();
 					onDraggingChange(false);


### PR DESCRIPTION
## Summary

- preserve the custom rotation cursor on the SVG that owns pointer capture
- restore the previous SVG cursor after the pointer session ends
- avoid reapplying the same custom cursor on every pointer move
- cover the active and completed 3D rotation drag states in the existing Playwright workflow

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/inspector-section-collapse.test.mts --grep "collapses inactive static sections"`
- red/green regression verification
