### PR TITLE
`@remotion/studio`: Adapt outline handles to small selections

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -138,11 +138,16 @@ test.describe('inspector section collapse', () => {
 			() => !document.body.innerText.includes('Loading...'),
 			{timeout: 30_000},
 		);
-		await page.getByText('Tiny transform', {exact: true}).first().click();
 		const tinyScaleEdges = page.locator(
 			'[data-remotion-studio-scale-edge-contains-selection="true"]',
 		);
-		await expect(tinyScaleEdges).toHaveCount(2);
+		const tinyTransform = page
+			.getByText('Tiny transform', {exact: true})
+			.first();
+		await expect(async () => {
+			await tinyTransform.click();
+			await expect(tinyScaleEdges).toHaveCount(2, {timeout: 1_000});
+		}).toPass({timeout: 30_000});
 		expect(
 			await tinyScaleEdges.evaluateAll((edges) =>
 				edges.map((edge) =>

--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -138,6 +138,23 @@ test.describe('inspector section collapse', () => {
 			() => !document.body.innerText.includes('Loading...'),
 			{timeout: 30_000},
 		);
+		await page.getByText('Tiny transform', {exact: true}).first().click();
+		const tinyScaleEdges = page.locator(
+			'[data-remotion-studio-scale-edge-contains-selection="true"]',
+		);
+		await expect(tinyScaleEdges).toHaveCount(2);
+		expect(
+			await tinyScaleEdges.evaluateAll((edges) =>
+				edges.map((edge) =>
+					edge.getAttribute('data-remotion-studio-scale-edge'),
+				),
+			),
+		).toEqual(['right', 'bottom']);
+		await expect(
+			page.locator(
+				'[data-remotion-studio-rotation-corner-contains-selection="true"]',
+			),
+		).toHaveCount(0);
 
 		await select2DTransformAndWaitForInspector(page);
 		await expect(

--- a/packages/example/src/VisualMode3D.tsx
+++ b/packages/example/src/VisualMode3D.tsx
@@ -32,7 +32,7 @@ export const VisualMode3D: React.FC = () => {
 					height: 8,
 					rotate: '0deg',
 					scale: 1,
-					translate: '100px 100px',
+					translate: '450px 450px',
 					width: 8,
 				}}
 			>

--- a/packages/example/src/VisualMode3D.tsx
+++ b/packages/example/src/VisualMode3D.tsx
@@ -25,6 +25,19 @@ export const VisualMode3D: React.FC = () => {
 			>
 				<AbsoluteFill style={{backgroundColor: '#ff4d8d'}} />
 			</Sequence>
+			<Sequence
+				name="Tiny transform"
+				durationInFrames={120}
+				style={{
+					height: 8,
+					rotate: '0deg',
+					scale: 1,
+					translate: '100px 100px',
+					width: 8,
+				}}
+			>
+				<AbsoluteFill style={{backgroundColor: '#44cc88'}} />
+			</Sequence>
 		</AbsoluteFill>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -20,6 +20,7 @@ import {callApi} from './call-api';
 import {useConfirmationDialog} from './ConfirmationDialog';
 import {useSelectComposition} from './InitialCompositionLoader';
 import {showNotification} from './Notifications/NotificationCenter';
+import {getSelectedOutlineControlLayout} from './selected-outline-control-layout';
 import type {SelectedOutline} from './selected-outline-geometry';
 import {type SelectedOutlineSnapPoint} from './selected-outline-snap';
 import {
@@ -114,6 +115,10 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	const {setManuallyEnabled} = useContext(Transform3DModeStateContext);
 	const setHoveredSequence = useSetTimelineSequenceHover();
 	const targetRef = useRef(layoutTarget);
+	const controlLayout = useMemo(
+		() => getSelectedOutlineControlLayout(outline.points),
+		[outline.points],
+	);
 	useLayoutEffect(() => {
 		targetRef.current = layoutTarget;
 	}, [layoutTarget]);
@@ -537,12 +542,17 @@ const SelectedOutlineElementUnmemoized: React.FC<
 			/>
 			{controlTarget?.cropDrag === null &&
 			(layoutTarget?.containsSelection || hovered)
-				? (['top', 'right', 'bottom', 'left'] as const).map((edge) => (
+				? controlLayout.scaleEdges.map((edge) => (
 						<SelectedOutlineScaleEdgeLine
 							key={edge}
 							getAllScaleDragTargets={getAllScaleDragTargets}
 							dragging={dragging}
 							edge={edge}
+							hitWidth={
+								edge === 'top' || edge === 'bottom'
+									? controlLayout.scaleHitWidth.horizontal
+									: controlLayout.scaleHitWidth.vertical
+							}
 							outline={outline}
 							onContextMenuOpen={onContextMenuOpen}
 							onContextMenuOpenChange={onContextMenuOpenChange}
@@ -555,20 +565,20 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				: null}
 			{controlTarget?.cropDrag === null &&
 			(layoutTarget?.containsSelection || hovered)
-				? (
-						['top-left', 'top-right', 'bottom-right', 'bottom-left'] as const
-					).map((corner) => (
+				? controlLayout.rotationCorners.map(({corner, point}) => (
 						<SelectedOutlineRotationCornerHandle
 							key={corner}
 							getAllRotationDragTargets={getAllRotationDragTargets}
 							corner={corner}
 							dragging={dragging}
+							handlePoint={point}
 							outline={outline}
 							onContextMenuOpen={onContextMenuOpen}
 							onContextMenuOpenChange={onContextMenuOpenChange}
 							onDraggingChange={onDraggingChange}
 							onHoverChange={onHoverChange}
 							onSelect={onSelect}
+							radius={controlLayout.rotationHandleRadius}
 							target={controlTarget}
 						/>
 					))

--- a/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
+++ b/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
@@ -49,6 +49,7 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 	readonly getAllRotationDragTargets: () => readonly SelectedOutlineRotationDragTarget[];
 	readonly corner: SelectedOutlineRotationCorner;
 	readonly dragging: boolean;
+	readonly handlePoint: {readonly x: number; readonly y: number};
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpen: SelectedOutlineContextMenuOpenHandler;
@@ -58,17 +59,20 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
+	readonly radius: number;
 	readonly target: SelectedOutlineTarget | undefined;
 }> = ({
 	getAllRotationDragTargets,
 	corner,
 	dragging,
+	handlePoint,
 	outline,
 	onDraggingChange,
 	onContextMenuOpen,
 	onContextMenuOpenChange,
 	onHoverChange,
 	onSelect,
+	radius,
 	target,
 }) => {
 	const {getDragOverrides} = useContext(
@@ -340,9 +344,9 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 		<>
 			<circle
 				ref={circleRef}
-				cx={cornerInfo.point.x}
-				cy={cornerInfo.point.y}
-				r={12}
+				cx={handlePoint.x}
+				cy={handlePoint.y}
+				r={radius}
 				fill={TRANSPARENT}
 				stroke={TRANSPARENT}
 				vectorEffect="non-scaling-stroke"

--- a/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
+++ b/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
@@ -43,6 +43,7 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 	readonly getAllScaleDragTargets: () => readonly SelectedOutlineScaleDragTarget[];
 	readonly dragging: boolean;
 	readonly edge: SelectedOutlineScaleEdge;
+	readonly hitWidth: number;
 	readonly outline: SelectedOutline;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpen: SelectedOutlineContextMenuOpenHandler;
@@ -57,6 +58,7 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 	getAllScaleDragTargets,
 	dragging,
 	edge,
+	hitWidth,
 	outline,
 	onDraggingChange,
 	onContextMenuOpen,
@@ -280,7 +282,8 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 				x2={edgeInfo.end.x}
 				y2={edgeInfo.end.y}
 				stroke={TRANSPARENT}
-				strokeWidth={12}
+				strokeWidth={hitWidth}
+				strokeLinecap="butt"
 				vectorEffect="non-scaling-stroke"
 				pointerEvents="stroke"
 				cursor={edgeInfo.cursor}

--- a/packages/studio/src/components/selected-outline-control-layout.ts
+++ b/packages/studio/src/components/selected-outline-control-layout.ts
@@ -1,0 +1,126 @@
+import type {OutlinePoint, SelectedOutline} from './selected-outline-geometry';
+
+export type SelectedOutlineControlCorner =
+	| 'top-left'
+	| 'top-right'
+	| 'bottom-right'
+	| 'bottom-left';
+
+// Outline points are measured in overlay pixels, keeping these sizes independent of canvas zoom.
+const handleSize = 8;
+const targetHalfSize = 4.5;
+const smallOutlineSize = handleSize * 4;
+const tinyOutlineSize = handleSize * 2;
+
+const distance = (from: OutlinePoint, to: OutlinePoint) =>
+	Math.hypot(to.x - from.x, to.y - from.y);
+
+const normalize = (point: OutlinePoint): OutlinePoint | null => {
+	const length = Math.hypot(point.x, point.y);
+	if (length < 0.001) {
+		return null;
+	}
+
+	return {x: point.x / length, y: point.y / length};
+};
+
+const getRotationHandlePoint = ({
+	corner,
+	points,
+	radius,
+}: {
+	readonly corner: SelectedOutlineControlCorner;
+	readonly points: SelectedOutline['points'];
+	readonly radius: number;
+}): OutlinePoint => {
+	const [topLeft, topRight, bottomRight, bottomLeft] = points;
+	const {point, adjacent} = {
+		'top-left': {point: topLeft, adjacent: [topRight, bottomLeft]},
+		'top-right': {point: topRight, adjacent: [topLeft, bottomRight]},
+		'bottom-right': {point: bottomRight, adjacent: [topRight, bottomLeft]},
+		'bottom-left': {point: bottomLeft, adjacent: [topLeft, bottomRight]},
+	}[corner];
+	const firstDirection = normalize({
+		x: point.x - adjacent[0].x,
+		y: point.y - adjacent[0].y,
+	});
+	const secondDirection = normalize({
+		x: point.x - adjacent[1].x,
+		y: point.y - adjacent[1].y,
+	});
+	const outlineCenter = {
+		x: (topLeft.x + topRight.x + bottomRight.x + bottomLeft.x) / 4,
+		y: (topLeft.y + topRight.y + bottomRight.y + bottomLeft.y) / 4,
+	};
+	const fallbackDirection = normalize({
+		x: point.x - outlineCenter.x,
+		y: point.y - outlineCenter.y,
+	});
+	const direction =
+		firstDirection === null || secondDirection === null
+			? fallbackDirection
+			: normalize({
+					x: firstDirection.x + secondDirection.x,
+					y: firstDirection.y + secondDirection.y,
+				});
+
+	if (direction === null) {
+		return point;
+	}
+
+	return {
+		x: point.x + direction.x * radius,
+		y: point.y + direction.y * radius,
+	};
+};
+
+export const getSelectedOutlineControlLayout = (
+	points: SelectedOutline['points'],
+) => {
+	const [topLeft, topRight, bottomRight, bottomLeft] = points;
+	const horizontalExtent =
+		(distance(topLeft, topRight) + distance(bottomLeft, bottomRight)) / 2;
+	const verticalExtent =
+		(distance(topLeft, bottomLeft) + distance(topRight, bottomRight)) / 2;
+	const isSmallX = horizontalExtent < smallOutlineSize;
+	const isSmallY = verticalExtent < smallOutlineSize;
+	const isTinyX = horizontalExtent < tinyOutlineSize;
+	const isTinyY = verticalExtent < tinyOutlineSize;
+	const targetHalfSizeX = isSmallX ? targetHalfSize / 2 : targetHalfSize;
+	const targetHalfSizeY = isSmallY ? targetHalfSize / 2 : targetHalfSize;
+	const rotationHandleRadius = Math.max(targetHalfSizeX, targetHalfSizeY) * 1.5;
+	const scaleEdges = (['top', 'right', 'bottom', 'left'] as const).filter(
+		(edge) => {
+			// Preserve one scale control per axis when opposite edge targets would overlap.
+			if (edge === 'top') {
+				return !isTinyY;
+			}
+
+			if (edge === 'left') {
+				return !isTinyX;
+			}
+
+			return true;
+		},
+	);
+	const rotationCorners = (
+		['top-left', 'top-right', 'bottom-right', 'bottom-left'] as const
+	).map((corner) => ({
+		corner,
+		point: getRotationHandlePoint({
+			corner,
+			points,
+			radius: rotationHandleRadius,
+		}),
+	}));
+
+	return {
+		rotationCorners: isTinyX || isTinyY ? [] : rotationCorners,
+		rotationHandleRadius,
+		scaleEdges,
+		scaleHitWidth: {
+			horizontal: targetHalfSizeY * 2,
+			vertical: targetHalfSizeX * 2,
+		},
+	};
+};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {getInspectorSelectableItems} from '../components/InspectorSequenceSection';
+import {getSelectedOutlineControlLayout} from '../components/selected-outline-control-layout';
 import type {SelectedOutline} from '../components/selected-outline-geometry';
 import {
 	cropOutlinePoints,
@@ -6629,6 +6630,48 @@ test('Selected outline rotation corners use the outline corners and center', () 
 		'<svg width="24" height="24"',
 	);
 	expect(topRight.cursor).toContain('") 12 12, alias');
+});
+
+test('Selected outline controls adapt to the screen-space outline size', () => {
+	const normal = getSelectedOutlineControlLayout([
+		{x: 0, y: 0},
+		{x: 100, y: 0},
+		{x: 100, y: 50},
+		{x: 0, y: 50},
+	]);
+	const small = getSelectedOutlineControlLayout([
+		{x: 0, y: 0},
+		{x: 24, y: 0},
+		{x: 24, y: 24},
+		{x: 0, y: 24},
+	]);
+	const tiny = getSelectedOutlineControlLayout([
+		{x: 0, y: 0},
+		{x: 8, y: 0},
+		{x: 8, y: 8},
+		{x: 0, y: 8},
+	]);
+	const thin = getSelectedOutlineControlLayout([
+		{x: 0, y: 0},
+		{x: 8, y: 0},
+		{x: 8, y: 40},
+		{x: 0, y: 40},
+	]);
+
+	expect(normal.scaleEdges).toEqual(['top', 'right', 'bottom', 'left']);
+	expect(normal.scaleHitWidth).toEqual({horizontal: 9, vertical: 9});
+	expect(normal.rotationHandleRadius).toBe(6.75);
+	expect(normal.rotationCorners).toHaveLength(4);
+	expect(normal.rotationCorners[0].point.x).toBeCloseTo(-4.773);
+	expect(normal.rotationCorners[0].point.y).toBeCloseTo(-4.773);
+	expect(small.scaleHitWidth).toEqual({horizontal: 4.5, vertical: 4.5});
+	expect(small.rotationHandleRadius).toBe(3.375);
+	expect(small.rotationCorners).toHaveLength(4);
+	expect(tiny.scaleEdges).toEqual(['right', 'bottom']);
+	expect(tiny.rotationCorners).toEqual([]);
+	expect(thin.scaleEdges).toEqual(['top', 'right', 'bottom']);
+	expect(thin.scaleHitWidth).toEqual({horizontal: 9, vertical: 4.5});
+	expect(thin.rotationCorners).toEqual([]);
 });
 
 test('Selected outline rotation pivot follows transform origin', () => {


### PR DESCRIPTION
## Summary

- size Studio scale and rotation hit targets in screen space
- move rotation targets outside outline corners and reduce their radius
- collapse overlapping controls on small and tiny outlines while preserving one scale handle per axis
- cover normal, small, thin, and tiny layouts with geometry and browser tests

## Tests

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bunx playwright test e2e/inspector-section-collapse.test.mts --grep 'selects 3D rotation'`
- `bun run build`
- `bun run stylecheck`

Red/green verified by disabling the tiny-outline breakpoint and confirming the browser test reported four scale targets instead of two.

Closes #10204
