### PR TITLE
`@remotion/media`: give deferred audio waiters a turn when premounting ends

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -17,6 +17,7 @@ import {
 	getScheduledTime,
 	getTrimStartForAudioNode,
 } from './audio/get-scheduled-time';
+import {processNext} from './audio/sort-by-priority';
 import {drawPreviewOverlay} from './debug-overlay/preview-overlay';
 import {getDurationOrCompute} from './get-duration-or-compute';
 import {acquireSharedInput, releaseSharedInput} from './get-shared-input';
@@ -646,10 +647,12 @@ export class MediaPlayer {
 
 	public setIsPremounting(isPremounting: boolean): void {
 		this.premountAwareDelayPlayback.setIsPremounting(isPremounting);
+		processNext();
 	}
 
 	public setIsPostmounting(isPostmounting: boolean): void {
 		this.premountAwareDelayPlayback.setIsPostmounting(isPostmounting);
+		processNext();
 	}
 
 	public async setLoop(

--- a/packages/media/src/test/premount-arm-kicks-scheduler.test.ts
+++ b/packages/media/src/test/premount-arm-kicks-scheduler.test.ts
@@ -1,0 +1,110 @@
+import type {useBufferState} from 'remotion';
+import {expect, test} from 'vitest';
+import {waitForTurn} from '../audio/sort-by-priority';
+import {MediaPlayer} from '../media-player';
+
+const makePlayer = ({
+	isPremounting,
+	isPostmounting,
+}: {
+	isPremounting: boolean;
+	isPostmounting: boolean;
+}) => {
+	return new MediaPlayer({
+		canvas: null,
+		src: '/bigbuckbunny.mp4',
+		logLevel: 'info',
+		sharedAudioContext: null,
+		loop: false,
+		trimBefore: undefined,
+		trimAfter: undefined,
+		playbackRate: 1,
+		globalPlaybackRate: 1,
+		audioStreamIndex: 0,
+		fps: 30,
+		debugOverlay: false,
+		bufferState: {
+			delayPlayback: () => ({unblock: () => undefined}),
+		} as unknown as ReturnType<typeof useBufferState>,
+		isPremounting,
+		isPostmounting,
+		durationInFrames: 100,
+		onVideoFrameCallback: null,
+		playing: false,
+		sequenceOffset: 0,
+		credentials: undefined,
+		requestInit: undefined,
+		tagType: 'audio',
+		getEffects: () => [],
+		getEffectChainState: () => null,
+	});
+};
+
+const sleep = (ms: number) =>
+	new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});
+
+const parkWaiter = () => {
+	const events: string[] = [];
+	let priority: number | null = 3;
+
+	waitForTurn({
+		getPriority: () => priority,
+		fn: () => Promise.resolve('deferred'),
+		onDone: (_, triggerNext) => {
+			events.push('done');
+			triggerNext();
+		},
+		onError: (err) => {
+			events.push((err as Error).name);
+		},
+	});
+
+	return {
+		events,
+		setPriority: (newPriority: number | null) => {
+			priority = newPriority;
+		},
+	};
+};
+
+test('ending premounting gives deferred audio waiters a turn', async () => {
+	const {events, setPriority} = parkWaiter();
+	const mediaPlayer = makePlayer({isPremounting: true, isPostmounting: false});
+
+	setPriority(1);
+	await sleep(50);
+	expect(events).toEqual([]);
+
+	mediaPlayer.setIsPremounting(false);
+	await sleep(50);
+	expect(events).toEqual(['done']);
+});
+
+test('ending postmounting gives deferred audio waiters a turn', async () => {
+	const {events, setPriority} = parkWaiter();
+	const mediaPlayer = makePlayer({isPremounting: false, isPostmounting: true});
+
+	setPriority(1);
+	await sleep(50);
+	expect(events).toEqual([]);
+
+	mediaPlayer.setIsPostmounting(false);
+	await sleep(50);
+	expect(events).toEqual(['done']);
+});
+
+test('the kick keeps deferring waiters beyond the horizon and sweeps stale ones', async () => {
+	const {events, setPriority} = parkWaiter();
+	const mediaPlayer = makePlayer({isPremounting: true, isPostmounting: false});
+
+	mediaPlayer.setIsPremounting(false);
+	await sleep(50);
+	expect(events).toEqual([]);
+
+	setPriority(null);
+	mediaPlayer.setIsPremounting(true);
+	await sleep(50);
+	expect(events).toEqual(['StaleWaiterError']);
+});


### PR DESCRIPTION
## Problem

`processNext()` in `sort-by-priority.ts` defers any waiter whose slot is more than 2 seconds out, and deferred waiters are only re-evaluated when something re-enters the scheduler. Almost everything does: every iterator start or restart goes through `waitForTurn`, and ongoing playback re-enters it constantly via decode chains and per-frame seeks.

One path doesn't. A premounted `<Sequence>`'s audio iterator starts priming while its content is still far in the future, so its decode waiter is deferred. When premounting ends, the delay-playback handle arms and blocks playback — and blocked playback produces no scheduler traffic at all. The handle waits on the scheduler, the scheduler waits on a kick, and the kick would have come from the playback the handle is blocking. The Player hangs in a buffering state it can never leave.

## Fix

Run `processNext()` when a `MediaPlayer`'s premounting/postmounting state changes — the moment its handles may arm and playback starts depending on deferred work. By then the sequence's audio target is at the playhead, so the waiter is inside the horizon and dispatches immediately. Two call sites, no API changes, no timers; extra calls are no-ops since `processNext()` re-evaluates and returns.

An earlier revision of this PR made the scheduler re-arm itself with a timeout instead. Event-driven is better: the arm transition is the only entry into the deadlock (every other iterator lifecycle passes through `waitForTurn`, which already kicks), there is no background timer in library code, and it works even while the shared audio context is suspended and priorities are frozen.

## Production evidence

We (Bevyl) hit this in production with chunked compositions — each ~20s window premounts a `<Sequence>` whose audio waiter is deferred at mount, and a window arming under the wrong timing froze playback indefinitely. We have shipped a workaround via `patchedDependencies` since 4.0.484; this is the root-cause fix.

## Tests

`premount-arm-kicks-scheduler.test.ts`, three tests with priorities that decay like the real audio clock:

- The deadlock repro: a deferred waiter enters the horizon and is asserted to still be parked (nothing kicked the scheduler), then `setIsPremounting(false)` dispatches it.
- The same through `setIsPostmounting(false)` — the second call site.
- The kick re-evaluates rather than force-dispatches: a waiter far beyond the horizon stays deferred through a kick, and one that went stale is swept with `StaleWaiterError`.
