### PR TITLE
`@remotion/lambda-python`: Respect forced bucket for still renders

### DIFF
--- a/packages/it-tests/src/monorepo/python-package.test.ts
+++ b/packages/it-tests/src/monorepo/python-package.test.ts
@@ -209,13 +209,7 @@ test('Python package should create the same renderStill payload as normal Lambda
 		});
 	const jsonOutput = toParse.substring(0, toParse.lastIndexOf('}') + 1);
 	const {streamed: _, ...parsedJson} = JSON.parse(jsonOutput);
-	// remove the bucketName field because request input does not have that value
-	// forceBucketName is being set in bucketName
-	const {bucketName, streamed, ...newObject} = nativeVersion;
-	const assertValue = {
-		...newObject,
-		forceBucketName: nativeVersion.bucketName,
-	};
+	const {streamed, ...assertValue} = nativeVersion;
 	expect(removeUndefined(parsedJson)).toEqual(removeUndefined(assertValue));
 });
 const removeUndefined = (data: unknown) => {

--- a/packages/lambda-python/remotion_lambda/models.py
+++ b/packages/lambda-python/remotion_lambda/models.py
@@ -521,7 +521,7 @@ class RenderStillParams:
             'forceHeight': self.force_height,
             'forceFps': self.force_fps,
             'forceDurationInFrames': self.force_duration_in_frames,
-            'forceBucketName': self.force_bucket_name,
+            'bucketName': self.force_bucket_name,
             'deleteAfter': self.delete_after,
             'attempt': self.attempt,
             'offthreadVideoCacheSizeInBytes': self.offthreadvideo_cache_size_in_bytes,

--- a/packages/lambda-python/tests/test_render_client_render_still.py
+++ b/packages/lambda-python/tests/test_render_client_render_still.py
@@ -5,6 +5,19 @@ from remotion_lambda.remotionclient import RemotionClient
 
 
 class TestRemotionClient(TestCase):
+    def test_force_bucket_name_is_serialized_as_bucket_name(self):
+        render_still_params = RenderStillParams(
+            composition="still-helloworld",
+            force_bucket_name="remotionlambda-useast1-testbucket",
+        )
+
+        serialized_params = render_still_params.serialize_params()
+
+        self.assertEqual(
+            serialized_params['bucketName'], 'remotionlambda-useast1-testbucket'
+        )
+        self.assertNotIn('forceBucketName', serialized_params)
+
     def test_remotion_construct_request(self):
         client = RemotionClient(
             region="us-east-1", serve_url="testbed", function_name="remotion-render"


### PR DESCRIPTION
## Summary

- serialize `RenderStillParams.force_bucket_name` as the Lambda payload's `bucketName` field
- add a regression test for the Python still payload
- restore direct payload parity between the Python and JavaScript Lambda clients

## Tests

- `python -m pytest`
- `bun test src/monorepo/python-package.test.ts --run --timeout 40000`
- `bun run build`
- `bun run stylecheck`

Closes #10398
