### PR TITLE
`remotion`: Support connected compositions in `<Series.Sequence>`

### DIFF
--- a/packages/core/src/series/index.tsx
+++ b/packages/core/src/series/index.tsx
@@ -5,7 +5,10 @@ import React, {
 	type PropsWithChildren,
 } from 'react';
 import type {SequenceControls} from '../CompositionManager.js';
-import {addSequenceStackTraces} from '../enable-sequence-stack-traces.js';
+import {
+	addSequenceStackTraces,
+	getSingleChildComponent,
+} from '../enable-sequence-stack-traces.js';
 import {Interactive} from '../Interactive.js';
 import {
 	sequenceSchemaDefaultLayoutNone,
@@ -220,6 +223,9 @@ const SeriesInner: FC<SeriesProps> = (props) => {
 								from={currentStartFrame}
 								durationInFrames={durationInFramesProp}
 								{...passedProps}
+								_remotionInternalSingleChildComponent={getSingleChildComponent(
+									sequenceChildren,
+								)}
 							>
 								<IsNotInsideSeriesProvider>
 									{sequenceChildren}

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -436,6 +436,7 @@ test('Series.Sequence registers with its own visual controls', () => {
 	const registeredSequences: TSequence[] = [];
 	const firstStack = 'Error\n    at FirstSeriesSequence';
 	const secondStack = 'Error\n    at SecondSeriesSequence';
+	const ConnectedComposition: React.FC = () => null;
 
 	render(
 		<SequenceTestWrapper
@@ -451,7 +452,7 @@ test('Series.Sequence registers with its own visual controls', () => {
 						_remotionInternalStack: firstStack,
 					} as {readonly _remotionInternalStack: string})}
 				>
-					First
+					<ConnectedComposition />
 				</Series.Sequence>
 				<Series.Sequence
 					durationInFrames={20}
@@ -487,6 +488,7 @@ test('Series.Sequence registers with its own visual controls', () => {
 		firstStack,
 		secondStack,
 	]);
+	expect(seriesSequences[0]?.singleChildComponent).toBe(ConnectedComposition);
 });
 
 test('Interactive.withSchema preserves source stacks through controls without consuming a public stack prop', () => {


### PR DESCRIPTION
## Summary

- forward the direct child component from `Series.Sequence` to its underlying timeline sequence
- enable Studio to match `Series.Sequence` children with registered connected compositions
- extend the mounted sequence-registration workflow with regression coverage

## Testing

- `bun test src/test/sequence-register-once.test.tsx --test-name-pattern 'Series.Sequence registers with its own visual controls'` (from `packages/core`)
- `bun run build`
- `bun run stylecheck`

Red/green verified by removing the forwarding prop and confirming the regression assertion receives `null` instead of the connected composition component.
