### PR TITLE
`@remotion/bundler`: do not crash when TypeScript exposes no `sys`

### DIFF
--- a/packages/bundler/src/esbuild-loader/index.ts
+++ b/packages/bundler/src/esbuild-loader/index.ts
@@ -46,12 +46,13 @@ async function ESBuildLoader(
 	if (!('tsconfigRaw' in transformOptions) && isTypescriptInstalled()) {
 		// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 		const typescript = require('typescript') as typeof import('typescript');
-		const tsConfig = typescript.readConfigFile(
-			tsConfigPath,
-			typescript.sys.readFile,
-		);
+		// TypeScript 7 (@typescript/native-preview) does not expose `sys` on the CommonJS export
+		const sys = typescript.sys as typeof typescript.sys | undefined;
+		if (sys) {
+			const tsConfig = typescript.readConfigFile(tsConfigPath, sys.readFile);
 
-		transformOptions.tsconfigRaw = tsConfig.config;
+			transformOptions.tsconfigRaw = tsConfig.config;
+		}
 	}
 
 	// https://github.com/privatenumber/esbuild-loader/pull/107


### PR DESCRIPTION
## Problem

`ESBuildLoader` reads the project's `tsconfig.json` via `typescript.readConfigFile(tsConfigPath, typescript.sys.readFile)`. On workspaces where the installed `typescript` is the native preview (TypeScript 7 / `@typescript/native-preview`), the CommonJS export does not expose `sys`, so bundling crashes with `Cannot read properties of undefined (reading 'readFile')`.

## Fix

Guard on `sys` being present. When it is not, fall back to the exact behavior Remotion already has when TypeScript is not installed at all (esbuild transforms without `tsconfigRaw`).

## Tradeoffs

On TS installs without `sys`, `tsconfigRaw` is not populated — same as the no-TypeScript path today. That seems strictly better than crashing the bundle step.

We have been running this patch in production at Bevyl (via `patchedDependencies`) since 4.0.484.