### PR TITLE
Internal: Stabilize canvas context menu E2E test

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -158,16 +158,18 @@ test.describe('visual mode', () => {
 		await page.mouse.click(canvasItemCenter.x, canvasItemCenter.y, {
 			button: 'right',
 		});
-		await page.mouse.move(10, 10);
-		// Portals do not reliably trigger pointerleave in headless Chromium.
-		await page
-			.locator('.remotion-studio-composition-container')
-			.dispatchEvent('pointerleave');
 
 		const duplicateButton = page.getByRole('button', {
 			name: 'Duplicate',
 			exact: true,
 		});
+		await expect(duplicateButton).toBeVisible();
+
+		await page.mouse.move(10, 10);
+		// Portals do not reliably trigger pointerleave in headless Chromium.
+		await page
+			.locator('.remotion-studio-composition-container')
+			.dispatchEvent('pointerleave');
 		await expect(duplicateButton).toBeVisible();
 	});
 


### PR DESCRIPTION
## Summary

- wait for the canvas context menu to finish opening before simulating the pointer leaving the canvas
- keep the final assertion that the menu remains visible after the leave event
- remove the race between asynchronous menu item resolution and outline cleanup seen in CI

Tracked in #8375.

## Testing

- `bunx playwright test e2e/studio.test.mts --grep "should keep canvas item context menus open"` (10 successful focused executions total)
- `bun run build`
- `bun run stylecheck`
