### PR TITLE
`@remotion/media`: restart audio after `destroyIterator()` even if seek parameters are unchanged

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -639,6 +639,9 @@ export const audioIteratorManager = ({
 			// getCurrentAnchor() cannot hand out a stale mapping (from a previous
 			// rate/trim) during the window before a new iterator is started.
 			currentAnchor = null;
+			// seek() dedups against currentSeek before checking whether an
+			// iterator exists - reset it so the next seek restarts audio.
+			currentSeek = {...currentSeek, time: -1};
 			unblockCurrentDelayHandle();
 		},
 		seek,

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -405,3 +405,18 @@ test('should not decode + schedule audio chunks beyond the end time', async () =
 
 	expect(scheduledChunks.length).toBe(23);
 });
+
+test('seek to the same time after destroyIterator() starts a new iterator', async () => {
+	const {seek, manager} = await prepare();
+
+	seek({time: 2});
+	expect(manager.getAudioIteratorsCreated()).toBe(1);
+	expect(manager.getAudioBufferIterator()).not.toBe(null);
+
+	manager.destroyIterator();
+	expect(manager.getAudioBufferIterator()).toBe(null);
+
+	seek({time: 2});
+	expect(manager.getAudioIteratorsCreated()).toBe(2);
+	expect(manager.getAudioBufferIterator()).not.toBe(null);
+});


### PR DESCRIPTION
## Problem

`audioIteratorManager.seek()` deduplicates: it returns early when every seek parameter matches the previous call — **before** checking whether an iterator actually exists.

`destroyIterator()` tears down the iterator (e.g. on an audio sync anchor change) but leaves `currentSeek` populated. The per-frame `seekTo(currentTime)` that follows carries the same time as the last seek, so it is deduplicated away and nothing ever restarts the iterator: dead air until the playhead value changes for some other reason.

`destroyIterator()` already resets `currentAnchor` for exactly this kind of staleness — this PR gives `currentSeek` the same treatment by invalidating its `time` (using the same `-1` sentinel the initial state uses, "do not prevent first seek").

## Fix

Reset the dedup state in `destroyIterator()` so the next `seek()` — even with identical parameters — starts a new iterator.

Added a regression test using the existing harness in `audio-iterator.test.ts`: seek → destroy → seek with the same parameters must create a second iterator.

We hit this in production (silent playback after anchor changes) and have been running this fix via `patchedDependencies` since 4.0.484.

## Tradeoffs

None known: the reset only widens when a new iterator may start; all other dedup parameters stay intact.