### PR TITLE
Elements: Improve narrow page layout

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -1,10 +1,20 @@
 .workbench {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 24px;
 	margin-top: 28px;
 	margin-bottom: 28px;
 }
 
-.previewColumn,
+.previewColumn {
+	flex: 3 1 700px;
+	min-width: 0;
+}
+
 .actionsColumn {
+	container: actions-column / inline-size;
+	flex: 1 1 260px;
 	min-width: 0;
 }
 
@@ -243,14 +253,7 @@
 	color: var(--ifm-color-emphasis-700);
 }
 
-@media (min-width: 1200px) {
-	.workbench {
-		display: grid;
-		grid-template-columns: minmax(0, 3fr) minmax(260px, 1fr);
-		align-items: start;
-		gap: 24px;
-	}
-
+@container actions-column (max-width: 400px) {
 	.actionsColumn .actionRow,
 	.actionsColumn .contributors,
 	.actionsColumn .contributorList {

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -63,14 +63,12 @@ h6 {
 	display: none;
 }
 
-@media (min-width: 1200px) {
-	.plugin-id-elements main > .container {
-		max-width: 1440px;
-	}
+.plugin-id-elements main > .container {
+	max-width: 1440px;
+}
 
-	.plugin-id-elements main > .container > .row > .col {
-		max-width: 100% !important;
-	}
+.plugin-id-elements main > .container > .row > .col {
+	max-width: 100% !important;
 }
 
 .plugin-id-elements .theme-doc-markdown > h1:first-child {


### PR DESCRIPTION
## Summary

- make the Element workbench wrap based on its available width instead of the viewport width
- display the details card as a full-width second block on narrower layouts
- let Element pages use the full documentation content width at smaller breakpoints
- adapt compact action-card styling to the card's own width

## Verification

- `bun run build`
- `bun run stylecheck`
- visually checked the Moving Pill Captions page at 1104px, 1280px, and 1440px viewport widths
