### PR TITLE
`template-render-server`: Prevent failed render from poisoning queue

### DIFF
--- a/packages/template-render-server/server/render-queue.ts
+++ b/packages/template-render-server/server/render-queue.ts
@@ -121,7 +121,8 @@ export const makeRenderQueue = ({
       },
     });
 
-    queue = queue.then(() => processRender(jobId));
+    const render = queue.then(() => processRender(jobId));
+    queue = render.catch(() => undefined);
   };
 
   function createJob(data: JobData) {


### PR DESCRIPTION
## Summary

- keep the render-server template queue usable after a queued render rejects
- preserve serialization by continuing the shared chain from a handled promise

Follow-up to the queue isolation review note on #10211.

## Testing

- `bunx turbo run lint --filter=template-render-server`
- `bun run build`
- `bun run stylecheck`
