### PR TITLE
`remotion`: Allow changing CanvasImage source in Visual Mode

### DIFF
--- a/packages/core/src/canvas-image/CanvasImage.tsx
+++ b/packages/core/src/canvas-image/CanvasImage.tsx
@@ -42,6 +42,12 @@ import {withInteractivitySchema} from '../with-interactivity-schema.js';
 import type {CanvasImageCanvasProps, CanvasImageProps} from './props.js';
 
 export const canvasImageSchema = {
+	src: {
+		type: 'asset',
+		default: undefined,
+		description: 'Source',
+		keyframable: false,
+	},
 	...baseSchema,
 	...cropSchema,
 	...premountSchema,

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -276,7 +276,13 @@ test('<CanvasImage> registers its canvas as the outline ref', async () => {
 	});
 });
 
-test('<CanvasImage> exposes non-keyframable premounting schema fields', () => {
+test('<CanvasImage> schema exposes src and non-keyframable premounting fields', () => {
+	expect(canvasImageSchema.src).toEqual({
+		type: 'asset',
+		default: undefined,
+		description: 'Source',
+		keyframable: false,
+	});
 	expect(canvasImageSchema.premountFor.keyframable).toBe(false);
 	expect(canvasImageSchema.postmountFor.keyframable).toBe(false);
 });

--- a/packages/studio/src/components/QuickSwitcher/asset-search.ts
+++ b/packages/studio/src/components/QuickSwitcher/asset-search.ts
@@ -44,6 +44,7 @@ const componentAssetTypes: Record<string, AssetFileType> = {
 	'dev.remotion.media.Audio': 'audio',
 	'dev.remotion.media.Video': 'video',
 	'dev.remotion.remotion.AnimatedImage': 'image',
+	'dev.remotion.remotion.CanvasImage': 'image',
 	'dev.remotion.remotion.Img': 'image',
 };
 

--- a/packages/studio/src/test/quick-switcher-asset-search.test.ts
+++ b/packages/studio/src/test/quick-switcher-asset-search.test.ts
@@ -74,6 +74,9 @@ test('gets an asset type query for interactive media components', () => {
 	expect(
 		getAssetSearchQueryForComponent('dev.remotion.remotion.AnimatedImage'),
 	).toBe('type:image ');
+	expect(
+		getAssetSearchQueryForComponent('dev.remotion.remotion.CanvasImage'),
+	).toBe('type:image ');
 	expect(getAssetSearchQueryForComponent('com.example.Custom')).toBe('');
 	expect(getAssetSearchQueryForComponent(null)).toBe('');
 });


### PR DESCRIPTION
## Summary

- expose the `CanvasImage` `src` prop as an asset field in Visual Mode
- restrict its source picker to image assets, matching `Img` and `AnimatedImage`
- add regression coverage for the schema and asset filtering

## Tests

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/canvas-image.test.tsx` in `packages/core`
- `bun test src/test/quick-switcher-asset-search.test.ts` in `packages/studio`

Closes #10379
