### PR TITLE
`@remotion/media`: Restart audio after iterator destruction

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -78,13 +78,6 @@ export const audioIteratorManager = ({
 	getStartTime,
 	initialMuted,
 	drawDebugOverlay,
-	initialPlaybackRate,
-	initialTrimBefore,
-	initialTrimAfter,
-	initialSequenceOffset,
-	initialSequenceDurationInFrames,
-	initialLoop,
-	initialFps,
 }: {
 	audioTrack: InputAudioTrack;
 	delayPlaybackHandleIfNotPremounting: () => DelayPlaybackIfNotPremounting;
@@ -95,27 +88,19 @@ export const audioIteratorManager = ({
 	getStartTime: () => number;
 	initialMuted: boolean;
 	drawDebugOverlay: () => void;
-	initialPlaybackRate: number;
-	initialTrimBefore: number | undefined;
-	initialTrimAfter: number | undefined;
-	initialSequenceOffset: number;
-	initialSequenceDurationInFrames: number;
-	initialLoop: boolean;
-	initialFps: number;
 }) => {
 	let muted = initialMuted;
 	let currentVolume = 1;
-	let currentSeek = {
-		// do not prevent first seek
-		time: -1,
-		playbackRate: initialPlaybackRate,
-		trimBefore: initialTrimBefore,
-		trimAfter: initialTrimAfter,
-		sequenceOffset: initialSequenceOffset,
-		sequenceDurationInFrames: initialSequenceDurationInFrames,
-		loop: initialLoop,
-		fps: initialFps,
-	};
+	let currentSeek: {
+		time: number;
+		playbackRate: number;
+		trimBefore: number | undefined;
+		trimAfter: number | undefined;
+		sequenceOffset: number;
+		sequenceDurationInFrames: number;
+		loop: boolean;
+		fps: number;
+	} | null = null;
 
 	const gainNode = sharedAudioContext.audioContext.createGain();
 	gainNode.connect(sharedAudioContext.gainNode);
@@ -539,6 +524,7 @@ export const audioIteratorManager = ({
 		}
 
 		if (
+			currentSeek !== null &&
 			currentSeek.time === newTime &&
 			currentSeek.playbackRate === playbackRate &&
 			currentSeek.trimBefore === trimBefore &&
@@ -639,6 +625,7 @@ export const audioIteratorManager = ({
 			// getCurrentAnchor() cannot hand out a stale mapping (from a previous
 			// rate/trim) during the window before a new iterator is started.
 			currentAnchor = null;
+			currentSeek = null;
 			unblockCurrentDelayHandle();
 		},
 		seek,

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -391,15 +391,8 @@ export class MediaPlayer {
 					getStartTime: () => this.getStartTime(),
 					initialMuted,
 					drawDebugOverlay: this.drawDebugOverlay,
-					initialPlaybackRate: this.playbackRate * this.globalPlaybackRate,
 					getSequenceDurationInSeconds: () =>
 						this.getSequenceDurationInSeconds(),
-					initialTrimBefore: this.trimBefore,
-					initialTrimAfter: this.trimAfter,
-					initialSequenceOffset: this.sequenceOffset,
-					initialSequenceDurationInFrames: this.sequenceDurationInFrames,
-					initialLoop: this.loop,
-					initialFps: this.fps,
 				});
 			}
 

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -77,13 +77,6 @@ const prepare = async (options?: {
 		getStartTime: () => startTime,
 		initialMuted: false,
 		drawDebugOverlay: () => {},
-		initialPlaybackRate: 1,
-		initialTrimBefore: undefined,
-		initialTrimAfter: undefined,
-		initialSequenceOffset: 0,
-		initialSequenceDurationInFrames: 10,
-		initialLoop: loop,
-		initialFps: 30,
 	});
 
 	const scheduledChunks: number[] = [];
@@ -404,4 +397,19 @@ test('should not decode + schedule audio chunks beyond the end time', async () =
 	}
 
 	expect(scheduledChunks.length).toBe(23);
+});
+
+test('seek to the same time after destroyIterator() starts a new iterator', async () => {
+	const {seek, manager} = await prepare();
+
+	seek({time: 2});
+	expect(manager.getAudioIteratorsCreated()).toBe(1);
+	expect(manager.getAudioBufferIterator()).not.toBe(null);
+
+	manager.destroyIterator();
+	expect(manager.getAudioBufferIterator()).toBe(null);
+
+	seek({time: 2});
+	expect(manager.getAudioIteratorsCreated()).toBe(2);
+	expect(manager.getAudioBufferIterator()).not.toBe(null);
 });

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -126,13 +126,6 @@ test('same goes for audio', async () => {
 		getStartTime: () => 0,
 		initialMuted: false,
 		drawDebugOverlay: () => {},
-		initialPlaybackRate: 1,
-		initialTrimBefore: undefined,
-		initialTrimAfter: undefined,
-		initialSequenceOffset: 0,
-		initialSequenceDurationInFrames: 10,
-		initialLoop: false,
-		initialFps: 30,
 	});
 
 	const nonceManager = makeNonceManager();


### PR DESCRIPTION
## Problem

`audioIteratorManager.seek()` deduplicates identical seek parameters. After `destroyIterator()` removes the active iterator, the cached parameters remain, so the next seek to the same time is skipped and audio does not restart.

## Solution

Represent the cached seek as nullable state and clear it whenever the iterator is destroyed. This models the cache validity directly instead of assigning a magic `-1` time sentinel.

Starting without a cached seek also removes the initial seek parameters that were previously required only to construct the sentinel state.

## Testing

- Added a browser regression test covering seek → destroy → identical seek.
- Verified that the test fails without invalidation and passes with the fix.
- Ran `bun run build`.
- Ran `bun run stylecheck`.

Supersedes #10417.
