### PR TITLE
`@remotion/studio`: keep easing handles on default cursor

### DIFF
--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -745,7 +745,6 @@ export const EasingEditor: React.FC<{
 	const springRef = useRef(spring);
 	const liveOverrideVersionRef = useRef(0);
 	const pendingOverrideTargetsRef = useRef<SelectedEasingUpdate[]>([]);
-	const [activeHandle, setActiveHandle] = useState<HandleIndex | null>(null);
 
 	useEffect(() => {
 		const nextBezier = easingToBezier(state.initialEasing);
@@ -1086,7 +1085,6 @@ export const EasingEditor: React.FC<{
 			event.preventDefault();
 			event.stopPropagation();
 			const bezierBeforeDrag = [...bezierRef.current] as CubicBezierTuple;
-			setActiveHandle(handle);
 			updateHandleFromPointer(handle, event);
 			startCapturedPointerSession({
 				event,
@@ -1106,8 +1104,6 @@ export const EasingEditor: React.FC<{
 						bezierRef.current = bezierBeforeDrag;
 						setBezier(bezierBeforeDrag);
 					}
-
-					setActiveHandle(null);
 				},
 			});
 		},
@@ -1260,7 +1256,7 @@ export const EasingEditor: React.FC<{
 							strokeWidth={2}
 							vectorEffect="non-scaling-stroke"
 							pointerEvents={disabled ? 'none' : 'all'}
-							cursor={activeHandle === 0 ? 'grabbing' : 'default'}
+							cursor="default"
 							onPointerDown={(event) => onHandlePointerDown(0, event)}
 						/>
 						<circle
@@ -1272,7 +1268,7 @@ export const EasingEditor: React.FC<{
 							strokeWidth={2}
 							vectorEffect="non-scaling-stroke"
 							pointerEvents={disabled ? 'none' : 'all'}
-							cursor={activeHandle === 1 ? 'grabbing' : 'default'}
+							cursor="default"
 							onPointerDown={(event) => onHandlePointerDown(1, event)}
 						/>
 					</svg>


### PR DESCRIPTION
Fixes #10390

The bezier easing editor handles currently switch the SVG cursor to `grabbing` while a handle is active. In practice this makes the cursor flicker between a grab-style affordance and the default pointer while adjusting the curve, even though the interaction is just direct manipulation of the handle.

This keeps the handle interaction unchanged, but leaves the cursor as `default` for both bezier handles and removes the now-unused active-handle cursor state. Dragging still starts from the same circles, previews the curve while moving, commits on pointer up, and rolls back on cancellation through the existing pointer-session flow.

Validation:

- `git diff --check`
- `bun x oxfmt packages/studio/src/components/Timeline/EasingEditorModal.tsx --check`
- `(cd packages/studio && bun run lint -- src/components/Timeline/EasingEditorModal.tsx)` (0 errors; existing repository warnings outside this file)
- `bun run makestudio`

Visual note:

- The issue video shows the before state. Because this change is specifically the native cursor affordance, a static screenshot would not capture the after state reliably; the code path now sets both SVG handles to `cursor="default"` while preserving the same pointer-down handlers.