### PR TITLE
`@remotion/studio`: Select newly created compositions

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -187,6 +187,47 @@ test.describe('visual mode', () => {
 		});
 	});
 
+	test('should navigate to a newly created composition', async ({page}) => {
+		const compositionId = 'NewlyCreatedComposition';
+		const compositionFile = path.join(
+			exampleDir,
+			'src',
+			`${compositionId}.tsx`,
+		);
+
+		try {
+			await page.goto(`${STUDIO_URL}/schema-test`);
+			await expect(page).toHaveTitle(/schema-test/, {timeout: 15_000});
+
+			await page.getByRole('button', {name: 'File', exact: true}).click();
+			await page
+				.getByRole('button', {name: 'New composition...', exact: true})
+				.click();
+			await page
+				.getByRole('textbox', {name: 'Composition ID'})
+				.fill(compositionId);
+
+			const createButton = page.getByRole('button', {
+				name: /Add to .*/,
+			});
+			await expect(createButton).toBeEnabled();
+			await createButton.click();
+
+			await expect(page).toHaveURL(`${STUDIO_URL}/${compositionId}`, {
+				timeout: 5_000,
+			});
+			await expect(page).toHaveTitle(new RegExp(compositionId), {
+				timeout: 5_000,
+			});
+		} finally {
+			const undoButton = page.getByRole('button', {name: /^Undo/});
+			if (await undoButton.isEnabled()) {
+				await undoButton.click();
+				await expect.poll(() => fs.existsSync(compositionFile)).toBe(false);
+			}
+		}
+	});
+
 	test('untoggling the free license removes it from the config', async ({
 		page,
 	}) => {

--- a/packages/studio/src/helpers/use-create-composition.ts
+++ b/packages/studio/src/helpers/use-create-composition.ts
@@ -28,22 +28,6 @@ const toPascalCase = (value: string) => {
 	return candidate;
 };
 
-const waitForComposition = (compositionId: string) => {
-	return new Promise<void>((resolve) => {
-		const started = Date.now();
-		const interval = window.setInterval(() => {
-			const compositionNames = window.remotion_getCompositionNames?.() ?? [];
-			if (
-				compositionNames.includes(compositionId) ||
-				Date.now() - started > 10000
-			) {
-				window.clearInterval(interval);
-				resolve();
-			}
-		}, 100);
-	});
-};
-
 export const getUniqueCompositionName = (
 	compositions: _InternalTypes['AnyComposition'][],
 ) => {
@@ -140,7 +124,6 @@ export const useCreateComposition = ({
 			});
 
 			if (result.success) {
-				await waitForComposition(newId);
 				selectComposition(
 					{
 						id: newId,


### PR DESCRIPTION
## Summary

- select a newly created composition immediately after its codemod succeeds
- remove the stale composition-name polling that delayed navigation by 10 seconds
- add a Studio Playwright regression test covering URL and title navigation

## Test plan

- `bunx playwright test e2e/studio.test.mts --grep 'should navigate to a newly created composition'`
- `bun run build`
- `bun run stylecheck`
- manually create a composition in Studio and verify immediate navigation

Closes #10331
