### PR TITLE
`@remotion/lambda-client`: honor custom `requestHandler` when invoking functions

### DIFF
--- a/packages/lambda-client/src/call-lambda-async.ts
+++ b/packages/lambda-client/src/call-lambda-async.ts
@@ -6,6 +6,7 @@ import type {
 } from '@remotion/serverless-client';
 import {getLambdaClient} from './aws-clients';
 import type {AwsRegion} from './regions';
+import type {RequestHandler} from './types';
 
 export const callFunctionAsyncImplementation = async <
 	T extends ServerlessRoutines,
@@ -15,6 +16,7 @@ export const callFunctionAsyncImplementation = async <
 	payload,
 	region,
 	timeoutInTest,
+	requestHandler,
 }: CallFunctionOptions<T, Provider>): Promise<void> => {
 	const stringifiedPayload = JSON.stringify(payload);
 	if (stringifiedPayload.length > 256 * 1024) {
@@ -26,7 +28,7 @@ export const callFunctionAsyncImplementation = async <
 	const result = await getLambdaClient(
 		region as AwsRegion,
 		timeoutInTest,
-		null,
+		(requestHandler ?? null) as RequestHandler | null,
 	).send(
 		new InvokeCommand({
 			FunctionName: functionName,

--- a/packages/lambda-client/src/call-lambda-streaming.ts
+++ b/packages/lambda-client/src/call-lambda-streaming.ts
@@ -19,6 +19,7 @@ import {
 } from '@remotion/serverless-client';
 import {getLambdaClient} from './aws-clients';
 import type {AwsRegion} from './regions';
+import type {RequestHandler} from './types';
 
 const STREAM_STALL_TIMEOUT = 30000;
 const LAMBDA_STREAM_STALL = `AWS did not invoke Lambda in ${STREAM_STALL_TIMEOUT}ms`;
@@ -38,17 +39,19 @@ const invokeStreamOrTimeout = async <Provider extends CloudProvider>({
 	functionName,
 	type,
 	payload,
+	requestHandler,
 }: {
 	region: Provider['region'];
 	timeoutInTest: number;
 	functionName: string;
 	type: string;
 	payload: Record<string, unknown>;
+	requestHandler: Provider['requestHandler'] | null;
 }) => {
 	const resProm = getLambdaClient(
 		region as AwsRegion,
 		timeoutInTest,
-		null,
+		(requestHandler ?? null) as RequestHandler | null,
 	).send(
 		new InvokeWithResponseStreamCommand({
 			FunctionName: functionName,
@@ -88,6 +91,7 @@ const callLambdaWithStreamingWithoutRetry = async <
 	region,
 	timeoutInTest,
 	receivedStreamingPayload,
+	requestHandler,
 }: CallFunctionOptions<T, Provider> & {
 	receivedStreamingPayload: OnMessage<Provider>;
 }): Promise<void> => {
@@ -97,6 +101,7 @@ const callLambdaWithStreamingWithoutRetry = async <
 		region,
 		timeoutInTest,
 		type,
+		requestHandler,
 	});
 
 	const {onData, clear} = makeStreamer((status, messageTypeId, data) => {

--- a/packages/lambda-client/src/call-lambda-sync.ts
+++ b/packages/lambda-client/src/call-lambda-sync.ts
@@ -8,6 +8,7 @@ import type {
 } from '@remotion/serverless-client';
 import {getLambdaClient} from './aws-clients';
 import type {AwsRegion} from './regions';
+import type {RequestHandler} from './types';
 
 const callLambdaSyncWithoutRetry = async <
 	T extends ServerlessRoutines,
@@ -17,6 +18,7 @@ const callLambdaSyncWithoutRetry = async <
 	payload,
 	region,
 	timeoutInTest,
+	requestHandler,
 }: CallFunctionOptions<T, Provider>): Promise<
 	OrError<ServerlessReturnValues<Provider>[T]>
 > => {
@@ -24,7 +26,7 @@ const callLambdaSyncWithoutRetry = async <
 	const res = await getLambdaClient(
 		region as AwsRegion,
 		timeoutInTest,
-		null,
+		(requestHandler ?? null) as RequestHandler | null,
 	).send(
 		new InvokeCommand({
 			FunctionName: functionName,

--- a/packages/lambda-client/src/get-service-client.ts
+++ b/packages/lambda-client/src/get-service-client.ts
@@ -26,13 +26,11 @@ const getCredentialsHash = ({
 	region,
 	service,
 	forcePathStyle,
-	requestHandler,
 }: {
 	region: string;
 	customCredentials: CustomCredentials<AwsProvider> | null;
 	service: keyof ServiceMapping;
 	forcePathStyle: boolean;
-	requestHandler: RequestHandler | null;
 }): string => {
 	const hashComponents: {[key: string]: unknown} = {};
 
@@ -70,7 +68,6 @@ const getCredentialsHash = ({
 	hashComponents.region = region;
 	hashComponents.service = service;
 	hashComponents.forcePathStyle = forcePathStyle;
-	hashComponents.requestHandler = requestHandler;
 
 	return random(JSON.stringify(hashComponents)).toString().replace('0.', '');
 };
@@ -86,6 +83,24 @@ const _clients: Partial<
 		| STSClient
 	>
 > = {};
+
+// Custom handlers cannot be serialized into the cache key; key by identity instead
+const _clientsWithCustomHandler = new WeakMap<
+	object,
+	Partial<Record<string, ServiceMapping[keyof ServiceMapping]>>
+>();
+
+const getCustomHandlerClientCache = (requestHandler: object) => {
+	const existing = _clientsWithCustomHandler.get(requestHandler);
+	if (existing) {
+		return existing;
+	}
+
+	const created: Partial<Record<string, ServiceMapping[keyof ServiceMapping]>> =
+		{};
+	_clientsWithCustomHandler.set(requestHandler, created);
+	return created;
+};
 
 export function getServiceClient<T extends keyof ServiceMapping>({
 	region,
@@ -133,10 +148,13 @@ export function getServiceClient<T extends keyof ServiceMapping>({
 		customCredentials,
 		service,
 		forcePathStyle,
-		requestHandler,
 	});
 
-	if (!_clients[key]) {
+	const cache = requestHandler
+		? getCustomHandlerClientCache(requestHandler)
+		: _clients;
+
+	if (!cache[key]) {
 		checkCredentials();
 
 		const lambdaOptions =
@@ -148,12 +166,8 @@ export function getServiceClient<T extends keyof ServiceMapping>({
 					}
 				: undefined;
 
-		// Merge custom requestHandler with lambda options
-		const finalRequestHandler = requestHandler
-			? lambdaOptions
-				? {...requestHandler, ...lambdaOptions}
-				: requestHandler
-			: lambdaOptions;
+		// Spreading a handler instance (e.g. NodeHttpHandler) would strip its prototype
+		const finalRequestHandler = requestHandler ?? lambdaOptions;
 
 		const client = customCredentials
 			? new Client({
@@ -187,8 +201,8 @@ export function getServiceClient<T extends keyof ServiceMapping>({
 			return client as ServiceMapping[T];
 		}
 
-		_clients[key] = client;
+		cache[key] = client;
 	}
 
-	return _clients[key] as ServiceMapping[T];
+	return cache[key] as ServiceMapping[T];
 }


### PR DESCRIPTION
## Problem

`CallFunctionOptions` accepts a `requestHandler`, and callers such as `renderMediaOnLambda()` pass it down — but all three invoke paths drop it and hardcode `null` when constructing the Lambda client:

- `callLambdaSyncWithoutRetry` (`call-lambda-sync.ts`)
- `callFunctionAsyncImplementation` (`call-lambda-async.ts`)
- `invokeStreamOrTimeout` (`call-lambda-streaming.ts`)

So a user-supplied `requestHandler` (e.g. a `NodeHttpHandler` with custom socket/request timeouts) is silently ignored for the actual `InvokeCommand` calls.

Two more issues surface once the handler does reach `getServiceClient`:

1. **Spread breaks handler instances.** `{...requestHandler, ...lambdaOptions}` copies only own enumerable properties, stripping the prototype of class-based handlers like `NodeHttpHandler` — the SDK then receives an object without a usable `handle()`.
2. **Cache collisions.** The client cache key JSON-stringifies the handler. Handler instances mostly serialize to the same JSON (their config is held in promises/private fields), so two different handlers collide on one key and whichever client was constructed first silently wins.

## Fix

- Thread `requestHandler` through all three invoke paths (same `as` cast style the files already use for `region`).
- Use a custom `requestHandler` as-is instead of spreading it.
- Cache clients with a custom `requestHandler` by handler identity (`WeakMap`) instead of serializing the handler into the cache key. Long-lived callers that reuse one handler (e.g. `getRenderProgress` polling through a proxy) keep client reuse; distinct handlers no longer collide; the handler is also no longer `JSON.stringify`-ed on every call.

## Tradeoffs

- With a custom handler, the caller's handler is used verbatim and the Lambda `httpsAgent: {maxSockets}` default is no longer merged in. The previous spread was not a safe merge in either direction: for instance handlers it stripped the prototype, and for plain-object handlers `lambdaOptions` was spread last, so a caller-supplied `httpsAgent` (the documented proxy setup) was silently replaced by `{maxSockets}` on Lambda clients. The one case the old merge genuinely handled — a plain-object handler with no `httpsAgent` of its own — now configures socket concurrency on its own handler instead.

We have been running these fixes in production at Bevyl via `patchedDependencies` since 4.0.484.
