### PR TITLE
`@remotion/web-renderer`: Allow still renders during media renders

### DIFF
--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -41,7 +41,7 @@ import {
 	type WebRendererPageResponsiveness,
 } from './page-responsiveness';
 import type {CompositionCalculateMetadataOrExplicit} from './props-if-has-props';
-import {onlyOneRenderAtATimeQueue} from './render-operations-queue';
+import {onlyOneMediaRenderAtATimeQueue} from './render-operations-queue';
 import {resolveAudioCodec} from './resolve-audio-codec';
 import {sendUsageEvent} from './send-telemetry-event';
 import {createLayer, type HtmlInCanvasLayerOutcome} from './take-screenshot';
@@ -744,7 +744,7 @@ export const renderMediaOnWeb = <
 	const codec =
 		options.videoCodec ?? getDefaultVideoCodecForContainer(container) ?? null;
 
-	onlyOneRenderAtATimeQueue.ref = onlyOneRenderAtATimeQueue.ref
+	onlyOneMediaRenderAtATimeQueue.ref = onlyOneMediaRenderAtATimeQueue.ref
 		.catch(() => Promise.resolve())
 		.then(() =>
 			internalRenderMediaOnWeb<Schema, Props>({
@@ -778,5 +778,5 @@ export const renderMediaOnWeb = <
 			}),
 		);
 
-	return onlyOneRenderAtATimeQueue.ref as Promise<RenderMediaOnWebResult>;
+	return onlyOneMediaRenderAtATimeQueue.ref as Promise<RenderMediaOnWebResult>;
 };

--- a/packages/web-renderer/src/render-operations-queue.ts
+++ b/packages/web-renderer/src/render-operations-queue.ts
@@ -1,3 +1,7 @@
-export const onlyOneRenderAtATimeQueue = {
+export const onlyOneMediaRenderAtATimeQueue = {
+	ref: Promise.resolve() as Promise<unknown>,
+};
+
+export const onlyOneStillRenderAtATimeQueue = {
 	ref: Promise.resolve() as Promise<unknown>,
 };

--- a/packages/web-renderer/src/render-still-on-web.tsx
+++ b/packages/web-renderer/src/render-still-on-web.tsx
@@ -11,7 +11,7 @@ import {supportsNestedHtmlInCanvas} from './html-in-canvas';
 import {makeInternalState} from './internal-state';
 import type {CompositionCalculateMetadataOrExplicit} from './props-if-has-props';
 import type {InputPropsIfHasProps} from './render-media-on-web';
-import {onlyOneRenderAtATimeQueue} from './render-operations-queue';
+import {onlyOneStillRenderAtATimeQueue} from './render-operations-queue';
 import {
 	createRenderStillOnWebResult,
 	type RenderStillOnWebResult,
@@ -237,7 +237,7 @@ export const renderStillOnWeb = <
 >(
 	options: RenderStillOnWebOptions<Schema, Props>,
 ): Promise<RenderStillOnWebResult> => {
-	onlyOneRenderAtATimeQueue.ref = onlyOneRenderAtATimeQueue.ref
+	onlyOneStillRenderAtATimeQueue.ref = onlyOneStillRenderAtATimeQueue.ref
 		.catch(() => Promise.resolve())
 		.then(() =>
 			internalRenderStillOnWeb<Schema, Props>({
@@ -256,5 +256,5 @@ export const renderStillOnWeb = <
 			}),
 		);
 
-	return onlyOneRenderAtATimeQueue.ref as Promise<RenderStillOnWebResult>;
+	return onlyOneStillRenderAtATimeQueue.ref as Promise<RenderStillOnWebResult>;
 };

--- a/packages/web-renderer/src/test/render-still.test.tsx
+++ b/packages/web-renderer/src/test/render-still.test.tsx
@@ -1,5 +1,7 @@
-import {useCurrentFrame} from 'remotion';
-import {test} from 'vitest';
+import {useEffect, useState} from 'react';
+import {useCurrentFrame, useDelayRender} from 'remotion';
+import {expect, test} from 'vitest';
+import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {testImage} from './utils';
@@ -62,4 +64,79 @@ test('should be able to read frame number', async () => {
 	).blob({format: 'png'});
 
 	await testImage({blob, testId: 'frame-number'});
+});
+
+test('should render a still while a media render is in progress', async (t) => {
+	if (t.task.file.projectName === 'webkit') {
+		t.skip();
+		return;
+	}
+
+	let notifyMediaStarted: () => void = () => undefined;
+	const mediaStarted = new Promise<void>((resolve) => {
+		notifyMediaStarted = resolve;
+	});
+	let notifyStillStarted: () => void = () => undefined;
+	const stillStarted = new Promise<void>((resolve) => {
+		notifyStillStarted = resolve;
+	});
+	let releaseMedia: () => void = () => undefined;
+	const mediaReleased = new Promise<void>((resolve) => {
+		releaseMedia = resolve;
+	});
+
+	const Component: React.FC<{type: 'media' | 'still'}> = ({type}) => {
+		const {delayRender, continueRender} = useDelayRender();
+		const [handle] = useState(() =>
+			type === 'media' ? delayRender('Waiting to release media render') : null,
+		);
+
+		useEffect(() => {
+			if (type === 'still') {
+				notifyStillStarted();
+				return;
+			}
+
+			notifyMediaStarted();
+			mediaReleased.then(() => continueRender(handle!));
+		}, [continueRender, handle, type]);
+
+		return <div style={{width: 100, height: 100, backgroundColor: 'red'}} />;
+	};
+
+	const composition = {
+		component: Component,
+		id: 'parallel-media-and-still-test',
+		width: 100,
+		height: 100,
+		fps: 30,
+		durationInFrames: 1,
+		defaultProps: {type: 'media' as const},
+	};
+
+	const mediaRender = renderMediaOnWeb({
+		licenseKey: 'free-license',
+		composition,
+		inputProps: {type: 'media' as const},
+		outputTarget: 'arraybuffer',
+	});
+	await mediaStarted;
+
+	const stillRender = renderStillOnWeb({
+		licenseKey: 'free-license',
+		composition,
+		frame: 0,
+		inputProps: {type: 'still' as const},
+	});
+	const stillStartedBeforeMediaFinished = await Promise.race([
+		stillStarted.then(() => true),
+		new Promise<false>((resolve) => {
+			setTimeout(() => resolve(false), 5000);
+		}),
+	]);
+
+	releaseMedia();
+	await Promise.all([mediaRender, stillRender]);
+
+	expect(stillStartedBeforeMediaFinished).toBe(true);
 });


### PR DESCRIPTION
## Summary
- use independent serial queues for `renderMediaOnWeb()` and `renderStillOnWeb()`
- allow one still render to run while one media render is in progress
- keep media-media and still-still renders serialized as before

The render queue was introduced alongside the OPFS media output target. Still renders do not use that output target, but currently wait behind long-running media exports because both operations share the same queue.

## Test plan
- [x] Add a browser regression test that pauses a media render and verifies a still render starts before it finishes
- [x] Run `bun run makewebrenderer`
- [x] Run web-renderer lint and formatting checks
- [x] Run the full web-renderer browser suite (687 passed, 27 skipped)

Made with [Cursor](https://cursor.com)