### PR TITLE
`@remotion/studio`: Flatten preview toolbar controls

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useState} from 'react';
 import {Internals} from 'remotion';
 import {checkFullscreenSupport} from '../helpers/check-fullscreen-support';
 import {BACKGROUND, BORDER_BLACK_ALPHA_50} from '../helpers/colors';
+import {PREVIEW_TOOLBAR_CLASS_NAME} from '../helpers/inject-css';
 import {
 	useIsStill,
 	useIsVideoComposition,
@@ -111,7 +112,10 @@ export const PreviewToolbar: React.FC<{
 	);
 
 	return (
-		<div style={container} className="css-reset">
+		<div
+			style={container}
+			className={`css-reset ${PREVIEW_TOOLBAR_CLASS_NAME}`}
+		>
 			<div style={sideContainer}>
 				<div style={padding} />
 				{isMobileLayout ? null : (

--- a/packages/studio/src/helpers/inject-css.ts
+++ b/packages/studio/src/helpers/inject-css.ts
@@ -10,6 +10,8 @@ import {
 } from './colors';
 import {makeHoverableCSS} from './hoverable';
 
+export const PREVIEW_TOOLBAR_CLASS_NAME = '__remotion_preview_toolbar';
+
 const makeDefaultGlobalCSS = () => {
 	const dragAreaFactor = 2;
 	const fromMiddle = 50 / dragAreaFactor;
@@ -69,6 +71,14 @@ const makeDefaultGlobalCSS = () => {
 	    outline: none;
 	    box-shadow: ${FOCUS_BOX_SHADOW};
 	  }
+
+  .${PREVIEW_TOOLBAR_CLASS_NAME} button {
+    border-radius: 0 !important;
+  }
+
+  .${PREVIEW_TOOLBAR_CLASS_NAME} button:focus {
+    box-shadow: none !important;
+  }
 
   .__remotion-composition-selector-item:focus,
   .__remotion-inspector-inline-action:focus,


### PR DESCRIPTION
## Summary

- remove rounded corners from preview toolbar controls
- remove the focus shadow within the preview toolbar only

## Verification

- `bun run build`
- `bun run stylecheck`
- verified focused and unfocused control styles in the local Studio
