### PR TITLE
`remotion`: Clamp crop values to valid range

### DIFF
--- a/packages/core/src/sequence-crop.ts
+++ b/packages/core/src/sequence-crop.ts
@@ -95,9 +95,9 @@ export const validateSequenceCrop = (
 			);
 		}
 
-		if (value < 0 || value > 1) {
+		if (value > 100) {
 			throw new RangeError(
-				`The "${name}" prop of ${componentName} must be between 0 and 1, but got ${value}.`,
+				`The "${name}" prop of ${componentName} must be between 0 and 1, but got ${value}. The crop range is 0 to 1, not 0 to 100.`,
 			);
 		}
 	}

--- a/packages/core/src/test/Img.test.tsx
+++ b/packages/core/src/test/Img.test.tsx
@@ -463,9 +463,9 @@ test('<Img> forwards crop props to the CanvasImage fallback', () => {
 
 test('<Img> keeps its component name in crop errors from the fallback', () => {
 	expect(() =>
-		renderImg(<Img cropLeft={1.1} effects={[makeEffect()]} src={testImgUrl} />),
+		renderImg(<Img cropLeft={101} effects={[makeEffect()]} src={testImgUrl} />),
 	).toThrow(
-		'The "cropLeft" prop of <Img /> must be between 0 and 1, but got 1.1.',
+		'The "cropLeft" prop of <Img /> must be between 0 and 1, but got 101. The crop range is 0 to 1, not 0 to 100.',
 	);
 });
 

--- a/packages/core/src/test/sequence-crop.test.tsx
+++ b/packages/core/src/test/sequence-crop.test.tsx
@@ -1,5 +1,6 @@
 import {afterEach, expect, test} from 'bun:test';
 import {cleanup, render} from '@testing-library/react';
+import {Interactive} from '../Interactive.js';
 import {resolveSequenceCrop} from '../sequence-crop.js';
 import {Sequence} from '../Sequence.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
@@ -92,15 +93,28 @@ test('clashing crops meet in the middle', () => {
 	).toEqual({left: 0.5, right: 0.5, top: 0.5, bottom: 0.5});
 });
 
-test('rejects crops outside the 0 to 1 range', () => {
+test('clamps crop values outside the 0 to 1 range', () => {
+	const {container} = render(
+		<WrapSequenceContext>
+			<Interactive.Div cropLeft={-0.1} cropRight={1.1}>
+				Content
+			</Interactive.Div>
+		</WrapSequenceContext>,
+	);
+
+	const element = container.firstElementChild as HTMLDivElement;
+	expect(element.style.clipPath).toBe('inset(0% 100% 0% 0%)');
+});
+
+test('rejects crop values above 100 with a range hint', () => {
 	expect(() =>
 		render(
 			<WrapSequenceContext>
-				<Sequence cropLeft={1.1}>Content</Sequence>
+				<Interactive.Div cropLeft={101}>Content</Interactive.Div>
 			</WrapSequenceContext>,
 		),
 	).toThrow(
-		'The "cropLeft" prop of <Sequence /> must be between 0 and 1, but got 1.1.',
+		'The "cropLeft" prop of <Interactive.Div> must be between 0 and 1, but got 101. The crop range is 0 to 1, not 0 to 100.',
 	);
 });
 


### PR DESCRIPTION
## Summary

- Clamp crop values below 0 and above 1 instead of rejecting small overshoots
- Reject values above 100 with guidance that crop values use the 0-to-1 range
- Add regression coverage using a rendered `<Interactive.Div>`

## Testing

- `bun test src/test/sequence-crop.test.tsx` in `packages/core`
- `bun run build`
- `bun run stylecheck`

Closes #10369
