### PR TITLE
`@remotion/promo-pages`: Update homepage parameterization panel

### DIFF
--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -56,7 +56,7 @@ export const NewLanding: React.FC<{
 						<div className={makeVideosRowClassName}>
 							<MakeVideosProgrammatically
 								title="Parameterization"
-								description="Organize your assets and connect your data to it."
+								description="Organize your assets and connect your data."
 								videoSrc="/img/design-systems.webm"
 								fallbackVideoSrc="/img/design-systems.mp4"
 								links={[
@@ -64,7 +64,7 @@ export const NewLanding: React.FC<{
 										label: 'Parameterization',
 										href: '/docs/parameterized-rendering',
 									},
-									{label: 'Motion Design systems', href: '/design-systems'},
+									{label: 'Motion design systems', href: '/design-systems'},
 								]}
 							/>
 							<MakeVideosAgentically

--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -55,12 +55,16 @@ export const NewLanding: React.FC<{
 						<ReactSourceOfTruth />
 						<div className={makeVideosRowClassName}>
 							<MakeVideosProgrammatically
-								title="Design systems"
-								description="Create a library of animated assets for your organization."
+								title="Parameterization"
+								description="Organize your assets and connect your data to it."
 								videoSrc="/img/design-systems.webm"
 								fallbackVideoSrc="/img/design-systems.mp4"
 								links={[
-									{label: 'Motion design systems', href: '/design-systems'},
+									{
+										label: 'Parameterization',
+										href: '/docs/parameterized-rendering',
+									},
+									{label: 'Motion Design systems', href: '/design-systems'},
 								]}
 							/>
 							<MakeVideosAgentically


### PR DESCRIPTION
## Summary

- rename the homepage Design systems panel to Parameterization
- update its description to focus on organized assets connected to data
- link to both parameterization docs and motion design systems

## Checks

- `bun run build`
- `bun run stylecheck`

Closes #9635
