### PR TITLE
Internal: Add docs Studio Zed task

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -30,5 +30,13 @@
 		"reveal": "always",
 		"hide": "never",
 		"save": "all"
+	},
+	{
+		"label": "start docs studio",
+		"command": "bun remotion",
+		"cwd": "$ZED_WORKTREE_ROOT/packages/docs",
+		"reveal": "always",
+		"hide": "never",
+		"save": "all"
 	}
 ]


### PR DESCRIPTION
## Summary

- add a Zed task that starts Remotion Studio from `packages/docs`
- keep the task running in a visible terminal for local docs development

## Verification

- `bunx oxfmt .zed/tasks.json --write`
- `bun run build`
- `bun run stylecheck`
