### PR TITLE
`@remotion/media`: Remove desynchronized canvas hint

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -182,7 +182,6 @@ export class MediaPlayer {
 		if (canvas) {
 			const context = canvas.getContext('2d', {
 				alpha: true,
-				desynchronized: true,
 			}) as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
 
 			if (!context) {

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -230,7 +230,6 @@ const VideoForPreviewAssertedShowing: React.FC<
 		canvas.height = cached.height;
 		const ctx = canvas.getContext('2d', {
 			alpha: true,
-			desynchronized: true,
 		});
 		if (!ctx) {
 			return;


### PR DESCRIPTION
## Summary

Remove the `desynchronized` canvas context hint from `@remotion/media` video playback.

This keeps canvas presentation synchronized with the browser compositor, including when drawing an initially cached frame between consecutive videos.

## Validation

- `bunx oxfmt packages/media/src/media-player.ts packages/media/src/video/video-for-preview.tsx --write`
- `bun run build`
- `bun run stylecheck`
