### PR TITLE
Fix editor fallback action

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -562,6 +562,92 @@ test.describe('visual mode', () => {
 			),
 		).toEqual([]);
 	});
+
+	test('should fall back to the preferred installed editor if no editor is running', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'remotion_editorName', {
+				configurable: true,
+				get: () => null,
+				set: () => undefined,
+			});
+		});
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultEditor: null,
+						installedEditors: [
+							{
+								id: 'cursor',
+								name: 'Cursor',
+								nameWithType: 'Cursor Editor',
+							},
+							{id: 'vscode', name: 'Code', nameWithType: 'Code'},
+							{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+						],
+					},
+				},
+			});
+		});
+		await page.route('**/api/default-coding-agent-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultCodingAgent: null,
+						installedCodingAgents: [],
+						installedTerminals: [],
+					},
+				},
+			});
+		});
+		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/open-in-editor', async (route) => {
+			openInEditorRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {success: true, data: {success: true}},
+			});
+		});
+
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+		const projectLocation = page.getByTitle(exampleDir);
+		const primaryOpenInZed = projectLocation.getByRole('button', {
+			name: 'Open in Zed',
+			exact: true,
+		});
+		await expect(primaryOpenInZed).toBeVisible({timeout: 15_000});
+		await expect(primaryOpenInZed).toBeEnabled();
+
+		await projectLocation
+			.getByRole('button', {name: 'Open in another app', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Cursor', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Code', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Zed', exact: true}),
+		).toHaveCount(0);
+
+		await page.keyboard.press('Escape');
+		await expect(
+			page.getByRole('button', {name: 'Cursor', exact: true}),
+		).toBeHidden();
+		await primaryOpenInZed.click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+			]);
+	});
+
 	test('should use standalone and contextual app names in portaled context menus', async ({
 		context,
 		page,

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -94,6 +94,9 @@ export const InspectorOpenInEditor: React.FC<{
 	);
 
 	const preferredEditorId = getPreferredEditorId(editorInfo);
+	const preferredEditor = editorInfo?.installedEditors.find(
+		(editor) => editor.id === preferredEditorId,
+	);
 	const openWithCodingAgent = useCallback(
 		async (codingAgentId: DefaultCodingAgent, codingAgentName: string) => {
 			try {
@@ -110,15 +113,21 @@ export const InspectorOpenInEditor: React.FC<{
 		},
 		[contextForAgents],
 	);
-	const editorName = window.remotion_editorName ?? 'default editor';
+	const editorName =
+		window.remotion_editorName ??
+		preferredEditor?.nameWithType ??
+		'default editor';
 	const canOpenDefault =
-		location !== null && window.remotion_editorName !== null;
+		location !== null &&
+		(window.remotion_editorName !== null || preferredEditorId !== null);
 	const onOpenDefault: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(event) => {
 			event.stopPropagation();
-			openWithEditor(null).catch(() => undefined);
+			openWithEditor(
+				window.remotion_editorName === null ? preferredEditorId : null,
+			).catch(() => undefined);
 		},
-		[openWithEditor],
+		[openWithEditor, preferredEditorId],
 	);
 	const onDropdownOpenChange = useCallback((open: boolean) => {
 		setDropdownOpened(open);

--- a/packages/studio/src/components/use-default-editor-info.ts
+++ b/packages/studio/src/components/use-default-editor-info.ts
@@ -13,13 +13,51 @@ export const canUseEditorPicker = (previewServerConnected: boolean) => {
 	);
 };
 
+const preferredFallbackEditorIds: EditorPickerId[] = [
+	'zed',
+	'vscode',
+	'cursor',
+];
+
 export const getPreferredEditorId = (
 	editorInfo: GetDefaultEditorInfoResponse | null,
 ): EditorPickerId | null => {
+	const runningEditorId = editorInfo?.installedEditors.find(
+		(editor) => editor.nameWithType === window.remotion_editorName,
+	)?.id;
+	if (runningEditorId) {
+		return runningEditorId;
+	}
+
+	if (window.remotion_editorName !== null) {
+		return null;
+	}
+
+	const configuredEditorId = editorInfo?.installedEditors.find(
+		(editor) => editor.id === editorInfo.defaultEditor,
+	)?.id;
+	if (configuredEditorId) {
+		return configuredEditorId;
+	}
+
 	return (
-		editorInfo?.installedEditors.find(
-			(editor) => editor.nameWithType === window.remotion_editorName,
-		)?.id ?? null
+		editorInfo?.installedEditors
+			.slice()
+			.sort((a, b) => {
+				const aPriority = preferredFallbackEditorIds.indexOf(a.id);
+				const bPriority = preferredFallbackEditorIds.indexOf(b.id);
+				const normalizedAPriority =
+					aPriority === -1 ? Number.POSITIVE_INFINITY : aPriority;
+				const normalizedBPriority =
+					bPriority === -1 ? Number.POSITIVE_INFINITY : bPriority;
+
+				if (normalizedAPriority !== normalizedBPriority) {
+					return normalizedAPriority - normalizedBPriority;
+				}
+
+				return a.nameWithType.localeCompare(b.nameWithType);
+			})
+			.at(0)?.id ?? null
 	);
 };
 

--- a/packages/studio/src/test/default-editor-info.test.ts
+++ b/packages/studio/src/test/default-editor-info.test.ts
@@ -1,0 +1,107 @@
+import {afterEach, expect, test} from 'bun:test';
+import {getPreferredEditorId} from '../components/use-default-editor-info';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
+});
+
+const installTestWindow = (editorName: string | null) => {
+	const testWindow: Pick<Window, 'remotion_editorName'> = {
+		remotion_editorName: editorName,
+	};
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: testWindow,
+	});
+};
+
+test('prefers the running editor when one is detected', () => {
+	installTestWindow('Cursor Editor');
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [
+				{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
+			],
+		}),
+	).toBe('cursor');
+});
+
+test('does not fall back if the running editor is not in the installed list', () => {
+	installTestWindow('Custom Editor');
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [
+				{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
+			],
+		}),
+	).toBe(null);
+});
+
+test('prefers the configured default editor before fallback ordering', () => {
+	installTestWindow(null);
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: 'cursor',
+			installedEditors: [
+				{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
+			],
+		}),
+	).toBe('cursor');
+});
+
+test('falls back to Zed, VS Code, Cursor, then alphabetical order', () => {
+	installTestWindow(null);
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [
+				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
+				{id: 'vscode', name: 'Code', nameWithType: 'Code'},
+				{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+			],
+		}),
+	).toBe('zed');
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [
+				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
+				{id: 'vscode', name: 'Code', nameWithType: 'Code'},
+			],
+		}),
+	).toBe('vscode');
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [
+				{id: 'webstorm', name: 'WebStorm', nameWithType: 'WebStorm'},
+				{
+					id: 'sublime-text',
+					name: 'Sublime Text',
+					nameWithType: 'Sublime Text',
+				},
+			],
+		}),
+	).toBe('sublime-text');
+});


### PR DESCRIPTION
## Summary

Fixes #10076.

When Studio cannot detect a running editor and no default editor is configured, the primary "Open in editor" action now uses the best installed editor instead of becoming disabled. The fallback order follows the issue: Zed first, then VS Code, then Cursor, then the remaining installed editors alphabetically.

The existing running-editor behavior stays unchanged. If Studio has a running editor name, the primary action still opens that editor and does not silently switch to a fallback.

## Verification

- bun test src/test/default-editor-info.test.ts src/test/sequence-context-menu-items.test.ts
- OPEN_SOURCE_PW_BROWSERS_PATH=/Users/godcorn/cursor/open-source/.cache/ms-playwright PLAYWRIGHT_BROWSERS_PATH="$OPEN_SOURCE_PW_BROWSERS_PATH" bunx playwright test e2e/studio.test.mts -g "should fall back to the preferred installed editor"
- bunx turbo run make --filter="@remotion/cli" --filter="@remotion/studio"
- bunx turbo run make --filter="@remotion/example"
- bun run formatting
- bun run lint (0 errors; existing warnings only)
