### PR TITLE
`@remotion/studio`: Allow precise timeline inputs

### DIFF
--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import assert from 'node:assert';
-import {expect, test} from '@playwright/test';
+import {expect, type Locator, type Page, test} from '@playwright/test';
 import {wave} from '@remotion/effects/wave';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {apiCall} from './api-call.mts';
@@ -20,6 +20,19 @@ const getLine = (input: string, search: string) => {
 	}
 
 	return line + 1;
+};
+
+const selectScalePrecisionAndWaitFor = async ({
+	page,
+	locator,
+}: {
+	readonly page: Page;
+	readonly locator: Locator;
+}) => {
+	await expect(async () => {
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+		await expect(locator).toBeVisible({timeout: 1_000});
+	}).toPass({timeout: 15_000});
 };
 
 test.describe('effect keyframes', () => {
@@ -112,8 +125,6 @@ test.describe('effect keyframes', () => {
 			{timeout: 30_000},
 		);
 
-		await page.getByTitle('Scale precision', {exact: true}).first().click();
-
 		const scaleRow = page
 			.getByText('Scale', {exact: true})
 			.locator('..')
@@ -121,7 +132,7 @@ test.describe('effect keyframes', () => {
 		const scaleDragger = scaleRow
 			.locator('button.__remotion_input_dragger')
 			.first();
-		await expect(scaleDragger).toBeVisible({timeout: 15_000});
+		await selectScalePrecisionAndWaitFor({page, locator: scaleDragger});
 		await scaleDragger.click();
 
 		const input = scaleRow.locator('input[type="text"]');
@@ -156,8 +167,6 @@ test.describe('effect keyframes', () => {
 			{timeout: 30_000},
 		);
 
-		await page.getByTitle('Scale precision', {exact: true}).first().click();
-
 		const rotationRow = page
 			.getByText('Rotation', {exact: true})
 			.locator('..')
@@ -165,7 +174,7 @@ test.describe('effect keyframes', () => {
 		const rotationDragger = rotationRow.locator(
 			'button.__remotion_input_dragger',
 		);
-		await expect(rotationDragger).toBeVisible({timeout: 15_000});
+		await selectScalePrecisionAndWaitFor({page, locator: rotationDragger});
 		await rotationDragger.click();
 
 		const input = rotationRow.locator('input[type="text"]');
@@ -202,8 +211,12 @@ test.describe('effect keyframes', () => {
 			{timeout: 30_000},
 		);
 
-		await page.getByTitle('Scale precision', {exact: true}).first().click();
-		await page.getByRole('button', {name: 'Expand Crop', exact: true}).click();
+		const expandCrop = page.getByRole('button', {
+			name: 'Expand Crop',
+			exact: true,
+		});
+		await selectScalePrecisionAndWaitFor({page, locator: expandCrop});
+		await expandCrop.click();
 
 		const cropRow = page
 			.getByText('Crop left', {exact: true})
@@ -244,8 +257,9 @@ test.describe('effect keyframes', () => {
 			{timeout: 30_000},
 		);
 
-		await page.getByTitle('Scale precision', {exact: true}).first().click();
-		await page.getByText('wave()', {exact: true}).click();
+		const waveRow = page.getByText('wave()', {exact: true});
+		await selectScalePrecisionAndWaitFor({page, locator: waveRow});
+		await waveRow.click();
 
 		const amplitudeRow = page
 			.getByText('Amplitude', {exact: true})

--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -192,6 +192,91 @@ test.describe('effect keyframes', () => {
 			.toBe(true);
 	});
 
+	test('accepts a crop value that is more precise than its interaction step', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+		await page.getByRole('button', {name: 'Expand Crop', exact: true}).click();
+
+		const cropRow = page
+			.getByText('Crop left', {exact: true})
+			.locator('..')
+			.locator('..');
+		await cropRow.locator('button.__remotion_input_dragger').click();
+
+		const input = cropRow.locator('input[type="text"]');
+		await expect(input).toBeVisible();
+		await input.fill('0.005');
+		await input.press('ArrowUp');
+		await expect(input).toHaveValue('0.015');
+		await input.fill('0.005');
+		await input.press('Enter');
+		await expect(input).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('cropLeft={0.005}');
+				},
+				{
+					message: 'Expected the precise crop value to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+	});
+
+	test('accepts an effect parameter that is more precise than its interaction step', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+		await page.getByText('wave()', {exact: true}).click();
+
+		const amplitudeRow = page
+			.getByText('Amplitude', {exact: true})
+			.locator('..')
+			.locator('..');
+		await amplitudeRow.locator('button.__remotion_input_dragger').click();
+
+		const input = amplitudeRow.locator('input[type="text"]');
+		await expect(input).toBeVisible();
+		await input.fill('60.525');
+		await input.press('ArrowUp');
+		await expect(input).toHaveValue('61.525');
+		await input.fill('60.525');
+		await input.press('Enter');
+		await expect(input).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('amplitude: 60.525');
+				},
+				{
+					message:
+						'Expected the precise effect parameter to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+	});
+
 	test('collapses timeline tracks until a property or effect is selected', async ({
 		page,
 	}) => {

--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -146,6 +146,52 @@ test.describe('effect keyframes', () => {
 			.toBe(true);
 	});
 
+	test('accepts a rotation value that is more precise than its interaction step', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+
+		const rotationRow = page
+			.getByText('Rotation', {exact: true})
+			.locator('..')
+			.locator('..');
+		const rotationDragger = rotationRow.locator(
+			'button.__remotion_input_dragger',
+		);
+		await expect(rotationDragger).toBeVisible({timeout: 15_000});
+		await rotationDragger.click();
+
+		const input = rotationRow.locator('input[type="text"]');
+		await expect(input).toBeVisible();
+		await input.fill('0.525');
+		await input.press('ArrowUp');
+		await expect(input).toHaveValue('1.525');
+		await input.fill('0.525');
+		await input.press('Enter');
+		await expect(input).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes("rotate: '0.525deg'");
+				},
+				{
+					message:
+						'Expected the precise rotation value to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+	});
+
 	test('collapses timeline tracks until a property or effect is selected', async ({
 		page,
 	}) => {

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -26,7 +26,7 @@ export const EffectKeyframeE2e: React.FC = () => {
 				width={1080}
 				height={1080}
 				color="#1f2429"
-				style={{scale: 1}}
+				style={{rotate: '0deg', scale: 1}}
 				effects={[wave({})]}
 			/>
 			<Solid

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -26,6 +26,7 @@ export const EffectKeyframeE2e: React.FC = () => {
 				width={1080}
 				height={1080}
 				color="#1f2429"
+				cropLeft={0}
 				style={{rotate: '0deg', scale: 1}}
 				effects={[wave({})]}
 			/>

--- a/packages/studio/src/components/Timeline/TimelineNumberField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineNumberField.tsx
@@ -65,6 +65,9 @@ export const TimelineNumberField: React.FC<{
 	const configuredStep =
 		field.fieldSchema.type === 'number' ? field.fieldSchema.step : undefined;
 	const step = configuredStep ?? 1;
+	const allowStepMismatch =
+		field.group === 'crop' ||
+		('kind' in field && field.kind === 'effect-field');
 
 	const formatter = useCallback(
 		(v: number | string) => {
@@ -99,6 +102,7 @@ export const TimelineNumberField: React.FC<{
 			step={step}
 			formatter={formatter}
 			rightAlign={false}
+			allowStepMismatch={allowStepMismatch}
 		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -100,7 +100,7 @@ export const TimelineRotationField: React.FC<{
 	const serializeValue = useCallback(
 		(value: number) =>
 			isCssRotation
-				? serializeCssRotation(value, decimalPlaces)
+				? serializeCssRotation(value, Math.max(6, decimalPlaces))
 				: normalizeTimelineNumber(value),
 		[decimalPlaces, isCssRotation],
 	);
@@ -251,6 +251,7 @@ export const TimelineRotationField: React.FC<{
 			step={step}
 			formatter={formatter}
 			rightAlign={false}
+			allowStepMismatch
 			aria-label={isCssRotation ? 'Rotation Z' : 'Rotation angle'}
 		/>
 	);
@@ -280,6 +281,7 @@ export const TimelineRotationField: React.FC<{
 						step={step}
 						formatter={formatter}
 						rightAlign={false}
+						allowStepMismatch
 						aria-label={`Rotation ${rotationLabel}`}
 					/>
 				))}


### PR DESCRIPTION
## Summary

- allow timeline rotation, crop, and numeric effect inputs to accept values that do not align with the interaction step
- preserve up to six decimal places when serializing precise CSS rotations
- keep configured steps for dragging and arrow-key increments
- add end-to-end regressions for precise rotation, crop, and effect values

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/input-dragger.test.ts packages/studio/src/test/timeline-field-utils.test.ts`
- `bunx playwright test e2e/effect-keyframes.test.mts --grep 'accepts a rotation value'`
- `bunx playwright test e2e/effect-keyframes.test.mts --grep 'accepts (a crop|an effect parameter)'`

Closes #10389
