### PR TITLE
`remotion`: Fix 3D rotation interpolation from zero degrees

### DIFF
--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -760,8 +760,14 @@ const interpolateString = ({
 	const hasAxisRotation = initiallyParsedOutputRange.some(
 		(parsed) => parsed.axisRotation,
 	);
+	const posterizedInput =
+		options?.posterize === undefined
+			? input
+			: Math.floor(input / options.posterize) * options.posterize;
+	const segmentIndex =
+		inputRange.length === 1 ? 0 : findRange(posterizedInput, inputRange);
 	const parsedOutputRange = hasAxisRotation
-		? initiallyParsedOutputRange.map((parsed) => {
+		? initiallyParsedOutputRange.map((parsed, index) => {
 				if (parsed.kind !== 'rotate') {
 					return parsed;
 				}
@@ -776,9 +782,24 @@ const interpolateString = ({
 					);
 				}
 
+				// A zero-degree rotation is the identity regardless of its axis. Reusing
+				// the active neighbor's axis prevents the axis from drifting while the
+				// angle interpolates away from zero.
+				const adjacentAxisRotation =
+					parsed.values[0] === 0
+						? index === segmentIndex
+							? initiallyParsedOutputRange[index + 1]
+							: index === segmentIndex + 1
+								? initiallyParsedOutputRange[index - 1]
+								: undefined
+						: undefined;
+				const axis = adjacentAxisRotation?.axisRotation
+					? adjacentAxisRotation.values
+					: ([0, 0, 1] as const);
+
 				return {
 					kind: 'rotate' as const,
-					values: [0, 0, 1, parsed.values[0]] as [
+					values: [axis[0], axis[1], axis[2], parsed.values[0]] as [
 						number,
 						number,
 						number,

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -422,5 +422,5 @@ test('interpolates 3D rotation keyframes as one property', () => {
 			output: undefined,
 		},
 	});
-	expect(result).toBe('0.5 0 0.5 45deg');
+	expect(result).toBe('1 0 0 45deg');
 });

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -522,8 +522,15 @@ test('Interpolates rotate strings', () => {
 		'0.5 0.5 0 50deg',
 	);
 	expect(interpolate(15, [0, 30], ['0deg', '1 0 0 100deg'])).toBe(
-		'0.5 0 0.5 50deg',
+		'1 0 0 50deg',
 	);
+	expect(
+		interpolate(
+			15,
+			[0, 30],
+			['0deg', '0.901683 0.345591 -0.259873 25.880675deg'],
+		),
+	).toBe('0.901683 0.345591 -0.259873 12.940338deg');
 });
 
 test('String interpolation supports easing, extrapolation and posterization', () => {


### PR DESCRIPTION
## Summary

- Preserve the neighboring 3D rotation axis when interpolating from or to `0deg`
- Prevent the rotation axis from drifting while the angle interpolates away from the identity rotation
- Add a regression test using the axis-angle values from the issue

## Testing

- `bun test packages/core/src/test/interpolate.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10442
