### PR TITLE
`@remotion/studio`: Fix modal dismissal after pointer movement

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -356,6 +356,11 @@ test.describe('visual mode', () => {
 				codingAgentInfoRequests: 1,
 				editorInfoRequests: 1,
 			});
+			await page.mouse.move(10, 100);
+			await page.mouse.down();
+			await page.mouse.move(13, 101);
+			await page.mouse.up();
+			await expect(dialog).toBeHidden();
 		} finally {
 			fs.writeFileSync(configFile, configBeforeTest);
 		}
@@ -1070,12 +1075,9 @@ test.describe('visual mode', () => {
 		await openInAnotherApp.click();
 		await expect(changeDefaultApps).toBeVisible();
 		// The menu overlay intercepts pointerleave; clicking it closes the menu
-		// through the same outside-click path a user would take. Retry the click
-		// until the new layer has registered as the highest z-index context.
-		await expect(async () => {
-			await page.mouse.click(10, 100);
-			await expect(changeDefaultApps).toBeHidden({timeout: 1_000});
-		}).toPass({timeout: 10_000});
+		// through the same outside-click path a user would take.
+		await page.mouse.click(10, 100);
+		await expect(changeDefaultApps).toBeHidden();
 		await expect(openInAnotherApp).toHaveCSS(
 			'background-color',
 			'rgba(0, 0, 0, 0)',

--- a/packages/studio/src/components/ColorPicker/AlphaSlider.tsx
+++ b/packages/studio/src/components/ColorPicker/AlphaSlider.tsx
@@ -5,7 +5,7 @@ import {
 	COLOR_PICKER_ALPHA_TRANSPARENT,
 	COLOR_PICKER_HANDLE_SHADOW,
 } from '../../helpers/colors';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {
 	CHECKER_BACKGROUND_COLOR,
 	CHECKER_BACKGROUND_IMAGE,
@@ -85,9 +85,9 @@ export const AlphaSlider: React.FC<{
 			updateFromEvent(e.clientX, false);
 			let lastClientX = e.clientX;
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event: e.nativeEvent,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: (ev) => {
 					lastClientX = ev.clientX;
 					updateFromEvent(ev.clientX, false);

--- a/packages/studio/src/components/ColorPicker/HueSlider.tsx
+++ b/packages/studio/src/components/ColorPicker/HueSlider.tsx
@@ -5,7 +5,7 @@ import {
 	COLOR_PICKER_HANDLE_SHADOW,
 	COLOR_PICKER_HUE_GRADIENT,
 } from '../../helpers/colors';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 
 const SLIDER_HEIGHT = 12;
 const HANDLE_WIDTH = 8;
@@ -56,9 +56,9 @@ export const HueSlider: React.FC<{
 			updateFromEvent(e.clientX, false);
 			let lastClientX = e.clientX;
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event: e.nativeEvent,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: (ev) => {
 					lastClientX = ev.clientX;
 					updateFromEvent(ev.clientX, false);

--- a/packages/studio/src/components/ColorPicker/SaturationValueArea.tsx
+++ b/packages/studio/src/components/ColorPicker/SaturationValueArea.tsx
@@ -6,7 +6,7 @@ import {
 	COLOR_PICKER_SATURATION_BLACK_GRADIENT,
 	COLOR_PICKER_SATURATION_VALUE_GRADIENT,
 } from '../../helpers/colors';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 
 const AREA_HEIGHT = 140;
 
@@ -76,9 +76,9 @@ export const SaturationValueArea: React.FC<{
 			updateFromEvent(e.clientX, e.clientY, false);
 			let lastPosition = {clientX: e.clientX, clientY: e.clientY};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event: e.nativeEvent,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: (ev) => {
 					lastPosition = {clientX: ev.clientX, clientY: ev.clientY};
 					updateFromEvent(ev.clientX, ev.clientY, false);

--- a/packages/studio/src/components/EditorGuides/Guide.tsx
+++ b/packages/studio/src/components/EditorGuides/Guide.tsx
@@ -5,7 +5,7 @@ import {
 	isGuidePointerUpAClick,
 	type GuidePointerDownPosition,
 } from '../../helpers/editor-guide-selection';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import type {Guide} from '../../state/editor-guides';
 import {
 	EditorShowGuidesContext,
@@ -163,9 +163,9 @@ const GuideComp: React.FC<{
 			shouldCreateGuideRef.current = false;
 			setDraggingGuideId(() => guide.id);
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event: e.nativeEvent,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: (moveEvent) => {
 					updateHasMovedGuide(moveEvent.clientX, moveEvent.clientY);
 					moveGuidePointerRef.current?.(moveEvent);

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -10,7 +10,7 @@ import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
 import {getRulerPoints, getRulerScaleRange} from '../../helpers/editor-ruler';
 import type {AssetMetadata} from '../../helpers/get-asset-metadata';
 import type {Dimensions} from '../../helpers/is-current-selected-still';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {useStudioCanvasDimensions} from '../../helpers/use-studio-canvas-dimensions';
 import {
 	EditorShowGuidesContext,
@@ -260,9 +260,9 @@ export const EditorRulers: React.FC<{
 
 	const onPointerSessionStart = useCallback(
 		(event: React.PointerEvent<HTMLCanvasElement>, guideId: string) => {
-			startPointerSession({
+			startCapturedPointerSession({
 				event: event.nativeEvent,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: (moveEvent) => onMouseMove(moveEvent, guideId),
 				onEnd: () => finishGuideInteraction(guideId),
 			});

--- a/packages/studio/src/components/Menu/MenuItem.tsx
+++ b/packages/studio/src/components/Menu/MenuItem.tsx
@@ -8,7 +8,7 @@ import {
 	getBackgroundFromHoverState,
 } from '../../helpers/colors';
 import {HOVERABLE_CLASS_NAME, hoverableStyle} from '../../helpers/hoverable';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {MenuContent} from '../NewComposition/MenuContent';
@@ -119,9 +119,9 @@ export const MenuItem: React.FC<{
 
 				onItemSelected(id);
 
-				startPointerSession({
+				startCapturedPointerSession({
 					event: e.nativeEvent,
-					target: e.currentTarget,
+					captureTarget: e.currentTarget,
 					onEnd: (reason, evt) => {
 						if (
 							(reason === 'pointerup' || reason === 'buttons-released') &&

--- a/packages/studio/src/components/ModalContainer.tsx
+++ b/packages/studio/src/components/ModalContainer.tsx
@@ -62,7 +62,6 @@ export const ModalContainer: React.FC<{
 				disabled={noZIndex}
 				onOutsideClick={onOutsideClick}
 				onEscape={onEscape}
-				stackOnHighest
 			>
 				<div style={{...panel, ...panelStyle}}>{children}</div>
 			</HigherZIndex>

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -1,14 +1,11 @@
 import React, {useContext, useEffect} from 'react';
-import ReactDOM from 'react-dom';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {SelectedModalContext, SetSelectedModalContext} from '../state/modals';
-import {useZIndex} from '../state/z-index';
 import {AskAiModal} from './AskAiModal';
 import {ConfirmationDialog} from './ConfirmationDialog';
 import {EffectPickerModal} from './EffectPickerModal';
 import {InstallPackageModal} from './InstallPackage';
-import {getPortal} from './Menu/portals';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
 import {DeleteFolder} from './NewComposition/DeleteFolder';
 import {DuplicateComposition} from './NewComposition/DuplicateComposition';
@@ -31,7 +28,6 @@ export const Modals: React.FC<{
 }> = ({readOnlyStudio}) => {
 	const modalContextType = useContext(SelectedModalContext);
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
-	const {currentZIndex} = useZIndex();
 	const {previewServerState, subscribeToEvent} = useContext(
 		StudioServerConnectionCtx,
 	);
@@ -51,7 +47,7 @@ export const Modals: React.FC<{
 		});
 	}, [setSelectedModal, subscribeToEvent]);
 
-	return ReactDOM.createPortal(
+	return (
 		<>
 			{modalContextType && modalContextType.type === 'new-comp' && (
 				<NewComposition
@@ -217,9 +213,6 @@ export const Modals: React.FC<{
 				<SvgImportDialog state={modalContextType} />
 			)}
 			{getStudioAskAIEnabled() && <AskAiModal />}
-		</>,
-		// Modals must be above overlays opened from the editor, such as the
-		// floating sidebars used in the mobile layout.
-		getPortal(currentZIndex + 1),
+		</>
 	);
 };

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -7,7 +7,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {interpolate} from 'remotion';
 import {BLUE, TRANSPARENT} from '../../helpers/colors';
 import {noop} from '../../helpers/noop';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {getClickLock, setClickLock} from '../../state/input-dragger-click-lock';
 import {HigherZIndex} from '../../state/z-index';
 import {
@@ -657,9 +657,9 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 				onValueChange(nextValue);
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event: e.nativeEvent,
-				target,
+				captureTarget: target,
 				onMove: moveListener,
 				onEnd: (reason) => {
 					pointerDownRef.current = false;

--- a/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
+++ b/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
@@ -1,7 +1,7 @@
 import React, {useContext} from 'react';
 import {Internals} from 'remotion';
 import {TRANSPARENT} from '../helpers/colors';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {canvasRotationCursor} from './canvas-rotation-cursor';
 import {
@@ -251,9 +251,9 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 
 			// The polygon gates pointer-down, while the stable overlay keeps the
 			// session alive after the pointer leaves the selected item.
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: svg,
+				captureTarget: svg,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlineCropControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineCropControls.tsx
@@ -5,7 +5,7 @@ import {
 	SELECTED_OUTLINE_DROP_SHADOW,
 	TRANSPARENT,
 } from '../helpers/colors';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -342,9 +342,9 @@ const CropHandle: React.FC<{
 					});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -7,7 +7,7 @@ import {
 	TRANSPARENT,
 } from '../helpers/colors';
 import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ContextMenuForTarget} from './ContextMenu';
@@ -374,9 +374,9 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 					});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
+++ b/packages/studio/src/components/SelectedOutlineRotationCornerHandle.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useMemo, useRef} from 'react';
 import {Internals} from 'remotion';
 import {TRANSPARENT} from '../helpers/colors';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ContextMenuForTarget} from './ContextMenu';
 import {
@@ -307,9 +307,9 @@ export const SelectedOutlineRotationCornerHandle: React.FC<{
 					});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
+++ b/packages/studio/src/components/SelectedOutlineScaleEdgeLine.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useMemo, useRef} from 'react';
 import {Internals} from 'remotion';
 import {TRANSPARENT} from '../helpers/colors';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {ContextMenuForTarget} from './ContextMenu';
 import {
 	forceSpecificCursor,
@@ -246,9 +246,9 @@ export const SelectedOutlineScaleEdgeLine: React.FC<{
 					});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlineTransformOriginHandle.tsx
+++ b/packages/studio/src/components/SelectedOutlineTransformOriginHandle.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {BLUE, SELECTED_OUTLINE_DROP_SHADOW} from '../helpers/colors';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {
 	forceSpecificCursor,
@@ -339,9 +339,9 @@ export const SelectedOutlineTransformOriginHandle: React.FC<{
 					});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/SelectedOutlineUvControls.tsx
+++ b/packages/studio/src/components/SelectedOutlineUvControls.tsx
@@ -3,7 +3,7 @@ import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BLUE, SELECTED_OUTLINE_UV_DROP_SHADOW, WHITE} from '../helpers/colors';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
-import {startPointerSession} from '../helpers/pointer-session';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {
 	forceSpecificCursor,
@@ -398,9 +398,9 @@ const SelectedUvEllipseStartHandle: React.FC<{
 				});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});
@@ -544,9 +544,9 @@ const SelectedUvEllipseResizeHandle: React.FC<{
 				});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});
@@ -763,9 +763,9 @@ const SelectedUvEllipseRotationHandle: React.FC<{
 				});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});
@@ -1002,9 +1002,9 @@ const SelectedUvHandleCircle: React.FC<{
 				});
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: onPointerMove,
 				onEnd: onPointerUp,
 			});

--- a/packages/studio/src/components/Splitter/SplitterHandle.tsx
+++ b/packages/studio/src/components/Splitter/SplitterHandle.tsx
@@ -1,6 +1,6 @@
 import {PlayerInternals} from '@remotion/player';
 import React, {useContext, useEffect, useRef} from 'react';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {
 	forceSpecificCursor,
 	stopForcingSpecificCursor,
@@ -123,9 +123,9 @@ export const SplitterHandle: React.FC<{
 				}
 			};
 
-			endDrag = startPointerSession({
+			endDrag = startCapturedPointerSession({
 				event: e,
-				target: current,
+				captureTarget: current,
 				onMove: onPointerMove,
 				onEnd: (reason, endEvent) => {
 					if (

--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -26,7 +26,7 @@ import {
 	WHITE_ALPHA_35,
 	WHITE_ALPHA_72,
 } from '../../helpers/colors';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {Checkbox} from '../Checkbox';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {InputDragger} from '../NewComposition/InputDragger';
@@ -1088,9 +1088,9 @@ export const EasingEditor: React.FC<{
 			const bezierBeforeDrag = [...bezierRef.current] as CubicBezierTuple;
 			setActiveHandle(handle);
 			updateHandleFromPointer(handle, event);
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target: event.currentTarget,
+				captureTarget: event.currentTarget,
 				onMove: (moveEvent) => {
 					updateHandleFromPointer(handle, moveEvent);
 				},

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
 import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
@@ -328,9 +328,9 @@ const TimelineDragHandlerInner: React.FC = () => {
 			return;
 		}
 
-		return startPointerSession({
+		return startCapturedPointerSession({
 			event: dragging,
-			target: dragging.target,
+			captureTarget: dragging.target,
 			onMove: onPointerMoveScrubbing,
 			onEnd: (reason, endEvent) => {
 				if (

--- a/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
@@ -2,7 +2,7 @@ import {PlayerInternals} from '@remotion/player';
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 import {Internals, useVideoConfig} from 'remotion';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {
 	useTimelineInOutFramePosition,
 	useTimelineSetInOutFramePosition,
@@ -317,9 +317,9 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 			return;
 		}
 
-		return startPointerSession({
+		return startCapturedPointerSession({
 			event: inOutDragging,
-			target: inOutDragging.target,
+			captureTarget: inOutDragging.target,
 			onMove: onPointerMoveInOut,
 			onEnd: (reason, endEvent) => {
 				if (

--- a/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerEye.tsx
@@ -5,7 +5,7 @@ import {
 	LIGHT_COLOR,
 	WHITE,
 } from '../../helpers/colors';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import type {RenderInlineAction} from '../InlineAction';
 
 const eyeIcon: React.CSSProperties = {
@@ -100,9 +100,9 @@ export const TimelineLayerEye: React.FC<{
 			layerPointedDown = hidden ? 'enable' : 'disable';
 			onInvoked(layerPointedDown);
 			lastPaintedLayerEye = e.currentTarget;
-			stopLayerPointerSession = startPointerSession({
+			stopLayerPointerSession = startCapturedPointerSession({
 				event: e,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: (moveEvent) => {
 					const pointedElement = document
 						.elementFromPoint(moveEvent.clientX, moveEvent.clientY)

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -37,7 +37,7 @@ import {
 	isStudioInteractivityEnabled,
 	isStudioSelectionEnabled,
 } from '../../helpers/interactivity-enabled';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {
 	buildTimelineTree,
 	flattenVisibleTreeNodes,
@@ -1698,9 +1698,9 @@ export const useTimelineMarqueeSelection = () => {
 				updateSelection(moveEvent.clientX, moveEvent.clientY);
 			};
 
-			startPointerSession({
+			startCapturedPointerSession({
 				event,
-				target,
+				captureTarget: target,
 				onMove: onPointerMove,
 				onEnd: (reason, endEvent) => {
 					if (

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -24,7 +24,7 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {TRANSPARENT} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {EditorSnappingContext} from '../../state/editor-snapping';
@@ -1182,9 +1182,9 @@ const TimelineSequenceLeftEdgeDragHandleInner: React.FC<{
 			return;
 		}
 
-		return startPointerSession({
+		return startCapturedPointerSession({
 			event: activeDragState,
-			target: activeDragState.target,
+			captureTarget: activeDragState.target,
 			onMove,
 			onEnd: (reason, endEvent) => {
 				if (
@@ -1502,9 +1502,9 @@ export const useTimelineSequenceFromDrag = ({
 			return;
 		}
 
-		return startPointerSession({
+		return startCapturedPointerSession({
 			event: activeDragState,
-			target: activeDragState.target,
+			captureTarget: activeDragState.target,
 			onMove,
 			onEnd: (reason, endEvent) => {
 				if (
@@ -1750,9 +1750,9 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 			return;
 		}
 
-		return startPointerSession({
+		return startCapturedPointerSession({
 			event: activeDragState,
-			target: activeDragState.target,
+			captureTarget: activeDragState.target,
 			onMove,
 			onEnd: (reason, endEvent) => {
 				if (

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -16,7 +16,7 @@ import type {
 import {Internals, useVideoConfig} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {startPointerSession} from '../../helpers/pointer-session';
+import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {callMoveKeyframes} from './call-move-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
@@ -725,9 +725,9 @@ export const useTimelineKeyframeDrag = ({
 				clearDraggedKeyframes();
 			};
 
-			stopPointerSession = startPointerSession({
+			stopPointerSession = startCapturedPointerSession({
 				event: e,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: onPointerMove,
 				onEnd: (reason) => {
 					if (reason === 'pointerup' || reason === 'buttons-released') {
@@ -1003,9 +1003,9 @@ export const useTimelineEasingKeyframeDrag = ({
 				clearDraggedKeyframes();
 			};
 
-			stopPointerSession = startPointerSession({
+			stopPointerSession = startCapturedPointerSession({
 				event: e,
-				target: e.currentTarget,
+				captureTarget: e.currentTarget,
 				onMove: onPointerMove,
 				onEnd: (reason) => {
 					if (reason === 'pointerup' || reason === 'buttons-released') {

--- a/packages/studio/src/helpers/pointer-session.ts
+++ b/packages/studio/src/helpers/pointer-session.ts
@@ -25,14 +25,14 @@ const getButtonMask = (button: number) => {
 	return 1 << button;
 };
 
-export const startPointerSession = ({
+const startPointerSession = ({
 	event,
-	target,
+	captureTarget,
 	onMove,
 	onEnd,
 }: {
 	event: PointerSessionEvent;
-	target: Element;
+	captureTarget: Element | null;
 	onMove?: (event: PointerEvent) => void;
 	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
 }): (() => void) => {
@@ -46,11 +46,14 @@ export const startPointerSession = ({
 		window.removeEventListener('pointercancel', handleCancel);
 		window.removeEventListener('blur', handleBlur);
 		document.removeEventListener('visibilitychange', handleVisibilityChange);
-		target.removeEventListener('lostpointercapture', handleLostPointerCapture);
+		captureTarget?.removeEventListener(
+			'lostpointercapture',
+			handleLostPointerCapture,
+		);
 
-		if (target.hasPointerCapture?.(pointerId)) {
+		if (captureTarget?.hasPointerCapture?.(pointerId)) {
 			try {
-				target.releasePointerCapture(pointerId);
+				captureTarget.releasePointerCapture(pointerId);
 			} catch {
 				// The browser may already have released capture.
 			}
@@ -112,10 +115,17 @@ export const startPointerSession = ({
 		}
 	}
 
-	try {
-		target.setPointerCapture?.(pointerId);
-	} catch {
-		// Capture is best-effort for detached or browser-owned targets.
+	if (captureTarget) {
+		try {
+			captureTarget.setPointerCapture?.(pointerId);
+		} catch {
+			// Capture is best-effort for detached targets.
+		}
+
+		captureTarget.addEventListener(
+			'lostpointercapture',
+			handleLostPointerCapture,
+		);
 	}
 
 	window.addEventListener('pointermove', handleMove);
@@ -123,7 +133,38 @@ export const startPointerSession = ({
 	window.addEventListener('pointercancel', handleCancel);
 	window.addEventListener('blur', handleBlur);
 	document.addEventListener('visibilitychange', handleVisibilityChange);
-	target.addEventListener('lostpointercapture', handleLostPointerCapture);
 
 	return () => end('manual', null);
+};
+
+// Use for a gesture owned by a Studio control, such as a slider or resize
+// handle. `captureTarget` is normally the pointerdown handler's currentTarget.
+export const startCapturedPointerSession = ({
+	event,
+	captureTarget,
+	onMove,
+	onEnd,
+}: {
+	event: PointerSessionEvent;
+	captureTarget: Element;
+	onMove?: (event: PointerEvent) => void;
+	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
+}) => {
+	return startPointerSession({event, captureTarget, onMove, onEnd});
+};
+
+// Use when observing a gesture that started elsewhere. This deliberately does
+// not capture the pointer from the element under it.
+export const observePointerRelease = ({
+	event,
+	onEnd,
+}: {
+	event: PointerSessionEvent;
+	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
+}) => {
+	return startPointerSession({
+		event,
+		captureTarget: null,
+		onEnd,
+	});
 };

--- a/packages/studio/src/state/z-index.tsx
+++ b/packages/studio/src/state/z-index.tsx
@@ -1,12 +1,11 @@
 import React, {
 	createContext,
 	useContext,
-	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 } from 'react';
-import {startPointerSession} from '../helpers/pointer-session';
+import {observePointerRelease} from '../helpers/pointer-session';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {HighestZIndexContext} from './highest-z-index';
 import {getClickLock} from './input-dragger-click-lock';
@@ -54,31 +53,30 @@ export const HigherZIndex: React.FC<{
 	readonly children: React.ReactNode;
 	readonly disabled?: boolean;
 	readonly outsideClickButton?: 'any' | 'primary';
-	readonly stackOnHighest?: boolean;
 }> = ({
 	children,
 	onEscape,
 	onOutsideClick,
 	disabled,
 	outsideClickButton = 'any',
-	stackOnHighest = false,
 }) => {
 	const context = useContext(ZIndexContext);
 	const highestContext = useContext(HighestZIndexContext);
 	const {registerZIndex, unregisterZIndex} = highestContext;
 	const containerRef = useRef<HTMLDivElement>(null);
-	const stackedIndex = useRef<number | null>(null);
-
-	if (disabled || !stackOnHighest) {
-		stackedIndex.current = null;
-	} else if (stackedIndex.current === null) {
-		stackedIndex.current =
-			Math.max(context.currentIndex, highestContext.highestIndex) + 1;
-	}
+	const highestIndexRef = useRef(highestContext.highestIndex);
+	const onOutsideClickRef = useRef(onOutsideClick);
+	const outsideClickButtonRef = useRef(outsideClickButton);
 
 	const currentIndex = disabled
 		? context.currentIndex
-		: (stackedIndex.current ?? context.currentIndex + 1);
+		: context.currentIndex + 1;
+
+	useLayoutEffect(() => {
+		highestIndexRef.current = highestContext.highestIndex;
+		onOutsideClickRef.current = onOutsideClick;
+		outsideClickButtonRef.current = outsideClickButton;
+	}, [highestContext.highestIndex, onOutsideClick, outsideClickButton]);
 
 	useLayoutEffect(() => {
 		if (disabled) {
@@ -89,7 +87,7 @@ export const HigherZIndex: React.FC<{
 		return () => unregisterZIndex(currentIndex);
 	}, [currentIndex, disabled, registerZIndex, unregisterZIndex]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (disabled) {
 			return;
 		}
@@ -97,7 +95,10 @@ export const HigherZIndex: React.FC<{
 		let endPointerSession: (() => void) | null = null;
 
 		const listener = (downEvent: PointerEvent) => {
-			if (outsideClickButton === 'primary' && downEvent.button !== 0) {
+			if (
+				outsideClickButtonRef.current === 'primary' &&
+				downEvent.button !== 0
+			) {
 				return;
 			}
 
@@ -108,16 +109,20 @@ export const HigherZIndex: React.FC<{
 				return;
 			}
 
+			// The topmost layer owns the full pointer gesture. Layers may mount or
+			// unmount before pointerup, but that must not cancel or transfer dismissal.
+			if (highestIndexRef.current !== currentIndex) {
+				return;
+			}
+
 			endPointerSession?.();
-			endPointerSession = startPointerSession({
+			endPointerSession = observePointerRelease({
 				event: downEvent,
-				target: downEvent.target as Element,
 				onEnd: (reason, upEvent) => {
 					endPointerSession = null;
 					if (
 						(reason === 'pointerup' || reason === 'buttons-released') &&
 						upEvent &&
-						highestContext.highestIndex === currentIndex &&
 						!getClickLock()
 					) {
 						const target =
@@ -125,17 +130,13 @@ export const HigherZIndex: React.FC<{
 							(upEvent.target as Element);
 						if (document.contains(target)) {
 							upEvent.stopPropagation();
-							onOutsideClick(target);
+							onOutsideClickRef.current(target);
 						}
 					}
 				},
 			});
 		};
 
-		// The capture phase for the pointerdown that opened this layer has already
-		// passed, so installing the listener immediately cannot dismiss the new layer.
-		// Waiting for the next animation frame would leave a window in which a fast
-		// outside click is missed.
 		window.addEventListener('pointerdown', listener, true);
 		return () => {
 			endPointerSession?.();
@@ -143,13 +144,7 @@ export const HigherZIndex: React.FC<{
 
 			return window.removeEventListener('pointerdown', listener, true);
 		};
-	}, [
-		currentIndex,
-		disabled,
-		highestContext.highestIndex,
-		onOutsideClick,
-		outsideClickButton,
-	]);
+	}, [currentIndex, disabled]);
 
 	const value = useMemo((): ZIndex => {
 		return {

--- a/packages/studio/src/test/pointer-session.test.ts
+++ b/packages/studio/src/test/pointer-session.test.ts
@@ -1,7 +1,8 @@
 import {expect, test} from 'bun:test';
 import {
+	observePointerRelease,
 	type PointerSessionEndReason,
-	startPointerSession,
+	startCapturedPointerSession,
 } from '../helpers/pointer-session';
 
 class CaptureTarget extends EventTarget {
@@ -63,9 +64,9 @@ test('pointer sessions filter their pointer and clean up every termination path'
 		const target = new CaptureTarget();
 		const moves: number[] = [];
 		const endings: PointerSessionEndReason[] = [];
-		startPointerSession({
+		startCapturedPointerSession({
 			event: {button: 0, pointerId: 4},
-			target: target as unknown as Element,
+			captureTarget: target as unknown as Element,
 			onMove: (event) => moves.push(event.pointerId),
 			onEnd: (reason) => endings.push(reason),
 		});
@@ -137,9 +138,9 @@ test('pointer sessions filter their pointer and clean up every termination path'
 			const sessionTarget = new CaptureTarget();
 			const reasons: PointerSessionEndReason[] = [];
 			const pointerId = index + 10;
-			startPointerSession({
+			startCapturedPointerSession({
 				event: {button: 0, pointerId},
-				target: sessionTarget as unknown as Element,
+				captureTarget: sessionTarget as unknown as Element,
 				onEnd: (reason) => reasons.push(reason),
 			});
 			terminationCase.trigger(sessionTarget, pointerId);
@@ -147,6 +148,61 @@ test('pointer sessions filter their pointer and clean up every termination path'
 			expect(reasons).toEqual([terminationCase.reason]);
 			expect(sessionTarget.releasedPointers).toEqual([pointerId]);
 		}
+	} finally {
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: originalWindow,
+		});
+		Object.defineProperty(globalThis, 'document', {
+			configurable: true,
+			value: originalDocument,
+		});
+	}
+});
+
+test('release observers do not capture the element under the pointer', () => {
+	const originalWindow = globalThis.window;
+	const originalDocument = globalThis.document;
+	const fakeWindow = new EventTarget() as Window & typeof globalThis;
+	const fakeDocument = new FakeDocument();
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: fakeWindow,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		configurable: true,
+		value: fakeDocument,
+	});
+
+	try {
+		const elementUnderPointer = new CaptureTarget();
+		const endings: PointerSessionEndReason[] = [];
+		const pointerDownEvent = {
+			button: 0,
+			pointerId: 20,
+			target: elementUnderPointer,
+		} as unknown as PointerEvent;
+		observePointerRelease({
+			event: pointerDownEvent,
+			onEnd: (reason) => endings.push(reason),
+		});
+
+		elementUnderPointer.dispatchEvent(
+			makePointerEvent('lostpointercapture', {
+				pointerId: 20,
+				buttons: 0,
+			}),
+		);
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointermove', {pointerId: 20, buttons: 1}),
+		);
+		expect(endings).toEqual([]);
+		expect(elementUnderPointer.releasedPointers).toEqual([]);
+
+		fakeWindow.dispatchEvent(
+			makePointerEvent('pointerup', {pointerId: 20, buttons: 0}),
+		);
+		expect(endings).toEqual(['pointerup']);
 	} finally {
 		Object.defineProperty(globalThis, 'window', {
 			configurable: true,


### PR DESCRIPTION
## Summary

- restore Studio modals to the regular z-index hierarchy now that mobile sidebars are no longer floating
- make the topmost outside-click layer own the full pointer gesture without capturing arbitrary outside elements
- split captured drag sessions from passive pointer-release observation to prevent slight movement from canceling modal dismissal
- tighten the modal and menu dismissal workflows and remove the retry-based flake mask

## Test plan

- `bun run build`
- `bunx turbo run make lint formatting --filter='@remotion/studio' --filter='@remotion/example' --no-update-notifier`
- `bun test src/test/pointer-session.test.ts` in `packages/studio`
- `bunx playwright test e2e/studio.test.mts --grep='settings reuse reactive runtime config|should clear the open-in-editor hover state when closing the menu'` in `packages/example`
