### PR TITLE
Elements: Use thumbnails for drag previews

### DIFF
--- a/packages/docs/src/components/Elements/ElementLibrary.tsx
+++ b/packages/docs/src/components/Elements/ElementLibrary.tsx
@@ -44,6 +44,7 @@ const ElementCard: React.FC<{
 	const [isFocused, setIsFocused] = useState(false);
 	const [isPointerOver, setIsPointerOver] = useState(false);
 	const [playbackFailed, setPlaybackFailed] = useState(false);
+	const posterRef = useRef<HTMLImageElement>(null);
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const shouldPlay =
 		!prefersReducedMotion && !playbackFailed && (isFocused || isPointerOver);
@@ -101,7 +102,7 @@ const ElementCard: React.FC<{
 						dataTransfer: event.dataTransfer,
 						payload: elementPayload,
 					});
-					setElementDragImage(event.dataTransfer);
+					setElementDragImage(event.dataTransfer, posterRef.current);
 				}}
 				onPointerEnter={activateFromPointer}
 				onPointerLeave={() => setIsPointerOver(false)}
@@ -113,6 +114,7 @@ const ElementCard: React.FC<{
 					style={{backgroundColor: ELEMENT_PREVIEW_BACKGROUND}}
 				>
 					<img
+						ref={posterRef}
 						alt=""
 						className={styles.previewMedia}
 						decoding="async"

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -4,6 +4,7 @@ import React, {
 	useCallback,
 	useId,
 	useMemo,
+	useRef,
 	useState,
 	type ReactNode,
 } from 'react';
@@ -45,6 +46,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	});
 	const [isDragging, setIsDragging] = useState(false);
 	const [isSourceVisible, setIsSourceVisible] = useState(false);
+	const posterRef = useRef<HTMLImageElement>(null);
 	const sourceId = useId();
 	const {height: previewHeight, width: previewWidth} =
 		getElementPreviewDimensions(definition);
@@ -85,6 +87,14 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 
 	return (
 		<div className={styles.workbench}>
+			<img
+				ref={posterRef}
+				alt=""
+				decoding="async"
+				draggable={false}
+				hidden
+				src={definition.preview.posterUrl}
+			/>
 			<Head>
 				{Seo.renderVideo({
 					height: previewHeight,
@@ -152,7 +162,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 											dataTransfer: event.dataTransfer,
 											payload: elementPayload,
 										});
-										setElementDragImage(event.dataTransfer);
+										setElementDragImage(event.dataTransfer, posterRef.current);
 									}}
 									size="sm"
 									style={{

--- a/packages/docs/src/components/Elements/element-drag-data.ts
+++ b/packages/docs/src/components/Elements/element-drag-data.ts
@@ -30,43 +30,40 @@ export const createElementPayloadFromDefinition = ({
 	});
 };
 
-const ELEMENT_ICON_PATH =
-	'M3 3.5C3 2.67157 3.67157 2 4.5 2H11.5C12.3284 2 13 2.67157 13 3.5V12.5C13 13.3284 12.3284 14 11.5 14H4.5C3.67157 14 3 13.3284 3 12.5V3.5ZM4.5 3.5V6H11.5V3.5H4.5ZM11.5 7.5H4.5V12.5H11.5V7.5Z';
+export const setElementDragImage = (
+	dataTransfer: DataTransfer,
+	poster: HTMLImageElement | null,
+) => {
+	if (
+		!poster?.complete ||
+		poster.naturalWidth === 0 ||
+		poster.naturalHeight === 0
+	) {
+		return;
+	}
 
-const makeElementDragImage = () => {
+	const scale = Math.min(
+		1,
+		96 / poster.naturalWidth,
+		64 / poster.naturalHeight,
+	);
+	const width = poster.naturalWidth * scale;
+	const height = poster.naturalHeight * scale;
 	const wrapper = document.createElement('div');
 	wrapper.style.position = 'fixed';
 	wrapper.style.top = '-1000px';
 	wrapper.style.left = '-1000px';
-	wrapper.style.width = '44px';
-	wrapper.style.height = '44px';
-	wrapper.style.display = 'flex';
-	wrapper.style.alignItems = 'center';
-	wrapper.style.justifyContent = 'center';
-	wrapper.style.borderRadius = '8px';
-	wrapper.style.background = '#0b0b0f';
-	wrapper.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.28)';
+	wrapper.style.width = `${width}px`;
+	wrapper.style.height = `${height}px`;
 
-	const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-	svg.setAttribute('viewBox', '0 0 16 16');
-	svg.setAttribute('width', '26');
-	svg.setAttribute('height', '26');
+	const image = document.createElement('img');
+	image.src = poster.currentSrc || poster.src;
+	image.style.display = 'block';
+	image.style.width = '100%';
+	image.style.height = '100%';
+	wrapper.appendChild(image);
 
-	const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-	path.setAttribute('d', ELEMENT_ICON_PATH);
-	path.setAttribute('fill', 'white');
-
-	svg.appendChild(path);
-	wrapper.appendChild(svg);
-
-	return wrapper;
-};
-
-export const setElementDragImage = (dataTransfer: DataTransfer) => {
-	const dragImage = makeElementDragImage();
-	document.body.appendChild(dragImage);
-	dataTransfer.setDragImage(dragImage, 22, 22);
-	requestAnimationFrame(() => {
-		document.body.removeChild(dragImage);
-	});
+	document.body.appendChild(wrapper);
+	dataTransfer.setDragImage(wrapper, width / 2, height / 2);
+	requestAnimationFrame(() => wrapper.remove());
 };


### PR DESCRIPTION
## Summary

- replace the generic Element drag icon with each Element's poster image
- constrain drag previews to 96×64 pixels while preserving their aspect ratio
- preload the poster on Element detail pages so both drag entry points use the same preview

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- verified in Chrome that gallery cards and detail-page install buttons use the correct centered 96×54 preview for a 16:9 Element

Closes #10493
