### PR TITLE
`@remotion/timeline-utils`: Guard waveform canvas against negative width

### DIFF
--- a/packages/timeline-utils/src/audio-waveform-worker.ts
+++ b/packages/timeline-utils/src/audio-waveform-worker.ts
@@ -63,7 +63,7 @@ const drawPartialWaveform = (
 	});
 	const targetCanvas = new OffscreenCanvas(
 		Math.max(1, Math.ceil(loopWidth)),
-		message.height,
+		Math.max(1, Math.ceil(message.height)),
 	);
 	drawBars({
 		canvas: targetCanvas,
@@ -103,8 +103,11 @@ const renderWaveform = async (message: AudioWaveformWorkerRenderMessage) => {
 	latestRequestId = message.requestId;
 
 	try {
-		canvas.width = message.width;
-		canvas.height = message.height;
+		// The timeline layout can hand us a zero or slightly negative width for
+		// very short sequences (track width minus the border). Setting a negative
+		// value on OffscreenCanvas throws a DOMException, so clamp before assigning.
+		canvas.width = Math.max(0, Math.ceil(message.width));
+		canvas.height = Math.max(0, Math.ceil(message.height));
 
 		const peaks = await loadWaveformPeaks(message.src, controller.signal, {
 			onProgress: ({peaks: nextPeaks}) => {

--- a/packages/timeline-utils/src/audio-waveform/draw-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/draw-peaks.ts
@@ -57,7 +57,7 @@ export const drawBars = ({
 	// `createImageData(0, h)` / `(w, 0)` throws a DOMException, which
 	// surfaces in Studio's console for compositions with many audio
 	// sequences — some segments are 0 px wide at certain zoom levels.
-	if (w === 0 || height === 0) {
+	if (w <= 0 || height <= 0) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Guard the Studio audio waveform worker against zero or negative canvas dimensions.

## Problem

`getTimelineSequenceLayout` intentionally lays out very short sequences with a track width of 0 (or slightly negative, since the border width is subtracted from the spatial width). For audio sequences, that width is forwarded verbatim to the waveform worker, which assigns it to the `OffscreenCanvas`:

```
Failed to set the 'width' property on 'OffscreenCanvas': Value is outside the 'unsigned long' value range.
```

This surfaces as an error overlay in Studio whenever a composition contains many short audio sequences (e.g. a few-frame SFX cue) and the timeline is zoomed out or the window is narrow enough that a track rounds to ≤ 0 px. #7293 already guards `drawBars` against a zero-width canvas, but the `=== 0` check lets negative values through, and the assignment in the worker happens before `drawBars` is reached.

## Fix

- `audio-waveform-worker.ts`: clamp `width` / `height` to ≥ 0 before assigning them to the transferred canvas (and ≥ 1 for the temporary loop canvas), so a negative layout width becomes a harmless empty canvas.
- `draw-peaks.ts`: widen the existing early return from `=== 0` to `<= 0`.

No behavior change for normal-width tracks.

## Repro

Any composition with a handful of `<Audio>` sequences of ~4 frames on a long timeline (e.g. 170 s at 30 fps); shrink the Studio window until the timeline error appears.
