### PR TITLE
perf(media-parser): avoid redundant completion checks

### DIFF
--- a/packages/media-parser/src/check-if-done.ts
+++ b/packages/media-parser/src/check-if-done.ts
@@ -3,22 +3,26 @@ import {Log} from './log';
 import type {ParserState} from './state/parser-state';
 
 export const checkIfDone = async (state: ParserState) => {
-	const startCheck = Date.now();
-	const hasAll = hasAllInfo({
-		state,
-	});
-	state.timings.timeCheckingIfDone += Date.now() - startCheck;
+	if (state.mode === 'query') {
+		const startCheck = Date.now();
+		const hasAll = hasAllInfo({
+			state,
+		});
+		state.timings.timeCheckingIfDone += Date.now() - startCheck;
 
-	if (hasAll && state.mode === 'query') {
-		Log.verbose(state.logLevel, 'Got all info, skipping to the end.');
-		state.increaseSkippedBytes(
-			state.contentLength - state.iterator.counter.getOffset(),
-		);
+		if (hasAll) {
+			Log.verbose(state.logLevel, 'Got all info, skipping to the end.');
+			state.increaseSkippedBytes(
+				state.contentLength - state.iterator.counter.getOffset(),
+			);
 
-		return true;
+			return true;
+		}
 	}
 
-	if (state.iterator.counter.getOffset() === state.contentLength) {
+	const offset = state.iterator.counter.getOffset();
+
+	if (offset === state.contentLength) {
 		if (
 			state.structure.getStructure().type === 'm3u' &&
 			!state.m3u.getAllChunksProcessedOverall()
@@ -38,8 +42,7 @@ export const checkIfDone = async (state: ParserState) => {
 	}
 
 	if (
-		state.iterator.counter.getOffset() + state.iterator.bytesRemaining() ===
-			state.contentLength &&
+		offset + state.iterator.bytesRemaining() === state.contentLength &&
 		state.errored
 	) {
 		Log.verbose(state.logLevel, 'Reached end of file and errorred');

--- a/packages/media-parser/src/emit-all-info.ts
+++ b/packages/media-parser/src/emit-all-info.ts
@@ -5,18 +5,16 @@ import type {ParserState} from './state/parser-state';
 
 export const emitAllInfo = async (state: ParserState) => {
 	// Force assign
-	const allFields = (
-		Object.keys(state.fields) as (keyof Options<ParseMediaFields>)[]
-	).reduce(
-		(acc, key) => {
-			if (state.fields?.[key]) {
-				acc[key] = true;
-			}
+	const allFields: Record<keyof Options<ParseMediaFields>, boolean> =
+		{} as Record<keyof Options<ParseMediaFields>, boolean>;
 
-			return acc;
-		},
-		{} as Record<keyof Options<ParseMediaFields>, boolean>,
-	);
+	const keys = Object.keys(state.fields) as (keyof Options<ParseMediaFields>)[];
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (state.fields[key]) {
+			allFields[key] = true;
+		}
+	}
 
 	await emitAvailableInfo({
 		hasInfo: allFields,

--- a/packages/media-parser/src/has-all-info.ts
+++ b/packages/media-parser/src/has-all-info.ts
@@ -16,142 +16,150 @@ import type {AllParseMediaFields} from './options';
 import {maySkipVideoData} from './state/may-skip-video-data';
 import type {ParserState} from './state/parser-state';
 
+const checkKey = (
+	key: keyof Options<AllParseMediaFields>,
+	state: ParserState,
+	structure: ReturnType<typeof state.structure.getStructureOrNull>,
+): boolean => {
+	if (key === 'slowStructure') {
+		return false;
+	}
+
+	if (key === 'durationInSeconds') {
+		return Boolean(structure && hasDuration(state));
+	}
+
+	if (key === 'slowDurationInSeconds') {
+		return Boolean(structure && hasSlowDuration(state));
+	}
+
+	if (
+		key === 'dimensions' ||
+		key === 'rotation' ||
+		key === 'unrotatedDimensions'
+	) {
+		return Boolean(structure && hasDimensions(state));
+	}
+
+	if (key === 'fps') {
+		return Boolean(structure && hasFps(state));
+	}
+
+	if (key === 'slowFps') {
+		return Boolean(structure && hasFpsSuitedForSlowFps(state));
+	}
+
+	if (key === 'isHdr') {
+		return Boolean(structure && hasHdr(state));
+	}
+
+	if (key === 'videoCodec') {
+		return Boolean(structure && hasVideoCodec(state));
+	}
+
+	if (key === 'audioCodec') {
+		return Boolean(structure && hasAudioCodec(state));
+	}
+
+	if (key === 'tracks') {
+		return Boolean(structure && getHasTracks(state, true));
+	}
+
+	if (key === 'keyframes') {
+		return Boolean(structure && hasKeyframes(state));
+	}
+
+	if (key === 'internalStats') {
+		return true;
+	}
+
+	if (key === 'size') {
+		return true;
+	}
+
+	if (key === 'mimeType') {
+		return true;
+	}
+
+	if (key === 'name') {
+		return true;
+	}
+
+	if (key === 'container') {
+		return Boolean(structure && hasContainer(structure));
+	}
+
+	if (key === 'metadata' || key === 'location' || key === 'images') {
+		return Boolean(structure && hasMetadata(structure));
+	}
+
+	if (
+		key === 'slowKeyframes' ||
+		key === 'slowVideoBitrate' ||
+		key === 'slowAudioBitrate' ||
+		key === 'slowNumberOfFrames'
+	) {
+		return false;
+	}
+
+	if (key === 'numberOfAudioChannels') {
+		return hasNumberOfAudioChannels(state);
+	}
+
+	if (key === 'sampleRate') {
+		return hasSampleRate(state);
+	}
+
+	if (key === 'm3uStreams') {
+		return m3uHasStreams(state);
+	}
+
+	throw new Error(
+		`Unknown field passed: ${key satisfies never}. Available fields: ${Object.keys(
+			state.fields,
+		).join(', ')}`,
+	);
+};
+
 export const getAvailableInfo = ({
 	state,
 }: {
 	state: ParserState;
 }): Record<keyof Options<ParseMediaFields>, boolean> => {
-	const keys = Object.entries(state.fields).filter(([, value]) => value) as [
-		keyof Options<ParseMediaFields>,
-		boolean,
-	][];
-
+	const entries: Record<keyof Options<ParseMediaFields>, boolean> =
+		{} as Record<keyof Options<ParseMediaFields>, boolean>;
 	const structure = state.structure.getStructureOrNull();
 
-	const infos = keys.map(([_key]) => {
-		const key = _key as keyof Options<AllParseMediaFields>;
-		if (key === 'slowStructure') {
-			return false;
+	const keys = Object.keys(state.fields) as (keyof Options<ParseMediaFields>)[];
+
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (state.fields[key]) {
+			entries[key] = checkKey(
+				key as keyof Options<AllParseMediaFields>,
+				state,
+				structure,
+			);
 		}
-
-		if (key === 'durationInSeconds') {
-			return Boolean(structure && hasDuration(state));
-		}
-
-		if (key === 'slowDurationInSeconds') {
-			const res = Boolean(structure && hasSlowDuration(state));
-			return res;
-		}
-
-		if (
-			key === 'dimensions' ||
-			key === 'rotation' ||
-			key === 'unrotatedDimensions'
-		) {
-			return Boolean(structure && hasDimensions(state));
-		}
-
-		if (key === 'fps') {
-			return Boolean(structure && hasFps(state));
-		}
-
-		if (key === 'slowFps') {
-			// In case FPS is available an non-null, it also works for `slowFps`
-			return Boolean(structure && hasFpsSuitedForSlowFps(state));
-		}
-
-		if (key === 'isHdr') {
-			return Boolean(structure && hasHdr(state));
-		}
-
-		if (key === 'videoCodec') {
-			return Boolean(structure && hasVideoCodec(state));
-		}
-
-		if (key === 'audioCodec') {
-			return Boolean(structure && hasAudioCodec(state));
-		}
-
-		if (key === 'tracks') {
-			return Boolean(structure && getHasTracks(state, true));
-		}
-
-		if (key === 'keyframes') {
-			return Boolean(structure && hasKeyframes(state));
-		}
-
-		if (key === 'internalStats') {
-			return true;
-		}
-
-		if (key === 'size') {
-			return true;
-		}
-
-		if (key === 'mimeType') {
-			return true;
-		}
-
-		if (key === 'name') {
-			return true;
-		}
-
-		if (key === 'container') {
-			return Boolean(structure && hasContainer(structure));
-		}
-
-		if (key === 'metadata' || key === 'location' || key === 'images') {
-			return Boolean(structure && hasMetadata(structure));
-		}
-
-		if (
-			key === 'slowKeyframes' ||
-			key === 'slowVideoBitrate' ||
-			key === 'slowAudioBitrate' ||
-			key === 'slowNumberOfFrames'
-		) {
-			return false;
-		}
-
-		if (key === 'numberOfAudioChannels') {
-			return hasNumberOfAudioChannels(state);
-		}
-
-		if (key === 'sampleRate') {
-			return hasSampleRate(state);
-		}
-
-		if (key === 'm3uStreams') {
-			return m3uHasStreams(state);
-		}
-
-		throw new Error(
-			`Unknown field passed: ${key satisfies never}. Available fields: ${Object.keys(
-				state.fields,
-			).join(', ')}`,
-		);
-	});
-
-	const entries: [keyof Options<ParseMediaFields>, boolean][] = [];
-	let i = 0;
-
-	for (const [key] of keys) {
-		entries.push([key, infos[i++]]);
 	}
 
-	return Object.fromEntries(entries) as Record<
-		keyof Options<ParseMediaFields>,
-		boolean
-	>;
+	return entries;
 };
 
 export const hasAllInfo = ({state}: {state: ParserState}) => {
-	const availableInfo = getAvailableInfo({
-		state,
-	});
+	const structure = state.structure.getStructureOrNull();
 
-	if (!Object.values(availableInfo).every(Boolean)) {
-		return false;
+	const keys = Object.keys(state.fields) as (keyof Options<ParseMediaFields>)[];
+
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (state.fields[key]) {
+			if (
+				!checkKey(key as keyof Options<AllParseMediaFields>, state, structure)
+			) {
+				return false;
+			}
+		}
 	}
 
 	if (maySkipVideoData({state})) {


### PR DESCRIPTION
## Summary

- Skip `hasAllInfo()` during full/download parses, where its result cannot terminate parsing early
- Reuse direct field checks instead of allocating intermediate entry/value arrays
- Keep query-mode early exit and final field emission behavior unchanged

## Performance

The accepted [Weco run](https://dashboard.weco.ai/share/h5ItWomvu5NozsE4QSkIxx8b5iNPcjK6) improved the five-container full-parse metric from `7471.262026` ms to `5794.572009` ms (22.4%).

Two independent frozen-evaluator replay pairs reproduced the improvement:

| Replay | Baseline | This change | Improvement |
| --- | ---: | ---: | ---: |
| 1 | 7293.491 ms | 5594.422 ms | 23.3% |
| 2 | 7465.765 ms | 5618.529 ms | 24.7% |

The evaluator covers MOV, MP4, AVI, MPEG-TS, and WebM, including mutable AVI AVC track metadata. Returned fields, callback values/order, tracks, sample counts, and fast-query results matched exactly.

## Validation

- `bunx turbo run formatting lint make testwebcodecs --filter=@remotion/media-parser --no-update-notifier`
- 183 tests passed, 3 skipped, 0 failed

## Tradeoffs

`timeCheckingIfDone` now measures query-mode completion checks only. Full/download parses no longer perform or report work whose result was unused.
