### PR TITLE
Fix selected outline drag hit-testing

### DIFF
--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -161,12 +161,23 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			const interaction = getOutlineSelectionInteraction(event);
 			const shouldUpdateSelection =
 				!selected || interaction.shiftKey || interaction.toggleKey;
-			if (shouldUpdateSelection) {
-				onSelect(target.selection, interaction);
-			}
+
+			const selectedDragTargets = getAllDragTargets();
+			const deferSelection =
+				!selected &&
+				!interaction.shiftKey &&
+				!interaction.toggleKey &&
+				selectedDragTargets.length > 0;
 
 			if (drag === null || interaction.shiftKey || interaction.toggleKey) {
+				if (shouldUpdateSelection) {
+					onSelect(target.selection, interaction);
+				}
 				return;
+			}
+
+			if (!deferSelection && shouldUpdateSelection) {
+				onSelect(target.selection, interaction);
 			}
 
 			if (commitPendingInspectorFields()) {
@@ -176,11 +187,19 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			const startPointerX = event.clientX;
 			const startPointerY = event.clientY;
 			const dragStates = getSelectedOutlineDragStates({
-				dragTargets: selected ? getAllDragTargets() : [drag],
+				dragTargets: deferSelection
+					? selectedDragTargets
+					: selected
+						? selectedDragTargets
+						: [drag],
 				getDragOverrides,
 				timelinePosition: getCurrentFrame(),
 			});
-			const dragOutlines = selected ? getAllDragOutlines() : [outline];
+			const dragOutlines = deferSelection
+				? getAllDragOutlines()
+				: selected
+					? getAllDragOutlines()
+					: [outline];
 			let lastValues = new Map<string, string>();
 			let currentPointerX = startPointerX;
 			let currentPointerY = startPointerY;
@@ -325,9 +344,13 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 
 				if (changes.length === 0) {
 					clearSelectedOutlineDragOverrides({clearDragOverrides, dragStates});
+
+					if (deferSelection && !dragStarted) {
+						onSelect(target.selection, interaction);
+					}
+
 					return;
 				}
-
 				const staticChanges = changes.filter(
 					(change): change is SelectedOutlineStaticDragChange =>
 						change.type === 'static',

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -58,6 +58,44 @@ import type {
 	TimelineSelection,
 	TimelineSelectionInteraction,
 } from './Timeline/TimelineSelection';
+const isPointInsidePolygon = (
+	point: {x: number; y: number},
+	polygon: readonly {x: number; y: number}[],
+): boolean => {
+	let inside = false;
+	for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+		const {x: xi, y: yi} = polygon[i];
+		const {x: xj, y: yj} = polygon[j];
+		const intersects =
+			yi > point.y !== yj > point.y &&
+			point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+		if (intersects) {
+			inside = !inside;
+		}
+	}
+
+	return inside;
+};
+
+const isPointerInsideSelectedOutline = (
+	event: {clientX: number; clientY: number},
+	outlines: readonly SelectedOutline[],
+	polygonEl: SVGPolygonElement | null,
+): boolean => {
+	const svg = polygonEl?.ownerSVGElement;
+	const ctm = svg?.getScreenCTM();
+	if (!svg || !ctm) {
+		return false;
+	}
+
+	const screenPoint = svg.createSVGPoint();
+	screenPoint.x = event.clientX;
+	screenPoint.y = event.clientY;
+	const {x, y} = screenPoint.matrixTransform(ctm.inverse());
+	return outlines.some((selectedOutline) =>
+		isPointInsidePolygon({x, y}, selectedOutline.points),
+	);
+};
 
 const SelectedOutlinePolygonUnmemoized: React.FC<{
 	readonly compositionHeight: number;
@@ -163,12 +201,17 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				!selected || interaction.shiftKey || interaction.toggleKey;
 
 			const selectedDragTargets = getAllDragTargets();
+			const allDragOutlines = getAllDragOutlines();
 			const deferSelection =
 				!selected &&
 				!interaction.shiftKey &&
 				!interaction.toggleKey &&
-				selectedDragTargets.length > 0;
-
+				selectedDragTargets.length > 0 &&
+				isPointerInsideSelectedOutline(
+					event,
+					allDragOutlines,
+					polygonRef.current,
+				);
 			if (drag === null || interaction.shiftKey || interaction.toggleKey) {
 				if (shouldUpdateSelection) {
 					onSelect(target.selection, interaction);
@@ -182,6 +225,10 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			}
 
 			if (commitPendingInspectorFields()) {
+				if (deferSelection) {
+					onSelect(target.selection, interaction);
+				}
+
 				return;
 			}
 
@@ -196,11 +243,8 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				getDragOverrides,
 				timelinePosition: getCurrentFrame(),
 			});
-			const dragOutlines = deferSelection
-				? getAllDragOutlines()
-				: selected
-					? getAllDragOutlines()
-					: [outline];
+			const dragOutlines =
+				deferSelection || selected ? allDragOutlines : [outline];
 			let lastValues = new Map<string, string>();
 			let currentPointerX = startPointerX;
 			let currentPointerY = startPointerY;

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -173,6 +173,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				if (shouldUpdateSelection) {
 					onSelect(target.selection, interaction);
 				}
+
 				return;
 			}
 
@@ -351,6 +352,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 
 					return;
 				}
+
 				const staticChanges = changes.filter(
 					(change): change is SelectedOutlineStaticDragChange =>
 						change.type === 'static',


### PR DESCRIPTION
## Issue

Fixes #10456

## Summary

When an outline was already selected, dragging from an overlapping unselected outline could cause the wrong target to be dragged. This change keeps normal click selection behavior intact while ensuring the already-selected outline remains the drag target once the pointer movement becomes a drag.

## Changes

* Preserve normal click selection of overlapping outlines.
* Keep the already-selected outline as the drag target when dragging from an overlapping area.
* Avoid changing the global outline rendering order, so existing hit-testing and selection behavior remains intact.
