### PR TITLE
`@remotion/mac-cursors`: Implement hidden schema

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -212,18 +212,29 @@ test.describe('visual mode', () => {
 			'[data-timeline-marquee-item][title="Copy rotation target"]',
 		);
 		await expect(sourceRow).toBeVisible({timeout: 15_000});
-		await page
-			.getByTitle('Copy rotation source', {exact: true})
-			.first()
-			.click({button: 'right'});
-		await page.getByRole('button', {name: 'Rotate', exact: true}).click();
+		await expect(targetRow).toBeVisible({timeout: 15_000});
+		const rotateButton = page.getByRole('button', {
+			name: 'Rotate',
+			exact: true,
+		});
+		await expect(async () => {
+			await page
+				.getByTitle('Copy rotation source', {exact: true})
+				.first()
+				.click({button: 'right'});
+			await expect(rotateButton).toBeVisible({timeout: 1000});
+		}).toPass({timeout: 15_000});
+		await rotateButton.click();
 		await page.keyboard.press('ControlOrMeta+c');
 
-		await page
-			.getByTitle('Copy rotation target', {exact: true})
-			.first()
-			.click({button: 'right'});
-		await page.getByRole('button', {name: 'Rotate', exact: true}).click();
+		await expect(async () => {
+			await page
+				.getByTitle('Copy rotation target', {exact: true})
+				.first()
+				.click({button: 'right'});
+			await expect(rotateButton).toBeVisible({timeout: 1000});
+		}).toPass({timeout: 15_000});
+		await rotateButton.click();
 		await page.keyboard.press('ControlOrMeta+v');
 
 		await expect

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -11,6 +11,8 @@ import {
 import {navigateToLostNodePathE2e, navigateToSchemaTest} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
+const macCursorsFile = path.join(exampleDir, 'src', 'MacCursors', 'index.tsx');
+
 const dropAssetOnCanvas = async ({
 	assetPath,
 	durationInSeconds,
@@ -253,6 +255,38 @@ test.describe('visual mode', () => {
 			.toContain(
 				'<AbsoluteFill name="Copy rotation target" style={{rotate: \'0deg\'}} />',
 			);
+	});
+
+	test('should toggle the visibility of a macOS cursor', async ({page}) => {
+		const originalSource = fs.readFileSync(macCursorsFile, 'utf-8');
+
+		try {
+			await page.goto(`${STUDIO_URL}/mac-cursors`);
+			const cursorLabel = page
+				.getByText('Hideable cursor', {exact: true})
+				.first();
+			const visibilityToggle = cursorLabel
+				.locator('..')
+				.locator('..')
+				.locator('[data-timeline-layer-eye]');
+			await expect(async () => {
+				await expect(cursorLabel).toBeVisible({timeout: 1000});
+				await expect(visibilityToggle).toBeVisible({timeout: 1000});
+			}).toPass({timeout: 15_000});
+
+			await visibilityToggle.click();
+			await expect
+				.poll(() => {
+					const source = fs.readFileSync(macCursorsFile, 'utf-8');
+					const cursorNameIndex = source.indexOf('name="Hideable cursor"');
+					const tagStart = source.lastIndexOf('<MacOSCursor', cursorNameIndex);
+					const tagEnd = source.indexOf('/>', cursorNameIndex);
+					return source.slice(tagStart, tagEnd + 2);
+				})
+				.toContain('hidden');
+		} finally {
+			fs.writeFileSync(macCursorsFile, originalSource);
+		}
 	});
 
 	test('should not open the editor when selecting text in the inspector', async ({

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -10,6 +10,7 @@ import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
 import {Issue8216} from './Issue8216/Issue8216';
 import {LightLeakExample} from './LightLeak';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
+import {MacCursorsExample} from './MacCursors';
 import {NewVideoComp} from './NewVideo';
 import {RotationKeyframeE2e} from './RotationKeyframeE2e';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
@@ -110,6 +111,14 @@ export const E2eTestRoot: React.FC = () => {
 			<Composition
 				id="package-absolute-fill"
 				component={LightLeakExample}
+				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
+			<Composition
+				id="mac-cursors"
+				component={MacCursorsExample}
 				width={1080}
 				height={1080}
 				fps={30}

--- a/packages/example/src/MacCursors/index.tsx
+++ b/packages/example/src/MacCursors/index.tsx
@@ -11,7 +11,11 @@ export const MacCursorsExample: React.FC = () => {
 
 	return (
 		<AbsoluteFill style={{backgroundColor: '#ddd'}}>
-			<MacOSCursor cursor="pointer" style={{left: 350, top: 540, scale: 4}} />
+			<MacOSCursor
+				name="Hideable cursor"
+				cursor="pointer"
+				style={{left: 350, top: 540, scale: 4}}
+			/>
 			<MacOSCursor
 				cursor={interpolate(frame, [0, 45], ['pointer', 'custom'], {
 					easing: Easing.step1,

--- a/packages/mac-cursors/src/MacOSCursor.tsx
+++ b/packages/mac-cursors/src/MacOSCursor.tsx
@@ -15,7 +15,8 @@ export type MacOSCursorProps = InteractiveBaseProps & {
 	readonly style?: CSSProperties;
 };
 
-export const macOSCursorSchema = {
+export const macOSCursorSchema: InteractivitySchema = {
+	...Interactive.baseSchema,
 	cursor: {
 		type: 'enum',
 		default: 'default',

--- a/packages/mac-cursors/src/test/resolve-cursor.test.ts
+++ b/packages/mac-cursors/src/test/resolve-cursor.test.ts
@@ -43,10 +43,15 @@ test('resolves named, custom, hidden, and unknown cursors', () => {
 });
 
 test('cursor schema exposes named cursors as a keyframable enum', () => {
-	expect(macOSCursorSchema.cursor.keyframable).toBe(true);
-	expect(macOSCursorSchema.cursor.variants.default).toEqual({});
-	expect(macOSCursorSchema.cursor.variants['ne-resize']).toEqual({});
-	expect(macOSCursorSchema.cursor.variants.custom).toEqual({
+	const cursorSchema = macOSCursorSchema.cursor;
+	if (cursorSchema.type !== 'enum') {
+		throw new Error('Expected cursor schema to be an enum');
+	}
+
+	expect(cursorSchema.keyframable).toBe(true);
+	expect(cursorSchema.variants.default).toEqual({});
+	expect(cursorSchema.variants['ne-resize']).toEqual({});
+	expect(cursorSchema.variants.custom).toEqual({
 		customCursor: {
 			type: 'text-content',
 			default: '',


### PR DESCRIPTION
## Summary

- expose the base interactivity schema on `<MacOSCursor>` so its timeline visibility control can persist `hidden`
- add an E2E composition and workflow that hides a macOS cursor and verifies the source edit
- stabilize the property-copy E2E by retrying context-menu opening until asynchronous node-path information makes Rotate available

## Testing

- `bun test packages/mac-cursors/src/test`
- `bunx playwright test e2e/studio.test.mts --grep "should (copy a keyframed property between component types|toggle the visibility of a macOS cursor)"`
- red/green verified by removing `Interactive.baseSchema`, rebuilding, and confirming the visibility E2E fails on the missing eye control
- `bun run build`
- `bun run stylecheck`

Closes #10393
