### PR TITLE
`@remotion/studio`: Add easing icons to context menu

### DIFF
--- a/packages/studio/src/components/Timeline/EasingEditorModal.tsx
+++ b/packages/studio/src/components/Timeline/EasingEditorModal.tsx
@@ -177,8 +177,6 @@ const presetButtonBase: React.CSSProperties = {
 
 const presetPreviewSvgStyle: React.CSSProperties = {
 	display: 'block',
-	height: PRESET_PREVIEW_HEIGHT,
-	width: PRESET_PREVIEW_WIDTH,
 };
 
 const coordinatesGridBase: React.CSSProperties = {
@@ -557,6 +555,45 @@ const getPresetPreviewPath = (easing: TimelineEasingValue) => {
 	return points.join(' ');
 };
 
+export const EasingPresetPreview: React.FC<{
+	readonly color: string;
+	readonly easing: TimelineEasingValue;
+	readonly height?: number;
+	readonly nonScalingStroke?: boolean;
+	readonly strokeWidth?: number;
+	readonly width?: number;
+}> = ({
+	color,
+	easing,
+	height = PRESET_PREVIEW_HEIGHT,
+	nonScalingStroke = false,
+	strokeWidth = 2,
+	width = PRESET_PREVIEW_WIDTH,
+}) => {
+	const path = useMemo(() => getPresetPreviewPath(easing), [easing]);
+
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox={`0 0 ${PRESET_PREVIEW_WIDTH} ${PRESET_PREVIEW_HEIGHT}`}
+			style={presetPreviewSvgStyle}
+			aria-hidden="true"
+			focusable={false}
+		>
+			<path
+				d={path}
+				fill="none"
+				stroke={color}
+				strokeWidth={strokeWidth}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				vectorEffect={nonScalingStroke ? 'non-scaling-stroke' : undefined}
+			/>
+		</svg>
+	);
+};
+
 const pointFromBezier = (bezier: CubicBezierTuple, handle: HandleIndex) => {
 	const x = handle === 0 ? bezier[0] : bezier[2];
 	const y = handle === 0 ? bezier[1] : bezier[3];
@@ -652,10 +689,6 @@ const EasingPresetButton: React.FC<{
 }> = ({currentEasing, disabled, onClick, preset}) => {
 	const selected = areEasingsEqual(currentEasing, preset.easing);
 	const [hovered, setHovered] = useState(false);
-	const path = useMemo(
-		() => getPresetPreviewPath(preset.easing),
-		[preset.easing],
-	);
 	const onPointerEnter = useCallback(() => {
 		setHovered(true);
 	}, []);
@@ -686,23 +719,10 @@ const EasingPresetButton: React.FC<{
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 		>
-			<svg
-				width={PRESET_PREVIEW_WIDTH}
-				height={PRESET_PREVIEW_HEIGHT}
-				viewBox={`0 0 ${PRESET_PREVIEW_WIDTH} ${PRESET_PREVIEW_HEIGHT}`}
-				style={presetPreviewSvgStyle}
-				aria-hidden="true"
-				focusable={false}
-			>
-				<path
-					d={path}
-					fill="none"
-					stroke={selected || hovered ? WHITE : LIGHT_TEXT}
-					strokeWidth={2}
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-			</svg>
+			<EasingPresetPreview
+				color={selected || hovered ? WHITE : LIGHT_TEXT}
+				easing={preset.easing}
+			/>
 		</button>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeEasingLine.tsx
@@ -5,12 +5,13 @@ import {
 import React, {useCallback, useContext, useMemo, useRef} from 'react';
 import {Internals, useVideoConfig} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
-import {BLUE, WHITE_ALPHA_10} from '../../helpers/colors';
+import {BLUE, LIGHT_TEXT, WHITE_ALPHA_10} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {ContextMenuForTarget} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {EasingPresetPreview} from './EasingEditorModal';
 import {
 	TIMELINE_MARQUEE_ITEM_ATTR,
 	useCurrentTimelineSelectionStateAsRef,
@@ -163,7 +164,16 @@ const TimelineKeyframeEasingLineInteraction: React.FC<
 					id: 'linear',
 					keyHint: null,
 					label: 'Linear',
-					leftItem: null,
+					leftItem: (
+						<EasingPresetPreview
+							color={LIGHT_TEXT}
+							easing={LINEAR_KEYFRAME_EASING}
+							height={18}
+							nonScalingStroke
+							strokeWidth={5}
+							width={18}
+						/>
+					),
 					disabled: previewServerState.type !== 'connected',
 					onClick: () => updateEasing(LINEAR_KEYFRAME_EASING),
 					quickSwitcherLabel: null,
@@ -175,7 +185,16 @@ const TimelineKeyframeEasingLineInteraction: React.FC<
 					id: preset.id,
 					keyHint: null,
 					label: preset.label,
-					leftItem: null,
+					leftItem: (
+						<EasingPresetPreview
+							color={LIGHT_TEXT}
+							easing={preset.easing}
+							height={18}
+							nonScalingStroke
+							strokeWidth={5}
+							width={18}
+						/>
+					),
 					disabled: previewServerState.type !== 'connected',
 					onClick: () => updateEasing(preset.easing),
 					quickSwitcherLabel: null,


### PR DESCRIPTION
## Summary

- reuse the easing inspector curve previews in the timeline easing context menu
- keep compact preview strokes legible at menu-icon size
- show icons for Linear and every easing preset

## Validation

- `bun run build`
- `bun run stylecheck`

Closes #10386
