### PR TITLE
remotion.dev/brand: Add second Skills 2 code change

### DIFF
--- a/packages/brand/src/Root.tsx
+++ b/packages/brand/src/Root.tsx
@@ -170,7 +170,7 @@ export const RemotionRoot: React.FC = () => {
 					durationInFrames={180}
 					fps={30}
 					width={1920}
-					height={1080}
+					height={1920}
 				/>
 				<Composition
 					id="Skills2Announcement"

--- a/packages/brand/src/Root.tsx
+++ b/packages/brand/src/Root.tsx
@@ -167,7 +167,7 @@ export const RemotionRoot: React.FC = () => {
 				<Composition
 					id="Skills2CodeChange"
 					component={Skills2CodeChange}
-					durationInFrames={180}
+					durationInFrames={360}
 					fps={30}
 					width={1920}
 					height={1080}

--- a/packages/brand/src/Root.tsx
+++ b/packages/brand/src/Root.tsx
@@ -167,7 +167,7 @@ export const RemotionRoot: React.FC = () => {
 				<Composition
 					id="Skills2CodeChange"
 					component={Skills2CodeChange}
-					durationInFrames={360}
+					durationInFrames={180}
 					fps={30}
 					width={1920}
 					height={1080}

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -429,7 +429,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										display: 'inline-block',
 										whiteSpace: 'pre',
 										color: token.color,
-										opacity: interpolate(frame, [90, 108], [1, 0], {
+										opacity: interpolate(frame, [45, 54], [1, 0], {
 											easing: Easing.bezier(0.4, 0, 1, 1),
 											extrapolateLeft: 'clamp',
 											extrapolateRight: 'clamp',
@@ -458,12 +458,12 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 											? token.color
 											: interpolateColors(
 													frame,
-													[108, 126],
+													[54, 63],
 													[token.color, afterToken.color],
 												),
 									translate: `${interpolate(
 										frame,
-										[108, 126],
+										[54, 63],
 										[beforePosition.x, afterPosition.x],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -472,7 +472,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										},
 									)}px ${interpolate(
 										frame,
-										[108, 126],
+										[54, 63],
 										[beforePosition.y, afterPosition.y],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -505,7 +505,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 									display: 'inline-block',
 									whiteSpace: 'pre',
 									color: token.color,
-									opacity: interpolate(frame, [126, 144], [0, 1], {
+									opacity: interpolate(frame, [63, 72], [0, 1], {
 										easing: Easing.bezier(0, 0, 0.2, 1),
 										extrapolateLeft: 'clamp',
 										extrapolateRight: 'clamp',
@@ -538,14 +538,10 @@ export const Skills2CodeChange: React.FC = () => {
 					}),
 				]}
 			/>
-			<Sequence durationInFrames={180} name="Spring to interpolate">
+			<Sequence durationInFrames={90} name="Spring to interpolate">
 				<CodeChange codeChange={springCodeChange} />
 			</Sequence>
-			<Sequence
-				from={180}
-				durationInFrames={180}
-				name="Sequence to Video props"
-			>
+			<Sequence from={90} durationInFrames={90} name="Sequence to Video props">
 				<CodeChange codeChange={sequenceCodeChange} />
 			</Sequence>
 		</AbsoluteFill>

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -15,41 +15,45 @@ import {
 } from 'remotion';
 
 const springCodeBefore = `const progress =
-  spring({fps, frame, durationInFrames: 20, config: {damping: 200}}) -
-  spring({
-    fps,
-    frame,
-    delay: durationInFrames - 20,
-    durationInFrames: 20,
-    config: {damping: 200},
-  });
+	spring({fps, frame, durationInFrames: 20, config: {damping: 200}}) -
+	spring({
+		fps,
+		frame,
+		delay: durationInFrames - 20,
+		durationInFrames: 20,
+		config: {damping: 200},
+	});
 
 return (
-  <div style={{
-    translate: interpolate(progress, [0, 1], [0, 200]),
-  }} />
+	<div
+		style={{
+			translate: interpolate(progress, [0, 1], [0, 200]),
+		}}
+	/>
 );`;
 
 const springCodeAfter = `return (
-  <div style={{
-    translate: interpolate(
-      frame,
-      [0, 20, durationInFrames - 20, durationInFrames],
-      [0, 200, 200, 0],
-      {
-        easing: Easing.spring({damping: 200}),
-      },
-    ),
-  }} />
+	<div
+		style={{
+			translate: interpolate(
+				frame,
+				[0, 20, durationInFrames - 20, durationInFrames],
+				[0, 200, 200, 0],
+				{
+					easing: Easing.spring({damping: 200}),
+				},
+			),
+		}}
+	/>
 );`;
 
 const sequenceCodeBefore = `<Sequence from={30}>
-  <Sequence from={-15}>
-    <Video src="https://remotion.media/video.mp4" />
-  </Sequence>
-</Sequence>`;
+	<Sequence from={-15}>
+		<Video src="https://remotion.media/video.mp4" />
+	</Sequence>
+</Sequence>;`;
 
-const sequenceCodeAfter = `<Video trimBefore={15} from={30} />`;
+const sequenceCodeAfter = `<Video trimBefore={15} from={30} />;`;
 
 type TokenKind =
 	| 'whitespace'

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -311,6 +311,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 	codeChange,
 }) => {
 	const frame = useCurrentFrame();
+	const posterizedFrame = Math.floor(frame / 3) * 3;
 	const scale = useCurrentScale();
 	const {height} = useVideoConfig();
 	const beforeMeasurementRef = useRef<HTMLPreElement>(null);
@@ -429,7 +430,6 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 						if (afterIndex === undefined) {
 							const exitAngle = beforeIndex * Math.PI * (3 - Math.sqrt(5));
 							const exitDistance = 2400;
-							const posterizedFrame = Math.floor(frame / 3) * 3;
 							return (
 								<span
 									key={`removed-${token.id}`}
@@ -497,12 +497,12 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										token.color === afterToken.color
 											? token.color
 											: interpolateColors(
-													frame,
-													[90, 108],
-													[token.color, afterToken.color],
-												),
+												frame,
+												[90, 108],
+												[token.color, afterToken.color],
+											),
 									translate: `${interpolate(
-										frame,
+										posterizedFrame,
 										[90, 108],
 										[beforePosition.x, afterPosition.x],
 										{
@@ -511,7 +511,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 											extrapolateRight: 'clamp',
 										},
 									)}px ${interpolate(
-										frame,
+										posterizedFrame,
 										[90, 108],
 										[beforePosition.y, afterPosition.y],
 										{

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -220,7 +220,8 @@ const matchTokens = (
 	before: VisibleToken[],
 	after: VisibleToken[],
 ): [number, number][] => {
-	const lengths = Array.from({length: before.length + 1}, () =>
+	const semanticTokenScore = before.length + after.length;
+	const scores = Array.from({length: before.length + 1}, () =>
 		Array<number>(after.length + 1).fill(0),
 	);
 
@@ -229,9 +230,15 @@ const matchTokens = (
 			const tokensMatch =
 				before[row].kind === after[column].kind &&
 				before[row].value === after[column].value;
-			lengths[row][column] = tokensMatch
-				? lengths[row + 1][column + 1] + 1
-				: Math.max(lengths[row + 1][column], lengths[row][column + 1]);
+			// Keep meaningful tokens moving even when matching more punctuation would
+			// produce a longer sequence.
+			const matchScore =
+				before[row].kind === 'punctuation' || before[row].kind === 'operator'
+					? 1
+					: semanticTokenScore;
+			scores[row][column] = tokensMatch
+				? scores[row + 1][column + 1] + matchScore
+				: Math.max(scores[row + 1][column], scores[row][column + 1]);
 		}
 	}
 
@@ -247,8 +254,7 @@ const matchTokens = (
 			beforeIndex++;
 			afterIndex++;
 		} else if (
-			lengths[beforeIndex + 1][afterIndex] >=
-			lengths[beforeIndex][afterIndex + 1]
+			scores[beforeIndex + 1][afterIndex] >= scores[beforeIndex][afterIndex + 1]
 		) {
 			beforeIndex++;
 		} else {

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -6,7 +6,6 @@ import {
 	Interactive,
 	interpolate,
 	interpolateColors,
-	Sequence,
 	Solid,
 	useCurrentFrame,
 	useCurrentScale,
@@ -37,29 +36,7 @@ return (
 	</Sequence>
 );`;
 
-const springCodeAfter = `return (
-	<Sequence from={30}>
-		<Sequence from={-15}>
-			<Video
-				src="https://remotion.media/video.mp4"
-				style={{
-					translate: interpolate(
-						frame,
-						[0, 20, durationInFrames - 20, durationInFrames],
-						[0, 200, 200, 0],
-						{
-							easing: Easing.spring({damping: 200}),
-						},
-					),
-				}}
-			/>
-		</Sequence>
-	</Sequence>
-);`;
-
-const sequenceCodeBefore = springCodeAfter;
-
-const sequenceCodeAfter = `return (
+const combinedCodeAfter = `return (
 	<Video
 		src="https://remotion.media/video.mp4"
 		trimBefore={15}
@@ -319,10 +296,9 @@ const prepareCodeChange = (before: string, after: string): CodeChangeData => {
 	};
 };
 
-const springCodeChange = prepareCodeChange(springCodeBefore, springCodeAfter);
-const sequenceCodeChange = prepareCodeChange(
-	sequenceCodeBefore,
-	sequenceCodeAfter,
+const combinedCodeChange = prepareCodeChange(
+	springCodeBefore,
+	combinedCodeAfter,
 );
 
 const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
@@ -455,7 +431,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										display: 'inline-block',
 										whiteSpace: 'pre',
 										color: token.color,
-										opacity: interpolate(frame, [45, 54], [1, 0], {
+										opacity: interpolate(frame, [90, 108], [1, 0], {
 											easing: Easing.bezier(0.4, 0, 1, 1),
 											extrapolateLeft: 'clamp',
 											extrapolateRight: 'clamp',
@@ -484,12 +460,12 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 											? token.color
 											: interpolateColors(
 													frame,
-													[54, 63],
+													[108, 126],
 													[token.color, afterToken.color],
 												),
 									translate: `${interpolate(
 										frame,
-										[54, 63],
+										[108, 126],
 										[beforePosition.x, afterPosition.x],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -498,7 +474,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										},
 									)}px ${interpolate(
 										frame,
-										[54, 63],
+										[108, 126],
 										[beforePosition.y, afterPosition.y],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -531,7 +507,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 									display: 'inline-block',
 									whiteSpace: 'pre',
 									color: token.color,
-									opacity: interpolate(frame, [63, 72], [0, 1], {
+									opacity: interpolate(frame, [126, 144], [0, 1], {
 										easing: Easing.bezier(0, 0, 0.2, 1),
 										extrapolateLeft: 'clamp',
 										extrapolateRight: 'clamp',
@@ -564,12 +540,7 @@ export const Skills2CodeChange: React.FC = () => {
 					}),
 				]}
 			/>
-			<Sequence durationInFrames={90} name="Spring to interpolate">
-				<CodeChange codeChange={springCodeChange} />
-			</Sequence>
-			<Sequence from={90} durationInFrames={90} name="Sequence to Video props">
-				<CodeChange codeChange={sequenceCodeChange} />
-			</Sequence>
+			<CodeChange codeChange={combinedCodeChange} />
 		</AbsoluteFill>
 	);
 };

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -8,7 +8,6 @@ import {
 	interpolateColors,
 	Solid,
 	useCurrentFrame,
-	useCurrentScale,
 	useDelayRender,
 	useVideoConfig,
 } from 'remotion';
@@ -312,7 +311,6 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 }) => {
 	const frame = useCurrentFrame();
 	const posterizedFrame = Math.floor(frame / 3) * 3;
-	const scale = useCurrentScale();
 	const {height} = useVideoConfig();
 	const beforeMeasurementRef = useRef<HTMLPreElement>(null);
 	const afterMeasurementRef = useRef<HTMLPreElement>(null);
@@ -333,7 +331,9 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 			tokenCount: number,
 		): TokenPosition[] => {
 			const preBounds = pre.getBoundingClientRect();
-			const verticalOffset = (height - preBounds.height / scale) / 2;
+			const measurementScaleX = preBounds.width / pre.offsetWidth;
+			const measurementScaleY = preBounds.height / pre.offsetHeight;
+			const verticalOffset = (height - pre.offsetHeight) / 2;
 			const positions = Array.from({length: tokenCount}, () => ({x: 0, y: 0}));
 			const elements = pre.querySelectorAll<HTMLElement>('[data-token-index]');
 
@@ -341,8 +341,10 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 				const index = Number(element.dataset.tokenIndex);
 				const bounds = element.getBoundingClientRect();
 				positions[index] = {
-					x: (bounds.left - preBounds.left) / scale,
-					y: verticalOffset + (bounds.top - preBounds.top) / scale,
+					x: (bounds.left - preBounds.left) / measurementScaleX,
+					y:
+						verticalOffset +
+						(bounds.top - preBounds.top) / measurementScaleY,
 				};
 			});
 
@@ -359,7 +361,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 				codeChange.after.visible.length,
 			),
 		});
-	}, [codeChange, height, scale]);
+	}, [codeChange, height]);
 
 	useEffect(() => {
 		if (layouts && !hasContinued.current) {

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -427,6 +427,8 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 							codeChange.afterIndexByBeforeIndex.get(beforeIndex);
 
 						if (afterIndex === undefined) {
+							const exitAngle = beforeIndex * Math.PI * (3 - Math.sqrt(5));
+							const exitDistance = 2400;
 							return (
 								<span
 									key={`removed-${token.id}`}
@@ -437,12 +439,41 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										display: 'inline-block',
 										whiteSpace: 'pre',
 										color: token.color,
-										opacity: interpolate(frame, [90, 108], [1, 0], {
-											easing: Easing.bezier(0.4, 0, 1, 1),
-											extrapolateLeft: 'clamp',
-											extrapolateRight: 'clamp',
-										}),
-										translate: `${beforePosition.x}px ${beforePosition.y}px`,
+										rotate: `${interpolate(
+											frame,
+											[90, 108],
+											[0, beforeIndex % 2 === 0 ? 720 : -720],
+											{
+												easing: Easing.bezier(0.4, 0, 1, 1),
+												extrapolateLeft: 'clamp',
+												extrapolateRight: 'clamp',
+											},
+										)}deg`,
+										translate: `${interpolate(
+											frame,
+											[90, 108],
+											[
+												beforePosition.x,
+												beforePosition.x + Math.cos(exitAngle) * exitDistance,
+											],
+											{
+												easing: Easing.bezier(0.4, 0, 1, 1),
+												extrapolateLeft: 'clamp',
+												extrapolateRight: 'clamp',
+											},
+										)}px ${interpolate(
+											frame,
+											[90, 108],
+											[
+												beforePosition.y,
+												beforePosition.y + Math.sin(exitAngle) * exitDistance,
+											],
+											{
+												easing: Easing.bezier(0.4, 0, 1, 1),
+												extrapolateLeft: 'clamp',
+												extrapolateRight: 'clamp',
+											},
+										)}px`,
 									}}
 								>
 									{token.value}

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -326,6 +326,9 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 			return;
 		}
 
+		const verticalOffset =
+			(height - beforeMeasurementRef.current.offsetHeight) / 2;
+
 		const measure = (
 			pre: HTMLPreElement,
 			tokenCount: number,
@@ -333,7 +336,6 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 			const preBounds = pre.getBoundingClientRect();
 			const measurementScaleX = preBounds.width / pre.offsetWidth;
 			const measurementScaleY = preBounds.height / pre.offsetHeight;
-			const verticalOffset = (height - pre.offsetHeight) / 2;
 			const positions = Array.from({length: tokenCount}, () => ({x: 0, y: 0}));
 			const elements = pre.querySelectorAll<HTMLElement>('[data-token-index]');
 

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -6,6 +6,7 @@ import {
 	Interactive,
 	interpolate,
 	interpolateColors,
+	Sequence,
 	Solid,
 	useCurrentFrame,
 	useCurrentScale,
@@ -13,7 +14,7 @@ import {
 	useVideoConfig,
 } from 'remotion';
 
-const codeBefore = `const progress =
+const springCodeBefore = `const progress =
   spring({fps, frame, durationInFrames: 20, config: {damping: 200}}) -
   spring({
     fps,
@@ -29,7 +30,7 @@ return (
   }} />
 );`;
 
-const codeAfter = `return (
+const springCodeAfter = `return (
   <div style={{
     translate: interpolate(
       frame,
@@ -41,6 +42,14 @@ const codeAfter = `return (
     ),
   }} />
 );`;
+
+const sequenceCodeBefore = `<Sequence from={30}>
+  <Sequence from={-15}>
+    <Video src="https://remotion.media/video.mp4" />
+  </Sequence>
+</Sequence>`;
+
+const sequenceCodeAfter = `<Video trimBefore={15} from={30} />`;
 
 type TokenKind =
 	| 'whitespace'
@@ -81,6 +90,13 @@ type TokenPosition = {
 type CodeLayouts = {
 	readonly before: TokenPosition[];
 	readonly after: TokenPosition[];
+};
+
+type CodeChangeData = {
+	readonly before: TokenizedCode;
+	readonly after: TokenizedCode;
+	readonly afterIndexByBeforeIndex: Map<number, number>;
+	readonly matchedAfterIndexes: Set<number>;
 };
 
 const getTokenColor = (kind: TokenKind) => {
@@ -155,9 +171,9 @@ const tokenizeCode = (code: string): TokenizedCode => {
 				kind = 'keyword';
 			} else if (['spring', 'interpolate'].includes(identifier)) {
 				kind = 'function';
-			} else if (identifier === 'div') {
+			} else if (['div', 'Sequence', 'Video'].includes(identifier)) {
 				kind = 'tag';
-			} else if (identifier === 'style') {
+			} else if (['style', 'src', 'trimBefore', 'from'].includes(identifier)) {
 				kind = 'attribute';
 			} else if (identifier === 'progress') {
 				kind = 'variable';
@@ -262,15 +278,30 @@ const renderTokenStream = (tokens: CodeToken[], prefix: string) => {
 	});
 };
 
-const beforeCode = tokenizeCode(codeBefore);
-const afterCode = tokenizeCode(codeAfter);
-const tokenMatches = matchTokens(beforeCode.visible, afterCode.visible);
-const afterIndexByBeforeIndex = new Map(tokenMatches);
-const matchedAfterIndexes = new Set(
-	tokenMatches.map(([, afterIndex]) => afterIndex),
+const prepareCodeChange = (before: string, after: string): CodeChangeData => {
+	const beforeCode = tokenizeCode(before);
+	const afterCode = tokenizeCode(after);
+	const tokenMatches = matchTokens(beforeCode.visible, afterCode.visible);
+
+	return {
+		before: beforeCode,
+		after: afterCode,
+		afterIndexByBeforeIndex: new Map(tokenMatches),
+		matchedAfterIndexes: new Set(
+			tokenMatches.map(([, afterIndex]) => afterIndex),
+		),
+	};
+};
+
+const springCodeChange = prepareCodeChange(springCodeBefore, springCodeAfter);
+const sequenceCodeChange = prepareCodeChange(
+	sequenceCodeBefore,
+	sequenceCodeAfter,
 );
 
-export const Skills2CodeChange: React.FC = () => {
+const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
+	codeChange,
+}) => {
 	const frame = useCurrentFrame();
 	const scale = useCurrentScale();
 	const {height} = useVideoConfig();
@@ -310,10 +341,16 @@ export const Skills2CodeChange: React.FC = () => {
 		};
 
 		setLayouts({
-			before: measure(beforeMeasurementRef.current, beforeCode.visible.length),
-			after: measure(afterMeasurementRef.current, afterCode.visible.length),
+			before: measure(
+				beforeMeasurementRef.current,
+				codeChange.before.visible.length,
+			),
+			after: measure(
+				afterMeasurementRef.current,
+				codeChange.after.visible.length,
+			),
 		});
-	}, [height, scale]);
+	}, [codeChange, height, scale]);
 
 	useEffect(() => {
 		if (layouts && !hasContinued.current) {
@@ -322,6 +359,170 @@ export const Skills2CodeChange: React.FC = () => {
 		}
 	}, [continueRender, handle, layouts]);
 
+	return (
+		<Interactive.Div
+			name="Code"
+			style={{
+				position: 'absolute',
+				left: 148,
+				top: 0,
+				right: 148,
+				bottom: 0,
+				fontFamily:
+					'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
+				fontSize: 38,
+				lineHeight: 1.35,
+				tabSize: 2,
+			}}
+		>
+			<pre
+				ref={beforeMeasurementRef}
+				aria-hidden="true"
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: 'max-content',
+					margin: 0,
+					font: 'inherit',
+					lineHeight: 'inherit',
+					whiteSpace: 'pre',
+					visibility: 'hidden',
+					pointerEvents: 'none',
+				}}
+			>
+				{renderTokenStream(codeChange.before.stream, 'before')}
+			</pre>
+			<pre
+				ref={afterMeasurementRef}
+				aria-hidden="true"
+				style={{
+					position: 'absolute',
+					left: 0,
+					top: 0,
+					width: 'max-content',
+					margin: 0,
+					font: 'inherit',
+					lineHeight: 'inherit',
+					whiteSpace: 'pre',
+					visibility: 'hidden',
+					pointerEvents: 'none',
+				}}
+			>
+				{renderTokenStream(codeChange.after.stream, 'after')}
+			</pre>
+
+			{layouts
+				? codeChange.before.visible.map((token, beforeIndex) => {
+						const beforePosition = layouts.before[beforeIndex];
+						const afterIndex =
+							codeChange.afterIndexByBeforeIndex.get(beforeIndex);
+
+						if (afterIndex === undefined) {
+							return (
+								<span
+									key={`removed-${token.id}`}
+									style={{
+										position: 'absolute',
+										left: 0,
+										top: 0,
+										display: 'inline-block',
+										whiteSpace: 'pre',
+										color: token.color,
+										opacity: interpolate(frame, [90, 108], [1, 0], {
+											easing: Easing.bezier(0.4, 0, 1, 1),
+											extrapolateLeft: 'clamp',
+											extrapolateRight: 'clamp',
+										}),
+										translate: `${beforePosition.x}px ${beforePosition.y}px`,
+									}}
+								>
+									{token.value}
+								</span>
+							);
+						}
+
+						const afterToken = codeChange.after.visible[afterIndex];
+						const afterPosition = layouts.after[afterIndex];
+						return (
+							<span
+								key={`matched-${token.id}-${afterToken.id}`}
+								style={{
+									position: 'absolute',
+									left: 0,
+									top: 0,
+									display: 'inline-block',
+									whiteSpace: 'pre',
+									color:
+										token.color === afterToken.color
+											? token.color
+											: interpolateColors(
+													frame,
+													[108, 126],
+													[token.color, afterToken.color],
+												),
+									translate: `${interpolate(
+										frame,
+										[108, 126],
+										[beforePosition.x, afterPosition.x],
+										{
+											easing: Easing.spring({damping: 200}),
+											extrapolateLeft: 'clamp',
+											extrapolateRight: 'clamp',
+										},
+									)}px ${interpolate(
+										frame,
+										[108, 126],
+										[beforePosition.y, afterPosition.y],
+										{
+											easing: Easing.spring({damping: 200}),
+											extrapolateLeft: 'clamp',
+											extrapolateRight: 'clamp',
+										},
+									)}px`,
+								}}
+							>
+								{token.value}
+							</span>
+						);
+					})
+				: null}
+
+			{layouts
+				? codeChange.after.visible.map((token, afterIndex) => {
+						if (codeChange.matchedAfterIndexes.has(afterIndex)) {
+							return null;
+						}
+
+						const afterPosition = layouts.after[afterIndex];
+						return (
+							<span
+								key={`added-${token.id}`}
+								style={{
+									position: 'absolute',
+									left: 0,
+									top: 0,
+									display: 'inline-block',
+									whiteSpace: 'pre',
+									color: token.color,
+									opacity: interpolate(frame, [126, 144], [0, 1], {
+										easing: Easing.bezier(0, 0, 0.2, 1),
+										extrapolateLeft: 'clamp',
+										extrapolateRight: 'clamp',
+									}),
+									translate: `${afterPosition.x}px ${afterPosition.y}px`,
+								}}
+							>
+								{token.value}
+							</span>
+						);
+					})
+				: null}
+		</Interactive.Div>
+	);
+};
+
+export const Skills2CodeChange: React.FC = () => {
 	return (
 		<AbsoluteFill style={{backgroundColor: '#f5fafb'}}>
 			<Solid
@@ -337,164 +538,16 @@ export const Skills2CodeChange: React.FC = () => {
 					}),
 				]}
 			/>
-			<Interactive.Div
-				name="Code"
-				style={{
-					position: 'absolute',
-					left: 148,
-					top: 0,
-					right: 148,
-					bottom: 0,
-					fontFamily:
-						'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
-					fontSize: 38,
-					lineHeight: 1.35,
-					tabSize: 2,
-				}}
+			<Sequence durationInFrames={180} name="Spring to interpolate">
+				<CodeChange codeChange={springCodeChange} />
+			</Sequence>
+			<Sequence
+				from={180}
+				durationInFrames={180}
+				name="Sequence to Video props"
 			>
-				<pre
-					ref={beforeMeasurementRef}
-					aria-hidden="true"
-					style={{
-						position: 'absolute',
-						left: 0,
-						top: 0,
-						width: 'max-content',
-						margin: 0,
-						font: 'inherit',
-						lineHeight: 'inherit',
-						whiteSpace: 'pre',
-						visibility: 'hidden',
-						pointerEvents: 'none',
-					}}
-				>
-					{renderTokenStream(beforeCode.stream, 'before')}
-				</pre>
-				<pre
-					ref={afterMeasurementRef}
-					aria-hidden="true"
-					style={{
-						position: 'absolute',
-						left: 0,
-						top: 0,
-						width: 'max-content',
-						margin: 0,
-						font: 'inherit',
-						lineHeight: 'inherit',
-						whiteSpace: 'pre',
-						visibility: 'hidden',
-						pointerEvents: 'none',
-					}}
-				>
-					{renderTokenStream(afterCode.stream, 'after')}
-				</pre>
-
-				{layouts
-					? beforeCode.visible.map((token, beforeIndex) => {
-							const beforePosition = layouts.before[beforeIndex];
-							const afterIndex = afterIndexByBeforeIndex.get(beforeIndex);
-
-							if (afterIndex === undefined) {
-								return (
-									<span
-										key={`removed-${token.id}`}
-										style={{
-											position: 'absolute',
-											left: 0,
-											top: 0,
-											display: 'inline-block',
-											whiteSpace: 'pre',
-											color: token.color,
-											opacity: interpolate(frame, [90, 108], [1, 0], {
-												easing: Easing.bezier(0.4, 0, 1, 1),
-												extrapolateLeft: 'clamp',
-												extrapolateRight: 'clamp',
-											}),
-											translate: `${beforePosition.x}px ${beforePosition.y}px`,
-										}}
-									>
-										{token.value}
-									</span>
-								);
-							}
-
-							const afterToken = afterCode.visible[afterIndex];
-							const afterPosition = layouts.after[afterIndex];
-							return (
-								<span
-									key={`matched-${token.id}-${afterToken.id}`}
-									style={{
-										position: 'absolute',
-										left: 0,
-										top: 0,
-										display: 'inline-block',
-										whiteSpace: 'pre',
-										color:
-											token.color === afterToken.color
-												? token.color
-												: interpolateColors(
-														frame,
-														[108, 126],
-														[token.color, afterToken.color],
-													),
-										translate: `${interpolate(
-											frame,
-											[108, 126],
-											[beforePosition.x, afterPosition.x],
-											{
-												easing: Easing.spring({damping: 200}),
-												extrapolateLeft: 'clamp',
-												extrapolateRight: 'clamp',
-											},
-										)}px ${interpolate(
-											frame,
-											[108, 126],
-											[beforePosition.y, afterPosition.y],
-											{
-												easing: Easing.spring({damping: 200}),
-												extrapolateLeft: 'clamp',
-												extrapolateRight: 'clamp',
-											},
-										)}px`,
-									}}
-								>
-									{token.value}
-								</span>
-							);
-						})
-					: null}
-
-				{layouts
-					? afterCode.visible.map((token, afterIndex) => {
-							if (matchedAfterIndexes.has(afterIndex)) {
-								return null;
-							}
-
-							const afterPosition = layouts.after[afterIndex];
-							return (
-								<span
-									key={`added-${token.id}`}
-									style={{
-										position: 'absolute',
-										left: 0,
-										top: 0,
-										display: 'inline-block',
-										whiteSpace: 'pre',
-										color: token.color,
-										opacity: interpolate(frame, [126, 144], [0, 1], {
-											easing: Easing.bezier(0, 0, 0.2, 1),
-											extrapolateLeft: 'clamp',
-											extrapolateRight: 'clamp',
-										}),
-										translate: `${afterPosition.x}px ${afterPosition.y}px`,
-									}}
-								>
-									{token.value}
-								</span>
-							);
-						})
-					: null}
-			</Interactive.Div>
+				<CodeChange codeChange={sequenceCodeChange} />
+			</Sequence>
 		</AbsoluteFill>
 	);
 };

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -429,6 +429,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 						if (afterIndex === undefined) {
 							const exitAngle = beforeIndex * Math.PI * (3 - Math.sqrt(5));
 							const exitDistance = 2400;
+							const posterizedFrame = Math.floor(frame / 3) * 3;
 							return (
 								<span
 									key={`removed-${token.id}`}
@@ -440,7 +441,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										whiteSpace: 'pre',
 										color: token.color,
 										rotate: `${interpolate(
-											frame,
+											posterizedFrame,
 											[90, 108],
 											[0, beforeIndex % 2 === 0 ? 720 : -720],
 											{
@@ -450,7 +451,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 											},
 										)}deg`,
 										translate: `${interpolate(
-											frame,
+											posterizedFrame,
 											[90, 108],
 											[
 												beforePosition.x,
@@ -462,7 +463,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 												extrapolateRight: 'clamp',
 											},
 										)}px ${interpolate(
-											frame,
+											posterizedFrame,
 											[90, 108],
 											[
 												beforePosition.y,

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -567,7 +567,7 @@ export const Skills2CodeChange: React.FC = () => {
 		<AbsoluteFill style={{backgroundColor: '#f5fafb'}}>
 			<Solid
 				width={1920}
-				height={1080}
+				height={1920}
 				color="#f5fafb"
 				style={{position: 'absolute'}}
 				effects={[

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -25,15 +25,45 @@ const springCodeBefore = `const progress =
 	});
 
 return (
-	<div
-		style={{
-			translate: interpolate(progress, [0, 1], [0, 200]),
-		}}
-	/>
+	<Sequence from={30}>
+		<Sequence from={-15}>
+			<Video
+				src="https://remotion.media/video.mp4"
+				style={{
+					translate: interpolate(progress, [0, 1], [0, 200]),
+				}}
+			/>
+		</Sequence>
+	</Sequence>
 );`;
 
 const springCodeAfter = `return (
-	<div
+	<Sequence from={30}>
+		<Sequence from={-15}>
+			<Video
+				src="https://remotion.media/video.mp4"
+				style={{
+					translate: interpolate(
+						frame,
+						[0, 20, durationInFrames - 20, durationInFrames],
+						[0, 200, 200, 0],
+						{
+							easing: Easing.spring({damping: 200}),
+						},
+					),
+				}}
+			/>
+		</Sequence>
+	</Sequence>
+);`;
+
+const sequenceCodeBefore = springCodeAfter;
+
+const sequenceCodeAfter = `return (
+	<Video
+		src="https://remotion.media/video.mp4"
+		trimBefore={15}
+		from={30}
 		style={{
 			translate: interpolate(
 				frame,
@@ -46,14 +76,6 @@ const springCodeAfter = `return (
 		}}
 	/>
 );`;
-
-const sequenceCodeBefore = `<Sequence from={30}>
-	<Sequence from={-15}>
-		<Video src="https://remotion.media/video.mp4" />
-	</Sequence>
-</Sequence>;`;
-
-const sequenceCodeAfter = `<Video trimBefore={15} from={30} />;`;
 
 type TokenKind =
 	| 'whitespace'
@@ -374,7 +396,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 				bottom: 0,
 				fontFamily:
 					'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
-				fontSize: 38,
+				fontSize: 34,
 				lineHeight: 1.35,
 				tabSize: 2,
 			}}

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -497,12 +497,12 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 											? token.color
 											: interpolateColors(
 													frame,
-													[108, 126],
+													[90, 108],
 													[token.color, afterToken.color],
 												),
 									translate: `${interpolate(
 										frame,
-										[108, 126],
+										[90, 108],
 										[beforePosition.x, afterPosition.x],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -511,7 +511,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 										},
 									)}px ${interpolate(
 										frame,
-										[108, 126],
+										[90, 108],
 										[beforePosition.y, afterPosition.y],
 										{
 											easing: Easing.spring({damping: 200}),
@@ -544,7 +544,7 @@ const CodeChange: React.FC<{readonly codeChange: CodeChangeData}> = ({
 									display: 'inline-block',
 									whiteSpace: 'pre',
 									color: token.color,
-									opacity: interpolate(frame, [126, 144], [0, 1], {
+									opacity: interpolate(frame, [108, 126], [0, 1], {
 										easing: Easing.bezier(0, 0, 0.2, 1),
 										extrapolateLeft: 'clamp',
 										extrapolateRight: 'clamp',

--- a/packages/brand/src/Skills2CodeChange.tsx
+++ b/packages/brand/src/Skills2CodeChange.tsx
@@ -128,7 +128,7 @@ const getTokenColor = (kind: TokenKind) => {
 	}
 
 	if (kind === 'identifier') {
-		return '#57606a';
+		return '#24292f';
 	}
 
 	return '#24292f';


### PR DESCRIPTION
## Summary

- combine both code changes into one direct transition on the same `<Video>`
- simplify the animation math and move the sequence timing onto video props simultaneously
- run the combined transition in a single 180-frame composition
- format every displayed code example with the repository's Prettier configuration
- preserve stable semantic tokens such as `Video`, `src`, and the source URL during the morph
- spin removed tokens out in deterministic directions before new tokens appear
- reposition preserved tokens concurrently with the outward spin
- render generic code identifiers in full black for stronger contrast
- posterize the exploding-token position and rotation to three-frame steps
- posterize preserved-token translation to the same three-frame steps
- expand the composition to a square 1920×1920 canvas with balanced vertical padding
- derive token coordinates from the measured code element so parent scale and translation do not distort the morph
- anchor both code snippets to the original snippet’s top edge throughout the transformation

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/nested-sequences.test.tsx` from `packages/core`
- `bun test packages/media/src/test/get-time-in-seconds.test.ts`
- `bunx turbo run bundle --filter='@remotion/brand' --no-update-notifier`
