### PR TITLE
`@remotion/studio`: Enable undo while color picker is open

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -92,6 +92,65 @@ test.describe('visual mode', () => {
 		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
 	});
 
+	test('should commit a color drag before the picker closes', async ({
+		page,
+	}) => {
+		const barChartFile = path.join(exampleDir, 'src', 'BarChart.tsx');
+		const originalSource = fs.readFileSync(barChartFile, 'utf-8');
+
+		try {
+			await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+			await expect(page).toHaveURL(/AnimatedBarChart/, {timeout: 15_000});
+
+			if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
+				await page.locator('[data-sidebar-toggle="right"]').click();
+			}
+
+			await page
+				.locator('[data-timeline-marquee-item][title="North bar"]')
+				.click();
+			await page
+				.getByRole('button', {name: '#000', exact: true})
+				.first()
+				.click();
+
+			const hexInput = page.getByRole('textbox', {name: 'Hex'});
+			await expect(hexInput).toBeVisible();
+			const saturationValueArea = page.locator(
+				'div[style*="cursor: crosshair"]',
+			);
+			const box = await saturationValueArea.boundingBox();
+			if (box === null) {
+				throw new Error('Color picker saturation area has no bounding box');
+			}
+
+			await page.mouse.move(
+				box.x + box.width * 0.25,
+				box.y + box.height * 0.75,
+			);
+			await page.mouse.down();
+			await page.mouse.move(
+				box.x + box.width * 0.75,
+				box.y + box.height * 0.25,
+			);
+			await page.mouse.up();
+
+			await expect(hexInput).toBeVisible();
+			await expect
+				.poll(() => fs.readFileSync(barChartFile, 'utf-8'))
+				.toMatch(/position: 'relative',\n\s+color: '#[0-9a-f]{6}',/);
+			await expect(page.getByRole('button', {name: /^Undo/})).toBeEnabled();
+			await page.keyboard.press('ControlOrMeta+z');
+
+			await expect
+				.poll(() => fs.readFileSync(barChartFile, 'utf-8'))
+				.toBe(originalSource);
+			await expect(hexInput).toHaveValue('#000000');
+		} finally {
+			fs.writeFileSync(barChartFile, originalSource);
+		}
+	});
+
 	test('should preserve the sequence inspector scroll position when adding an effect', async ({
 		page,
 	}) => {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -106,13 +106,16 @@ test.describe('visual mode', () => {
 				await page.locator('[data-sidebar-toggle="right"]').click();
 			}
 
-			await page
-				.locator('[data-timeline-marquee-item][title="North bar"]')
-				.click();
-			await page
+			const colorButton = page
 				.getByRole('button', {name: '#000', exact: true})
-				.first()
-				.click();
+				.first();
+			await expect(async () => {
+				await page
+					.locator('[data-timeline-marquee-item][title="North bar"]')
+					.click();
+				await expect(colorButton).toBeVisible({timeout: 1_000});
+			}).toPass({timeout: 15_000});
+			await colorButton.click();
 
 			const hexInput = page.getByRole('textbox', {name: 'Hex'});
 			await expect(hexInput).toBeVisible();

--- a/packages/studio/src/components/UndoRedoButtons.tsx
+++ b/packages/studio/src/components/UndoRedoButtons.tsx
@@ -89,6 +89,8 @@ export const UndoRedoButtons: React.FC = () => {
 	}, []);
 
 	useEffect(() => {
+		// Visual controls such as the color picker commit edits while their popup
+		// remains open. Keep undo and redo available in that higher z-index context.
 		const undo = keybindings.registerKeybinding({
 			event: 'keydown',
 			key: 'z',
@@ -104,7 +106,7 @@ export const UndoRedoButtons: React.FC = () => {
 			},
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
+			keepRegisteredWhenNotHighestContext: true,
 		});
 
 		const redoWithShiftZ = keybindings.registerKeybinding({
@@ -122,7 +124,7 @@ export const UndoRedoButtons: React.FC = () => {
 			},
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
+			keepRegisteredWhenNotHighestContext: true,
 		});
 
 		const redoWithY = isMac
@@ -138,7 +140,7 @@ export const UndoRedoButtons: React.FC = () => {
 					},
 					preventDefault: true,
 					triggerIfInputFieldFocused: false,
-					keepRegisteredWhenNotHighestContext: false,
+					keepRegisteredWhenNotHighestContext: true,
 				});
 
 		return () => {


### PR DESCRIPTION
## Summary

- keep Studio undo and redo shortcuts registered while a higher z-index control is open
- allow color changes committed on pointer release to be undone without dismissing the color picker
- add a Studio E2E workflow covering drag, source persistence, and Cmd/Ctrl+Z

## Test plan

- `bunx playwright test e2e/studio.test.mts --grep='should commit a color drag before the picker closes'`
- `bun run build`
- `bun run stylecheck`

Closes #10372
