### PR TITLE
Elements: Improve search result hierarchy

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -19,24 +19,34 @@ const compareStrings = (a: string, b: string) => {
 
 const sidebars: SidebarsConfig = {
 	elementsSidebar: [
-		'index',
-		'contributing',
 		{
-			type: 'html',
-			value:
-				'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>',
-			defaultStyle: true,
-		},
-		...elementCategories.map(({category, label}) => ({
-			type: 'category' as const,
-			label,
-			link: {type: 'doc' as const, id: `${category}/index`},
+			type: 'category',
+			label: 'Elements',
+			link: {type: 'doc', id: 'index'},
+			collapsible: true,
 			collapsed: false,
-			items: Object.entries(elementRegistry)
-				.filter(([, metadata]) => metadata.category === category)
-				.sort(([, a], [, b]) => compareStrings(a.displayName, b.displayName))
-				.map(([slug]) => `${slug}/index`),
-		})),
+			items: [
+				'contributing',
+				{
+					type: 'html',
+					value:
+						'<hr style="margin: 4px 0 4px calc(-1 * var(--ifm-menu-link-padding-horizontal)); width: calc(100% + var(--ifm-menu-link-padding-horizontal)); border-bottom: none"/>',
+					defaultStyle: true,
+				},
+				...elementCategories.map(({category, label}) => ({
+					type: 'category' as const,
+					label,
+					link: {type: 'doc' as const, id: `${category}/index`},
+					collapsible: false,
+					items: Object.entries(elementRegistry)
+						.filter(([, metadata]) => metadata.category === category)
+						.sort(([, a], [, b]) =>
+							compareStrings(a.displayName, b.displayName),
+						)
+						.map(([slug]) => `${slug}/index`),
+				})),
+			],
+		},
 	],
 };
 

