### PR TITLE
`@remotion/studio`: Use conventional font picker scrollbar

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineFontFamilyField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineFontFamilyField.tsx
@@ -19,7 +19,10 @@ import {CaretDown} from '../../icons/caret';
 import {Checkmark} from '../../icons/Checkmark';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
 import {Spacing} from '../layout';
-import {MENU_INITIATOR_CLASSNAME} from '../Menu/is-menu-item';
+import {
+	MENU_INITIATOR_CLASSNAME,
+	VERTICAL_SCROLLBAR_CLASSNAME,
+} from '../Menu/is-menu-item';
 import {getPortal} from '../Menu/portals';
 import {
 	SHADOW_TOWARDS_BOTTOM,
@@ -772,6 +775,7 @@ export const TimelineFontFamilyField: React.FC<{
 											<div
 												ref={listRef}
 												style={listStyle}
+												className={VERTICAL_SCROLLBAR_CLASSNAME}
 												onScroll={(event) => {
 													setScrollTop(event.currentTarget.scrollTop);
 												}}


### PR DESCRIPTION
## Summary

- apply Studio's shared vertical scrollbar styling to the font picker
- match other scrollable areas such as the effect picker and quick switcher

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #10370
