### PR TITLE
`@remotion/studio`: Preserve inspector scroll when adding effects

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -92,6 +92,47 @@ test.describe('visual mode', () => {
 		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
 	});
 
+	test('should preserve the sequence inspector scroll position when adding an effect', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		const addEffectButton = page.getByTitle('Add effect', {exact: true});
+		if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
+			await page.locator('[data-sidebar-toggle="right"]').click();
+		}
+
+		await expect(async () => {
+			await page.getByTitle('Scale precision', {exact: true}).first().click();
+			await expect(addEffectButton).toBeVisible({timeout: 1000});
+		}).toPass({timeout: 15_000});
+		const inspector = page
+			.locator('.__remotion-vertical-scrollbar')
+			.filter({has: addEffectButton});
+		await expect(inspector).toHaveCount(1);
+		await inspector.evaluate((element) => {
+			element.scrollTop = element.scrollHeight;
+		});
+		await addEffectButton.click();
+
+		const scrollTopBefore = await inspector.evaluate(
+			(element) => element.scrollTop,
+		);
+		expect(scrollTopBefore).toBeGreaterThan(0);
+		const effectPicker = page.getByRole('dialog');
+		await effectPicker.getByPlaceholder('Search effects...').fill('blur');
+		await effectPicker.getByText('blur()', {exact: true}).click();
+
+		await expect
+			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
+			.toContain("import {blur} from '@remotion/effects/blur';");
+		await expect(page.getByText('blur()', {exact: true})).toBeVisible();
+		const scrollTopAfter = await inspector.evaluate(
+			(element) => element.scrollTop,
+		);
+		expect(scrollTopAfter).toBeGreaterThan(0);
+	});
+
 	test('should keep canvas item context menus open', async ({page}) => {
 		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
 		await expect(

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -215,6 +215,7 @@ const SequenceExpandedInspector: React.FC<{
 	const sourceLocation = useSequenceInspectorSourceLocation(track.sequence);
 	const connectedCompositions = useConnectedCompositions({track});
 	const {validatedLocation} = sourceLocation;
+	const stackKey = track.sequence.getStack();
 	const sequenceSelection = useMemo((): Extract<
 		TimelineSelection,
 		{type: 'sequence'}
@@ -275,7 +276,11 @@ const SequenceExpandedInspector: React.FC<{
 			className={VERTICAL_SCROLLBAR_CLASSNAME}
 			onPointerDown={selectSequenceOnInspectorPointerDown}
 		>
-			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
+			<SequenceInspectorHeader
+				key={stackKey ?? track.sequence.id}
+				sourceLocation={sourceLocation}
+				track={track}
+			/>
 			<SequenceInspectorDuplicationSection track={track} />
 			{connectedCompositions.length > 0 ? (
 				<>
@@ -321,13 +326,7 @@ export const SequenceSelectionInspector: React.FC<{
 		return <InspectorMessage>Sequence inspector unavailable</InspectorMessage>;
 	}
 
-	const stackKey = track.sequence.getStack();
-
 	return (
-		<SequenceExpandedInspector
-			key={stackKey ?? track.sequence.id}
-			track={track}
-			readOnlyStudio={readOnlyStudio}
-		/>
+		<SequenceExpandedInspector track={track} readOnlyStudio={readOnlyStudio} />
 	);
 };

--- a/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
+++ b/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
@@ -16,7 +16,7 @@ export const SubscribeToNodePaths: FC<{
 	readonly effects: readonly EffectDefinition<unknown>[];
 }> = ({overrideId, componentIdentity, schema, getStack, effects}) => {
 	const {resolvedLocation, stack, preferMappedNodePath} =
-		useResolveStackAndReactToChange(getStack);
+		useResolveStackAndReactToChange(getStack, overrideId);
 
 	const effectSubscriptions = useMemo<InteractivitySchema[]>(() => {
 		return effects

--- a/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
+++ b/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
@@ -20,6 +20,7 @@ export const useOpenSequenceInApps = (sequence: TSequence) => {
 	const previewConnected = previewServerState.type === 'connected';
 	const {resolvedLocation: originalLocation} = useResolveStackAndReactToChange(
 		sequence.getStack,
+		sequence.controls?.overrideId ?? sequence.id,
 	);
 	const editorPickerAvailable = canUseEditorPicker(previewConnected);
 	const editorInfo = useDefaultEditorInfo(editorPickerAvailable);

--- a/packages/studio/src/components/Timeline/use-resolved-stack-react-to-change.ts
+++ b/packages/studio/src/components/Timeline/use-resolved-stack-react-to-change.ts
@@ -26,6 +26,7 @@ const matchesSourceLocation = (
 
 export const useResolveStackAndReactToChange = (
 	getStack: () => string | null,
+	sequenceIdentity: string,
 ) => {
 	const {subscribeToEvent} = useContext(StudioServerConnectionCtx);
 	const {fastRefreshes} = useContext(FastRefreshContext);
@@ -34,13 +35,37 @@ export const useResolveStackAndReactToChange = (
 		preferMappedNodePath: true,
 	}));
 	const resolvedLocationFromStack = useResolvedStack(stackState.stack);
-	const resolvedLocation = hasResolvedStack(stackState.stack)
+	const stackIsResolved = hasResolvedStack(stackState.stack);
+	const lastResolvedLocation = useRef(resolvedLocationFromStack);
+	if (stackIsResolved) {
+		lastResolvedLocation.current = resolvedLocationFromStack;
+	}
+
+	const resolvedLocation = stackIsResolved
 		? resolvedLocationFromStack
-		: null;
+		: stackState.preferMappedNodePath
+			? null
+			: lastResolvedLocation.current;
 	const resolvedLocationRef = useRef(resolvedLocation);
 	resolvedLocationRef.current = resolvedLocation;
 	const getStackRef = useRef(getStack);
 	getStackRef.current = getStack;
+
+	useEffect(() => {
+		const newStack = getStackRef.current();
+		setStackState((current) => {
+			if (newStack === current.stack) {
+				return current;
+			}
+
+			return {
+				stack: newStack,
+				// A different identity means a different selected sequence. Its existing
+				// node path mapping is still preferred.
+				preferMappedNodePath: true,
+			};
+		});
+	}, [sequenceIdentity]);
 
 	useEffect(() => {
 		if (fastRefreshes === 0) {


### PR DESCRIPTION
## Summary

- remount only the sequence inspector header when its stack changes
- retain the last resolved source location during same-sequence Fast Refresh
- distinguish sequence changes with stable Visual Mode identity
- add an end-to-end regression test for adding an effect while the inspector is scrolled

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "preserve the sequence inspector scroll position"`
- `bun test src` in `packages/studio`
