### PR TITLE
Docs: Link Cursor plugin marketplace

### DIFF
--- a/packages/docs/docs/ai/cursor-plugin.mdx
+++ b/packages/docs/docs/ai/cursor-plugin.mdx
@@ -10,7 +10,9 @@ It can help you create and edit Remotion projects and includes [Remotion Agent S
 
 ## Installation
 
-Clone the plugin into Cursor's local plugin directory:
+[Install the Remotion plugin from the Cursor Marketplace](https://cursor.com/marketplace/remotion).
+
+Alternatively, clone the plugin into Cursor's local plugin directory:
 
 ```bash title="Terminal"
 mkdir -p ~/.cursor/plugins/local

--- a/packages/docs/docs/ai/plugins.mdx
+++ b/packages/docs/docs/ai/plugins.mdx
@@ -28,7 +28,9 @@ Use the Remotion plugin in Claude Code.
 
 Use the Remotion plugin in Cursor.
 
-[Install and use the Cursor plugin](/docs/ai/cursor-plugin).
+[Install the Remotion plugin from the Cursor Marketplace](https://cursor.com/marketplace/remotion).
+
+[Learn how to use the Cursor plugin](/docs/ai/cursor-plugin).
 
 ## Kimi Code plugin
 


### PR DESCRIPTION
## Why

Cursor users currently see manual cloning as the primary installation path even though the Remotion plugin is available in the official Cursor Marketplace. Linking the Marketplace gives them a direct, familiar installation entry while keeping the local clone path available when needed.

## What changed

- Added the official Cursor Marketplace link as the primary installation option.
- Kept the existing manual clone instructions as an alternative.

Closes #10429.

## Validation

- `bunx oxfmt packages/docs/docs/ai/cursor-plugin.mdx --check`
- `git diff --check`
- Verified `https://cursor.com/marketplace/remotion` returns HTTP 200.
