### PR TITLE
Docs: Fix Lambda proxy page heading

### DIFF
--- a/packages/docs/docs/lambda/proxy.mdx
+++ b/packages/docs/docs/lambda/proxy.mdx
@@ -6,7 +6,7 @@ sidebar_label: Using a proxy
 crumb: 'Lambda'
 ---
 
-#Using a proxy with Remotion Lambda<AvailableFrom v="4.0.315" />
+# Using a proxy with Remotion Lambda<AvailableFrom v="4.0.315" />
 
 Remotion Lambda supports using HTTP/HTTPS proxies for all AWS API calls by accepting a `requestHandler` option that allows you to pass a custom AWS SDK request handler.
 


### PR DESCRIPTION
## Summary

- Fix the Markdown syntax for the Remotion Lambda proxy page heading so it renders as an H1.

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun render-cards.ts`

Closes #10497

## Preview

- [Lambda proxy documentation](https://remotion-git-codex-fix-lambda-proxy-h1-remotion.vercel.app/docs/lambda/proxy)
