### PR TITLE
Internal: Load Element preview upload credentials from docs

### DIFF
--- a/.agents/skills/accept-element/SKILL.md
+++ b/.agents/skills/accept-element/SKILL.md
@@ -46,7 +46,7 @@ Ask the maintainer to visually compare the committed assets with the fresh rende
 
 ## 3. Upload the exact approved files
 
-With maintainer R2 credentials available, run:
+With maintainer R2 credentials in `packages/docs/.env`, run:
 
 ```bash
 cd packages/docs
@@ -55,6 +55,8 @@ bun run upload-element-preview \
   --source=submission
 cd ../..
 ```
+
+Running the command from `packages/docs` makes Bun load `packages/docs/.env`. Element preview uploads do not use `packages/remotion-media/.env`; do not use the generic `upload-r2` or `offload-r2` skills for them.
 
 This command uploads the exact files from `packages/docs/static/elements`; it does not rerender or delete them. The explicit submission source validates that the assets are committed and unmodified, then checks the local paths, signatures, combined size, uploaded sizes, public HTTP responses, and content types. Do not continue unless both uploads are verified.
 

--- a/.agents/skills/offload-r2/SKILL.md
+++ b/.agents/skills/offload-r2/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: offload-r2
-description: Upload Remotion repository media assets to the Cloudflare R2 bucket behind remotion.media, switch source code to hosted URLs, and retain ignored local working copies. Use when binaries should remain available locally for editing or previewing but must not be committed to Git.
+description: Upload Remotion repository media assets to the Cloudflare R2 bucket behind remotion.media, switch source code to hosted URLs, and retain ignored local working copies. Use when binaries should remain available locally for editing or previewing but must not be committed to Git. Do not use for Remotion Element previews.
 ---
 
 # Offload R2 Asset
 
 Host media on `https://remotion.media/` while preserving the original file in the worktree as an ignored local copy.
+
+Do not use this skill for Remotion Element previews. Follow the `submit-element` or `accept-element` skill instead; the dedicated uploader runs from `packages/docs` and loads `packages/docs/.env`.
 
 ## Workflow
 

--- a/.agents/skills/submit-element/SKILL.md
+++ b/.agents/skills/submit-element/SKILL.md
@@ -43,8 +43,13 @@ printf 'GitHub user: %s\nRepository permission: %s\n' \
 Use the **direct member path** only when `permission` is `write`, `maintain`, or `admin`. Before continuing on that path, verify without printing their values that Bun can read both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`:
 
 ```bash
-bun -e 'process.exit(Bun.env.AWS_ACCESS_KEY_ID && Bun.env.AWS_SECRET_ACCESS_KEY ? 0 : 1)'
+(
+  cd packages/docs
+  bun -e 'process.exit(Bun.env.AWS_ACCESS_KEY_ID && Bun.env.AWS_SECRET_ACCESS_KEY ? 0 : 1)'
+)
 ```
+
+The subshell is intentional: Bun loads `packages/docs/.env` because the working directory is `packages/docs`. Element preview uploads do not use `packages/remotion-media/.env`; do not use the generic `upload-r2` or `offload-r2` skills for them.
 
 If a repository writer is missing either credential, stop and report that direct preview upload credentials are required. Do not silently commit temporary assets for them.
 
@@ -108,7 +113,7 @@ bun run upload-element-preview \
 cd ../..
 ```
 
-The uploader validates the local URLs, signatures, combined size, uploaded sizes, public HTTP responses, and content types. Do not continue unless both uploads are verified.
+The uploader validates the local URLs, signatures, combined size, uploaded sizes, public HTTP responses, and content types. Running it from `packages/docs` makes Bun load `packages/docs/.env`. Do not continue unless both uploads are verified.
 
 Then:
 

--- a/.agents/skills/upload-r2/SKILL.md
+++ b/.agents/skills/upload-r2/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: upload-r2
-description: Upload large Remotion repository assets to the Cloudflare R2 bucket behind remotion.media and replace local public/ assets with hosted URLs. Use when a file is too large for Git or when a PR should avoid committing media binaries by hosting them on remotion.media.
+description: Upload large Remotion repository assets to the Cloudflare R2 bucket behind remotion.media and replace local public/ assets with hosted URLs. Use when a file is too large for Git or when a PR should avoid committing media binaries by hosting them on remotion.media. Do not use for Remotion Element previews.
 ---
 
 # Upload R2 Asset
 
 Use this for large media assets that should be hosted on `https://remotion.media/` instead of committed to Git.
+
+Do not use this skill for Remotion Element previews. Follow the `submit-element` or `accept-element` skill instead; the dedicated uploader runs from `packages/docs` and loads `packages/docs/.env`.
 
 ## Workflow
 

--- a/packages/docs/upload-element-preview.ts
+++ b/packages/docs/upload-element-preview.ts
@@ -149,7 +149,7 @@ if (totalSize > maxCombinedSize) {
 
 if (!Bun.env.AWS_ACCESS_KEY_ID || !Bun.env.AWS_SECRET_ACCESS_KEY) {
 	throw new Error(
-		'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY',
+		'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Run this command from packages/docs so Bun loads packages/docs/.env.',
 	);
 }
 


### PR DESCRIPTION
## Summary

- Run the Element submission credential preflight from `packages/docs` so Bun loads `packages/docs/.env`.
- Keep Element preview uploads on their dedicated workflow instead of the generic R2 upload skills and `packages/remotion-media/.env`.
- Make the uploader's missing-credentials error identify the expected working directory and env file.

## Verification

- `bunx oxfmt packages/docs/upload-element-preview.ts --write`
- `bun run build`
- `bun run stylecheck`
- `(cd packages/docs && bun -e 'process.exit(Bun.env.AWS_ACCESS_KEY_ID && Bun.env.AWS_SECRET_ACCESS_KEY ? 0 : 1)')`
- `git diff --check`
