### PR TITLE
Internal: Add Zed task for docs development server

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -32,6 +32,14 @@
 		"save": "all"
 	},
 	{
+		"label": "start docs dev server",
+		"command": "bun run start",
+		"cwd": "$ZED_WORKTREE_ROOT/packages/docs",
+		"reveal": "always",
+		"hide": "never",
+		"save": "all"
+	},
+	{
 		"label": "start docs studio",
 		"command": "bun remotion",
 		"cwd": "$ZED_WORKTREE_ROOT/packages/docs",


### PR DESCRIPTION
## Summary

- add a Zed task for starting the documentation development server
- run the existing docs `start` script from `packages/docs`

## Verification

- `bunx oxfmt .zed/tasks.json --write`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
