### PR TITLE
Elements: Expand source code to full height

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -46,7 +46,6 @@
 }
 
 .sourceViewport {
-	height: 360px;
 	overflow: auto;
 	overscroll-behavior: contain;
 	background: #282a36;
@@ -263,10 +262,6 @@
 }
 
 @media (max-width: 600px) {
-	.sourceViewport {
-		height: 320px;
-	}
-
 	.sourceViewportCollapsed {
 		height: 160px;
 	}

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -46,8 +46,6 @@
 }
 
 .sourceViewport {
-	overflow: auto;
-	overscroll-behavior: contain;
 	background: #282a36;
 }
 


### PR DESCRIPTION
## Summary

- let expanded Element source code use its full content height
- keep the compact collapsed source preview on desktop and mobile
- allow the page to keep scrolling while the pointer is over expanded source code

## Verification

- `bunx oxfmt packages/docs/src/components/Elements/ElementPage.module.css --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
