### PR TITLE
remotion.dev/convert: Scale cursor while pressed

### DIFF
--- a/packages/convert/app/components/CanvasCaptureCursor.tsx
+++ b/packages/convert/app/components/CanvasCaptureCursor.tsx
@@ -2,17 +2,22 @@ import {MacOSCursor} from '@remotion/mac-cursors';
 import React from 'react';
 import {useCurrentFrame, useVideoConfig} from 'remotion';
 import type {CanvasCaptureCursorData} from '~/lib/canvas-capture-metadata';
-import {findCanvasCaptureCursorAtTime} from '~/lib/canvas-capture-metadata';
+import {
+	findCanvasCaptureCursorAtTime,
+	isCanvasCapturePointerDownAtTime,
+} from '~/lib/canvas-capture-metadata';
 
 export const CanvasCaptureCursor: React.FC<{
 	readonly cursorData: CanvasCaptureCursorData;
 	readonly cursorScale: number;
-}> = ({cursorData, cursorScale}) => {
+	readonly cursorPressedScale: number;
+}> = ({cursorData, cursorScale, cursorPressedScale}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
+	const timeInSeconds = frame / fps;
 	const cursor = findCanvasCaptureCursorAtTime(
 		cursorData.mouseMovements,
-		frame / fps,
+		timeInSeconds,
 	);
 
 	if (!cursor || cursor.canvasX === null || cursor.canvasY === null) {
@@ -32,7 +37,16 @@ export const CanvasCaptureCursor: React.FC<{
 		>
 			<MacOSCursor
 				cursor={cursor.cursor}
-				scale={cursorData.captureMetadata.density * cursorScale}
+				scale={
+					cursorData.captureMetadata.density *
+					cursorScale *
+					(isCanvasCapturePointerDownAtTime(
+						cursorData.pointerClicks,
+						timeInSeconds,
+					)
+						? cursorPressedScale
+						: 1)
+				}
 			/>
 		</div>
 	);

--- a/packages/convert/app/components/ConvertUi.tsx
+++ b/packages/convert/app/components/ConvertUi.tsx
@@ -93,6 +93,8 @@ const ConvertUI = ({
 	setShowCursor,
 	cursorScale,
 	setCursorScale,
+	cursorPressedScale,
+	setCursorPressedScale,
 }: {
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
 	readonly currentVideoCodec: InputVideoTrack['codec'] | null;
@@ -126,6 +128,8 @@ const ConvertUI = ({
 	readonly setShowCursor: React.Dispatch<React.SetStateAction<boolean>>;
 	readonly cursorScale: number;
 	readonly setCursorScale: React.Dispatch<React.SetStateAction<number>>;
+	readonly cursorPressedScale: number;
+	readonly setCursorPressedScale: React.Dispatch<React.SetStateAction<number>>;
 }) => {
 	const {crop, mirror, rotate} = videoEditState;
 	const [enableConvert, setEnableConvert] = useState(() =>
@@ -390,6 +394,7 @@ const ConvertUI = ({
 								? makeCanvasCaptureVideoProcessor({
 										cursorData,
 										cursorScale,
+										cursorPressedScale,
 										sourceDimensions: dimensions,
 										rotation: userRotation,
 										crop: videoCrop ?? null,
@@ -593,6 +598,7 @@ const ConvertUI = ({
 		mirror,
 		cursorData,
 		cursorScale,
+		cursorPressedScale,
 		dimensions,
 		renderCursor,
 	]);
@@ -758,6 +764,8 @@ const ConvertUI = ({
 					setShowCursor={setShowCursor}
 					cursorScale={cursorScale}
 					setCursorScale={setCursorScale}
+					cursorPressedScale={cursorPressedScale}
+					setCursorPressedScale={setCursorPressedScale}
 				/>
 				{order.map((section) => {
 					if (inputIsAudioExclusively && isVideoOnlySection(section)) {

--- a/packages/convert/app/components/CursorControls.tsx
+++ b/packages/convert/app/components/CursorControls.tsx
@@ -8,7 +8,17 @@ export const CursorControls: React.FC<{
 	readonly setShowCursor: React.Dispatch<React.SetStateAction<boolean>>;
 	readonly cursorScale: number;
 	readonly setCursorScale: React.Dispatch<React.SetStateAction<number>>;
-}> = ({available, showCursor, setShowCursor, cursorScale, setCursorScale}) => {
+	readonly cursorPressedScale: number;
+	readonly setCursorPressedScale: React.Dispatch<React.SetStateAction<number>>;
+}> = ({
+	available,
+	showCursor,
+	setShowCursor,
+	cursorScale,
+	setCursorScale,
+	cursorPressedScale,
+	setCursorPressedScale,
+}) => {
 	if (!available) {
 		return null;
 	}
@@ -31,6 +41,19 @@ export const CursorControls: React.FC<{
 					<div className="flex flex-row text-sm text-gray-700 pt-2">
 						<div className="flex-1">Cursor scale</div>
 						<div className="tabular-nums">{cursorScale.toFixed(2)}×</div>
+					</div>
+					<Slider
+						className="mt-4"
+						aria-label="Pressed cursor scale"
+						min={0.25}
+						max={1}
+						step={0.05}
+						value={[cursorPressedScale]}
+						onValueChange={(value) => setCursorPressedScale(value[0])}
+					/>
+					<div className="flex flex-row text-sm text-gray-700 pt-2">
+						<div className="flex-1">Pressed cursor scale</div>
+						<div className="tabular-nums">{cursorPressedScale.toFixed(2)}×</div>
 					</div>
 				</div>
 			) : null}

--- a/packages/convert/app/components/FileAvailable.tsx
+++ b/packages/convert/app/components/FileAvailable.tsx
@@ -54,6 +54,7 @@ export const FileAvailable: React.FC<{
 	const [trimOutFrame, setTrimOutFrame] = useState<number | null>(null);
 	const [showCursor, setShowCursor] = useState(true);
 	const [cursorScale, setCursorScale] = useState(1);
+	const [cursorPressedScale, setCursorPressedScale] = useState(0.8);
 
 	const [waveform, setWaveform] = useState<number[]>([]);
 
@@ -102,6 +103,7 @@ export const FileAvailable: React.FC<{
 							cursorData={cursorData}
 							showCursor={showCursor}
 							cursorScale={cursorScale}
+							cursorPressedScale={cursorPressedScale}
 							onPlaybackTimeChange={setPlaybackTime}
 						/>
 						<div className="h-8" />
@@ -165,6 +167,8 @@ export const FileAvailable: React.FC<{
 											setShowCursor={setShowCursor}
 											cursorScale={cursorScale}
 											setCursorScale={setCursorScale}
+											cursorPressedScale={cursorPressedScale}
+											setCursorPressedScale={setCursorPressedScale}
 										/>
 									</div>
 								) : null}

--- a/packages/convert/app/components/MediaPlayer.tsx
+++ b/packages/convert/app/components/MediaPlayer.tsx
@@ -123,6 +123,7 @@ const RemotionMediaPreview: React.FC<{
 	readonly mirrorVertical: boolean;
 	readonly cursorData: CanvasCaptureCursorData | null;
 	readonly cursorScale: number;
+	readonly cursorPressedScale: number;
 }> = ({
 	src,
 	isAudio,
@@ -132,6 +133,7 @@ const RemotionMediaPreview: React.FC<{
 	mirrorVertical,
 	cursorData,
 	cursorScale,
+	cursorPressedScale,
 }) => {
 	const frame = useCurrentFrame();
 	const {durationInFrames, width, height} = useVideoConfig();
@@ -154,6 +156,7 @@ const RemotionMediaPreview: React.FC<{
 						<CanvasCaptureCursor
 							cursorData={cursorData}
 							cursorScale={cursorScale}
+							cursorPressedScale={cursorPressedScale}
 						/>
 					) : null}
 				</div>
@@ -192,6 +195,7 @@ export function VideoPlayer({
 	cursorData,
 	showCursor,
 	cursorScale,
+	cursorPressedScale,
 	onPlaybackTimeChange,
 }: {
 	readonly src: Source;
@@ -213,6 +217,7 @@ export function VideoPlayer({
 	readonly cursorData: CanvasCaptureCursorData | null;
 	readonly showCursor: boolean;
 	readonly cursorScale: number;
+	readonly cursorPressedScale: number;
 	readonly onPlaybackTimeChange: (timeInSeconds: number) => void;
 	readonly setUnclampedRect: React.Dispatch<
 		React.SetStateAction<CropRectangle>
@@ -321,6 +326,7 @@ export function VideoPlayer({
 							mirrorVertical,
 							cursorData: showCursor ? cursorData : null,
 							cursorScale,
+							cursorPressedScale,
 						}}
 						durationInFrames={durationInFrames}
 						compositionWidth={playerDimensions.width}

--- a/packages/convert/app/lib/canvas-capture-conversion.ts
+++ b/packages/convert/app/lib/canvas-capture-conversion.ts
@@ -2,11 +2,11 @@ import {resolveCursor} from '@remotion/mac-cursors';
 import {VideoSample, type CropRectangle} from 'mediabunny';
 import type {Dimensions} from './calculate-new-dimensions-from-dimensions';
 import {normalizeVideoRotation} from './calculate-new-dimensions-from-dimensions';
-import type {
-	CanvasCaptureCursorData,
-	CanvasCaptureMouseMovement,
+import type {CanvasCaptureCursorData} from './canvas-capture-metadata';
+import {
+	findCanvasCaptureCursorAtTime,
+	isCanvasCapturePointerDownAtTime,
 } from './canvas-capture-metadata';
-import {findCanvasCaptureCursorAtTime} from './canvas-capture-metadata';
 
 export const CURSOR_SAMPLE_MERGE_THRESHOLD_IN_SECONDS = 0.001;
 
@@ -19,55 +19,55 @@ export type CanvasCaptureSampleMoment = {
 export const getCanvasCaptureSampleMoments = ({
 	timestamp,
 	duration,
-	mouseMovements,
+	cursorStateChanges,
 }: {
 	readonly timestamp: number;
 	readonly duration: number;
-	readonly mouseMovements: readonly CanvasCaptureMouseMovement[];
+	readonly cursorStateChanges: readonly {readonly timeInSeconds: number}[];
 }): CanvasCaptureSampleMoment[] => {
 	const endTimestamp = timestamp + duration;
 	const moments: Array<Omit<CanvasCaptureSampleMoment, 'duration'>> = [
 		{timestamp, cursorLookupTimestamp: timestamp},
 	];
 	let low = 0;
-	let high = mouseMovements.length;
+	let high = cursorStateChanges.length;
 	while (low < high) {
 		const middle = Math.floor((low + high) / 2);
-		if (mouseMovements[middle].timeInSeconds < timestamp) {
+		if (cursorStateChanges[middle].timeInSeconds < timestamp) {
 			low = middle + 1;
 		} else {
 			high = middle;
 		}
 	}
 
-	for (let index = low; index < mouseMovements.length; index++) {
-		const movement = mouseMovements[index];
-		if (movement.timeInSeconds >= endTimestamp) {
+	for (let index = low; index < cursorStateChanges.length; index++) {
+		const stateChange = cursorStateChanges[index];
+		if (stateChange.timeInSeconds >= endTimestamp) {
 			break;
 		}
 
 		const previousMoment = moments[moments.length - 1];
 		if (
-			movement.timeInSeconds - previousMoment.timestamp <=
+			stateChange.timeInSeconds - previousMoment.timestamp <=
 			CURSOR_SAMPLE_MERGE_THRESHOLD_IN_SECONDS
 		) {
 			moments[moments.length - 1] = {
 				...previousMoment,
-				cursorLookupTimestamp: movement.timeInSeconds,
+				cursorLookupTimestamp: stateChange.timeInSeconds,
 			};
 			continue;
 		}
 
 		if (
-			endTimestamp - movement.timeInSeconds <=
+			endTimestamp - stateChange.timeInSeconds <=
 			CURSOR_SAMPLE_MERGE_THRESHOLD_IN_SECONDS
 		) {
 			continue;
 		}
 
 		moments.push({
-			timestamp: movement.timeInSeconds,
-			cursorLookupTimestamp: movement.timeInSeconds,
+			timestamp: stateChange.timeInSeconds,
+			cursorLookupTimestamp: stateChange.timeInSeconds,
 		});
 	}
 
@@ -171,6 +171,7 @@ export const getCanvasCaptureScaleToSample = ({
 export const makeCanvasCaptureVideoProcessor = ({
 	cursorData,
 	cursorScale,
+	cursorPressedScale,
 	sourceDimensions,
 	rotation,
 	crop,
@@ -180,6 +181,7 @@ export const makeCanvasCaptureVideoProcessor = ({
 }: {
 	readonly cursorData: CanvasCaptureCursorData;
 	readonly cursorScale: number;
+	readonly cursorPressedScale: number;
 	readonly sourceDimensions: Dimensions;
 	readonly rotation: number;
 	readonly crop: CropRectangle | null;
@@ -191,6 +193,13 @@ export const makeCanvasCaptureVideoProcessor = ({
 		...movement,
 		timeInSeconds: movement.timeInSeconds - timestampOffset,
 	}));
+	const pointerClicks = cursorData.pointerClicks.map((click) => ({
+		...click,
+		timeInSeconds: click.timeInSeconds - timestampOffset,
+	}));
+	const cursorStateChanges = [...mouseMovements, ...pointerClicks].sort(
+		(a, b) => a.timeInSeconds - b.timeInSeconds,
+	);
 	const imageCache = new Map<string, Promise<HTMLImageElement>>();
 
 	const loadImage = (src: string) => {
@@ -216,7 +225,7 @@ export const makeCanvasCaptureVideoProcessor = ({
 			const moments = getCanvasCaptureSampleMoments({
 				timestamp: sample.timestamp,
 				duration: sample.duration,
-				mouseMovements,
+				cursorStateChanges,
 			});
 			const sourceFrame = sample.toVideoFrame();
 			const outputSamples: VideoSample[] = [];
@@ -267,6 +276,12 @@ export const makeCanvasCaptureVideoProcessor = ({
 							const scale =
 								cursorData.captureMetadata.density *
 								cursorScale *
+								(isCanvasCapturePointerDownAtTime(
+									pointerClicks,
+									moment.cursorLookupTimestamp,
+								)
+									? cursorPressedScale
+									: 1) *
 								getCanvasCaptureScaleToSample({
 									sourceDimensions,
 									rotation,

--- a/packages/convert/app/lib/canvas-capture-metadata.ts
+++ b/packages/convert/app/lib/canvas-capture-metadata.ts
@@ -9,6 +9,11 @@ export type CanvasCaptureMouseMovement = {
 	readonly cursor: string;
 };
 
+export type CanvasCapturePointerClick = {
+	readonly timeInSeconds: number;
+	readonly type: 'pointer-down' | 'pointer-up';
+};
+
 export type CanvasCaptureMetadata = {
 	readonly density: number;
 };
@@ -16,6 +21,7 @@ export type CanvasCaptureMetadata = {
 export type CanvasCaptureCursorData = {
 	readonly captureMetadata: CanvasCaptureMetadata;
 	readonly mouseMovements: CanvasCaptureMouseMovement[];
+	readonly pointerClicks: CanvasCapturePointerClick[];
 };
 
 export const findCanvasCaptureCursorAtTime = (
@@ -38,6 +44,28 @@ export const findCanvasCaptureCursorAtTime = (
 	}
 
 	return latest;
+};
+
+export const isCanvasCapturePointerDownAtTime = (
+	pointerClicks: readonly CanvasCapturePointerClick[],
+	timeInSeconds: number,
+) => {
+	let low = 0;
+	let high = pointerClicks.length - 1;
+	let latest: CanvasCapturePointerClick | null = null;
+
+	while (low <= high) {
+		const middle = Math.floor((low + high) / 2);
+		const click = pointerClicks[middle];
+		if (click.timeInSeconds <= timeInSeconds) {
+			latest = click;
+			low = middle + 1;
+		} else {
+			high = middle - 1;
+		}
+	}
+
+	return latest?.type === 'pointer-down';
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -94,9 +122,35 @@ export const parseCanvasCaptureCursorData = (
 		});
 	}
 
+	const pointerClicks: CanvasCapturePointerClick[] = [];
+	if (parsed.pointerClicks !== undefined) {
+		if (!Array.isArray(parsed.pointerClicks)) {
+			return null;
+		}
+
+		for (const click of parsed.pointerClicks) {
+			if (
+				!isRecord(click) ||
+				!isFiniteNumber(click.timeInSeconds) ||
+				click.timeInSeconds < 0 ||
+				(click.type !== 'pointer-down' && click.type !== 'pointer-up')
+			) {
+				return null;
+			}
+
+			pointerClicks.push({
+				timeInSeconds: click.timeInSeconds,
+				type: click.type,
+			});
+		}
+	}
+
 	return {
 		captureMetadata: {density: parsed.captureMetadata.density},
 		mouseMovements: mouseMovements.sort(
+			(a, b) => a.timeInSeconds - b.timeInSeconds,
+		),
+		pointerClicks: pointerClicks.sort(
 			(a, b) => a.timeInSeconds - b.timeInSeconds,
 		),
 	};

--- a/packages/convert/test/canvas-capture-conversion.test.ts
+++ b/packages/convert/test/canvas-capture-conversion.test.ts
@@ -17,11 +17,12 @@ test('samples video frames and cursor changes while merging tiny deltas', () => 
 	const moments = getCanvasCaptureSampleMoments({
 		timestamp: 1,
 		duration: 0.04,
-		mouseMovements: [
+		cursorStateChanges: [
 			movement(0.5),
 			movement(1.0005),
 			movement(1.01),
 			movement(1.0104),
+			{timeInSeconds: 1.02},
 			movement(1.0395),
 			movement(1.05),
 		],
@@ -41,9 +42,14 @@ test('samples video frames and cursor changes while merging tiny deltas', () => 
 			timestamp: 1.01,
 			cursorLookupTimestamp: 1.0104,
 		},
+		{
+			timestamp: 1.02,
+			cursorLookupTimestamp: 1.02,
+		},
 	]);
 	expect(moments[0].duration).toBeCloseTo(0.01);
-	expect(moments[1].duration).toBeCloseTo(0.03);
+	expect(moments[1].duration).toBeCloseTo(0.01);
+	expect(moments[2].duration).toBeCloseTo(0.02);
 });
 
 test('maps cursor coordinates through rotation, crop, and resize', () => {

--- a/packages/convert/test/canvas-capture-cursor.test.tsx
+++ b/packages/convert/test/canvas-capture-cursor.test.tsx
@@ -19,6 +19,7 @@ test('renders the recorded cursor at its captured position in the Player', async
 			fps={30}
 			inputProps={{
 				cursorScale: 0.5,
+				cursorPressedScale: 0.8,
 				cursorData: {
 					captureMetadata: {density: 2},
 					mouseMovements: [
@@ -29,6 +30,7 @@ test('renders the recorded cursor at its captured position in the Player', async
 							cursor: `url("${customCursor}") 6 7, pointer`,
 						},
 					],
+					pointerClicks: [{timeInSeconds: 0, type: 'pointer-down'}],
 				},
 			}}
 		/>,
@@ -37,7 +39,7 @@ test('renders the recorded cursor at its captured position in the Player', async
 	await waitFor(() => {
 		const cursor = rendered.container.querySelector<HTMLImageElement>('img');
 		expect(cursor?.src).toBe(customCursor);
-		expect(cursor?.style.scale).toBe('1');
+		expect(cursor?.style.scale).toBe('0.8');
 		expect(cursor?.style.marginLeft).toBe('-6px');
 		expect(cursor?.style.marginTop).toBe('-7px');
 		expect(cursor?.parentElement?.style.left).toBe('200px');

--- a/packages/convert/test/canvas-capture-metadata.test.ts
+++ b/packages/convert/test/canvas-capture-metadata.test.ts
@@ -24,6 +24,10 @@ test('parses cursor data embedded by the canvas capture extension', () => {
 						cursor: 'pointer',
 					},
 				],
+				pointerClicks: [
+					{timeInSeconds: 0.75, type: 'pointer-down'},
+					{timeInSeconds: 1, type: 'pointer-up'},
+				],
 			}),
 		},
 	});
@@ -38,6 +42,10 @@ test('parses cursor data embedded by the canvas capture extension', () => {
 				cursor: 'pointer',
 			},
 		],
+		pointerClicks: [
+			{timeInSeconds: 0.75, type: 'pointer-down'},
+			{timeInSeconds: 1, type: 'pointer-up'},
+		],
 	});
 
 	expect(
@@ -45,5 +53,19 @@ test('parses cursor data embedded by the canvas capture extension', () => {
 			raw: {[CAPTURE_METADATA_TAG_KEY]: '{not JSON'},
 		}),
 	).toBeNull();
+	expect(
+		parseCanvasCaptureCursorData({
+			raw: {
+				[CAPTURE_METADATA_TAG_KEY]: JSON.stringify({
+					captureMetadata: {density: 1},
+					mouseMovements: [],
+				}),
+			},
+		}),
+	).toEqual({
+		captureMetadata: {density: 1},
+		mouseMovements: [],
+		pointerClicks: [],
+	});
 	expect(parseCanvasCaptureCursorData({title: 'Regular video'})).toBeNull();
 });

--- a/packages/convert/test/cursor-controls.test.tsx
+++ b/packages/convert/test/cursor-controls.test.tsx
@@ -10,6 +10,7 @@ const CursorControlsFixture: React.FC<{readonly available: boolean}> = ({
 }) => {
 	const [showCursor, setShowCursor] = useState(true);
 	const [cursorScale, setCursorScale] = useState(1);
+	const [cursorPressedScale, setCursorPressedScale] = useState(0.8);
 
 	return (
 		<CursorControls
@@ -18,6 +19,8 @@ const CursorControlsFixture: React.FC<{readonly available: boolean}> = ({
 			setShowCursor={setShowCursor}
 			cursorScale={cursorScale}
 			setCursorScale={setCursorScale}
+			cursorPressedScale={cursorPressedScale}
+			setCursorPressedScale={setCursorPressedScale}
 		/>
 	);
 };
@@ -31,10 +34,19 @@ test('only offers enabled cursor controls for canvas captures', () => {
 	expect(showCursor.getAttribute('aria-checked')).toBe('true');
 	const cursorScale = rendered.getByRole('slider', {name: 'Cursor scale'});
 	expect(rendered.getByText('1.00×')).not.toBeNull();
+	const cursorPressedScale = rendered.getByRole('slider', {
+		name: 'Pressed cursor scale',
+	});
+	expect(rendered.getByText('0.80×')).not.toBeNull();
 	fireEvent.keyDown(cursorScale, {key: 'ArrowRight'});
 	expect(rendered.getByText('1.05×')).not.toBeNull();
+	fireEvent.keyDown(cursorPressedScale, {key: 'ArrowRight'});
+	expect(rendered.getByText('0.85×')).not.toBeNull();
 
 	fireEvent.click(showCursor);
 	expect(showCursor.getAttribute('aria-checked')).toBe('false');
 	expect(rendered.queryByRole('slider', {name: 'Cursor scale'})).toBeNull();
+	expect(
+		rendered.queryByRole('slider', {name: 'Pressed cursor scale'}),
+	).toBeNull();
 });

--- a/packages/convert/test/media-player.test.tsx
+++ b/packages/convert/test/media-player.test.tsx
@@ -43,6 +43,7 @@ const TrimmingPlayer = () => {
 			cursorData={null}
 			showCursor={false}
 			cursorScale={1}
+			cursorPressedScale={0.8}
 			onPlaybackTimeChange={() => undefined}
 		/>
 	);


### PR DESCRIPTION
## Summary

- parse pointer-down and pointer-up events from canvas capture metadata
- scale pressed cursors to 0.8x by default in the preview and converted output
- add a control for configuring the pressed cursor scale
- split converted samples at pointer state changes for accurate click timing

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/convert && bun test test`
