### PR TITLE
`@remotion/studio`: Fix Inspector control indentation

### DIFF
--- a/packages/example/e2e/inspector-control-layout.test.mts
+++ b/packages/example/e2e/inspector-control-layout.test.mts
@@ -1,0 +1,146 @@
+import {expect, type Locator, test} from '@playwright/test';
+import {EXPANDED_SIDEBAR_STATE, STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+const getBox = async (locator: Locator) => {
+	const box = await locator.boundingBox();
+	expect(box).not.toBeNull();
+	return box!;
+};
+
+const expectInspectorControlsToUseAvailableWidth = async (
+	controlsHeader: Locator,
+	origin: Locator,
+	destination: Locator,
+	label: Locator,
+	labelInput: Locator,
+	routeColor: Locator,
+	keyframeButton: Locator,
+	colorButton: Locator,
+) => {
+	const [
+		headerBox,
+		originBox,
+		destinationBox,
+		labelBox,
+		labelInputBox,
+		routeColorBox,
+		keyframeButtonBox,
+		colorButtonBox,
+	] = await Promise.all([
+		getBox(controlsHeader),
+		getBox(origin),
+		getBox(destination),
+		getBox(label),
+		getBox(labelInput),
+		getBox(routeColor),
+		getBox(keyframeButton),
+		getBox(colorButton),
+	]);
+
+	for (const fieldBox of [
+		originBox,
+		destinationBox,
+		labelBox,
+		labelInputBox,
+		routeColorBox,
+	]) {
+		expect(Math.abs(fieldBox.x - headerBox.x)).toBeLessThanOrEqual(2);
+	}
+
+	expect(keyframeButtonBox.x).toBeGreaterThan(
+		routeColorBox.x + routeColorBox.width,
+	);
+	expect(keyframeButtonBox.x).toBeLessThan(colorButtonBox.x);
+};
+
+test.describe('Inspector control layout', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('does not indent controls after array fields', async ({page}) => {
+		await page.goto(`${STUDIO_URL}/inspector-control-layout-e2e`);
+		await expect(page).toHaveURL(/inspector-control-layout-e2e/, {
+			timeout: 15_000,
+		});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		const sequence = page
+			.getByText('Inspector control layout', {exact: true})
+			.first();
+		const origin = page.getByText('Origin [longitude, latitude]', {
+			exact: true,
+		});
+		await expect(async () => {
+			await sequence.click();
+			await expect(origin).toBeVisible({timeout: 1_000});
+		}).toPass({timeout: 30_000});
+
+		const controlsHeader = page.getByText('Controls', {exact: true});
+		const destination = page.getByText('Destination [longitude, latitude]', {
+			exact: true,
+		});
+		const label = page.getByText('Origin label', {exact: true});
+		const labelInput = page.getByRole('textbox');
+		const routeColor = page.getByText('Route color', {exact: true});
+		const keyframeButton = page
+			.getByRole('button', {name: 'Add keyframe'})
+			.first();
+		const colorButton = page.getByRole('button', {name: '#ff5c4d'});
+
+		await expectInspectorControlsToUseAvailableWidth(
+			controlsHeader,
+			origin,
+			destination,
+			label,
+			labelInput,
+			routeColor,
+			keyframeButton,
+			colorButton,
+		);
+
+		await page.getByRole('button', {name: '-0.1276', exact: true}).click();
+		await page.keyboard.press('Escape');
+		await expectInspectorControlsToUseAvailableWidth(
+			controlsHeader,
+			origin,
+			destination,
+			label,
+			labelInput,
+			routeColor,
+			keyframeButton,
+			colorButton,
+		);
+
+		const rightSplitter = page.locator('.remotion-splitter-vertical').last();
+		const splitterBox = await getBox(rightSplitter);
+		await page.mouse.move(
+			splitterBox.x + splitterBox.width / 2,
+			splitterBox.y + splitterBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(page.viewportSize()!.width - 250, splitterBox.y + 20);
+		await page.mouse.up();
+
+		await expectInspectorControlsToUseAvailableWidth(
+			controlsHeader,
+			origin,
+			destination,
+			label,
+			labelInput,
+			routeColor,
+			keyframeButton,
+			colorButton,
+		);
+	});
+});

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -7,6 +7,7 @@ import {
 	UnsymbolicatedErrorOverlayRepro,
 } from './ErrorOverlayE2e/ErrorOverlayRepro';
 import {HookOrderChangeE2e} from './HookOrderChangeE2e/HookOrderChangeRepro';
+import {InspectorControlLayoutE2e} from './InspectorControlLayoutE2e';
 import {Issue8216} from './Issue8216/Issue8216';
 import {LightLeakExample} from './LightLeak';
 import {LostNodePathRepro} from './LostNodePathE2e/LostNodePathRepro';
@@ -174,6 +175,14 @@ export const E2eTestRoot: React.FC = () => {
 			<Composition
 				id="rotation-keyframe-e2e"
 				component={RotationKeyframeE2e}
+				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
+			<Composition
+				id="inspector-control-layout-e2e"
+				component={InspectorControlLayoutE2e}
 				width={1080}
 				height={1080}
 				fps={30}

--- a/packages/example/src/InspectorControlLayoutE2e.tsx
+++ b/packages/example/src/InspectorControlLayoutE2e.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	Interactive,
+	Sequence,
+	type InteractivitySchema,
+	type SequenceControls,
+} from 'remotion';
+
+const inspectorControlLayoutSchema = {
+	first: {
+		type: 'array',
+		item: {type: 'number', step: 0.0001},
+		default: [-0.1276, 51.5072],
+		minLength: 2,
+		maxLength: 2,
+		newItemDefault: 0,
+		description: 'Origin [longitude, latitude]',
+	},
+	second: {
+		type: 'array',
+		item: {type: 'number', step: 0.0001},
+		default: [139.6917, 35.6895],
+		minLength: 2,
+		maxLength: 2,
+		newItemDefault: 0,
+		description: 'Destination [longitude, latitude]',
+	},
+	label: {
+		type: 'text-content',
+		default: 'London',
+		description: 'Origin label',
+	},
+	color: {
+		type: 'color',
+		default: '#ff5c4d',
+		description: 'Route color',
+	},
+	width: {
+		type: 'number',
+		default: 24,
+		min: 2,
+		max: 24,
+		step: 1,
+		hiddenFromList: false,
+		description: 'Route width',
+	},
+} as const satisfies InteractivitySchema;
+
+type InspectorControlLayoutProps = {
+	readonly name: string;
+	readonly first: readonly number[];
+	readonly second: readonly number[];
+	readonly label: string;
+	readonly color: string;
+	readonly width: number;
+};
+
+const InspectorControlLayoutInner: React.FC<
+	InspectorControlLayoutProps & {
+		readonly controls: SequenceControls | undefined;
+	}
+> = ({controls, name}) => {
+	return (
+		<Sequence name={name} controls={controls}>
+			<AbsoluteFill style={{backgroundColor: '#111'}} />
+		</Sequence>
+	);
+};
+
+const InteractiveInspectorControlLayout = Interactive.withSchema({
+	Component: InspectorControlLayoutInner,
+	componentName: '<InspectorControlLayout>',
+	componentIdentity: null,
+	schema: inspectorControlLayoutSchema,
+	supportsEffects: false,
+}) as React.FC<InspectorControlLayoutProps>;
+
+export const InspectorControlLayoutE2e: React.FC = () => {
+	return (
+		<InteractiveInspectorControlLayout
+			name="Inspector control layout"
+			first={[-0.1276, 51.5072]}
+			second={[139.6917, 35.6895]}
+			label="London"
+			color="#ff5c4d"
+			width={24}
+		/>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -52,6 +52,32 @@ const computedValueStyle: React.CSSProperties = {
 	lineHeight: '20px',
 };
 
+const metadataDraggerStyles: Record<
+	CompositionMetadataField,
+	React.CSSProperties
+> = {
+	durationInFrames: {
+		padding: '2px 0 2px 6px',
+		textAlign: 'right',
+		width: 92,
+	},
+	fps: {
+		padding: '2px 0 2px 6px',
+		textAlign: 'right',
+		width: 72,
+	},
+	height: {
+		padding: '2px 0 2px 6px',
+		textAlign: 'right',
+		width: 52,
+	},
+	width: {
+		padding: '2px 0 2px 6px',
+		textAlign: 'right',
+		width: 52,
+	},
+};
+
 const dimensionsControls: React.CSSProperties = {
 	alignItems: 'center',
 	color: 'inherit',
@@ -196,6 +222,7 @@ const CompositionMetadataValue: React.FC<{
 	) : (
 		<InputDragger
 			aria-label={fieldLabels[field]}
+			buttonStyle={metadataDraggerStyles[field]}
 			type="number"
 			value={dragValue ?? pendingValue?.value ?? value}
 			disabled={pendingValue !== null}
@@ -208,7 +235,7 @@ const CompositionMetadataValue: React.FC<{
 			dragDecimalPlaces={isFps ? 2 : 0}
 			formatter={formatValue}
 			rightAlign
-			small
+			style={metadataDraggerStyles[field]}
 		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineColorField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineColorField.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback} from 'react';
 import type {CanUpdateSequencePropStatusStatic} from 'remotion';
 import {BLACK_HEX, BLUE, LIGHT_TEXT} from '../../helpers/colors';
 import type {
@@ -73,12 +73,6 @@ export const TimelineColorField: React.FC<{
 		[onSave, onDragEnd, propStatus],
 	);
 
-	const swatchStyle = useMemo<React.CSSProperties>(() => {
-		return {
-			marginLeft: 5,
-		};
-	}, []);
-
 	if (currentValue === 'none') {
 		return (
 			<span style={containerStyle}>
@@ -107,7 +101,6 @@ export const TimelineColorField: React.FC<{
 				disabled={false}
 				name={field.key}
 				title={currentValue}
-				style={swatchStyle}
 			/>
 		</span>
 	);

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -480,6 +480,7 @@ export const TimelineEffectItem: React.FC<{
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={containsSelection}
+			isFieldRow={false}
 			outerHeight={null}
 		>
 			<span title={label} style={labelStyle}>

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -554,12 +554,14 @@ export const TimelineEffectPropItem: React.FC<{
 			onDoubleClick={onPropertyDoubleClick}
 			showSelectedBackground
 			containsSelection={false}
+			isFieldRow
 			outerHeight={null}
 		>
 			<TimelineFieldRowContent
 				field={field}
 				rowDepth={rowDepth}
 				selected={selection.selected}
+				keyframeControls={keyframeControls}
 			>
 				<TimelineEffectPropValueAtCurrentFrame
 					field={field}

--- a/packages/studio/src/components/Timeline/TimelineEnumField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEnumField.tsx
@@ -8,10 +8,6 @@ import type {
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {Combobox} from '../NewComposition/ComboBox';
 
-const comboboxStyle: React.CSSProperties = {
-	marginLeft: 8,
-};
-
 export const TimelineEnumField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly propStatus: CanUpdateSequencePropStatusStatic;
@@ -70,7 +66,6 @@ export const TimelineEnumField: React.FC<{
 			title={field.key}
 			selectedId={current}
 			values={items}
-			style={comboboxStyle}
 		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -120,6 +120,7 @@ const TimelineExpandedRowInner: React.FC<TimelineExpandedRowProps> = ({
 				onSelect={selection.onSelect}
 				showSelectedBackground
 				containsSelection={false}
+				isFieldRow={false}
 				outerHeight={null}
 			>
 				<span style={labelStyle}>{node.label}</span>
@@ -176,6 +177,7 @@ const TimelineExpandedRowInner: React.FC<TimelineExpandedRowProps> = ({
 			onSelect={selection.onSelect}
 			showSelectedBackground
 			containsSelection={false}
+			isFieldRow={false}
 			outerHeight={null}
 		>
 			<span style={labelStyle}>{node.label}</span>

--- a/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFieldRowContent.tsx
@@ -1,5 +1,8 @@
 import React, {useContext} from 'react';
-import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
+import {
+	SCHEMA_FIELD_ROW_HEIGHT,
+	type SchemaFieldInfo,
+} from '../../helpers/timeline-layout';
 import {
 	isTimelineFieldStacked,
 	timelineCompactStackedFieldValueColumnStyle,
@@ -7,15 +10,30 @@ import {
 	timelineStackedFieldContentStyle,
 } from './timeline-field-row-layout';
 import {TimelineFieldLabel} from './TimelineFieldLabel';
+import {TimelineRowKeyframeControlsColumn} from './TimelineRowChrome';
+import {TimelineRowLayoutContext} from './TimelineRowLayoutContext';
 import {Transform3DModeContext} from './Transform3DModeContext';
+
+const stackedHeaderStyle: React.CSSProperties = {
+	display: 'flex',
+	flex: `0 0 ${SCHEMA_FIELD_ROW_HEIGHT}px`,
+	minWidth: 0,
+};
+
+const stackedLabelStyle: React.CSSProperties = {
+	flex: 1,
+	minWidth: 0,
+};
 
 export const TimelineFieldRowContent: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly rowDepth: number;
 	readonly selected: boolean;
+	readonly keyframeControls: React.ReactNode;
 	readonly children: React.ReactNode;
-}> = ({field, rowDepth, selected, children}) => {
+}> = ({field, rowDepth, selected, keyframeControls, children}) => {
 	const transform3DMode = useContext(Transform3DModeContext);
+	const {keyframeControlsPlacement} = useContext(TimelineRowLayoutContext);
 	const stacked = isTimelineFieldStacked({field, transform3DMode});
 	const compactStacked = stacked && field.typeName !== 'text-content';
 	const label = (
@@ -38,10 +56,24 @@ export const TimelineFieldRowContent: React.FC<{
 		</div>
 	);
 
+	const controls =
+		keyframeControlsPlacement === 'after-label' ? (
+			<TimelineRowKeyframeControlsColumn depth={rowDepth}>
+				{keyframeControls}
+			</TimelineRowKeyframeControlsColumn>
+		) : null;
+
 	if (stacked) {
 		return (
 			<div style={timelineStackedFieldContentStyle}>
-				{label}
+				{controls ? (
+					<div style={stackedHeaderStyle}>
+						<div style={stackedLabelStyle}>{label}</div>
+						{controls}
+					</div>
+				) : (
+					label
+				)}
 				{value}
 			</div>
 		);
@@ -50,6 +82,7 @@ export const TimelineFieldRowContent: React.FC<{
 	return (
 		<>
 			{label}
+			{controls}
 			{value}
 		</>
 	);

--- a/packages/studio/src/components/Timeline/TimelineFontFamilyField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFontFamilyField.tsx
@@ -86,7 +86,6 @@ type FontFamilyOption = {
 };
 
 const triggerStyle: React.CSSProperties = {
-	marginLeft: 8,
 	padding: '3px 4px',
 	display: 'inline-flex',
 	alignItems: 'center',

--- a/packages/studio/src/components/Timeline/TimelineNumberField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineNumberField.tsx
@@ -7,7 +7,7 @@ import type {
 } from '../../helpers/timeline-layout';
 import {InputDragger} from '../NewComposition/InputDragger';
 import {formatTimelineFieldValueForDisplay} from './timeline-field-display-utils';
-import {draggerStyle} from './timeline-field-utils';
+import {draggerStyle, leftAlignedDraggerStyle} from './timeline-field-utils';
 
 export const TimelineNumberField: React.FC<{
 	readonly field: SchemaFieldInfo;
@@ -83,6 +83,7 @@ export const TimelineNumberField: React.FC<{
 		<InputDragger
 			type="number"
 			value={dragValue ?? (effectiveValue as number)}
+			buttonStyle={leftAlignedDraggerStyle}
 			style={draggerStyle}
 			status="ok"
 			small

--- a/packages/studio/src/components/Timeline/TimelineRotationField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRotationField.tsx
@@ -9,6 +9,7 @@ import {InputDragger} from '../NewComposition/InputDragger';
 import {
 	draggerStyle,
 	getTimelineDisplayDecimalPlaces,
+	leftAlignedDraggerStyle,
 	normalizeTimelineNumber,
 } from './timeline-field-utils';
 import {formatTimelineRotationFieldValue} from './timeline-rotation-field-utils';
@@ -240,6 +241,7 @@ export const TimelineRotationField: React.FC<{
 		<InputDragger
 			type="number"
 			value={dragValue ?? degrees}
+			buttonStyle={leftAlignedDraggerStyle}
 			style={draggerStyle}
 			status="ok"
 			small

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -32,6 +32,30 @@ const keyframeControlsColumnBaseStyle: React.CSSProperties = {
 	justifyContent: 'flex-start',
 };
 
+export const TimelineRowKeyframeControlsColumn: React.FC<{
+	readonly children: React.ReactNode;
+	readonly depth: number;
+}> = ({children, depth}) => {
+	const {basePadding, keyframeControlsPadding} = useContext(
+		TimelineRowLayoutContext,
+	);
+	const style = useMemo(
+		(): React.CSSProperties => ({
+			...keyframeControlsColumnBaseStyle,
+			boxSizing: keyframeControlsPadding === 0 ? undefined : 'border-box',
+			paddingLeft: keyframeControlsPadding,
+			width: getTimelineRowLeftChromeWidth(depth, basePadding),
+		}),
+		[basePadding, depth, keyframeControlsPadding],
+	);
+
+	return (
+		<div style={leftChromeStyle}>
+			<div style={style}>{children}</div>
+		</div>
+	);
+};
+
 export const TimelineRowChrome: React.FC<{
 	readonly depth: number;
 	readonly eye: React.ReactNode;
@@ -46,6 +70,7 @@ export const TimelineRowChrome: React.FC<{
 	readonly showSelectedBackground: boolean;
 	readonly containsSelection: boolean;
 	readonly hovered?: boolean;
+	readonly isFieldRow: boolean;
 	// When set, the chrome is wrapped in an outer container of this height with a
 	// bottom track separator. The background highlight and click target span the
 	// outer (used by sequence rows whose layer is taller than the chrome row).
@@ -70,6 +95,7 @@ export const TimelineRowChrome: React.FC<{
 	showSelectedBackground,
 	containsSelection,
 	hovered = false,
+	isFieldRow,
 	outerHeight,
 	onDragLeave,
 	onDragOver,
@@ -81,22 +107,12 @@ export const TimelineRowChrome: React.FC<{
 	const ref = useRef<HTMLDivElement>(null);
 	const {
 		basePadding,
-		keyframeControlsPadding,
+		keyframeControlsPlacement,
 		rowBorderRadius,
 		rowHorizontalMargin,
 	} = useContext(TimelineRowLayoutContext);
 	const indentWidth = getTimelineRowIndentWidth(depth);
 	useTimelineFocusableItem(selectionItem, ref);
-
-	const keyframeControlsColumnStyle = useMemo(
-		(): React.CSSProperties => ({
-			...keyframeControlsColumnBaseStyle,
-			boxSizing: keyframeControlsPadding === 0 ? undefined : 'border-box',
-			paddingLeft: keyframeControlsPadding,
-			width: getTimelineRowLeftChromeWidth(depth, basePadding),
-		}),
-		[basePadding, depth, keyframeControlsPadding],
-	);
 
 	const chromeColumnStyle = useMemo(
 		(): React.CSSProperties => ({
@@ -169,19 +185,25 @@ export const TimelineRowChrome: React.FC<{
 		};
 	}, [outerHeight, highlightBackground]);
 
+	const shouldRenderLeftChrome =
+		!isFieldRow || keyframeControlsPlacement === 'before-label';
 	const chrome = (
 		<>
-			<div style={leftChromeStyle}>
-				{keyframeControls ? (
-					<div style={keyframeControlsColumnStyle}>{keyframeControls}</div>
+			{shouldRenderLeftChrome ? (
+				keyframeControls ? (
+					<TimelineRowKeyframeControlsColumn depth={depth}>
+						{keyframeControls}
+					</TimelineRowKeyframeControlsColumn>
 				) : (
-					<div style={chromeColumnStyle}>
-						{eye}
-						{indentWidth > 0 ? <Padder depth={depth} /> : null}
-						{arrow}
+					<div style={leftChromeStyle}>
+						<div style={chromeColumnStyle}>
+							{eye}
+							{indentWidth > 0 ? <Padder depth={depth} /> : null}
+							{arrow}
+						</div>
 					</div>
-				)}
-			</div>
+				)
+			) : null}
 			{children}
 		</>
 	);

--- a/packages/studio/src/components/Timeline/TimelineRowLayoutContext.ts
+++ b/packages/studio/src/components/Timeline/TimelineRowLayoutContext.ts
@@ -1,4 +1,5 @@
 import {createContext} from 'react';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {
 	INSPECTOR_ROW_BASE_PADDING,
 	TIMELINE_ROW_BASE_PADDING,
@@ -8,6 +9,7 @@ type TimelineRowLayout = {
 	readonly basePadding: number;
 	readonly highlightSelectedLabel: boolean;
 	readonly keyframeControlsPadding: number;
+	readonly keyframeControlsPlacement: 'before-label' | 'after-label';
 	readonly rowBorderRadius: number;
 	readonly rowHorizontalMargin: number;
 };
@@ -16,14 +18,16 @@ export const INSPECTOR_TIMELINE_ROW_LAYOUT: TimelineRowLayout = {
 	basePadding: INSPECTOR_ROW_BASE_PADDING,
 	highlightSelectedLabel: false,
 	keyframeControlsPadding: 0,
+	keyframeControlsPlacement: 'after-label',
 	rowBorderRadius: 4,
-	rowHorizontalMargin: 4,
+	rowHorizontalMargin: INSPECTOR_PANEL_HORIZONTAL_PADDING,
 };
 
 export const TimelineRowLayoutContext = createContext<TimelineRowLayout>({
 	basePadding: TIMELINE_ROW_BASE_PADDING,
 	highlightSelectedLabel: true,
 	keyframeControlsPadding: TIMELINE_ROW_BASE_PADDING,
+	keyframeControlsPlacement: 'before-label',
 	rowBorderRadius: 0,
 	rowHorizontalMargin: 0,
 });

--- a/packages/studio/src/components/Timeline/TimelineScaleField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScaleField.tsx
@@ -21,12 +21,16 @@ const leftDraggerStyle: React.CSSProperties = {
 	paddingBottom: 2,
 	paddingLeft: 0,
 	paddingTop: 2,
+	textAlign: 'left',
+	width: 52,
 };
 
 const rightDraggerStyle: React.CSSProperties = {
 	paddingBottom: 2,
 	paddingRight: 0,
 	paddingTop: 2,
+	textAlign: 'left',
+	width: 52,
 };
 
 const containerStyle: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -1246,6 +1246,7 @@ const TimelineSequenceItemInner: React.FC<{
 			showSelectedBackground
 			containsSelection={containsSelection}
 			hovered={hovered}
+			isFieldRow={false}
 			outerHeight={outerHeight}
 			onDragLeave={canDropEffect ? onEffectDragLeave : undefined}
 			onDragOver={canDropEffect ? onEffectDragOver : undefined}

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -623,12 +623,14 @@ export const TimelineSequencePropItem: React.FC<{
 			onDoubleClick={onPropertyDoubleClick}
 			showSelectedBackground
 			containsSelection={false}
+			isFieldRow
 			outerHeight={null}
 		>
 			<TimelineFieldRowContent
 				field={field}
 				rowDepth={rowDepth}
 				selected={selection.selected}
+				keyframeControls={keyframeControls}
 			>
 				{fieldValue}
 			</TimelineFieldRowContent>

--- a/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-row-layout.ts
@@ -48,9 +48,9 @@ export const timelineFieldValueColumnStyle: React.CSSProperties = {
 export const timelineCompactStackedFieldValueColumnStyle: React.CSSProperties =
 	{
 		...timelineFieldValueColumnStyle,
-		marginBottom: -2,
+		marginBottom: -3,
 		position: 'relative',
-		top: -2,
+		top: -3,
 	};
 
 export const timelineStackedFieldContentStyle: React.CSSProperties = {

--- a/packages/studio/src/components/Timeline/timeline-field-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-utils.ts
@@ -55,3 +55,9 @@ export const normalizeTimelineNumber = (value: number): number => {
 export const draggerStyle: React.CSSProperties = {
 	width: 80,
 };
+
+export const leftAlignedDraggerStyle: React.CSSProperties = {
+	paddingBottom: 2,
+	paddingLeft: 0,
+	paddingTop: 2,
+};


### PR DESCRIPTION
## Summary

- Align Inspector schema fields with the panel instead of reserving Timeline chrome space
- Place Inspector keyframe controls between field labels and values while preserving the existing Timeline layout
- Add a Studio Playwright regression covering consecutive array fields and narrow Inspector widths

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bun run test:e2e e2e/inspector-control-layout.test.mts --project=chromium`

Closes #10174
