### PR TITLE
`@remotion/canvas-capture-extension`: Prefer MP4 when supported

### DIFF
--- a/packages/canvas-capture-extension/src/content.ts
+++ b/packages/canvas-capture-extension/src/content.ts
@@ -177,7 +177,7 @@ export const startContent = () => {
 					return;
 				}
 
-				const supportKey = `${format}:${preflight.outputSize.width}x${preflight.outputSize.height}`;
+				const supportKey = `${preflight.outputSize.width}x${preflight.outputSize.height}`;
 				outputSize = preflight.outputSize;
 				if (
 					encoderSupportKey === supportKey &&
@@ -188,24 +188,43 @@ export const startContent = () => {
 
 				encoderSupport = 'checking';
 				setStatus(
-					`Checking ${getFormatLabel(format)} support at ${outputSize.width}×${outputSize.height}…`,
+					`Checking H.264 MP4 support at ${outputSize.width}×${outputSize.height}…`,
 				);
-				const canEncode = await canEncodeCapture(format, outputSize);
+				const canEncodeMp4 = await canEncodeCapture('mp4', outputSize);
 				if (checkId !== encoderSupportCheckId) {
 					return;
 				}
 
-				if (canEncode) {
+				if (canEncodeMp4) {
+					format = 'mp4';
 					encoderSupport = 'supported';
 					encoderSupportKey = supportKey;
 					setStatus(
 						`Ready to record ${getFormatLabel(format)} at ${outputSize.width}×${outputSize.height}.`,
 					);
+					return;
+				}
+
+				setStatus(
+					`H.264 MP4 is unavailable at ${outputSize.width}×${outputSize.height}. Checking VP9 WebM…`,
+				);
+				const canEncodeWebm = await canEncodeCapture('webm', outputSize);
+				if (checkId !== encoderSupportCheckId) {
+					return;
+				}
+
+				if (canEncodeWebm) {
+					format = 'webm';
+					encoderSupport = 'supported';
+					encoderSupportKey = supportKey;
+					setStatus(
+						`H.264 MP4 is unavailable at ${outputSize.width}×${outputSize.height}. Ready to record VP9 WebM instead.`,
+					);
 				} else {
 					encoderSupport = 'unsupported';
 					encoderSupportKey = supportKey;
 					setStatus(
-						`${getFormatLabel(format)} encoding is not supported at ${outputSize.width}×${outputSize.height} in this browser. Reduce the scale or select a smaller area.`,
+						`Neither H.264 MP4 nor VP9 WebM encoding is supported at ${outputSize.width}×${outputSize.height} in this browser. Reduce the scale or select a smaller area.`,
 						true,
 					);
 				}
@@ -349,7 +368,7 @@ export const startContent = () => {
 			}
 		});
 
-		const setOptions = (nextScale: number, nextFormat: CaptureFormat) => {
+		const setOptions = (nextScale: number) => {
 			if (!Number.isFinite(nextScale) || nextScale <= 0) {
 				encoderSupportCheckId++;
 				encoderSupport = 'unsupported';
@@ -359,21 +378,11 @@ export const startContent = () => {
 				return false;
 			}
 
-			if (nextFormat !== 'mp4' && nextFormat !== 'webm') {
-				encoderSupportCheckId++;
-				encoderSupport = 'unsupported';
-				encoderSupportKey = null;
-				outputSize = null;
-				setStatus('Choose MP4 or WebM as the recording format.', true);
-				return false;
-			}
-
-			if (scale !== nextScale || format !== nextFormat) {
+			if (scale !== nextScale) {
 				encoderSupportKey = null;
 			}
 
 			scale = nextScale;
-			format = nextFormat;
 			updateHighlight();
 			return true;
 		};
@@ -417,7 +426,7 @@ export const startContent = () => {
 
 				if (request.command === 'set-options') {
 					if (!capture && !finalizing) {
-						if (setOptions(request.scale, request.format)) {
+						if (setOptions(request.scale)) {
 							await refreshEncoderSupport();
 						}
 					}
@@ -469,7 +478,7 @@ export const startContent = () => {
 						return getState();
 					}
 
-					if (!setOptions(request.scale, request.format)) {
+					if (!setOptions(request.scale)) {
 						return getState();
 					}
 

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
@@ -5,7 +5,6 @@ import {
 	isCapturePopupTargetMessage,
 	type CaptureControllerRequest,
 	type CaptureControllerState,
-	type CaptureFormat,
 } from '../../messages';
 
 const getStateRequest: CaptureControllerRequest = {
@@ -230,11 +229,10 @@ export const App: React.FC = () => {
 		state.selecting ||
 		(!state.recording && state.encoderSupport !== 'supported');
 
-	const updateOptions = (format: CaptureFormat, scale: number) => {
+	const updateOptions = (scale: number) => {
 		runCommand({
 			type: captureControllerMessageType,
 			command: 'set-options',
-			format,
 			scale,
 		}).catch(() => undefined);
 	};
@@ -251,21 +249,10 @@ export const App: React.FC = () => {
 
 			<section className="panel settings-panel">
 				<div className="field">
-					<label htmlFor="format">Format</label>
-					<select
-						id="format"
-						disabled={controlsDisabled || state?.recording}
-						value={state?.format ?? 'mp4'}
-						onChange={(event) =>
-							updateOptions(
-								event.currentTarget.value as CaptureFormat,
-								state?.scale ?? 1,
-							)
-						}
-					>
-						<option value="mp4">MP4 · H.264</option>
-						<option value="webm">WebM · VP9</option>
-					</select>
+					<label>Format</label>
+					<div className="format-value">
+						{state?.format === 'webm' ? 'WebM · VP9' : 'MP4 · H.264'}
+					</div>
 				</div>
 
 				<div className="field">
@@ -279,9 +266,7 @@ export const App: React.FC = () => {
 							disabled={controlsDisabled || state?.recording}
 							value={scaleInput}
 							onChange={(event) => setScaleInput(event.currentTarget.value)}
-							onBlur={() =>
-								updateOptions(state?.format ?? 'mp4', Number(scaleInput))
-							}
+							onBlur={() => updateOptions(Number(scaleInput))}
 							onKeyDown={(event) => {
 								if (event.key === 'Enter') {
 									event.currentTarget.blur();
@@ -373,7 +358,6 @@ export const App: React.FC = () => {
 						runCommand({
 							type: captureControllerMessageType,
 							command: 'start-recording',
-							format: state?.format ?? 'mp4',
 							scale: state?.scale ?? 1,
 						}).catch(() => undefined);
 					}}

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
@@ -27,19 +27,16 @@ body {
 }
 
 button,
-input,
-select {
+input {
 	font: inherit;
 }
 
-button,
-select {
+button {
 	cursor: pointer;
 }
 
 button:disabled,
-input:disabled,
-select:disabled {
+input:disabled {
 	cursor: default;
 	opacity: 0.48;
 }
@@ -113,7 +110,6 @@ h1 {
 }
 
 input,
-select,
 .format-value {
 	width: 100%;
 	height: 34px;
@@ -130,16 +126,11 @@ select,
 	padding: 0 9px;
 }
 
-select {
-	padding: 0 9px;
-}
-
 input {
 	padding: 0 8px;
 }
 
 input:focus,
-select:focus,
 button:focus-visible {
 	border-color: #0b84f3;
 	box-shadow: 0 0 0 2px rgba(11, 132, 243, 0.25);

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
@@ -113,7 +113,8 @@ h1 {
 }
 
 input,
-select {
+select,
+.format-value {
 	width: 100%;
 	height: 34px;
 	border: 1px solid rgba(255, 255, 255, 0.12);
@@ -121,6 +122,12 @@ select {
 	outline: none;
 	background: #2f363d;
 	color: #fff;
+}
+
+.format-value {
+	display: flex;
+	align-items: center;
+	padding: 0 9px;
 }
 
 select {

--- a/packages/canvas-capture-extension/src/messages.ts
+++ b/packages/canvas-capture-extension/src/messages.ts
@@ -51,7 +51,6 @@ export type CaptureControllerRequest =
 			readonly type: typeof captureControllerMessageType;
 			readonly command: 'set-options';
 			readonly scale: number;
-			readonly format: CaptureFormat;
 	  }
 	| {
 			readonly type: typeof captureControllerMessageType;
@@ -69,7 +68,6 @@ export type CaptureControllerRequest =
 			readonly type: typeof captureControllerMessageType;
 			readonly command: 'start-recording';
 			readonly scale: number;
-			readonly format: CaptureFormat;
 	  }
 	| {
 			readonly type: typeof captureControllerMessageType;


### PR DESCRIPTION
## Summary

- automatically prefer H.264 MP4 for Canvas Capture recordings
- fall back to VP9 WebM only when MP4 cannot encode the selected output size
- display the automatically selected format instead of offering a manual format selector

## Validation

- `bun run build`
- `bun run stylecheck`

Closes #10348
