### PR TITLE
`@remotion/studio`: Focus Assets tab while dragging asset

### DIFF
--- a/packages/studio/src/components/ExplorerPanel.tsx
+++ b/packages/studio/src/components/ExplorerPanel.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useImperativeHandle, useState} from 'react';
 import {BACKGROUND} from '../helpers/colors';
+import {isAssetUploadDragEvent} from '../helpers/use-asset-drag-events';
 import {AssetSelector} from './AssetSelector';
 import {CompositionSelector} from './CompositionSelector';
 import {CompSelectorRef} from './CompSelectorRef';
@@ -52,6 +53,14 @@ export const ExplorerPanel: React.FC<{
 		setPanel('assets');
 		persistSelectedOptionsSidebarPanel('assets');
 	}, []);
+	const onAssetDragEnter = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (isAssetUploadDragEvent(event)) {
+				onAssetsSelected();
+			}
+		},
+		[onAssetsSelected],
+	);
 
 	useImperativeHandle(explorerSidebarTabs, () => {
 		return {
@@ -87,7 +96,11 @@ export const ExplorerPanel: React.FC<{
 						>
 							Compositions
 						</Tab>
-						<Tab selected={panel === 'assets'} onClick={onAssetsSelected}>
+						<Tab
+							selected={panel === 'assets'}
+							onClick={onAssetsSelected}
+							onDragEnter={onAssetDragEnter}
+						>
 							Assets
 						</Tab>
 					</Tabs>

--- a/packages/studio/src/components/ExplorerPanel.tsx
+++ b/packages/studio/src/components/ExplorerPanel.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useImperativeHandle, useState} from 'react';
+import {useCallback, useImperativeHandle, useRef, useState} from 'react';
 import {BACKGROUND} from '../helpers/colors';
 import {isAssetUploadDragEvent} from '../helpers/use-asset-drag-events';
 import {AssetSelector} from './AssetSelector';
@@ -44,6 +44,7 @@ export const ExplorerPanel: React.FC<{
 	const [panel, setPanel] = useState<ExplorerSidebarPanel>(() =>
 		getSelectedPanel(),
 	);
+	const assetTabFocusTimer = useRef<number | null>(null);
 	const onCompositionsSelected = useCallback(() => {
 		setPanel('compositions');
 		persistSelectedOptionsSidebarPanel('compositions');
@@ -55,11 +56,29 @@ export const ExplorerPanel: React.FC<{
 	}, []);
 	const onAssetDragEnter = useCallback(
 		(event: React.DragEvent<HTMLDivElement>) => {
-			if (isAssetUploadDragEvent(event)) {
-				onAssetsSelected();
+			if (
+				isAssetUploadDragEvent(event) &&
+				assetTabFocusTimer.current === null
+			) {
+				assetTabFocusTimer.current = window.setTimeout(() => {
+					onAssetsSelected();
+					assetTabFocusTimer.current = null;
+				}, 500);
 			}
 		},
 		[onAssetsSelected],
+	);
+	const onAssetDragLeave = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			if (
+				isAssetUploadDragEvent(event) &&
+				assetTabFocusTimer.current !== null
+			) {
+				window.clearTimeout(assetTabFocusTimer.current);
+				assetTabFocusTimer.current = null;
+			}
+		},
+		[],
 	);
 
 	useImperativeHandle(explorerSidebarTabs, () => {
@@ -100,6 +119,7 @@ export const ExplorerPanel: React.FC<{
 							selected={panel === 'assets'}
 							onClick={onAssetsSelected}
 							onDragEnter={onAssetDragEnter}
+							onDragLeave={onAssetDragLeave}
 						>
 							Assets
 						</Tab>

--- a/packages/studio/src/components/Tabs/index.tsx
+++ b/packages/studio/src/components/Tabs/index.tsx
@@ -47,10 +47,11 @@ const selectorButton: React.CSSProperties = {
 
 export const Tab: React.FC<{
 	readonly children: React.ReactNode;
+	readonly onDragEnter?: React.DragEventHandler<HTMLDivElement>;
 	readonly onClick: React.MouseEventHandler<HTMLDivElement>;
 	readonly style?: React.CSSProperties;
 	readonly selected: boolean;
-}> = ({children, onClick, style, selected}) => {
+}> = ({children, onClick, onDragEnter, style, selected}) => {
 	const [hovered, setHovered] = useState(false);
 	const {tabIndex} = useZIndex();
 
@@ -83,6 +84,7 @@ export const Tab: React.FC<{
 			style={definiteStyle}
 			role="button"
 			onClick={onClick}
+			onDragEnter={onDragEnter}
 			tabIndex={tabIndex}
 			onPointerLeave={onPointerLeave}
 			onPointerEnter={onPointerEnter}

--- a/packages/studio/src/components/Tabs/index.tsx
+++ b/packages/studio/src/components/Tabs/index.tsx
@@ -48,10 +48,11 @@ const selectorButton: React.CSSProperties = {
 export const Tab: React.FC<{
 	readonly children: React.ReactNode;
 	readonly onDragEnter?: React.DragEventHandler<HTMLDivElement>;
+	readonly onDragLeave?: React.DragEventHandler<HTMLDivElement>;
 	readonly onClick: React.MouseEventHandler<HTMLDivElement>;
 	readonly style?: React.CSSProperties;
 	readonly selected: boolean;
-}> = ({children, onClick, onDragEnter, style, selected}) => {
+}> = ({children, onClick, onDragEnter, onDragLeave, style, selected}) => {
 	const [hovered, setHovered] = useState(false);
 	const {tabIndex} = useZIndex();
 
@@ -85,6 +86,7 @@ export const Tab: React.FC<{
 			role="button"
 			onClick={onClick}
 			onDragEnter={onDragEnter}
+			onDragLeave={onDragLeave}
 			tabIndex={tabIndex}
 			onPointerLeave={onPointerLeave}
 			onPointerEnter={onPointerEnter}


### PR DESCRIPTION
## Summary

- focus the Assets panel after a file hovers over its tab for 500ms
- support the same behavior for Studio render-output drags
- ignore unrelated Studio drag types

## Testing

- `bunx turbo run make lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`

Closes #10319
