### PR TITLE
`@remotion/remotion-media`: Make catalog crawlable

### DIFF
--- a/packages/remotion-media/README.md
+++ b/packages/remotion-media/README.md
@@ -1,6 +1,6 @@
 # @remotion/remotion-media
 
-Private package hosting [remotion.media](https://remotion.media): test media fixtures and a catalog UI for `@remotion/media`.
+Private package hosting [remotion.media](https://remotion.media): test media fixtures and a catalog UI.
 
 ## Development
 
@@ -22,7 +22,7 @@ Place `multiple-audio-streams.mov` in the package root before running `generate`
 
 ## Build and deploy
 
-Bundles the catalog UI and uploads to Cloudflare R2 when `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set:
+Bundles and pre-renders the catalog UI, generates `llms.txt`, `robots.txt`, and `sitemap.xml`, and uploads everything to Cloudflare R2 when `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set:
 
 ```bash
 bun run build
@@ -59,4 +59,6 @@ curl -I -H 'Accept: text/html' https://remotion.media/
 curl -I -H 'Accept: text/markdown' https://remotion.media/
 curl -I -A 'Claude-User' https://remotion.media/
 curl -I https://remotion.media/llms.txt
+curl -I https://remotion.media/robots.txt
+curl -I https://remotion.media/sitemap.xml
 ```

--- a/packages/remotion-media/build.ts
+++ b/packages/remotion-media/build.ts
@@ -1,9 +1,19 @@
 #!/usr/bin/env bun
-import {$, build, S3Client, type BuildConfig} from 'bun';
-import plugin from 'bun-plugin-tailwind';
-import {cpSync, existsSync, mkdirSync, readdirSync, writeFileSync} from 'fs';
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'fs';
 import {rm} from 'fs/promises';
 import path from 'path';
+import {$, build, S3Client, type BuildConfig} from 'bun';
+import plugin from 'bun-plugin-tailwind';
+import {createElement} from 'react';
+import {renderToString} from 'react-dom/server';
+import {App} from './src/App';
 import {makeLlmsText} from './src/llms';
 import variants from './variants.json';
 
@@ -126,14 +136,15 @@ const formatFileSize = (bytes: number): string => {
 	return `${size.toFixed(2)} ${units[unitIndex]}`;
 };
 
-const hlsContentTypes: Record<string, string> = {
+const explicitContentTypes: Record<string, string> = {
 	'.m3u8': 'application/vnd.apple.mpegurl',
 	'.m4s': 'video/iso.segment',
 	'.ts': 'video/mp2t',
+	'.xml': 'application/xml; charset=utf-8',
 };
 
 const getContentType = (file: string) => {
-	return hlsContentTypes[path.extname(file)];
+	return explicitContentTypes[path.extname(file)];
 };
 
 const r2Endpoint =
@@ -177,6 +188,42 @@ const result = await build({
 	...cliConfig, // Merge in any CLI-provided options
 });
 
+const generatedIndexPath = path.join(outdir, 'index.html');
+const rootPlaceholder = '<div id="root"></div>';
+const generatedIndex = readFileSync(generatedIndexPath, 'utf8');
+if (!generatedIndex.includes(rootPlaceholder)) {
+	throw new Error(`Could not find ${rootPlaceholder} in ${generatedIndexPath}`);
+}
+
+const prerenderedIndex = generatedIndex.replace(
+	rootPlaceholder,
+	`<div id="root">${renderToString(createElement(App))}</div>`,
+);
+writeFileSync(generatedIndexPath, prerenderedIndex);
+writeFileSync(path.join(outdir, 'llms.txt'), makeLlmsText(variants));
+writeFileSync(
+	path.join(outdir, 'robots.txt'),
+	[
+		'User-agent: *',
+		'Allow: /',
+		'',
+		'Sitemap: https://remotion.media/sitemap.xml',
+		'',
+	].join('\n'),
+);
+writeFileSync(
+	path.join(outdir, 'sitemap.xml'),
+	[
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+		'  <url>',
+		'    <loc>https://remotion.media/</loc>',
+		'  </url>',
+		'</urlset>',
+		'',
+	].join('\n'),
+);
+
 // Print the results
 const end = performance.now();
 
@@ -191,7 +238,8 @@ const buildTime = (end - start).toFixed(2);
 
 console.log(`\n✅ Build completed in ${buildTime}ms\n`);
 
-const filesDir = path.join(process.cwd(), 'files');
+const filesDir =
+	Bun.env.REMOTION_MEDIA_FILES_DIR ?? path.join(process.cwd(), 'files');
 mkdirSync(filesDir, {recursive: true});
 
 for await (const file of new Bun.Glob('chunk-*').scan(filesDir)) {
@@ -212,8 +260,6 @@ const files = readdirSync(outdir);
 for (const file of files) {
 	cpSync(path.join(outdir, file), path.join(filesDir, file));
 }
-
-writeFileSync(path.join(filesDir, 'llms.txt'), makeLlmsText(variants));
 
 if (!Bun.env.AWS_ACCESS_KEY_ID || !Bun.env.AWS_SECRET_ACCESS_KEY) {
 	console.log(

--- a/packages/remotion-media/package.json
+++ b/packages/remotion-media/package.json
@@ -14,6 +14,7 @@
 		"bundle": "bun run build.ts",
 		"clean": "bun clean.ts",
 		"lint": "eslint src && tsc",
+		"test": "bun test src/seo-build.test.ts",
 		"formatting": "prettier src --check"
 	},
 	"dependencies": {

--- a/packages/remotion-media/src/App.tsx
+++ b/packages/remotion-media/src/App.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from 'react';
 import variants from '../variants.json';
-import './index.css';
 import {getCategoryLabel} from './llms';
 
 const CopyLink = ({href}: {readonly href: string}) => {
@@ -15,12 +14,13 @@ const CopyLink = ({href}: {readonly href: string}) => {
 	};
 
 	return (
-		<span
+		<button
+			type="button"
 			onClick={handleCopy}
-			className=" text-sm hover:text-blue-500 cursor-pointer"
+			className="text-sm hover:text-blue-500 cursor-pointer"
 		>
 			{copied ? 'Copied' : 'Copy link'}
-		</span>
+		</button>
 	);
 };
 
@@ -30,7 +30,7 @@ const VideoVariant = ({
 	readonly variant: (typeof variants)[number];
 }) => {
 	return (
-		<div className="bg-white p-2 mb-2 border-2 border-b-4 rounded-md">
+		<article className="bg-white p-2 mb-2 border-2 border-b-4 rounded-md">
 			<a
 				href={`/${variant.fileNames[0]}`}
 				className="leading-tight hover:text-blue-500"
@@ -85,7 +85,7 @@ const VideoVariant = ({
 					))}
 				</div>
 			)}
-		</div>
+		</article>
 	);
 };
 
@@ -97,14 +97,14 @@ const CategoryGroup = ({
 	readonly variants: (typeof variants)[number][];
 }) => {
 	return (
-		<div id={`category-${category}`} className="scroll-mt-4">
-			<h3 className="text-lg font-bold mt-5 mb-4 font-brand">
+		<section id={`category-${category}`} className="scroll-mt-4">
+			<h2 className="text-lg font-bold mt-5 mb-4 font-brand">
 				{getCategoryLabel(category)}
-			</h3>
+			</h2>
 			{v.map((variant) => (
 				<VideoVariant key={variant.fileNames[0]} variant={variant} />
 			))}
-		</div>
+		</section>
 	);
 };
 
@@ -211,22 +211,28 @@ export function App() {
 	}, []);
 
 	return (
-		<div className="max-w-[960px] w-full m-auto mt-4 px-4 mb-20">
-			<h2 className="text-2xl font-bold mt-10 mb-2 font-brand">
-				Audio and video files for testing
-			</h2>
-			<p className="text-neutral-500 font-brand mt-1 mb-8">
-				All files are available on{' '}
-				<code className="font-brand text-brand">remotion.media/[filename]</code>
-				.
-				<br />
-				Hosted on Cloudflare R2 Free Tier, allowing for theoretically unlimited
-				bandwidth. <br />
-				Files may be used royalty-free and without attribution.
-				<br />
-				You can safely pass this website to an AI agent - a Markdown version of
-				this catalog will be returned automatically.
-			</p>
+		<main className="max-w-[960px] w-full m-auto mt-4 px-4 mb-20">
+			<h1 className="text-2xl font-bold mt-10 mb-2 font-brand">
+				Free audio and video files for testing
+			</h1>
+			<div className="text-neutral-500 font-brand mt-1 mb-8">
+				<p className="mb-3">
+					remotion.media is a CORS-enabled catalog of sample media files. Use
+					them to test media players, parsers, WebCodecs, transcoding, and
+					upload pipelines.
+				</p>
+				<p>
+					Browse {variants.length} fixtures across codecs, containers,
+					resolutions, frame rates, durations, sample rates, sound effects, and
+					HLS. Every file is available at{' '}
+					<code className="font-brand text-brand">
+						remotion.media/[filename]
+					</code>
+					. Files may be used royalty-free and without attribution. You can also
+					pass this website to an AI agent to receive a Markdown version of the
+					catalog.
+				</p>
+			</div>
 			<div className="flex gap-8 items-start">
 				<Sidebar
 					activeCategory={activeCategory}
@@ -242,7 +248,7 @@ export function App() {
 					))}
 				</div>
 			</div>
-		</div>
+		</main>
 	);
 }
 

