### PR TITLE
`@remotion/studio`: Prevent text selection from opening editor

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -182,6 +182,57 @@ test.describe('visual mode', () => {
 			);
 	});
 
+	test('should not open the editor when selecting text in the inspector', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			window.localStorage.setItem(
+				'remotion.sidebarRightCollapsing',
+				'expanded',
+			);
+			Object.defineProperty(window, 'remotion_editorName', {
+				configurable: true,
+				get: () => 'Test editor',
+				set: () => undefined,
+			});
+		});
+		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/open-in-editor', async (route) => {
+			openInEditorRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {success: true, data: {success: true}},
+			});
+		});
+
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+		const eyebrow = page.getByText('Eyebrow', {exact: true}).first();
+		await expect(eyebrow).toBeVisible({timeout: 15_000});
+		const textField = page.getByRole('textbox');
+		await expect(async () => {
+			await eyebrow.click();
+			await expect(textField).toHaveValue('Performance overview', {
+				timeout: 1_000,
+			});
+		}).toPass({timeout: 30_000});
+
+		await page.getByTitle('Text', {exact: true}).dblclick();
+		await expect.poll(() => openInEditorRequests.length).toBe(1);
+		openInEditorRequests.length = 0;
+
+		await textField.dblclick({position: {x: 20, y: 20}});
+		await expect
+			.poll(() =>
+				textField.evaluate((element) =>
+					element.value.slice(element.selectionStart, element.selectionEnd),
+				),
+			)
+			.toBe('overview');
+		// Headless Chromium does not consistently emit dblclick after selecting text.
+		await textField.dispatchEvent('dblclick');
+		await page.waitForTimeout(100);
+		expect(openInEditorRequests).toEqual([]);
+	});
+
 	test('should keep canvas item context menus open', async ({page}) => {
 		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
 		await expect(

--- a/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTextContentField.tsx
@@ -154,6 +154,7 @@ export const TimelineTextContentField: React.FC<{
 			defaultValue={currentValue}
 			onBlur={commitPending}
 			onChange={onChange}
+			onDoubleClick={(event) => event.stopPropagation()}
 			onKeyDownCapture={onKeyDownCapture}
 			style={textAreaStyle}
 		/>


### PR DESCRIPTION
## Summary

- prevent double-clicks inside the Inspector text editor from bubbling to the property row
- preserve native word selection inside the text field
- add an end-to-end regression test that keeps property-label editor navigation working

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test e2e/studio.test.mts --grep "should not open the editor when selecting text in the inspector"`