--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
 		{
 			type: 'category',
 			label: 'Elements',
+			className: 'elements-sidebar-root',
 			link: {type: 'doc', id: 'index'},
 			collapsible: true,
 			collapsed: false,
@@ -30,14 +31,15 @@ const sidebars: SidebarsConfig = {
 				{
 					type: 'html',
 					value:
-						'<hr style="margin: 4px 0 4px calc(-1 * var(--ifm-menu-link-padding-horizontal)); width: calc(100% + var(--ifm-menu-link-padding-horizontal)); border-bottom: none"/>',
+						'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>',
 					defaultStyle: true,
 				},
 				...elementCategories.map(({category, label}) => ({
 					type: 'category' as const,
 					label,
 					link: {type: 'doc' as const, id: `${category}/index`},
-					collapsible: false,
+					collapsible: true,
+					collapsed: false,
 					items: Object.entries(elementRegistry)
 						.filter(([, metadata]) => metadata.category === category)
 						.sort(([, a], [, b]) =>

--- a/packages/docs/src/components/Elements/ElementLibrary.module.css
+++ b/packages/docs/src/components/Elements/ElementLibrary.module.css
@@ -73,6 +73,7 @@
 }
 
 .title {
+	display: block;
 	margin: 0;
 	font-size: 1.125rem;
 	font-weight: 500;

--- a/packages/docs/src/components/Elements/ElementLibrary.tsx
+++ b/packages/docs/src/components/Elements/ElementLibrary.tsx
@@ -37,17 +37,15 @@ const usePrefersReducedMotion = () => {
 
 const ElementCard: React.FC<{
 	readonly definition: ElementDefinition;
-	readonly headingLevel: 2 | 3;
 	readonly prefersReducedMotion: boolean;
 	readonly sourceCode: string;
-}> = ({definition, headingLevel, prefersReducedMotion, sourceCode}) => {
+}> = ({definition, prefersReducedMotion, sourceCode}) => {
 	const [isFocused, setIsFocused] = useState(false);
 	const [isPointerOver, setIsPointerOver] = useState(false);
 	const [playbackFailed, setPlaybackFailed] = useState(false);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const shouldPlay =
 		!prefersReducedMotion && !playbackFailed && (isFocused || isPointerOver);
-	const Heading = headingLevel === 2 ? 'h2' : 'h3';
 	const elementPayload = useMemo(
 		() => createElementPayloadFromDefinition({definition, sourceCode}),
 		[definition, sourceCode],
@@ -135,7 +133,7 @@ const ElementCard: React.FC<{
 					) : null}
 				</div>
 				<div className={styles.content}>
-					<Heading className={styles.title}>{definition.displayName}</Heading>
+					<span className={styles.title}>{definition.displayName}</span>
 					<p className={styles.description}>{definition.description}</p>
 				</div>
 			</a>
@@ -145,10 +143,9 @@ const ElementCard: React.FC<{
 
 const ElementGrid: React.FC<{
 	readonly definitions: readonly ElementDefinition[];
-	readonly headingLevel: 2 | 3;
 	readonly prefersReducedMotion: boolean;
 	readonly sourceCodeBySlug: Readonly<Record<string, string>>;
-}> = ({definitions, headingLevel, prefersReducedMotion, sourceCodeBySlug}) => {
+}> = ({definitions, prefersReducedMotion, sourceCodeBySlug}) => {
 	return (
 		<ul className={styles.grid} role="list">
 			{definitions.map((definition) => {
@@ -163,7 +160,6 @@ const ElementGrid: React.FC<{
 					<ElementCard
 						key={definition.slug}
 						definition={definition}
-						headingLevel={headingLevel}
 						prefersReducedMotion={prefersReducedMotion}
 						sourceCode={sourceCode}
 					/>
@@ -192,7 +188,6 @@ export const ElementLibrary: React.FC<{
 						>
 							<ElementGrid
 								definitions={section.definitions}
-								headingLevel={2}
 								prefersReducedMotion={prefersReducedMotion}
 								sourceCodeBySlug={sourceCodeBySlug}
 							/>
@@ -213,7 +208,6 @@ export const ElementLibrary: React.FC<{
 						</h2>
 						<ElementGrid
 							definitions={section.definitions}
-							headingLevel={3}
 							prefersReducedMotion={prefersReducedMotion}
 							sourceCodeBySlug={sourceCodeBySlug}
 						/>

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -85,6 +85,16 @@ h6 {
 	display: none;
 }
 
+.elements-sidebar-root > .menu__list-item-collapsible--active > .menu__link {
+	pointer-events: none;
+}
+
+.elements-sidebar-root
+	> .menu__list-item-collapsible:not(.menu__list-item-collapsible--active)
+	> .menu__link--active {
+	color: var(--ifm-menu-color);
+}
+
 :root {
 	--ifm-color-primary: #0b84f3;
 	--ifm-color-primary-dark: #0a77db;

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -77,6 +77,14 @@ h6 {
 	margin-bottom: 0.75rem;
 }
 
+.elements-sidebar-root > .menu__list {
+	padding-left: 0;
+}
+
+.elements-sidebar-root > .menu__list-item-collapsible > .menu__caret {
+	display: none;
+}
+
 :root {
 	--ifm-color-primary: #0b84f3;
 	--ifm-color-primary-dark: #0a77db;

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -464,6 +464,7 @@ describe('Elements sidebar', () => {
 		expect(elementsCategory).toMatchObject({
 			type: 'category',
 			label: 'Elements',
+			className: 'elements-sidebar-root',
 			link: {type: 'doc', id: 'index'},
 			collapsible: true,
 			collapsed: false,
@@ -477,7 +478,7 @@ describe('Elements sidebar', () => {
 			{
 				type: 'html',
 				value:
-					'<hr style="margin: 4px 0 4px calc(-1 * var(--ifm-menu-link-padding-horizontal)); width: calc(100% + var(--ifm-menu-link-padding-horizontal)); border-bottom: none"/>',
+					'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>',
 				defaultStyle: true,
 			},
 		]);
@@ -562,7 +563,8 @@ describe('Elements sidebar', () => {
 				type: 'category',
 				label,
 				link: {type: 'doc', id: `${category}/index`},
-				collapsible: false,
+				collapsible: true,
+				collapsed: false,
 				items,
 			})),
 		);

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -316,8 +316,10 @@ describe('Element library', () => {
 
 		for (const definition of elementDefinitionList) {
 			expect(
-				overviewMarkup.split(`>${definition.displayName}</h3>`),
+				overviewMarkup.split(`>${definition.displayName}</span>`),
 			).toHaveLength(2);
+			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h2>`);
+			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h3>`);
 			expect(overviewMarkup).toContain(definition.description);
 			expect(overviewMarkup).toContain(definition.preview.posterUrl);
 			expect(overviewMarkup).toContain(getElementDocumentationUrl(definition));
@@ -449,18 +451,38 @@ describe('Elements sidebar', () => {
 			throw new Error('Elements sidebar must be an array');
 		}
 
-		expect(sidebar.slice(0, 3)).toEqual([
-			'index',
+		expect(sidebar).toHaveLength(1);
+		const elementsCategory = sidebar[0];
+		if (
+			typeof elementsCategory !== 'object' ||
+			elementsCategory === null ||
+			elementsCategory.type !== 'category'
+		) {
+			throw new Error('Elements sidebar must have an Elements root category');
+		}
+
+		expect(elementsCategory).toMatchObject({
+			type: 'category',
+			label: 'Elements',
+			link: {type: 'doc', id: 'index'},
+			collapsible: true,
+			collapsed: false,
+		});
+		if (!Array.isArray(elementsCategory.items)) {
+			throw new Error('Elements root category must contain sidebar items');
+		}
+
+		expect(elementsCategory.items.slice(0, 2)).toEqual([
 			'contributing',
 			{
 				type: 'html',
 				value:
-					'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>',
+					'<hr style="margin: 4px 0 4px calc(-1 * var(--ifm-menu-link-padding-horizontal)); width: calc(100% + var(--ifm-menu-link-padding-horizontal)); border-bottom: none"/>',
 				defaultStyle: true,
 			},
 		]);
 
-		const categories = sidebar.slice(3);
+		const categories = elementsCategory.items.slice(2);
 		const expectedCategories = [
 			{
 				category: 'backgrounds',
@@ -540,7 +562,7 @@ describe('Elements sidebar', () => {
 				type: 'category',
 				label,
 				link: {type: 'doc', id: `${category}/index`},
-				collapsed: false,
+				collapsible: false,
 				items,
 			})),
 		);


### PR DESCRIPTION
## Summary

- group the Elements sidebar under an active `Elements` root so Algolia uses it as the search hierarchy root
- keep category and Element pages at the same searchable page-title level
- render gallery card titles as non-heading labels to avoid duplicate search records
- remove the extra visual nesting from the sidebar, hide the root caret, and keep the inner categories collapsible

Fixes #10362 

## Testing

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`
- low-memory Docusaurus production build