--- a/packages/remotion-media/src/frontend.tsx
+++ b/packages/remotion-media/src/frontend.tsx
@@ -5,12 +5,18 @@
  * It is included in `src/index.html`.
  */
 
-import {createRoot} from 'react-dom/client';
+import {createRoot, hydrateRoot} from 'react-dom/client';
 import {App} from './App';
+import './index.css';
 
 function start() {
-	const root = createRoot(document.getElementById('root')!);
-	root.render(<App />);
+	const rootElement = document.getElementById('root')!;
+	if (rootElement.hasChildNodes()) {
+		hydrateRoot(rootElement, <App />);
+		return;
+	}
+
+	createRoot(rootElement).render(<App />);
 }
 
 if (document.readyState === 'loading') {

--- a/packages/remotion-media/src/index.html
+++ b/packages/remotion-media/src/index.html
@@ -3,7 +3,33 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>remotion.media</title>
+		<title>Free Audio &amp; Video Test Files | remotion.media</title>
+		<meta
+			name="description"
+			content="Download free, CORS-enabled sample audio and video files for testing codecs, containers, resolutions, frame rates, durations, and sample rates."
+		/>
+		<meta name="robots" content="index, follow" />
+		<link rel="canonical" href="https://remotion.media/" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://remotion.media/" />
+		<meta
+			property="og:title"
+			content="Free Audio &amp; Video Test Files | remotion.media"
+		/>
+		<meta
+			property="og:description"
+			content="Download free, CORS-enabled sample audio and video files across codecs, containers, resolutions, frame rates, durations, and sample rates."
+		/>
+		<meta property="og:site_name" content="remotion.media" />
+		<meta name="twitter:card" content="summary" />
+		<meta
+			name="twitter:title"
+			content="Free Audio &amp; Video Test Files | remotion.media"
+		/>
+		<meta
+			name="twitter:description"
+			content="Download free, CORS-enabled sample audio and video files for testing media workflows."
+		/>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/packages/remotion-media/src/seo-build.test.ts
+++ b/packages/remotion-media/src/seo-build.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'bun:test';
+import {mkdtemp, readFile, rm} from 'fs/promises';
+import {tmpdir} from 'os';
+import path from 'path';
+
+const packageRoot = path.resolve(import.meta.dir, '..');
+
+test('builds a crawlable media catalog and discovery files', async () => {
+	const temporaryDirectory = await mkdtemp(
+		path.join(tmpdir(), 'remotion-media-seo-'),
+	);
+	const outdir = path.join(temporaryDirectory, 'dist');
+	const filesDir = path.join(temporaryDirectory, 'files');
+
+	try {
+		const buildProcess = Bun.spawn({
+			cmd: [process.execPath, 'run', 'build.ts', `--outdir=${outdir}`],
+			cwd: packageRoot,
+			env: {
+				...process.env,
+				AWS_ACCESS_KEY_ID: '',
+				AWS_SECRET_ACCESS_KEY: '',
+				REMOTION_MEDIA_FILES_DIR: filesDir,
+			},
+			stderr: 'pipe',
+			stdout: 'ignore',
+		});
+		const [exitCode, stderr] = await Promise.all([
+			buildProcess.exited,
+			new Response(buildProcess.stderr).text(),
+		]);
+
+		if (exitCode !== 0) {
+			throw new Error(`Catalog build failed:\n${stderr}`);
+		}
+
+		const [html, robots, sitemap, llms] = await Promise.all([
+			readFile(path.join(filesDir, 'index.html'), 'utf8'),
+			readFile(path.join(filesDir, 'robots.txt'), 'utf8'),
+			readFile(path.join(filesDir, 'sitemap.xml'), 'utf8'),
+			readFile(path.join(filesDir, 'llms.txt'), 'utf8'),
+		]);
+
+		expect(html).toContain('<div id="root"><main');
+		expect(html).toContain('Free audio and video files for testing');
+		expect(html).toContain('video.mp4');
+		expect(html).toContain('name="description"');
+		expect(html).toContain(
+			'<link rel="canonical" href="https://remotion.media/"',
+		);
+		expect(html).not.toContain('<div id="root"></div>');
+		expect(robots).toContain('Sitemap: https://remotion.media/sitemap.xml');
+		expect(sitemap).toContain('<loc>https://remotion.media/</loc>');
+		expect(llms).toContain('# remotion.media');
+	} finally {
+		await rm(temporaryDirectory, {recursive: true, force: true});
+	}
+}, 30_000);


### PR DESCRIPTION
## Summary

- pre-render the complete remotion.media catalog into the deployed HTML so crawlers can index it without executing JavaScript
- add semantic page structure, focused catalog copy, canonical and social metadata
- generate `robots.txt` and `sitemap.xml` alongside the existing agent catalog
- hydrate the pre-rendered page while retaining client rendering during local development
- cover the final build artifacts with an integration test

## Testing

- `bunx oxfmt packages/remotion-media/README.md packages/remotion-media/build.ts packages/remotion-media/package.json packages/remotion-media/src/App.tsx packages/remotion-media/src/frontend.tsx packages/remotion-media/src/index.html packages/remotion-media/src/seo-build.test.ts --write`
- `cd packages/remotion-media && bun run formatting && bun run lint && bun run test`
- `bun run build`
- `bun run stylecheck`
