### PR TITLE
Elements: Add product discount callout

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -40,7 +40,10 @@ const sidebars: SidebarsConfig = {
 			label: 'Commerce',
 			link: {type: 'doc', id: 'commerce/index'},
 			collapsed: false,
-			items: ['commerce/product-offer/index'],
+			items: [
+				'commerce/product-discount-callout/index',
+				'commerce/product-offer/index',
+			],
 		},
 		{
 			type: 'category',

--- a/packages/docs/elements/commerce/product-discount-callout/index.mdx
+++ b/packages/docs/elements/commerce/product-discount-callout/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Product Discount Callout
+description: An animated product cutout with pricing and a hinged discount callout.
+image: https://remotion.media/elements/commerce-product-discount-callout-preview.png
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {elementDefinitions} from '@site/src/components/Elements/element-definitions';
+
+# Product Discount Callout
+
+<ElementPage definition={elementDefinitions['commerce/product-discount-callout']} sourceFile="./product-discount-callout.tsx" />
+
+The default product image is adapted from [a photo by Andrey Matveev on Pexels](https://www.pexels.com/photo/gray-shoe-on-gray-background-27361691/) under the [Pexels license](https://www.pexels.com/license/). The background was removed.

--- a/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
+++ b/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
@@ -1,0 +1,225 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import {makeCallout} from '@remotion/shapes';
+import React from 'react';
+import {
+	CanvasImage,
+	Easing,
+	Interactive,
+	interpolate,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+loadFont('normal', {
+	subsets: ['latin'],
+	weights: ['500', '600', '700'],
+});
+
+export const ProductDiscountCallout = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+	const discountCallout = makeCallout({
+		width: 260,
+		height: 86,
+		pointerLength: 24,
+		pointerBaseWidth: 42,
+		pointerPosition: 0.5,
+		pointerDirection: 'down',
+		cornerRadius: 14,
+	});
+
+	return (
+		<Interactive.Div
+			name="Container"
+			style={{
+				WebkitFontSmoothing: 'antialiased',
+				color: '#161714',
+				fontFamily: 'Inter',
+				height: '100%',
+				isolation: 'isolate',
+				opacity: interpolate(
+					frame,
+					[0, 8, durationInFrames - 14, durationInFrames - 1],
+					[0, 1, 1, 0],
+					{
+						easing: Easing.bezier(0.16, 1, 0.3, 1),
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+					},
+				),
+				overflow: 'hidden',
+				position: 'relative',
+				translate: interpolate(
+					frame,
+					[0, 16, durationInFrames - 16, durationInFrames - 1],
+					['-150px 0px', '0px 0px', '0px 0px', '110px 0px'],
+					{
+						easing: Easing.bezier(0.16, 1, 0.3, 1),
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+					},
+				),
+				width: '100%',
+				willChange: 'transform, opacity',
+			}}
+		>
+			<CanvasImage
+				fit="contain"
+				height={430}
+				name="Product image"
+				src="https://remotion.media/elements/product-discount-callout-gray-runner.png"
+				style={{
+					filter: 'drop-shadow(0px 28px 20px rgba(22, 23, 20, 0.18))',
+					left: 50,
+					position: 'absolute',
+					scale: interpolate(frame, [0, 18], [0.98, 1], {
+						easing: Easing.bezier(0.16, 1, 0.3, 1),
+						extrapolateLeft: 'clamp',
+						extrapolateRight: 'clamp',
+						output: 'perceptual-scale',
+					}),
+					top: 0,
+					willChange: 'transform',
+				}}
+				width={800}
+			/>
+
+			<Interactive.Div
+				name="Discount callout"
+				style={{
+					height: 110,
+					left: 150,
+					position: 'absolute',
+					rotate: interpolate(
+						frame,
+						[50, 57, 64, 70, 76],
+						['0deg', '10deg', '-7deg', '3deg', '0deg'],
+						{
+							easing: Easing.inOut(Easing.quad),
+							extrapolateLeft: 'clamp',
+							extrapolateRight: 'clamp',
+						},
+					),
+					top: 360,
+					transformOrigin: '50% 100%',
+					width: 260,
+					willChange: 'transform',
+				}}
+			>
+				<svg
+					height={discountCallout.height}
+					style={{
+						filter: 'drop-shadow(0px 9px 8px rgba(22, 23, 20, 0.16))',
+						height: '100%',
+						overflow: 'visible',
+						position: 'absolute',
+						width: '100%',
+					}}
+					viewBox={`0 0 ${discountCallout.width} ${discountCallout.height}`}
+					width={discountCallout.width}
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path d={discountCallout.path} fill="#d8ff52" />
+				</svg>
+				<div
+					style={{
+						alignItems: 'center',
+						display: 'flex',
+						fontSize: 43,
+						fontWeight: 700,
+						height: 86,
+						justifyContent: 'center',
+						letterSpacing: -1.8,
+						lineHeight: 1,
+						position: 'relative',
+					}}
+				>
+					20% OFF
+				</div>
+			</Interactive.Div>
+
+			<Interactive.Div
+				name="Current price"
+				style={{
+					fontSize: 104,
+					fontVariantNumeric: 'tabular-nums',
+					fontWeight: 700,
+					left: 150,
+					letterSpacing: -6,
+					lineHeight: 0.86,
+					maxWidth: 270,
+					overflow: 'hidden',
+					position: 'absolute',
+					textOverflow: 'ellipsis',
+					top: 490,
+					whiteSpace: 'nowrap',
+				}}
+			>
+				$79
+			</Interactive.Div>
+			<Interactive.Div
+				name="Original price"
+				style={{
+					color: '#6f736a',
+					fontSize: 28,
+					fontWeight: 600,
+					left: 154,
+					lineHeight: 1,
+					maxWidth: 245,
+					overflow: 'hidden',
+					position: 'absolute',
+					textDecoration: 'line-through',
+					textDecorationThickness: 2,
+					textOverflow: 'ellipsis',
+					top: 590,
+					whiteSpace: 'nowrap',
+				}}
+			>
+				$99
+			</Interactive.Div>
+
+			<div
+				style={{
+					backgroundColor: '#c9cdc4',
+					height: 118,
+					left: 444,
+					position: 'absolute',
+					top: 493,
+					width: 2,
+				}}
+			/>
+			<Interactive.Div
+				name="Product description"
+				style={{
+					left: 474,
+					maxWidth: 400,
+					overflow: 'hidden',
+					position: 'absolute',
+					top: 492,
+				}}
+			>
+				<div
+					style={{
+						fontSize: 38,
+						fontWeight: 700,
+						letterSpacing: -1.4,
+						lineHeight: 1.05,
+					}}
+				>
+					Everyday Runner
+				</div>
+				<div
+					style={{
+						color: '#5e6259',
+						fontSize: 23,
+						fontWeight: 500,
+						lineHeight: 1.3,
+						marginTop: 12,
+					}}
+				>
+					Lightweight comfort for daily miles.
+				</div>
+			</Interactive.Div>
+		</Interactive.Div>
+	);
+};

--- a/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
+++ b/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
@@ -83,7 +83,6 @@ export const ProductDiscountCallout = () => {
 				}}
 				width={800}
 			/>
-
 			<Interactive.Div
 				name="Discount callout"
 				style={{
@@ -121,7 +120,8 @@ export const ProductDiscountCallout = () => {
 				>
 					<path d={discountCallout.path} fill="#d8ff52" />
 				</svg>
-				<div
+				<Interactive.Div
+					name="Discount text"
 					style={{
 						alignItems: 'center',
 						display: 'flex',
@@ -135,9 +135,8 @@ export const ProductDiscountCallout = () => {
 					}}
 				>
 					20% OFF
-				</div>
+				</Interactive.Div>
 			</Interactive.Div>
-
 			<Interactive.Div
 				name="Current price"
 				style={{
@@ -177,7 +176,6 @@ export const ProductDiscountCallout = () => {
 			>
 				$99
 			</Interactive.Div>
-
 			<div
 				style={{
 					backgroundColor: '#c9cdc4',
@@ -188,8 +186,7 @@ export const ProductDiscountCallout = () => {
 					width: 2,
 				}}
 			/>
-			<Interactive.Div
-				name="Product description"
+			<div
 				style={{
 					left: 474,
 					maxWidth: 400,
@@ -198,7 +195,8 @@ export const ProductDiscountCallout = () => {
 					top: 492,
 				}}
 			>
-				<div
+				<Interactive.Div
+					name="Product name"
 					style={{
 						fontSize: 38,
 						fontWeight: 700,
@@ -207,8 +205,9 @@ export const ProductDiscountCallout = () => {
 					}}
 				>
 					Everyday Runner
-				</div>
-				<div
+				</Interactive.Div>
+				<Interactive.Div
+					name="Product description"
 					style={{
 						color: '#5e6259',
 						fontSize: 23,
@@ -218,8 +217,8 @@ export const ProductDiscountCallout = () => {
 					}}
 				>
 					Lightweight comfort for daily miles.
-				</div>
-			</Interactive.Div>
+				</Interactive.Div>
+			</div>
 		</Interactive.Div>
 	);
 };

--- a/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
+++ b/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
@@ -106,7 +106,6 @@ export const ProductDiscountCallout = () => {
 				}}
 			>
 				<svg
-					height={discountCallout.height}
 					style={{
 						filter: 'drop-shadow(0px 9px 8px rgba(22, 23, 20, 0.16))',
 						height: '100%',
@@ -115,7 +114,6 @@ export const ProductDiscountCallout = () => {
 						width: '100%',
 					}}
 					viewBox={`0 0 ${discountCallout.width} ${discountCallout.height}`}
-					width={discountCallout.width}
 					xmlns="http://www.w3.org/2000/svg"
 				>
 					<path d={discountCallout.path} fill="#d8ff52" />

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -10,6 +10,7 @@ import {RotatingStarburst} from '../../../elements/backgrounds/rotating-starburs
 import {MovingPillCaptions} from '../../../elements/captions/moving-pill-captions/moving-pill-captions';
 import {PoppingWordCaptions} from '../../../elements/captions/popping-word-captions/popping-word-captions';
 import {WordHighlightCaptions} from '../../../elements/captions/word-highlight-captions/word-highlight-captions';
+import {ProductDiscountCallout} from '../../../elements/commerce/product-discount-callout/product-discount-callout';
 import {ProductOffer} from '../../../elements/commerce/product-offer/product-offer';
 import {HorizontalBarChart} from '../../../elements/data/horizontal-bar-chart/horizontal-bar-chart';
 import {NumberCounter} from '../../../elements/data/number-counter/number-counter';
@@ -306,6 +307,34 @@ export const elementDefinitions = {
 		slug: 'data/number-counter',
 		installationMode: 'wrapped',
 		width: 1920,
+	},
+	'commerce/product-discount-callout': {
+		category: 'commerce',
+		component: ProductDiscountCallout,
+		contributors: [],
+		description:
+			'An animated product cutout with pricing and a hinged discount callout.',
+		dependencies: [
+			{name: '@remotion/google-fonts', version: null},
+			{name: '@remotion/shapes', version: null},
+		],
+		displayName: 'Product Discount Callout',
+		durationInFrames: 120,
+		elementHeight: 650,
+		elementWidth: 900,
+		fps: 30,
+		height: 1080,
+		posterFrame: 57,
+		preview: {
+			posterUrl:
+				'https://remotion.media/elements/commerce-product-discount-callout-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/commerce-product-discount-callout-preview.mp4',
+		},
+		previewPadding: 90,
+		slug: 'commerce/product-discount-callout',
+		installationMode: 'wrapped',
+		width: 1080,
 	},
 	'commerce/product-offer': {
 		category: 'commerce',


### PR DESCRIPTION
## Summary

- add a reusable commerce Element with a product cutout, current and original pricing, product copy, and a hinged discount callout
- make the discount text, product name, description, and pricing independently editable in Studio
- publish the product asset and verified poster and video previews on remotion.media
- register the Element in the Commerce gallery and sidebar

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- rendered and visually reviewed the poster and video previews

## Preview

- [Product Discount Callout](https://remotion-git-product-discount-callout-remotion.vercel.app/elements/commerce/product-discount-callout/)