### PR TITLE
Elements: Move news article highlight to Storytelling

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -66,13 +66,19 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: 'category',
+			label: 'Storytelling',
+			link: {type: 'doc', id: 'storytelling/index'},
+			collapsed: false,
+			items: ['text/news-article-headline-highlight/index'],
+		},
+		{
+			type: 'category',
 			label: 'Text',
 			link: {type: 'doc', id: 'text/index'},
 			collapsed: false,
 			items: [
 				'text/circle-marker/index',
 				'text/crossed-off/index',
-				'text/news-article-headline-highlight/index',
 				'text/strike-through/index',
 				'text/text-marker/index',
 			],

--- a/packages/docs/elements/storytelling/index.mdx
+++ b/packages/docs/elements/storytelling/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Storytelling
+description: Drop-in storytelling scenes for Remotion videos.
+---
+
+import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
+
+# Storytelling
+
+<ElementLibrary category="storytelling" />

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -387,7 +387,7 @@ export const elementDefinitions = {
 		width: 1920,
 	},
 	'text/news-article-headline-highlight': {
-		category: 'text',
+		category: 'storytelling',
 		component: NewsArticleHeadlineHighlight,
 		contributors: [],
 		description:


### PR DESCRIPTION
## Summary

- add a Storytelling category to Remotion Elements
- move News Article Headline Highlight from Text to Storytelling
- preserve the element's existing URL and preview asset paths

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter=docs --no-update-notifier`


## Preview

- [Storytelling Elements](https://remotion-git-news-article-highlight-storytelling-remotion.vercel.app/elements/storytelling/)
