### PR TITLE
Docs: Fix typos

### DIFF
--- a/packages/docs/docs/3-0-migration.mdx
+++ b/packages/docs/docs/3-0-migration.mdx
@@ -140,7 +140,7 @@ await renderStill({
   // ...
   output: "/tmp/still.png",
   onError: (err) => {
-    console.log("Error occured in browser", err);
+    console.log("Error occurred in browser", err);
   },
 });
 ```
@@ -152,7 +152,7 @@ try {
     output: "/tmp/still.png",
   });
 } catch (err) {
-  console.log("Error occured in browser", err);
+  console.log("Error occurred in browser", err);
 }
 ```
 

--- a/packages/docs/docs/4-0-migration.mdx
+++ b/packages/docs/docs/4-0-migration.mdx
@@ -181,7 +181,7 @@ Until now, you could optionally pass the `imageFormat` prop into `<OffthreadVide
 
 Now, you can instead use the optional `transparent` prop.
 
-Due to this this change, the `OffthreadVideoImageFormat` type is no longer neccessary and has therefore been removed.
+Due to this change, the `OffthreadVideoImageFormat` type is no longer necessary and has therefore been removed.
 
 ## `OffthreadVideoImageFormat` removed
 

--- a/packages/docs/docs/lambda/approuterwebhook.mdx
+++ b/packages/docs/docs/lambda/approuterwebhook.mdx
@@ -51,7 +51,7 @@ export const POST = appRouterWebhook({
   },
   onSuccess: () => console.log('Rendering Completed Successfully'),
   onError: () => console.log('Something went wrong while rendering'),
-  onTimeout: () => console.log('Timeout occured while rendering'),
+  onTimeout: () => console.log('Timeout occurred while rendering'),
 });
 
 export const OPTIONS = POST;

--- a/packages/docs/docs/lambda/expresswebhook.mdx
+++ b/packages/docs/docs/lambda/expresswebhook.mdx
@@ -51,7 +51,7 @@ const handler = expressWebhook({
   },
   onSuccess: () => console.log('Rendering Completed Successfully'),
   onError: () => console.log('Something went wrong while rendering'),
-  onTimeout: () => console.log('Timeout occured while rendering'),
+  onTimeout: () => console.log('Timeout occurred while rendering'),
 })
 
 router.post("/webhook", jsonParser, handler);

--- a/packages/docs/docs/lambda/pagesrouterwebhooks.mdx
+++ b/packages/docs/docs/lambda/pagesrouterwebhooks.mdx
@@ -51,7 +51,7 @@ const handler = pagesRouterWebhook({
   },
   onSuccess: () => console.log('Rendering Completed Successfully'),
   onError: () => console.log('Something went wrong while rendering'),
-  onTimeout: () => console.log('Timeout occured while rendering'),
+  onTimeout: () => console.log('Timeout occurred while rendering'),
 });
 export default handler;
 ```

--- a/packages/docs/docs/recorder/setup.mdx
+++ b/packages/docs/docs/recorder/setup.mdx
@@ -75,7 +75,7 @@ Once Bun is installed, run
 bun i
 ```
 
-to install all the neccessary dependencies.
+to install all the necessary dependencies.
 
 ## 4. Install Whisper.cpp (optional)
 


### PR DESCRIPTION
## What changed

Fixed a few small typos in the documentation:

- \`occured\` → \`occurred\` in `3-0-migration.mdx`, `lambda/approuterwebhook.mdx`, `lambda/expresswebhook.mdx`, and `lambda/pagesrouterwebhooks.mdx`
- \`neccessary\` → \`necessary\` in `4-0-migration.mdx` and `recorder/setup.mdx`
- Duplicated word ("this this change" → "this change") in `4-0-migration.mdx`

## Why

Minor spelling corrections found while reading through the docs. No functional or code changes, only documentation prose/comments.

## Notes for reviewer

- Docs-only change, no tests affected.
- This is my first contribution to Remotion 🙂