### PR TITLE
Docs: Add Aeon to resources (Tooling)

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -159,6 +159,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [GIF Pull request previews](https://github.com/stoat-dev/example-remotion)
 - [Loading compositions remotely](https://github.com/musafiroon/remotion-remote-composition)
 - [Generate matching music for Remotion videos](https://github.com/cindyxu1030/sonilo-video-to-music-cookbook/blob/main/recipes/render-to-music-workflow.md?rgh-link-date=2026-07-22T20%3A16%3A56.000Z)
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework whose skill renders MP4 videos from an agent-authored storyboard using a bundled Remotion project.
 
 ## Hacks
 


### PR DESCRIPTION
Adding [Aeon](https://github.com/aeonfun/aeon) to the **Tooling** section of the resources page.

Aeon is an open-source autonomous agent framework. One of its skills, `remotion`, bundles a real Remotion project and renders an MP4 from a storyboard JSON written by the agent, so Remotion powers the video-generation step end to end. It sits naturally alongside the existing agent-skill/tooling entries (e.g. video-shotcraft).

- Repo: https://github.com/aeonfun/aeon
- License: MIT, actively maintained
- One entry, appended to the end of the Tooling list, formatting matches the surrounding lines.

Disclosure: I maintain Aeon, so please feel free to reword or drop the entry if it isn't a fit.
