### PR TITLE
`@remotion/studio`: Derive splitting support from timing traits

### DIFF
--- a/packages/studio-server/src/codemods/split-jsx-sequence.ts
+++ b/packages/studio-server/src/codemods/split-jsx-sequence.ts
@@ -335,9 +335,7 @@ export const splitJsxSequence = async ({
 	const jsxElement = jsxPath.node as JSXElement;
 	const tagName = getSplittableSequenceTagName(jsxElement);
 	if (!hasSequenceTimingTraits(sequenceKeys)) {
-		throw new Error(
-			`<${tagName}> does not expose the sequence timing traits needed to split from source`,
-		);
+		throw new Error(`<${tagName}> cannot be split`);
 	}
 
 	const timing = readSequenceTiming(jsxElement);

--- a/packages/studio-server/src/codemods/split-jsx-sequence.ts
+++ b/packages/studio-server/src/codemods/split-jsx-sequence.ts
@@ -12,7 +12,10 @@ import type {
 	ReturnStatement,
 } from '@babel/types';
 import {cloneNode} from '@babel/types';
-import type {SequenceNodePathRemapping} from '@remotion/studio-shared';
+import {
+	hasSequenceTimingTraits,
+	type SequenceNodePathRemapping,
+} from '@remotion/studio-shared';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
 import {
@@ -228,40 +231,6 @@ const orderTimingAttributes = (element: JSXElement) => {
 	);
 };
 
-const splittableSequenceTags = new Set([
-	'AnimatedImage',
-	'Arrow',
-	'Audio',
-	'Callout',
-	'CanvasImage',
-	'Circle',
-	'Ellipse',
-	'Gif',
-	'Heart',
-	'Html5Audio',
-	'Html5Video',
-	'HtmlInCanvas',
-	'Img',
-	'OffthreadVideo',
-	'Pie',
-	'Polygon',
-	'Rect',
-	'RemotionRiveCanvas',
-	'Sequence',
-	'Solid',
-	'Spark',
-	'Star',
-	'Starburst',
-	'Triangle',
-	'Video',
-]);
-
-const unsupportedSequenceTags = new Set([
-	'Series.Sequence',
-	'TransitionSeries.Overlay',
-	'TransitionSeries.Sequence',
-]);
-
 const jsxMemberNameToString = (
 	name: JSXIdentifier | JSXMemberExpression,
 ): string => {
@@ -280,32 +249,6 @@ const jsxNameToString = (
 	}
 
 	return jsxMemberNameToString(name);
-};
-
-export const getSplitUnsupportedSequenceTagReason = (
-	tagName: string,
-): string | null => {
-	if (
-		tagName === 'Series.Sequence' ||
-		tagName === 'TransitionSeries.Sequence' ||
-		tagName === 'TransitionSeries.Overlay'
-	) {
-		return `<${tagName}> cannot be split from source`;
-	}
-
-	return null;
-};
-
-export const getIsSplittableSequenceTag = (tagName: string): boolean => {
-	if (unsupportedSequenceTags.has(tagName)) {
-		return false;
-	}
-
-	if (tagName.startsWith('Interactive.')) {
-		return true;
-	}
-
-	return splittableSequenceTags.has(tagName);
 };
 
 const getSplittableSequenceTagName = (element: JSXElement): string => {
@@ -360,11 +303,13 @@ const insertAfter = (
 export const splitJsxSequence = async ({
 	input,
 	nodePath,
+	sequenceKeys,
 	splitFrame,
 	prettierConfigOverride,
 }: {
 	input: string;
 	nodePath: SequenceNodePath;
+	sequenceKeys: string[];
 	splitFrame: number;
 	prettierConfigOverride?: Record<string, unknown> | null;
 }): Promise<{
@@ -389,14 +334,9 @@ export const splitJsxSequence = async ({
 
 	const jsxElement = jsxPath.node as JSXElement;
 	const tagName = getSplittableSequenceTagName(jsxElement);
-	const unsupportedReason = getSplitUnsupportedSequenceTagReason(tagName);
-	if (unsupportedReason) {
-		throw new Error(unsupportedReason);
-	}
-
-	if (!getIsSplittableSequenceTag(tagName)) {
+	if (!hasSequenceTimingTraits(sequenceKeys)) {
 		throw new Error(
-			`<${tagName}> does not support sequence timing props and cannot be split`,
+			`<${tagName}> does not expose the sequence timing traits needed to split from source`,
 		);
 	}
 

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -21,7 +21,11 @@ import {withSourceFileWriteQueue} from './source-file-write-queue';
 export const splitJsxSequenceHandler: ApiHandler<
 	SplitJsxSequenceRequest,
 	SplitJsxSequenceResponse
-> = ({input: {fileName, nodePath, splitFrame}, remotionRoot, logLevel}) =>
+> = ({
+	input: {fileName, nodePath, sequenceKeys, splitFrame},
+	remotionRoot,
+	logLevel,
+}) =>
 	withSourceFileWriteQueue(async () => {
 		try {
 			RenderInternals.Log.trace(
@@ -37,7 +41,12 @@ export const splitJsxSequenceHandler: ApiHandler<
 			const fileContents = readFileSync(absolutePath, 'utf-8');
 
 			const {output, formatted, nodeLabel, logLine, nodePathRemappings} =
-				await splitJsxSequence({input: fileContents, nodePath, splitFrame});
+				await splitJsxSequence({
+					input: fileContents,
+					nodePath,
+					sequenceKeys,
+					splitFrame,
+				});
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath,

--- a/packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts
+++ b/packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts
@@ -156,6 +156,7 @@ test('JSX structure routes broadcast and return node path mutations before writi
 			input: {
 				fileName,
 				nodePath: lineContainingToNodePath(before, 'name="c"'),
+				sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
 				splitFrame: 30,
 			},
 		});

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -183,13 +183,13 @@ test('splitJsxSequence rejects Series.Sequence', async () => {
 			'durationInFrames',
 			'trimBefore',
 		]),
-	).rejects.toThrow(/does not expose the sequence timing traits/);
+	).rejects.toThrow('<Series.Sequence> cannot be split');
 });
 
 test('splitJsxSequence rejects regular DOM elements', async () => {
 	await expect(
 		split('<div from={0} durationInFrames={50} />', 30, []),
-	).rejects.toThrow(/does not expose the sequence timing traits/);
+	).rejects.toThrow('<div> cannot be split');
 });
 
 const clearUndoStack = () => {

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -14,7 +14,7 @@ import {lineColumnToNodePath, lineContainingToNodePath} from './test-utils';
 
 const wrap = (
 	sequence: string,
-) => `import {Img, Interactive, Sequence, Series, Solid} from 'remotion';
+) => `import {AbsoluteFill, Img, Interactive, Sequence, Series, Solid} from 'remotion';
 import {Gif} from '@remotion/gif';
 
 export const Comp = () => {
@@ -27,12 +27,18 @@ export const Comp = () => {
 `;
 
 const sequenceLine = 7;
+const sequenceTimingKeys = ['from', 'durationInFrames', 'trimBefore'];
 
-const split = async (sequence: string, splitFrame: number) => {
+const split = async (
+	sequence: string,
+	splitFrame: number,
+	sequenceKeys = sequenceTimingKeys,
+) => {
 	const input = wrap(sequence);
 	const {output} = await splitJsxSequence({
 		input,
 		nodePath: lineColumnToNodePath(input, sequenceLine),
+		sequenceKeys,
 		splitFrame,
 	});
 
@@ -53,6 +59,7 @@ test('splitJsxSequence remaps following JSX siblings', async () => {
 	const {output, nodePathRemappings} = await splitJsxSequence({
 		input,
 		nodePath: lineContainingToNodePath(input, 'name="split"'),
+		sequenceKeys: sequenceTimingKeys,
 		splitFrame: 30,
 	});
 
@@ -121,6 +128,11 @@ test('splitJsxSequence splits from-only sequence', async () => {
 
 test('splitJsxSequence splits sequence-backed components', async () => {
 	expect(
+		await split('<AbsoluteFill from={0} durationInFrames={50} />', 30),
+	).toContain(
+		'<AbsoluteFill from={30} durationInFrames={20} trimBefore={30} />',
+	);
+	expect(
 		await split('<Img src="image.png" from={0} durationInFrames={50} />', 30),
 	).toContain(
 		'<Img src="image.png" from={30} durationInFrames={20} trimBefore={30} />',
@@ -167,14 +179,17 @@ test('splitJsxSequence rejects boundary and dynamic splits', async () => {
 
 test('splitJsxSequence rejects Series.Sequence', async () => {
 	await expect(
-		split('<Series.Sequence from={0} durationInFrames={50} />', 30),
-	).rejects.toThrow(/cannot be split from source/);
+		split('<Series.Sequence durationInFrames={50} />', 30, [
+			'durationInFrames',
+			'trimBefore',
+		]),
+	).rejects.toThrow(/does not expose the sequence timing traits/);
 });
 
 test('splitJsxSequence rejects regular DOM elements', async () => {
 	await expect(
-		split('<div from={0} durationInFrames={50} />', 30),
-	).rejects.toThrow(/does not support sequence timing props/);
+		split('<div from={0} durationInFrames={50} />', 30, []),
+	).rejects.toThrow(/does not expose the sequence timing traits/);
 });
 
 const clearUndoStack = () => {
@@ -224,7 +239,7 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 	try {
 		clearUndoStack();
 		const entryPoint = path.join(remotionRoot, 'Root.tsx');
-		const input = wrap('<Sequence from={0} durationInFrames={50} />');
+		const input = wrap('<AbsoluteFill from={0} durationInFrames={50} />');
 		writeFileSync(entryPoint, input);
 
 		const success = await splitJsxSequenceHandler(
@@ -232,6 +247,7 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 				input: {
 					fileName: entryPoint,
 					nodePath: lineColumnToNodePath(input, sequenceLine),
+					sequenceKeys: sequenceTimingKeys,
 					splitFrame: 30,
 				},
 				entryPoint,
@@ -241,7 +257,7 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 
 		expect(success.success).toBe(true);
 		expect(readFileSync(entryPoint, 'utf-8')).toContain(
-			'<Sequence from={30} durationInFrames={20} trimBefore={30} />',
+			'<AbsoluteFill from={30} durationInFrames={20} trimBefore={30} />',
 		);
 		expect(getUndoStack().length).toBe(1);
 
@@ -250,6 +266,7 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 				input: {
 					fileName: entryPoint,
 					nodePath: lineColumnToNodePath(input, sequenceLine),
+					sequenceKeys: sequenceTimingKeys,
 					splitFrame: 0,
 				},
 				entryPoint,

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -800,6 +800,7 @@ export type DuplicateJsxNodeResponse =
 export type SplitJsxSequenceRequest = {
 	fileName: string;
 	nodePath: SequenceNodePath;
+	sequenceKeys: string[];
 	splitFrame: number;
 };
 

--- a/packages/studio-shared/src/has-sequence-timing-traits.ts
+++ b/packages/studio-shared/src/has-sequence-timing-traits.ts
@@ -1,0 +1,5 @@
+const sequenceTimingTraits = ['from', 'durationInFrames', 'trimBefore'];
+
+export const hasSequenceTimingTraits = (sequenceKeys: readonly string[]) => {
+	return sequenceTimingTraits.every((trait) => sequenceKeys.includes(trait));
+};

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -163,6 +163,7 @@ export type {
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {compositionDragDataToSymbolicatedStack} from './composition-drag-data';
 export {REACT_REFRESH_FINISHED_EVENT} from './react-refresh-event';
+export {hasSequenceTimingTraits} from './has-sequence-timing-traits';
 export {
 	getConfigFileChangeMessage,
 	type ConfigFileChangeType,

--- a/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
@@ -1,3 +1,4 @@
+import {hasSequenceTimingTraits} from '@remotion/studio-shared';
 import type {
 	CanUpdateSequencePropStatus,
 	OverrideIdToNodePaths,
@@ -27,19 +28,6 @@ type SplitPropStatuses = Partial<
 		CanUpdateSequencePropStatus
 	>
 >;
-
-export const getTimelineSequenceSplitUnsupportedReason = (
-	componentName: string | null | undefined,
-): string | null => {
-	if (
-		componentName === '<TransitionSeries.Sequence>' ||
-		componentName === '<TransitionSeries.Overlay>'
-	) {
-		return `${componentName} cannot be split from source`;
-	}
-
-	return null;
-};
 
 const staticNumberish = (
 	status: CanUpdateSequencePropStatus | undefined,
@@ -93,13 +81,14 @@ export const getTimelineSequenceSplitEligibility = ({
 		};
 	}
 
-	const unsupportedReason = getTimelineSequenceSplitUnsupportedReason(
-		sequence.controls?.componentName,
-	);
-	if (unsupportedReason) {
+	if (
+		!hasSequenceTimingTraits(
+			selection.nodePathInfo.sequenceSubscriptionKey.sequenceKeys,
+		)
+	) {
 		return {
 			canSplit: false,
-			reason: unsupportedReason,
+			reason: 'Sequence does not expose timing traits that can be split',
 		};
 	}
 
@@ -167,6 +156,7 @@ export const splitTimelineSequenceFromSource = ({
 	return callApi('/api/split-jsx-sequence', {
 		fileName: nodePath.absolutePath,
 		nodePath: nodePath.nodePath,
+		sequenceKeys: nodePath.sequenceKeys,
 		splitFrame,
 	})
 		.then((result) => {

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -19,7 +19,7 @@ import {makeRuntimeValueStore} from './make-runtime-value-store';
 const makeKey = (nodePath: SequenceNodePath): SequencePropsSubscriptionKey => ({
 	absolutePath: '/tmp/Comp.tsx',
 	nodePath,
-	sequenceKeys: [],
+	sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
 	effectKeys: [],
 	videoConfigValues: null,
 });
@@ -167,6 +167,28 @@ test('getTimelineSequenceSplitEligibility rejects non-editable sequence shapes',
 	).toEqual({
 		canSplit: true,
 		nodePathInfo: makeNodePathInfo(['body', 2]),
+	});
+});
+
+test('getTimelineSequenceSplitEligibility derives timing support from schema keys', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0]);
+	const withoutFrom = {
+		...nodePathInfo,
+		sequenceSubscriptionKey: {
+			...nodePathInfo.sequenceSubscriptionKey,
+			sequenceKeys: ['durationInFrames', 'trimBefore'],
+		},
+	};
+
+	expect(
+		getTimelineSequenceSplitEligibility({
+			selection: {type: 'sequence', nodePathInfo: withoutFrom},
+			sequence: makeSequence(),
+			splitFrame: 30,
+		}),
+	).toEqual({
+		canSplit: false,
+		reason: 'Sequence does not expose timing traits that can be split',
 	});
 });
 


### PR DESCRIPTION
## Summary

- derive source-splitting support from the sequence timing traits exposed by a component
- remove the duplicated component-name allowlist from Studio and the split codemod
- allow sequence-backed components such as `<AbsoluteFill>` to split automatically
- keep components without `from`, `durationInFrames`, and `trimBefore` traits unsplittable

## Testing

- `bun test packages/studio-server/src/test/split-jsx-sequence.test.ts packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts packages/studio/src/test/split-selected-timeline-item.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10385
