### PR TITLE
`@remotion/studio`: Reserve Space for playback in composition sidebar

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -396,6 +396,19 @@ test.describe('visual mode', () => {
 		});
 	});
 
+	test('should play when a composition in the sidebar is focused', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/schema-test`);
+		await expect(page).toHaveURL(/schema-test/, {timeout: 15_000});
+
+		const otherComposition = page.getByTitle('AnimatedBarChart', {exact: true});
+		await otherComposition.press('Space');
+
+		await expect(page.getByRole('button', {name: 'Pause'})).toBeVisible();
+		await expect(page).toHaveURL(/schema-test/);
+	});
+
 	test('should navigate to a newly created composition', async ({page}) => {
 		const compositionId = 'NewlyCreatedComposition';
 		const compositionFile = path.join(

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -182,7 +182,7 @@ export const CompositionSelectorItem: React.FC<{
 
 	const onKeyDown = useCallback(
 		(evt: React.KeyboardEvent<HTMLElement>) => {
-			if (evt.key === 'Enter' || evt.key === ' ') {
+			if (evt.key === 'Enter') {
 				onClick(evt);
 			}
 		},


### PR DESCRIPTION
## Summary

- reserve Space for Studio playback when a composition sidebar row is focused
- keep Enter as the keyboard shortcut for activating sidebar compositions and folders
- add an E2E regression test that verifies playback starts without changing compositions

## Testing

- `bunx playwright test e2e/studio.test.mts --grep "should play when a composition in the sidebar is focused"`
- `bun run build`
- `bun run stylecheck`

Closes #10374
