### PR TITLE
`@remotion/studio`: Fix keyframe timing for composition frames

### DIFF
--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -432,8 +432,16 @@ export const Root = () => <Composition id="MyComp" component={Component} duratio
 	}
 
 	expect(subscription.status.props).toEqual({
-		from: {status: 'static', codeValue: 10},
-		durationInFrames: {status: 'static', codeValue: 20},
+		from: {
+			status: 'static',
+			codeValue: 10,
+			keyframeDisplayOffsetAdjustment: null,
+		},
+		durationInFrames: {
+			status: 'static',
+			codeValue: 20,
+			keyframeDisplayOffsetAdjustment: null,
+		},
 	});
 	expect(subscription.nodePath.absolutePath).toBe(fileName);
 
@@ -480,7 +488,11 @@ export const Root = () => <Composition id="MyComp" component={Component} duratio
 		throw new Error('Expected updated sequence props to be editable');
 	}
 
-	expect(update.result.props.from).toEqual({status: 'static', codeValue: 15});
+	expect(update.result.props.from).toEqual({
+		status: 'static',
+		codeValue: 15,
+		keyframeDisplayOffsetAdjustment: null,
+	});
 	expect(await operations.undo()).toEqual({
 		success: true,
 		nodePathMutation: null,

--- a/packages/core/src/get-effective-visual-mode-value.ts
+++ b/packages/core/src/get-effective-visual-mode-value.ts
@@ -14,6 +14,14 @@ export type ResolvedDragOverrideValue =
 			readonly value: unknown;
 	  };
 
+export const getFrameInKeyframedStatusClock = ({
+	frame,
+	status,
+}: {
+	readonly frame: number;
+	readonly status: CanUpdateSequencePropStatusKeyframed;
+}) => frame - (status.keyframeDisplayOffsetAdjustment ?? 0);
+
 export const resolveDragOverrideValue = ({
 	dragOverrideValue,
 	frame,
@@ -35,7 +43,10 @@ export const resolveDragOverrideValue = ({
 
 	const interpolated = interpolateKeyframedStatus({
 		forceSpringAllowTail: null,
-		frame,
+		frame: getFrameInKeyframedStatusClock({
+			frame,
+			status: dragOverrideValue.status,
+		}),
 		status: dragOverrideValue.status,
 	});
 	if (interpolated === null) {
@@ -72,7 +83,7 @@ export const getEffectiveVisualModeValue = ({
 		if (frame !== null) {
 			return interpolateKeyframedStatus({
 				forceSpringAllowTail: null,
-				frame,
+				frame: getFrameInKeyframedStatusClock({frame, status: propStatus}),
 				status: propStatus,
 			});
 		}

--- a/packages/core/src/test/drag-override-value.test.ts
+++ b/packages/core/src/test/drag-override-value.test.ts
@@ -12,6 +12,7 @@ import {
 
 const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
 	status: 'keyframed',
+	keyframeDisplayOffsetAdjustment: null,
 	interpolationFunction: 'interpolate',
 	keyframes: [
 		{frame: 0, value: 2},
@@ -201,6 +202,7 @@ test('computeEffectiveSchemaValuesDotNotation resolves static file tokens for as
 		propStatus: {
 			src: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'remotion-file:folder/new%20image.png',
 			},
 		},
@@ -215,6 +217,7 @@ test('getEffectiveVisualModeValue resolves static string drag overrides', () => 
 		getEffectiveVisualModeValue({
 			propStatus: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'Old',
 			},
 			dragOverrideValue: makeStaticDragOverride('New'),
@@ -228,6 +231,7 @@ test('getEffectiveVisualModeValue resolves static string drag overrides', () => 
 		getEffectiveVisualModeValue({
 			propStatus: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'Old',
 			},
 			dragOverrideValue: makeStaticDragOverride(''),
@@ -245,6 +249,7 @@ test('getEffectiveVisualModeValue resolves keyframed drag overrides at the sourc
 		getEffectiveVisualModeValue({
 			propStatus: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 2,
 			},
 			dragOverrideValue: makeKeyframedDragOverride({

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -8,6 +8,7 @@ test('interpolates linear numeric keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -25,6 +26,7 @@ test('interpolates linear numeric keyframes', () => {
 test('holds the previous keyframe value until the segment ends', () => {
 	const status: CanUpdateSequencePropStatusKeyframed = {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0},
@@ -55,6 +57,7 @@ test('holds the previous keyframe value until the segment ends', () => {
 test('holds non-numeric string keyframes until the segment ends', () => {
 	const status: CanUpdateSequencePropStatusKeyframed = {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 'default'},
@@ -88,6 +91,7 @@ test('interpolates numeric keyframes with perceptual-scale output', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -108,6 +112,7 @@ test('interpolates linear tuple keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: [0, 0.5]},
@@ -128,6 +133,7 @@ test('sorts keyframes before interpolating numeric values', () => {
 		frame: 75,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 100, value: 100},
@@ -149,6 +155,7 @@ test('clamps when extrapolation is clamp', () => {
 		frame: 120,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -169,6 +176,7 @@ test('posterizes the frame before interpolating numeric keyframes', () => {
 		frame: 17,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -189,6 +197,7 @@ test('returns single keyframe value', () => {
 		frame: 100,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [{frame: 0, value: 7}],
 			easing: [],
@@ -206,6 +215,7 @@ test('interpolates colors', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: '#000000'},
@@ -227,6 +237,7 @@ test('interpolates color keyframes with easing', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: 'black'},
@@ -247,6 +258,7 @@ test('posterizes the frame before interpolating color keyframes', () => {
 		frame: 17,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolateColors',
 			keyframes: [
 				{frame: 0, value: 'black'},
@@ -267,6 +279,7 @@ test('interpolates translate keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: '0px 0px'},
@@ -289,6 +302,7 @@ test('can force spring allowTail off for timeline value previews', () => {
 
 	const status: CanUpdateSequencePropStatusKeyframed = {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: '0px 1000px'},
@@ -350,6 +364,7 @@ test('interpolates rotate keyframes', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: '0deg'},
@@ -370,6 +385,7 @@ test('uses bezier easing', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 0},
@@ -391,6 +407,7 @@ test('interpolates scale strings component-wise', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 2},
@@ -411,6 +428,7 @@ test('interpolates 3D rotation keyframes as one property', () => {
 		frame: 30,
 		status: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: '0deg'},

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -654,8 +654,16 @@ test('Series.Sequence timing overrides cascade to later sequences', async () => 
 			[subscriptionKey]: {
 				canUpdate: true as const,
 				props: {
-					durationInFrames: {status: 'static' as const, codeValue: 10},
-					trimBefore: {status: 'static' as const, codeValue: 2},
+					durationInFrames: {
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 10,
+					},
+					trimBefore: {
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 2,
+					},
 				},
 				effects: [],
 			},

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -1,5 +1,6 @@
 import {findPropsToDelete} from './find-props-to-delete.js';
 import {
+	getFrameInKeyframedStatusClock,
 	getEffectiveVisualModeValue,
 	resolveDragOverrideValue,
 } from './get-effective-visual-mode-value.js';
@@ -126,9 +127,10 @@ export type CanUpdateSequencePropStatusKeyframed = {
 	status: 'keyframed';
 	interpolationFunction: CanUpdateSequencePropStatusInterpolationFunction;
 	/**
-	 * Added to the timeline track's keyframe display offset. This is non-zero
-	 * when the useCurrentFrame() call is outside a Sequence that wraps the
-	 * controlled element.
+	 * Added to the timeline track's keyframe display offset and subtracted from
+	 * the controlled element's local frame when evaluating the interpolation.
+	 * This is non-zero when the useCurrentFrame() call is outside a timing
+	 * element that wraps the controlled element.
 	 */
 	keyframeDisplayOffsetAdjustment: number | null;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
@@ -321,7 +323,7 @@ export const computeEffectiveSchemaValuesDotNotation = ({
 				} else if (frame !== null) {
 					const interpolated = interpolateKeyframedStatus({
 						forceSpringAllowTail: null,
-						frame,
+						frame: getFrameInKeyframedStatusClock({frame, status}),
 						status,
 					});
 					value = interpolated ?? currentValue[key];

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -18,7 +18,7 @@ import type {
 export type CanUpdateSequencePropStatusStatic = {
 	status: 'static';
 	codeValue: unknown;
-	keyframeDisplayOffsetAdjustment?: number;
+	keyframeDisplayOffsetAdjustment: number | null;
 	numericExpression?: VideoConfigNumericExpression;
 };
 
@@ -130,7 +130,7 @@ export type CanUpdateSequencePropStatusKeyframed = {
 	 * when the useCurrentFrame() call is outside a Sequence that wraps the
 	 * controlled element.
 	 */
-	keyframeDisplayOffsetAdjustment?: number;
+	keyframeDisplayOffsetAdjustment: number | null;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
 	easing: CanUpdateSequencePropStatusEasing[];
 	clamping: CanUpdateSequencePropStatusClamping;

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -18,6 +18,7 @@ import type {
 export type CanUpdateSequencePropStatusStatic = {
 	status: 'static';
 	codeValue: unknown;
+	keyframeDisplayOffsetAdjustment?: number;
 	numericExpression?: VideoConfigNumericExpression;
 };
 
@@ -124,6 +125,12 @@ export type CanUpdateSequencePropStatusComputed = {
 export type CanUpdateSequencePropStatusKeyframed = {
 	status: 'keyframed';
 	interpolationFunction: CanUpdateSequencePropStatusInterpolationFunction;
+	/**
+	 * Added to the timeline track's keyframe display offset. This is non-zero
+	 * when the useCurrentFrame() call is outside a Sequence that wraps the
+	 * controlled element.
+	 */
+	keyframeDisplayOffsetAdjustment?: number;
 	keyframes: CanUpdateSequencePropStatusKeyframe[];
 	easing: CanUpdateSequencePropStatusEasing[];
 	clamping: CanUpdateSequencePropStatusClamping;

--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -95,7 +95,7 @@ test.describe('effect keyframes', () => {
 			keyframes: [{frame: 30, value: 90}],
 			easing: [],
 			clamping: {left: 'clamp', right: 'clamp'},
-			keyframeDisplayOffsetAdjustment: null,
+			keyframeDisplayOffsetAdjustment: 0,
 		});
 
 		await expect

--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import assert from 'node:assert';
-import {expect, type Locator, type Page, test} from '@playwright/test';
+import {expect, test, type Locator, type Page} from '@playwright/test';
 import {wave} from '@remotion/effects/wave';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
+import fs from 'fs';
+import assert from 'node:assert';
 import {apiCall} from './api-call.mts';
 import {
 	EXPANDED_SIDEBAR_STATE,
@@ -72,6 +72,7 @@ test.describe('effect keyframes', () => {
 		expect(effectStatus.props.phase).toEqual({
 			status: 'static',
 			codeValue: undefined,
+			keyframeDisplayOffsetAdjustment: null,
 		});
 
 		const keyframe = await apiCall('/api/add-effect-keyframe', {
@@ -94,7 +95,7 @@ test.describe('effect keyframes', () => {
 			keyframes: [{frame: 30, value: 90}],
 			easing: [],
 			clamping: {left: 'clamp', right: 'clamp'},
-			posterize: undefined,
+			keyframeDisplayOffsetAdjustment: null,
 		});
 
 		await expect

--- a/packages/example/e2e/node-path-cache.test.mts
+++ b/packages/example/e2e/node-path-cache.test.mts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import assert from 'node:assert';
 import {expect, test} from '@playwright/test';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
+import fs from 'fs';
+import assert from 'node:assert';
 import {NoReactInternals} from 'remotion/no-react';
 import {apiCall} from './api-call.mts';
 import {newVideoFile} from './constants.mts';
@@ -136,6 +136,7 @@ test.describe('node-path cache for stale source maps', () => {
 		expect(result1.data.status.props.debugOverlay).toEqual({
 			status: 'static',
 			codeValue: true,
+			keyframeDisplayOffsetAdjustment: null,
 		});
 
 		const staleNodePath = result1.data.nodePath.nodePath;
@@ -173,6 +174,7 @@ test.describe('node-path cache for stale source maps', () => {
 		expect(result2.data.status.props.debugOverlay).toEqual({
 			status: 'static',
 			codeValue: true,
+			keyframeDisplayOffsetAdjustment: null,
 		});
 		expect(result2.data.nodePath.nodePath).not.toEqual(staleNodePath);
 	});

--- a/packages/example/e2e/sequence-shift-keyframes.test.mts
+++ b/packages/example/e2e/sequence-shift-keyframes.test.mts
@@ -34,15 +34,16 @@ test.describe('moving sequence keyframes', () => {
 			() => !document.body.innerText.includes('Loading...'),
 			{timeout: 30_000},
 		);
-		const outerDescendant = page.locator(
-			'[data-timeline-marquee-item][title="Outer frame descendant"]',
-		);
-		await expect(outerDescendant).toBeVisible({timeout: 15_000});
 		await page.keyboard.press('g');
 		const currentFrameInput = page.locator('input:focus');
 		await expect(currentFrameInput).toBeVisible();
-		await currentFrameInput.fill('12');
+		await currentFrameInput.fill('22');
 		await currentFrameInput.press('Enter');
+		await expect(
+			page.locator(
+				'[data-timeline-marquee-item][title="Outer frame descendant"]',
+			),
+		).toBeVisible({timeout: 15_000});
 		await expect(
 			page.locator(
 				'[data-timeline-marquee-item][title="Nested outer frame descendant"]',
@@ -61,8 +62,8 @@ test.describe('moving sequence keyframes', () => {
 			}, backgroundColor);
 		const getOuterTranslateX = () => getTranslateX('rgb(30, 144, 255)');
 		const getNestedOuterTranslateX = () => getTranslateX('rgb(255, 105, 180)');
-		await expect.poll(getOuterTranslateX).toBeCloseTo(100, 3);
-		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(120, 3);
+		await expect.poll(getOuterTranslateX).toBeCloseTo(250, 3);
+		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(210, 3);
 
 		const parent = page.locator(
 			'[data-timeline-marquee-item][title="<AbsoluteFill>"]',
@@ -77,27 +78,27 @@ test.describe('moving sequence keyframes', () => {
 		await page.mouse.down();
 		try {
 			await page.mouse.move(
-				box.x + box.width / 2 + box.width / 60,
+				box.x + box.width / 2 + box.width / 55,
 				box.y + box.height / 2,
 				{steps: 5},
 			);
-			await expect.poll(getOuterTranslateX).toBeCloseTo(50, 3);
-			await expect.poll(getNestedOuterTranslateX).toBeCloseTo(90, 3);
+			await expect.poll(getOuterTranslateX).toBeCloseTo(200, 3);
+			await expect.poll(getNestedOuterTranslateX).toBeCloseTo(180, 3);
 		} finally {
 			await page.mouse.up();
 		}
 		await expect
 			.poll(() => fs.readFileSync(sequenceShiftFile, 'utf-8'))
-			.toContain('from={1}');
-		await expect.poll(getOuterTranslateX).toBeCloseTo(50, 3);
-		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(90, 3);
+			.toContain('from={6}');
+		await expect.poll(getOuterTranslateX).toBeCloseTo(200, 3);
+		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(180, 3);
 		const source = fs.readFileSync(sequenceShiftFile, 'utf-8');
 		expect(source).toContain(
-			"translate: interpolate(frame, [11, 21], ['0px 0px', '500px 0px']",
+			"translate: interpolate(frame, [18, 28], ['0px 0px', '500px 0px']",
 		);
-		expect(source).toContain('opacity: interpolate(frame, [10, 20], [0, 1])');
-		expect(source).toContain(
-			"translate: interpolate(frame, [9, 19], ['0px 0px', '300px 0px']",
+		expect(source).toContain('opacity: interpolate(frame, [11, 21], [0, 1])');
+		expect(source).toMatch(
+			/translate: interpolate\(\s*frame,\s*\[16, 26\],\s*\['0px 0px', '300px 0px'\]/,
 		);
 		expect(source).toContain('opacity: interpolate(frame, [4, 14], [0, 1])');
 	});

--- a/packages/example/e2e/sequence-shift-keyframes.test.mts
+++ b/packages/example/e2e/sequence-shift-keyframes.test.mts
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+import {expect, test} from '@playwright/test';
+import {EXPANDED_SIDEBAR_STATE, STUDIO_URL, exampleDir} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+const sequenceShiftFile = path.join(
+	exampleDir,
+	'src',
+	'VisualModeTests',
+	'SequenceShiftRepro.tsx',
+);
+
+test.describe('moving sequence keyframes', () => {
+	let sourceBefore: string;
+
+	test.beforeEach(async () => {
+		sourceBefore = fs.readFileSync(sequenceShiftFile, 'utf-8');
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+		fs.writeFileSync(sequenceShiftFile, sourceBefore);
+	});
+
+	test('moves nested outer-clock descendant keyframes without double-shifting local-clock descendants', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/sequence-shift-repro`);
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+		const outerDescendant = page.locator(
+			'[data-timeline-marquee-item][title="Outer frame descendant"]',
+		);
+		await expect(outerDescendant).toBeVisible({timeout: 15_000});
+		await page.keyboard.press('g');
+		const currentFrameInput = page.locator('input:focus');
+		await expect(currentFrameInput).toBeVisible();
+		await currentFrameInput.fill('12');
+		await currentFrameInput.press('Enter');
+		await expect(
+			page.locator(
+				'[data-timeline-marquee-item][title="Nested outer frame descendant"]',
+			),
+		).toBeVisible({timeout: 15_000});
+		const getTranslateX = (backgroundColor: string) =>
+			page.evaluate((color) => {
+				const element = [...document.querySelectorAll('div')].find(
+					(candidate) => getComputedStyle(candidate).backgroundColor === color,
+				);
+				if (element === undefined) {
+					throw new Error(`Could not find the element with color ${color}`);
+				}
+
+				return Number.parseFloat(getComputedStyle(element).translate);
+			}, backgroundColor);
+		const getOuterTranslateX = () => getTranslateX('rgb(30, 144, 255)');
+		const getNestedOuterTranslateX = () => getTranslateX('rgb(255, 105, 180)');
+		await expect.poll(getOuterTranslateX).toBeCloseTo(100, 3);
+		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(120, 3);
+
+		const parent = page.locator(
+			'[data-timeline-marquee-item][title="<AbsoluteFill>"]',
+		);
+		await expect(parent).toBeVisible({timeout: 15_000});
+		const box = await parent.boundingBox();
+		if (box === null) {
+			throw new Error('Expected the parent sequence to have a bounding box');
+		}
+
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.down();
+		try {
+			await page.mouse.move(
+				box.x + box.width / 2 + box.width / 60,
+				box.y + box.height / 2,
+				{steps: 5},
+			);
+			await expect.poll(getOuterTranslateX).toBeCloseTo(50, 3);
+			await expect.poll(getNestedOuterTranslateX).toBeCloseTo(90, 3);
+		} finally {
+			await page.mouse.up();
+		}
+		await expect
+			.poll(() => fs.readFileSync(sequenceShiftFile, 'utf-8'))
+			.toContain('from={1}');
+		await expect.poll(getOuterTranslateX).toBeCloseTo(50, 3);
+		await expect.poll(getNestedOuterTranslateX).toBeCloseTo(90, 3);
+		const source = fs.readFileSync(sequenceShiftFile, 'utf-8');
+		expect(source).toContain(
+			"translate: interpolate(frame, [11, 21], ['0px 0px', '500px 0px']",
+		);
+		expect(source).toContain('opacity: interpolate(frame, [10, 20], [0, 1])');
+		expect(source).toContain(
+			"translate: interpolate(frame, [9, 19], ['0px 0px', '300px 0px']",
+		);
+		expect(source).toContain('opacity: interpolate(frame, [4, 14], [0, 1])');
+	});
+});

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -17,6 +17,7 @@ import {RotationKeyframeE2e} from './RotationKeyframeE2e';
 import {SchemaTest, schemaTestSchema} from './SchemaTest';
 import {VisualControls} from './VisualControls';
 import {VisualMode3D} from './VisualMode3D';
+import {SequenceShiftRepro} from './VisualModeTests/SequenceShiftRepro';
 
 const UseCurrentScaleOnLoad: React.FC = () => {
 	const scale = useCurrentScale();
@@ -179,6 +180,14 @@ export const E2eTestRoot: React.FC = () => {
 				height={1080}
 				fps={30}
 				durationInFrames={90}
+			/>
+			<Composition
+				id="sequence-shift-repro"
+				component={SequenceShiftRepro}
+				width={1280}
+				height={720}
+				fps={30}
+				durationInFrames={60}
 			/>
 			<Composition
 				id="inspector-control-layout-e2e"

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -301,6 +301,7 @@ import {
 } from './VisualModeTests/InteractiveComponents';
 import {Issue9170} from './VisualModeTests/Issue9170';
 import {OutlineSelectionCases} from './VisualModeTests/OutlineSelectionCases';
+import {SequenceShiftRepro} from './VisualModeTests/SequenceShiftRepro';
 import {SvgPaintSchema} from './VisualModeTests/SvgPaintSchema';
 import {VideoConfigExpressions} from './VisualModeTests/VideoConfigExpressions';
 import {VoiceVisualization} from './voice-visualization';
@@ -2846,6 +2847,14 @@ export const Index: React.FC = () => {
 				durationInFrames={180}
 			/>
 			<Folder name="VisualModeTests">
+				<Composition
+					id="sequence-shift-repro"
+					component={SequenceShiftRepro}
+					width={1280}
+					height={720}
+					fps={30}
+					durationInFrames={30}
+				/>
 				<Composition
 					id="outline-selection-cases"
 					component={OutlineSelectionCases}

--- a/packages/example/src/VisualModeTests/SequenceShiftRepro.tsx
+++ b/packages/example/src/VisualModeTests/SequenceShiftRepro.tsx
@@ -1,0 +1,22 @@
+import {AbsoluteFill, interpolate, Sequence, useCurrentFrame} from 'remotion';
+
+export const SequenceShiftRepro = () => {
+	// This hook runs outside the Sequence, so this is the composition frame.
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill style={{backgroundColor: 'black'}}>
+			<Sequence durationInFrames={30} from={-5}>
+				<AbsoluteFill
+					style={{
+						backgroundColor: 'dodgerblue',
+						translate: interpolate(frame, [10, 20], ['0px 0px', '500px 0px'], {
+							extrapolateLeft: 'clamp',
+							extrapolateRight: 'clamp',
+						}),
+					}}
+				/>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/VisualModeTests/SequenceShiftRepro.tsx
+++ b/packages/example/src/VisualModeTests/SequenceShiftRepro.tsx
@@ -1,21 +1,64 @@
 import {AbsoluteFill, interpolate, Sequence, useCurrentFrame} from 'remotion';
 
+const LocalFrameDescendant = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			name="Local frame descendant"
+			style={{opacity: interpolate(frame, [11, 21], [0, 1])}}
+			from={1}
+		/>
+	);
+};
+
+const NestedLocalFrameDescendant = () => {
+	const frame = useCurrentFrame();
+
+	return (
+		<AbsoluteFill
+			name="Nested local frame descendant"
+			style={{opacity: interpolate(frame, [4, 14], [0, 1])}}
+		/>
+	);
+};
+
 export const SequenceShiftRepro = () => {
 	// This hook runs outside the Sequence, so this is the composition frame.
 	const frame = useCurrentFrame();
 
 	return (
-		<AbsoluteFill style={{backgroundColor: 'black'}}>
-			<Sequence durationInFrames={30} from={-5}>
+		<AbsoluteFill style={{backgroundColor: 'black'}} from={5}>
+			<Sequence name="Shift parent" durationInFrames={30} from={2}>
 				<AbsoluteFill
+					name="Outer frame descendant"
 					style={{
 						backgroundColor: 'dodgerblue',
-						translate: interpolate(frame, [10, 20], ['0px 0px', '500px 0px'], {
+						translate: interpolate(frame, [17, 27], ['0px 0px', '500px 0px'], {
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						}),
 					}}
 				/>
+				<LocalFrameDescendant />
+				<Sequence name="Nested timing parent" durationInFrames={25} from={2}>
+					<AbsoluteFill
+						name="Nested outer frame descendant"
+						style={{
+							backgroundColor: 'hotpink',
+							translate: interpolate(
+								frame,
+								[15, 25],
+								['0px 0px', '300px 0px'],
+								{
+									extrapolateLeft: 'clamp',
+									extrapolateRight: 'clamp',
+								},
+							),
+						}}
+					/>
+					<NestedLocalFrameDescendant />
+				</Sequence>
 			</Sequence>
 		</AbsoluteFill>
 	);

--- a/packages/studio-codemods/src/sequence-props.ts
+++ b/packages/studio-codemods/src/sequence-props.ts
@@ -60,6 +60,7 @@ const staticStatus = (
 	numericExpression: VideoConfigNumericExpression | null,
 ): CanUpdatePropStatus => ({
 	status: 'static',
+	keyframeDisplayOffsetAdjustment: null,
 	codeValue,
 	...(numericExpression === null || numericExpression.type === 'literal'
 		? {}
@@ -663,6 +664,7 @@ export const getComputedStatus = (
 
 	return {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: interpolation.interpolationFunction,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,

--- a/packages/studio-codemods/src/sequence-props/can-update-effect-props.ts
+++ b/packages/studio-codemods/src/sequence-props/can-update-effect-props.ts
@@ -33,6 +33,7 @@ import {
 
 const staticStatus = (codeValue: unknown): CanUpdateSequencePropStatus => ({
 	status: 'static',
+	keyframeDisplayOffsetAdjustment: null,
 	codeValue,
 });
 
@@ -184,6 +185,7 @@ const getPropsFromObjectExpression = ({
 			out[key] = numericExpression
 				? {
 						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
 						codeValue: numericExpression.value,
 						...(numericExpression.type === 'literal'
 							? {}
@@ -195,6 +197,7 @@ const getPropsFromObjectExpression = ({
 
 		out[key] = {
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: extractStaticValue(valueExpr),
 		};
 	}

--- a/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-effect-props.ts
@@ -35,6 +35,7 @@ import {
 
 const staticStatus = (codeValue: unknown): CanUpdateSequencePropStatus => ({
 	status: 'static',
+	keyframeDisplayOffsetAdjustment: null,
 	codeValue,
 });
 
@@ -186,6 +187,7 @@ const getPropsFromObjectExpression = ({
 			out[key] = numericExpression
 				? {
 						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
 						codeValue: numericExpression.value,
 						...(numericExpression.type === 'literal'
 							? {}
@@ -197,6 +199,7 @@ const getPropsFromObjectExpression = ({
 
 		out[key] = {
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: extractStaticValue(valueExpr),
 		};
 	}

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -123,6 +123,7 @@ const staticStatus = (
 	numericExpression: VideoConfigNumericExpression | null,
 ): CanUpdatePropStatus => ({
 	status: 'static',
+	keyframeDisplayOffsetAdjustment: null,
 	codeValue,
 	...(numericExpression === null || numericExpression.type === 'literal'
 		? {}
@@ -709,7 +710,7 @@ const getRemotionImportNames = ({
 					(specifier.imported.type === 'StringLiteral' &&
 						specifier.imported.value === importedName))
 			) {
-				direct.add(specifier.local.name);
+				direct.add(specifier.local?.name ?? importedName);
 			}
 
 			if (specifier.type === 'ImportNamespaceSpecifier') {
@@ -1004,12 +1005,10 @@ export const getComputedStatus = (
 	return {
 		status: 'keyframed',
 		interpolationFunction: interpolation.interpolationFunction,
-		...(interpolation.keyframeDisplayOffsetAdjustment === 0
-			? {}
-			: {
-					keyframeDisplayOffsetAdjustment:
-						interpolation.keyframeDisplayOffsetAdjustment,
-				}),
+		keyframeDisplayOffsetAdjustment:
+			interpolation.keyframeDisplayOffsetAdjustment === 0
+				? null
+				: interpolation.keyframeDisplayOffsetAdjustment,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
 		clamping: interpolation.clamping,

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -811,36 +811,13 @@ const getJsxNumericAttribute = ({
 	return defaultValue;
 };
 
-const isRemotionSequence = ({
-	openingElement,
-	ast,
-}: {
-	openingElement: JSXOpeningElement;
-	ast: File;
-}): boolean => {
-	const imports = getRemotionImportNames({ast, importedName: 'Sequence'});
-	if (openingElement.name.type === 'JSXIdentifier') {
-		return imports.direct.has(openingElement.name.name);
-	}
-
-	return (
-		openingElement.name.type === 'JSXMemberExpression' &&
-		openingElement.name.object.type === 'JSXIdentifier' &&
-		openingElement.name.property.type === 'JSXIdentifier' &&
-		imports.namespaces.has(openingElement.name.object.name) &&
-		openingElement.name.property.name === 'Sequence'
-	);
-};
-
 const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
 	startPath,
 	endPath,
-	ast,
 	videoConfigValues,
 }: {
 	startPath: recast.types.NodePath;
 	endPath: recast.types.NodePath;
-	ast: File;
 	videoConfigValues: VideoConfigIdentifierValues;
 }): number | null => {
 	let current: recast.types.NodePath | null = startPath;
@@ -859,12 +836,9 @@ const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
 		if (currentNode.type === 'JSXElement') {
 			if (!hasSeenControlledElement) {
 				hasSeenControlledElement = true;
-			} else if (
-				isRemotionSequence({
-					openingElement: currentNode.openingElement,
-					ast,
-				})
-			) {
+			} else {
+				// Sequence-backed built-ins and userland components can both shift
+				// their children, so the prop names are the semantic boundary.
 				const from = getJsxNumericAttribute({
 					openingElement: currentNode.openingElement,
 					name: 'from',
@@ -926,7 +900,6 @@ const getDefaultFrameDisplayOffsetAdjustment = ({
 	return getFrameDisplayOffsetAdjustmentBetweenPaths({
 		startPath: jsxPath,
 		endPath: functionPath,
-		ast,
 		videoConfigValues,
 	});
 };
@@ -987,7 +960,6 @@ const getCurrentFrameDisplayOffsetAdjustment = ({
 	return getFrameDisplayOffsetAdjustmentBetweenPaths({
 		startPath: nodePath,
 		endPath: bindingScope.path,
-		ast,
 		videoConfigValues,
 	});
 };
@@ -1785,11 +1757,15 @@ const computeSequencePropsStatusFromAstAndIdentifiers = ({
 	const addDefaultKeyframeDisplayOffsetAdjustment = (
 		status: CanUpdateSequencePropStatus,
 	): CanUpdateSequencePropStatus => {
-		if (
-			status.status !== 'static' ||
-			defaultKeyframeDisplayOffsetAdjustment === null ||
-			defaultKeyframeDisplayOffsetAdjustment === 0
-		) {
+		if (status.status !== 'static') {
+			return status;
+		}
+
+		if (defaultKeyframeDisplayOffsetAdjustment === null) {
+			return computedStatus();
+		}
+
+		if (defaultKeyframeDisplayOffsetAdjustment === 0) {
 			return status;
 		}
 

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -553,7 +553,7 @@ const getInterpolationKeyframes = (
 			posterize: PropPosterize;
 			output: PropOutput;
 			interpolationFunction: PropInterpolationFunction;
-			keyframeDisplayOffsetAdjustment: number;
+			keyframeDisplayOffsetAdjustment: number | null;
 	  }
 	| undefined => {
 	if (node.type === 'TSAsExpression') {
@@ -619,13 +619,12 @@ const getInterpolationKeyframes = (
 		return undefined;
 	}
 
-	const keyframeDisplayOffsetAdjustment =
-		getCurrentFrameDisplayOffsetAdjustment({
-			node: frameArg as Expression,
-			ast,
-			videoConfigValues,
-		});
-	if (keyframeDisplayOffsetAdjustment === null) {
+	const frameDisplayOffset = getCurrentFrameDisplayOffsetAdjustment({
+		node: frameArg as Expression,
+		ast,
+		videoConfigValues,
+	});
+	if (frameDisplayOffset === null) {
 		return undefined;
 	}
 
@@ -681,7 +680,9 @@ const getInterpolationKeyframes = (
 		clamping: metadata.clamping,
 		posterize: metadata.posterize,
 		output: metadata.output,
-		keyframeDisplayOffsetAdjustment,
+		keyframeDisplayOffsetAdjustment: frameDisplayOffset.hasEnclosingElement
+			? frameDisplayOffset.adjustment
+			: null,
 	};
 };
 
@@ -819,9 +820,13 @@ const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
 	startPath: recast.types.NodePath;
 	endPath: recast.types.NodePath;
 	videoConfigValues: VideoConfigIdentifierValues;
-}): number | null => {
+}): {
+	readonly adjustment: number;
+	readonly hasEnclosingElement: boolean;
+} | null => {
 	let current: recast.types.NodePath | null = startPath;
 	let hasSeenControlledElement = false;
+	let hasEnclosingElement = false;
 	let adjustment = 0;
 	while (current && current.value !== endPath.value) {
 		const currentNode = current.value as Node;
@@ -837,6 +842,7 @@ const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
 			if (!hasSeenControlledElement) {
 				hasSeenControlledElement = true;
 			} else {
+				hasEnclosingElement = true;
 				// Sequence-backed built-ins and userland components can both shift
 				// their children, so the prop names are the semantic boundary.
 				const from = getJsxNumericAttribute({
@@ -862,7 +868,7 @@ const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
 		current = current.parentPath;
 	}
 
-	return current ? adjustment : null;
+	return current ? {adjustment, hasEnclosingElement} : null;
 };
 
 const getDefaultFrameDisplayOffsetAdjustment = ({
@@ -897,11 +903,12 @@ const getDefaultFrameDisplayOffsetAdjustment = ({
 		return null;
 	}
 
-	return getFrameDisplayOffsetAdjustmentBetweenPaths({
+	const result = getFrameDisplayOffsetAdjustmentBetweenPaths({
 		startPath: jsxPath,
 		endPath: functionPath,
 		videoConfigValues,
 	});
+	return result?.adjustment ?? null;
 };
 
 const getCurrentFrameDisplayOffsetAdjustment = ({
@@ -912,7 +919,10 @@ const getCurrentFrameDisplayOffsetAdjustment = ({
 	node: Expression;
 	ast: File;
 	videoConfigValues: VideoConfigIdentifierValues;
-}): number | null => {
+}): {
+	readonly adjustment: number;
+	readonly hasEnclosingElement: boolean;
+} | null => {
 	if (node.type === 'TSAsExpression') {
 		return getCurrentFrameDisplayOffsetAdjustment({
 			node: node.expression as Expression,
@@ -978,9 +988,7 @@ export const getComputedStatus = (
 		status: 'keyframed',
 		interpolationFunction: interpolation.interpolationFunction,
 		keyframeDisplayOffsetAdjustment:
-			interpolation.keyframeDisplayOffsetAdjustment === 0
-				? null
-				: interpolation.keyframeDisplayOffsetAdjustment,
+			interpolation.keyframeDisplayOffsetAdjustment,
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
 		clamping: interpolation.clamping,

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -7,6 +7,7 @@ import type {
 	JSXElement,
 	JSXOpeningElement,
 	NewExpression,
+	Node,
 	ObjectExpression,
 	ObjectProperty,
 	TSAsExpression,
@@ -551,6 +552,7 @@ const getInterpolationKeyframes = (
 			posterize: PropPosterize;
 			output: PropOutput;
 			interpolationFunction: PropInterpolationFunction;
+			keyframeDisplayOffsetAdjustment: number;
 	  }
 	| undefined => {
 	if (node.type === 'TSAsExpression') {
@@ -608,12 +610,21 @@ const getInterpolationKeyframes = (
 	if (
 		!frameArg ||
 		frameArg.type === 'SpreadElement' ||
-		!isCurrentFrameIdentifier(frameArg as Expression, ast) ||
 		!inputArg ||
 		!outputArg ||
 		inputArg.type !== 'ArrayExpression' ||
 		outputArg.type !== 'ArrayExpression'
 	) {
+		return undefined;
+	}
+
+	const keyframeDisplayOffsetAdjustment =
+		getCurrentFrameDisplayOffsetAdjustment({
+			node: frameArg as Expression,
+			ast,
+			videoConfigValues,
+		});
+	if (keyframeDisplayOffsetAdjustment === null) {
 		return undefined;
 	}
 
@@ -669,48 +680,315 @@ const getInterpolationKeyframes = (
 		clamping: metadata.clamping,
 		posterize: metadata.posterize,
 		output: metadata.output,
+		keyframeDisplayOffsetAdjustment,
 	};
 };
 
-const isUseCurrentFrameCall = (node: Expression): boolean => {
-	return (
-		node.type === 'CallExpression' &&
-		node.callee.type === 'Identifier' &&
-		node.callee.name === 'useCurrentFrame' &&
-		node.arguments.length === 0
-	);
-};
+const getRemotionImportNames = ({
+	ast,
+	importedName,
+}: {
+	ast: File;
+	importedName: string;
+}): {direct: Set<string>; namespaces: Set<string>} => {
+	const direct = new Set<string>();
+	const namespaces = new Set<string>();
+	for (const statement of ast.program.body) {
+		if (
+			statement.type !== 'ImportDeclaration' ||
+			statement.source.value !== 'remotion'
+		) {
+			continue;
+		}
 
-const isCurrentFrameIdentifier = (node: Expression, ast: File): boolean => {
-	if (node.type === 'TSAsExpression') {
-		return isCurrentFrameIdentifier(node.expression as Expression, ast);
+		for (const specifier of statement.specifiers ?? []) {
+			if (
+				specifier.type === 'ImportSpecifier' &&
+				((specifier.imported.type === 'Identifier' &&
+					specifier.imported.name === importedName) ||
+					(specifier.imported.type === 'StringLiteral' &&
+						specifier.imported.value === importedName))
+			) {
+				direct.add(specifier.local.name);
+			}
+
+			if (specifier.type === 'ImportNamespaceSpecifier') {
+				namespaces.add(specifier.local.name);
+			}
+		}
 	}
 
-	if (node.type !== 'Identifier') {
+	return {direct, namespaces};
+};
+
+const isUseCurrentFrameCall = (node: Expression, ast: File): boolean => {
+	if (node.type !== 'CallExpression' || node.arguments.length !== 0) {
 		return false;
 	}
 
-	let hasUseCurrentFrameDeclaration = false;
-	let hasOtherDeclaration = false;
+	const imports = getRemotionImportNames({
+		ast,
+		importedName: 'useCurrentFrame',
+	});
+	if (node.callee.type === 'Identifier') {
+		return imports.direct.has(node.callee.name);
+	}
 
+	return (
+		node.callee.type === 'MemberExpression' &&
+		!node.callee.computed &&
+		node.callee.object.type === 'Identifier' &&
+		node.callee.property.type === 'Identifier' &&
+		imports.namespaces.has(node.callee.object.name) &&
+		node.callee.property.name === 'useCurrentFrame'
+	);
+};
+
+const findNodePath = (
+	ast: File,
+	target: Node,
+): recast.types.NodePath | null => {
+	let found: recast.types.NodePath | null = null;
 	recast.types.visit(ast, {
+		visitNode(p) {
+			if (p.node === target) {
+				found = p as unknown as recast.types.NodePath;
+				return false;
+			}
+
+			return this.traverse(p);
+		},
+	});
+
+	return found;
+};
+
+const getJsxNumericAttribute = ({
+	openingElement,
+	name,
+	defaultValue,
+	videoConfigValues,
+}: {
+	openingElement: JSXOpeningElement;
+	name: string;
+	defaultValue: number;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): number | null => {
+	if (
+		openingElement.attributes.some(
+			(attribute) => attribute.type === 'JSXSpreadAttribute',
+		)
+	) {
+		return null;
+	}
+
+	for (let index = openingElement.attributes.length - 1; index >= 0; index--) {
+		const attribute = openingElement.attributes[index];
+		if (
+			attribute.type !== 'JSXAttribute' ||
+			attribute.name.type !== 'JSXIdentifier' ||
+			attribute.name.name !== name
+		) {
+			continue;
+		}
+
+		if (
+			attribute.value?.type !== 'JSXExpressionContainer' ||
+			attribute.value.expression.type === 'JSXEmptyExpression'
+		) {
+			return null;
+		}
+
+		return (
+			parseVideoConfigNumericExpression({
+				node: attribute.value.expression,
+				videoConfigValues,
+			})?.value ?? null
+		);
+	}
+
+	return defaultValue;
+};
+
+const isRemotionSequence = ({
+	openingElement,
+	ast,
+}: {
+	openingElement: JSXOpeningElement;
+	ast: File;
+}): boolean => {
+	const imports = getRemotionImportNames({ast, importedName: 'Sequence'});
+	if (openingElement.name.type === 'JSXIdentifier') {
+		return imports.direct.has(openingElement.name.name);
+	}
+
+	return (
+		openingElement.name.type === 'JSXMemberExpression' &&
+		openingElement.name.object.type === 'JSXIdentifier' &&
+		openingElement.name.property.type === 'JSXIdentifier' &&
+		imports.namespaces.has(openingElement.name.object.name) &&
+		openingElement.name.property.name === 'Sequence'
+	);
+};
+
+const getFrameDisplayOffsetAdjustmentBetweenPaths = ({
+	startPath,
+	endPath,
+	ast,
+	videoConfigValues,
+}: {
+	startPath: recast.types.NodePath;
+	endPath: recast.types.NodePath;
+	ast: File;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): number | null => {
+	let current: recast.types.NodePath | null = startPath;
+	let hasSeenControlledElement = false;
+	let adjustment = 0;
+	while (current && current.value !== endPath.value) {
+		const currentNode = current.value as Node;
+		if (
+			currentNode.type === 'FunctionDeclaration' ||
+			currentNode.type === 'FunctionExpression' ||
+			currentNode.type === 'ArrowFunctionExpression'
+		) {
+			return null;
+		}
+
+		if (currentNode.type === 'JSXElement') {
+			if (!hasSeenControlledElement) {
+				hasSeenControlledElement = true;
+			} else if (
+				isRemotionSequence({
+					openingElement: currentNode.openingElement,
+					ast,
+				})
+			) {
+				const from = getJsxNumericAttribute({
+					openingElement: currentNode.openingElement,
+					name: 'from',
+					defaultValue: 0,
+					videoConfigValues,
+				});
+				const trimBefore = getJsxNumericAttribute({
+					openingElement: currentNode.openingElement,
+					name: 'trimBefore',
+					defaultValue: 0,
+					videoConfigValues,
+				});
+				if (from === null || trimBefore === null) {
+					return null;
+				}
+
+				adjustment -= from - trimBefore;
+			}
+		}
+
+		current = current.parentPath;
+	}
+
+	return current ? adjustment : null;
+};
+
+const getDefaultFrameDisplayOffsetAdjustment = ({
+	jsxElement,
+	ast,
+	videoConfigValues,
+}: {
+	jsxElement: JSXOpeningElement;
+	ast: File;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): number | null => {
+	const jsxPath = findNodePath(ast, jsxElement);
+	if (!jsxPath) {
+		return null;
+	}
+
+	let functionPath: recast.types.NodePath | null = jsxPath.parentPath;
+	while (functionPath) {
+		const node = functionPath.value as Node;
+		if (
+			node.type === 'FunctionDeclaration' ||
+			node.type === 'FunctionExpression' ||
+			node.type === 'ArrowFunctionExpression'
+		) {
+			break;
+		}
+
+		functionPath = functionPath.parentPath;
+	}
+
+	if (!functionPath) {
+		return null;
+	}
+
+	return getFrameDisplayOffsetAdjustmentBetweenPaths({
+		startPath: jsxPath,
+		endPath: functionPath,
+		ast,
+		videoConfigValues,
+	});
+};
+
+const getCurrentFrameDisplayOffsetAdjustment = ({
+	node,
+	ast,
+	videoConfigValues,
+}: {
+	node: Expression;
+	ast: File;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): number | null => {
+	if (node.type === 'TSAsExpression') {
+		return getCurrentFrameDisplayOffsetAdjustment({
+			node: node.expression as Expression,
+			ast,
+			videoConfigValues,
+		});
+	}
+
+	if (node.type !== 'Identifier') {
+		return null;
+	}
+
+	const nodePath = findNodePath(ast, node);
+	const bindingScope = nodePath?.scope?.lookup(node.name);
+	if (!nodePath || !bindingScope) {
+		return null;
+	}
+
+	let matchingDeclarations = 0;
+	let isCurrentFrameBinding = false;
+	recast.types.visit(bindingScope.path, {
 		visitVariableDeclarator(p) {
 			const {id, init} = p.node;
-			if (id.type !== 'Identifier' || id.name !== node.name) {
+			if (
+				id.type !== 'Identifier' ||
+				id.name !== node.name ||
+				p.scope.lookup(node.name)?.path.node !== bindingScope.path.node
+			) {
 				return this.traverse(p);
 			}
 
-			if (init && isUseCurrentFrameCall(init as Expression)) {
-				hasUseCurrentFrameDeclaration = true;
-			} else {
-				hasOtherDeclaration = true;
-			}
+			matchingDeclarations++;
+			isCurrentFrameBinding = Boolean(
+				init && isUseCurrentFrameCall(init as Expression, ast),
+			);
 
 			return false;
 		},
 	});
 
-	return hasUseCurrentFrameDeclaration && !hasOtherDeclaration;
+	if (matchingDeclarations !== 1 || !isCurrentFrameBinding) {
+		return null;
+	}
+
+	return getFrameDisplayOffsetAdjustmentBetweenPaths({
+		startPath: nodePath,
+		endPath: bindingScope.path,
+		ast,
+		videoConfigValues,
+	});
 };
 
 export const getComputedStatus = (
@@ -726,6 +1004,12 @@ export const getComputedStatus = (
 	return {
 		status: 'keyframed',
 		interpolationFunction: interpolation.interpolationFunction,
+		...(interpolation.keyframeDisplayOffsetAdjustment === 0
+			? {}
+			: {
+					keyframeDisplayOffsetAdjustment:
+						interpolation.keyframeDisplayOffsetAdjustment,
+				}),
 		keyframes: interpolation.keyframes,
 		easing: interpolation.easing,
 		clamping: interpolation.clamping,
@@ -1493,11 +1777,50 @@ const computeSequencePropsStatusFromAstAndIdentifiers = ({
 		effects,
 		videoConfigValues: videoConfigIdentifierValues,
 	});
+	const defaultKeyframeDisplayOffsetAdjustment =
+		getDefaultFrameDisplayOffsetAdjustment({
+			jsxElement,
+			ast,
+			videoConfigValues: videoConfigIdentifierValues,
+		});
+	const addDefaultKeyframeDisplayOffsetAdjustment = (
+		status: CanUpdateSequencePropStatus,
+	): CanUpdateSequencePropStatus => {
+		if (
+			status.status !== 'static' ||
+			defaultKeyframeDisplayOffsetAdjustment === null ||
+			defaultKeyframeDisplayOffsetAdjustment === 0
+		) {
+			return status;
+		}
+
+		return {
+			...status,
+			keyframeDisplayOffsetAdjustment: defaultKeyframeDisplayOffsetAdjustment,
+		};
+	};
 
 	return {
 		canUpdate: true as const,
-		props: filteredProps,
-		effects: effectsStatuses,
+		props: Object.fromEntries(
+			Object.entries(filteredProps).map(([key, status]) => [
+				key,
+				addDefaultKeyframeDisplayOffsetAdjustment(status),
+			]),
+		),
+		effects: effectsStatuses.map((effectStatus) =>
+			effectStatus.canUpdate
+				? {
+						...effectStatus,
+						props: Object.fromEntries(
+							Object.entries(effectStatus.props).map(([key, status]) => [
+								key,
+								addDefaultKeyframeDisplayOffsetAdjustment(status),
+							]),
+						),
+					}
+				: effectStatus,
+		),
 	};
 };
 

--- a/packages/studio-server/src/test/compute-effect-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-effect-props-status.test.ts
@@ -60,10 +60,12 @@ test('computeEffectPropStatus reports static props as canUpdate=true with codeVa
 
 	expect(result.props.color).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'red',
 	});
 	expect(result.props.opacity).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.5,
 	});
 	expect(result.importPath).toBe('@remotion/effects/tint');
@@ -88,6 +90,7 @@ test('computeEffectPropStatus reports computed props', () => {
 	expect(result.props.color).toEqual({status: 'computed'});
 	expect(result.props.opacity).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.5,
 	});
 });
@@ -112,6 +115,7 @@ test('computeEffectPropStatus reports keyframes for inline interpolated effect p
 
 	expect(result.props.amount).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0.2},
@@ -144,6 +148,7 @@ test('computeEffectPropStatus reports output for inline interpolated effect prop
 
 	expect(result.props.amount).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0.2},
@@ -206,10 +211,12 @@ test('computeEffectPropStatus reports unset props as undefined codeValue', () =>
 
 	expect(result.props.color).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'red',
 	});
 	expect(result.props.opacity).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	});
 });
@@ -232,6 +239,7 @@ test('computeEffectPropStatus reports static array props', () => {
 
 	expect(result.props.colors).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: ['red', 'blue'],
 	});
 });
@@ -330,6 +338,7 @@ test('computeEffectPropStatus treats zero-arg effect as editable with undefined 
 
 	expect(result.props.amount).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	});
 });

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -1094,28 +1094,29 @@ export const Example: React.FC = () => {
 	});
 });
 
-test('computeSequencePropsStatus preserves the useCurrentFrame coordinate space across wrapping Sequences', () => {
+test('computeSequencePropsStatus preserves the useCurrentFrame coordinate space across userland timing components', () => {
 	const input = `import React from 'react';
-import {AbsoluteFill, interpolate, Sequence, useCurrentFrame} from 'remotion';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+import {Timing} from './Timing';
 
 export const Example: React.FC = () => {
 	const frame = useCurrentFrame();
 	return (
-		<Sequence durationInFrames={30} from={-5}>
+		<Timing durationInFrames={30} from={-5} trimBefore={3}>
 			<AbsoluteFill
 				style={{
 					backgroundColor: 'dodgerblue',
 					translate: interpolate(frame, [10, 20], ['0px 0px', '500px 0px']),
 				}}
 			/>
-		</Sequence>
+		</Timing>
 	);
 };
 `;
 	const result = computeSequencePropsStatusFromContent({
 		videoConfigValues: null,
 		fileContents: input,
-		nodePath: getNodePathFromContent(input, 8),
+		nodePath: getNodePathFromContent(input, 9),
 		componentIdentity: null,
 		keys: ['style.backgroundColor', 'style.translate'],
 		effects: [],
@@ -1126,7 +1127,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.translate']).toMatchObject({
 		status: 'keyframed',
-		keyframeDisplayOffsetAdjustment: 5,
+		keyframeDisplayOffsetAdjustment: 8,
 		keyframes: [
 			{frame: 10, value: '0px 0px'},
 			{frame: 20, value: '500px 0px'},
@@ -1135,8 +1136,44 @@ export const Example: React.FC = () => {
 	expect(result.props['style.backgroundColor']).toEqual({
 		status: 'static',
 		codeValue: 'dodgerblue',
-		keyframeDisplayOffsetAdjustment: 5,
+		keyframeDisplayOffsetAdjustment: 8,
 	});
+});
+
+test('computeSequencePropsStatus reports computed when a timing component offset is uncertain', () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+import {Timing, getTimingProps} from './Timing';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	const timingProps = getTimingProps();
+	return (
+		<Timing {...timingProps}>
+			<AbsoluteFill
+				style={{
+					backgroundColor: 'dodgerblue',
+					translate: interpolate(frame, [10, 20], ['0px 0px', '500px 0px']),
+				}}
+			/>
+		</Timing>
+	);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		videoConfigValues: null,
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 10),
+		componentIdentity: null,
+		keys: ['style.backgroundColor', 'style.translate'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.translate']).toEqual({status: 'computed'});
+	expect(result.props['style.backgroundColor']).toEqual({status: 'computed'});
 });
 
 test('computeSequencePropsStatus should return keyframes for String-wrapped interpolated translate props', () => {

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -1013,6 +1013,51 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus preserves the useCurrentFrame coordinate space across wrapping Sequences', () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, interpolate, Sequence, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	return (
+		<Sequence durationInFrames={30} from={-5}>
+			<AbsoluteFill
+				style={{
+					backgroundColor: 'dodgerblue',
+					translate: interpolate(frame, [10, 20], ['0px 0px', '500px 0px']),
+				}}
+			/>
+		</Sequence>
+	);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		videoConfigValues: null,
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 8),
+		componentIdentity: null,
+		keys: ['style.backgroundColor', 'style.translate'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.translate']).toMatchObject({
+		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: 5,
+		keyframes: [
+			{frame: 10, value: '0px 0px'},
+			{frame: 20, value: '500px 0px'},
+		],
+	});
+	expect(result.props['style.backgroundColor']).toEqual({
+		status: 'static',
+		codeValue: 'dodgerblue',
+		keyframeDisplayOffsetAdjustment: 5,
+	});
+});
+
 test('computeSequencePropsStatus should return keyframes for String-wrapped interpolated translate props', () => {
 	const input = `import React from 'react';
 import {Easing, Sequence, interpolate, useCurrentFrame} from 'remotion';

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -1140,6 +1140,42 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus distinguishes a zero-offset outer frame clock from a local frame clock', () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+import {Timing} from './Timing';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	return (
+		<Timing from={0}>
+			<AbsoluteFill style={{opacity: interpolate(frame, [10, 20], [0, 1])}} />
+		</Timing>
+	);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		videoConfigValues: null,
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 9),
+		componentIdentity: null,
+		keys: ['style.opacity'],
+		effects: [],
+	});
+
+	expect(result.canUpdate).toBe(true);
+	if (!result.canUpdate) throw new Error('Expected canUpdate to be true');
+
+	expect(result.props['style.opacity']).toMatchObject({
+		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: 0,
+		keyframes: [
+			{frame: 10, value: 0},
+			{frame: 20, value: 1},
+		],
+	});
+});
+
 test('computeSequencePropsStatus reports computed when a timing component offset is uncertain', () => {
 	const input = `import React from 'react';
 import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -95,6 +95,7 @@ export const Fallback = () => <><Sequence name="First" /><Sequence name="Fallbac
 
 		expect(hook.status.props.name).toEqual({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: 'Hook',
 		});
 
@@ -105,8 +106,16 @@ export const Fallback = () => <><Sequence name="First" /><Sequence name="Fallbac
 		}
 
 		expect(create.status.props).toMatchObject({
-			name: {status: 'static', codeValue: 'Create'},
-			from: {status: 'static', codeValue: 150},
+			name: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 'Create',
+			},
+			from: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 150,
+			},
 		});
 
 		const child = getStatus('<HeroScene');
@@ -122,8 +131,16 @@ export const Fallback = () => <><Sequence name="First" /><Sequence name="Fallbac
 		}
 
 		expect(fallback.status.props).toMatchObject({
-			name: {status: 'static', codeValue: 'Fallback'},
-			from: {status: 'static', codeValue: 300},
+			name: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 'Fallback',
+			},
+			from: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 300,
+			},
 		});
 	} finally {
 		rmSync(remotionRoot, {recursive: true, force: true});
@@ -196,6 +213,7 @@ export const Example = () => {
 
 	expect(result.props.src).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: `${NoReactInternals.FILE_TOKEN}1.jpg`,
 	});
 });
@@ -229,6 +247,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.premountFor).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 60,
 		numericExpression: {
 			type: 'video-config-multiplication',
@@ -241,6 +260,7 @@ export const Example: React.FC = () => {
 	});
 	expect(result.props.postmountFor).toMatchObject({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 75,
 		numericExpression: {
 			type: 'video-config-multiplication',
@@ -250,11 +270,13 @@ export const Example: React.FC = () => {
 	expect(result.props.from).toEqual({status: 'computed'});
 	expect(result.props.offset).toMatchObject({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: -30,
 		numericExpression: {multiplier: -1},
 	});
 	expect(result.props['style.scale']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		keyframes: [
 			{frame: 0, value: 2},
 			{
@@ -295,14 +317,17 @@ export const Example = () => {
 
 	expect(result.props['style.borderWidth']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 12,
 	});
 	expect(result.props['style.borderStyle']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'dashed',
 	});
 	expect(result.props['style.borderColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'rgba(1, 2, 3, 0.5)',
 	});
 });
@@ -343,16 +368,48 @@ export const Example = () => {
 	});
 
 	expect(numeric.props).toMatchObject({
-		'style.borderTopLeftRadius': {status: 'static', codeValue: 12},
-		'style.borderTopRightRadius': {status: 'static', codeValue: 12},
-		'style.borderBottomRightRadius': {status: 'static', codeValue: 12},
-		'style.borderBottomLeftRadius': {status: 'static', codeValue: 12},
+		'style.borderTopLeftRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 12,
+		},
+		'style.borderTopRightRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 12,
+		},
+		'style.borderBottomRightRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 12,
+		},
+		'style.borderBottomLeftRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 12,
+		},
 	});
 	expect(pixelValues.props).toMatchObject({
-		'style.borderTopLeftRadius': {status: 'static', codeValue: 10},
-		'style.borderTopRightRadius': {status: 'static', codeValue: 20},
-		'style.borderBottomRightRadius': {status: 'static', codeValue: 30},
-		'style.borderBottomLeftRadius': {status: 'static', codeValue: 40},
+		'style.borderTopLeftRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 10,
+		},
+		'style.borderTopRightRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 20,
+		},
+		'style.borderBottomRightRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 30,
+		},
+		'style.borderBottomLeftRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 40,
+		},
 	});
 });
 
@@ -388,14 +445,17 @@ export const Example = () => {
 
 	expect(getStatus(6).props['style.borderRadius']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 12,
 	});
 	expect(getStatus(7).props['style.borderRadius']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 10,
 	});
 	expect(getStatus(8).props['style.borderRadius']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 8,
 	});
 	expect(getStatus(9).props['style.borderRadius']).toEqual({
@@ -403,6 +463,7 @@ export const Example = () => {
 	});
 	expect(getStatus(9).props['style.borderTopLeftRadius']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 10,
 	});
 });
@@ -426,6 +487,7 @@ export const Example = () => {
 
 	expect(result.props['style.borderRadius']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0},
@@ -574,10 +636,12 @@ export const Example = () => {
 
 	expect(beforeShorthand.props['style.borderWidth']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 2,
 	});
 	expect(afterShorthand.props['style.borderWidth']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 8,
 	});
 });
@@ -600,14 +664,17 @@ export const Example = () => {
 
 	expect(result.props['style.borderWidth']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 3,
 	});
 	expect(result.props['style.borderStyle']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'solid',
 	});
 	expect(result.props['style.borderColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'currentColor',
 	});
 });
@@ -630,6 +697,7 @@ export const Example = () => {
 
 	expect(result.props['style.backgroundColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'rgba(1, 2, 3, 0.5)',
 	});
 });
@@ -697,10 +765,12 @@ export const Example = () => {
 
 	expect(beforeShorthand.props['style.backgroundColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'red',
 	});
 	expect(afterShorthand.props['style.backgroundColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'blue',
 	});
 });
@@ -730,6 +800,7 @@ export const Example = () => {
 
 	expect(result.props['style.backgroundColor']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'black',
 	});
 });
@@ -753,15 +824,18 @@ test('canUpdateSequenceProps should flag computed props', () => {
 
 	expect(result.props.durationInFrames).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 60,
 	});
 	expect(result.props.hueShift).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 30,
 	});
 	expect(result.props.seed).toEqual({status: 'computed'});
 	expect(result.props.nonExistentProp).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	});
 });
@@ -791,6 +865,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -855,10 +930,12 @@ export const Example: React.FC = () => {
 
 	expect(result.props.progress).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 1,
 	});
 	expect(result.props.color).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'yellow',
 	});
 });
@@ -887,6 +964,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.from).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 10,
 	});
 });
@@ -916,6 +994,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -954,6 +1033,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.opacity']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 0},
@@ -1001,6 +1081,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.translate']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: '0px 59px'},
@@ -1090,6 +1171,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.translate']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: '0px 59px'},
@@ -1160,6 +1242,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.rotate']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 55, value: '19deg'},
@@ -1209,10 +1292,12 @@ test('computeSequencePropsStatus should detect static nested props', () => {
 
 	expect(result.props['style.opacity']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.5,
 	});
 	expect(result.props['style.scale']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 2,
 	});
 });
@@ -1239,6 +1324,7 @@ test('computeSequencePropsStatus should flag computed nested props', () => {
 	// scale is static
 	expect(result.props['style.scale']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 2,
 	});
 });
@@ -1271,7 +1357,11 @@ export const Example = () => {
 
 	expect(getColorStatus(8)).toEqual({status: 'computed'});
 	expect(getColorStatus(9)).toEqual({status: 'computed'});
-	expect(getColorStatus(10)).toEqual({status: 'static', codeValue: 'red'});
+	expect(getColorStatus(10)).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: 'red',
+	});
 });
 
 test('computeSequencePropsStatus should flag computed when parent is not an object', () => {
@@ -1312,6 +1402,7 @@ test('computeSequencePropsStatus should report unset nested props as undefined',
 
 	expect(result.props['style.rotate']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	});
 });
@@ -1333,6 +1424,7 @@ test('computeSequencePropsStatus should report unset when parent attribute missi
 
 	expect(result.props['style.opacity']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	});
 });
@@ -1354,6 +1446,7 @@ test('computeSequencePropsStatus should return keyframes for interpolated style 
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 2},
@@ -1406,6 +1499,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: '1.105 1.105'},
@@ -1452,6 +1546,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -1497,6 +1592,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -1535,6 +1631,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -1573,6 +1670,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props.color).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolateColors',
 		keyframes: [
 			{frame: 0, value: 'red'},
@@ -1731,6 +1829,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [
 			{frame: 0, value: 1},
@@ -1771,6 +1870,7 @@ export const Example: React.FC = () => {
 
 	expect(result.props['style.scale']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		easing: [
 			{type: 'bezier', x1: 0.42, y1: 0, x2: 1, y2: 1},
 			{type: 'bezier', x1: 1 / 3, y1: 0, x2: 2 / 3, y2: 1 / 3},
@@ -1838,7 +1938,11 @@ export const Example: React.FC = () => {
 		effects: [],
 	});
 
-	expect(result.props.children).toEqual({status: 'static', codeValue: 'Hello'});
+	expect(result.props.children).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: 'Hello',
+	});
 });
 
 test('computeSequencePropsStatus should detect static children attribute', () => {
@@ -1858,7 +1962,11 @@ export const Example: React.FC = () => {
 		effects: [],
 	});
 
-	expect(result.props.children).toEqual({status: 'static', codeValue: 'Hello'});
+	expect(result.props.children).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: 'Hello',
+	});
 });
 
 test('computeSequencePropsStatus should prefer static children attribute over JSX children', () => {
@@ -1878,7 +1986,11 @@ export const Example: React.FC = () => {
 		effects: [],
 	});
 
-	expect(result.props.children).toEqual({status: 'static', codeValue: 'Hello'});
+	expect(result.props.children).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: 'Hello',
+	});
 });
 
 test('computeSequencePropsStatus should detect empty JSX text children', () => {
@@ -1898,7 +2010,11 @@ export const Example: React.FC = () => {
 		effects: [],
 	});
 
-	expect(result.props.children).toEqual({status: 'static', codeValue: ''});
+	expect(result.props.children).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: '',
+	});
 });
 
 test('computeSequencePropsStatus should reject non-static text children', () => {

--- a/packages/studio-server/src/test/subscribe-to-sequence-props.test.ts
+++ b/packages/studio-server/src/test/subscribe-to-sequence-props.test.ts
@@ -119,6 +119,7 @@ export const Second = () => {
 			expect(result.nodePath.nodePath).toEqual(expectedNodePaths[index]);
 			expect(result.status.props.name).toEqual({
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: expectedNames[index],
 			});
 		}

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -660,7 +660,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.scale']).toMatchObject({
 		status: 'keyframed',
-		keyframeDisplayOffsetAdjustment: null,
+		keyframeDisplayOffsetAdjustment: 0,
 		easing: [{type: 'step1'}],
 	});
 });
@@ -1263,7 +1263,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.translate']).toEqual({
 		status: 'keyframed',
-		keyframeDisplayOffsetAdjustment: null,
+		keyframeDisplayOffsetAdjustment: 0,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 44, value: '100px 20px'}],
 		easing: [],
@@ -1414,7 +1414,7 @@ export default CenteredSolid;
 	});
 	expect(status.props.width).toEqual({
 		status: 'keyframed',
-		keyframeDisplayOffsetAdjustment: null,
+		keyframeDisplayOffsetAdjustment: 0,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 11, value: 240}],
 		easing: [],

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -82,6 +82,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.scale']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		keyframes: [
 			{frame: 0, value: 2},
 			{frame: 50, value: 2.5},
@@ -132,6 +133,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.opacity']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		keyframes: [
 			{frame: 1, value: 0.35},
 			{frame: 160, value: 1},
@@ -177,6 +179,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.opacity']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		keyframes: [
 			{frame: 0, value: 0.35},
 			{
@@ -657,6 +660,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.scale']).toMatchObject({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		easing: [{type: 'step1'}],
 	});
 });
@@ -1259,6 +1263,7 @@ export const Example: React.FC = () => {
 	});
 	expect(status.props['style.translate']).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 44, value: '100px 20px'}],
 		easing: [],
@@ -1409,6 +1414,7 @@ export default CenteredSolid;
 	});
 	expect(status.props.width).toEqual({
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 11, value: 240}],
 		easing: [],
@@ -1678,6 +1684,7 @@ test('updateSequenceKeyframes converts the last keyframe to a static value', asy
 	});
 	expect(status.props['style.scale']).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 320,
 	});
 });
@@ -1919,6 +1926,7 @@ test('updateSequenceKeyframes converts the last color keyframe to a static value
 	});
 	expect(status.props.color).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'blue',
 	});
 });

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -100,12 +100,7 @@ const addKeyframeToPropStatus = ({
 
 		return {
 			status: 'keyframed',
-			...(status.keyframeDisplayOffsetAdjustment === undefined
-				? {}
-				: {
-						keyframeDisplayOffsetAdjustment:
-							status.keyframeDisplayOffsetAdjustment,
-					}),
+			keyframeDisplayOffsetAdjustment: status.keyframeDisplayOffsetAdjustment,
 			interpolationFunction: getKeyframeInterpolationFunction({
 				schema,
 				key: fieldKey,
@@ -158,12 +153,14 @@ const getMissingPropStatus = ({
 	if (field && field.type !== 'hidden' && field.default !== undefined) {
 		return {
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: field.default,
 		};
 	}
 
 	return {
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: undefined,
 	};
 };

--- a/packages/studio-shared/src/optimistic-add-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-add-keyframe.ts
@@ -100,6 +100,12 @@ const addKeyframeToPropStatus = ({
 
 		return {
 			status: 'keyframed',
+			...(status.keyframeDisplayOffsetAdjustment === undefined
+				? {}
+				: {
+						keyframeDisplayOffsetAdjustment:
+							status.keyframeDisplayOffsetAdjustment,
+					}),
 			interpolationFunction: getKeyframeInterpolationFunction({
 				schema,
 				key: fieldKey,

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -43,12 +43,7 @@ const removeKeyframeFromPropStatus = ({
 	if (keyframes.length === 0) {
 		return {
 			status: 'static',
-			...(status.keyframeDisplayOffsetAdjustment === undefined
-				? {}
-				: {
-						keyframeDisplayOffsetAdjustment:
-							status.keyframeDisplayOffsetAdjustment,
-					}),
+			keyframeDisplayOffsetAdjustment: status.keyframeDisplayOffsetAdjustment,
 			codeValue:
 				valueWhenLastKeyframeDeleted === null
 					? status.keyframes[index].value

--- a/packages/studio-shared/src/optimistic-delete-keyframe.ts
+++ b/packages/studio-shared/src/optimistic-delete-keyframe.ts
@@ -43,6 +43,12 @@ const removeKeyframeFromPropStatus = ({
 	if (keyframes.length === 0) {
 		return {
 			status: 'static',
+			...(status.keyframeDisplayOffsetAdjustment === undefined
+				? {}
+				: {
+						keyframeDisplayOffsetAdjustment:
+							status.keyframeDisplayOffsetAdjustment,
+					}),
 			codeValue:
 				valueWhenLastKeyframeDeleted === null
 					? status.keyframes[index].value

--- a/packages/studio-shared/src/optimistic-update-for-effect-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-effect-prop-statuses.ts
@@ -37,7 +37,11 @@ export const optimisticUpdateForEffectPropStatuses = ({
 
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...target.props,
-		[fieldKey]: {status: 'static', codeValue: value},
+		[fieldKey]: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: value,
+		},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
+++ b/packages/studio-shared/src/optimistic-update-for-prop-statuses.ts
@@ -30,7 +30,11 @@ export const optimisticUpdateForPropStatuses = ({
 
 	const props: Record<string, CanUpdateSequencePropStatus> = {
 		...previous.props,
-		[fieldKey]: {status: 'static', codeValue: optimisticValue},
+		[fieldKey]: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: optimisticValue,
+		},
 	};
 
 	if (schema[fieldKey]?.type === 'enum') {

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -84,6 +84,7 @@ test('optimisticAddSequenceKeyframe uses interpolate for translate fields', () =
 		props: {
 			'style.translate': {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: '0px 59px',
 			},
 		},
@@ -124,6 +125,7 @@ test('optimisticAddSequenceKeyframe uses interpolate for rotation-css fields', (
 		props: {
 			'style.rotate': {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: '0deg',
 			},
 		},
@@ -164,6 +166,7 @@ test('optimisticAddSequenceKeyframe ignores non-keyframable fields', () => {
 		props: {
 			playbackRate: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 1,
 			},
 		},
@@ -195,6 +198,7 @@ test('optimisticAddSequenceKeyframe ignores enum fields', () => {
 		props: {
 			layout: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'absolute-fill',
 			},
 		},
@@ -237,7 +241,11 @@ test('optimisticAddSequenceKeyframe uses hold easing for enabled enum fields', (
 	const initial: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {
-			cursor: {status: 'static', codeValue: 'default'},
+			cursor: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 'default',
+			},
 		},
 		effects: [],
 	};
@@ -279,6 +287,7 @@ test('optimisticAddSequenceKeyframe appends a keyframe to an existing interpolat
 		props: {
 			scale: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -323,6 +332,7 @@ test('optimisticAddSequenceKeyframe duplicates the easing for the split segment'
 		props: {
 			scale: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -370,6 +380,7 @@ test('optimisticAddSequenceKeyframe uses linear easing outside the keyframe rang
 		props: {
 			scale: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -412,6 +423,7 @@ test('optimisticAddSequenceKeyframe updates an existing keyframe at the same fra
 		props: {
 			scale: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 1},
@@ -462,6 +474,7 @@ test('optimisticAddEffectKeyframe appends a keyframe on the target effect', () =
 				props: {
 					amount: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 0, value: 0.2}],
 						easing: [],
@@ -515,6 +528,7 @@ test('optimisticAddEffectKeyframe converts a static prop to a single keyframe', 
 				props: {
 					amount: {
 						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
 						codeValue: 0.2,
 					},
 				},

--- a/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-add-keyframe.test.ts
@@ -15,6 +15,7 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 			opacity: {
 				status: 'static',
 				codeValue: 0.5,
+				keyframeDisplayOffsetAdjustment: 5,
 			},
 		},
 		effects: [],
@@ -39,6 +40,7 @@ test('optimisticAddSequenceKeyframe converts a static prop to a single keyframe'
 	expect(status.keyframes).toEqual([{frame: 25, value: 0.75}]);
 	expect(status.easing).toEqual([]);
 	expect(status.clamping).toEqual({left: 'clamp', right: 'clamp'});
+	expect(status.keyframeDisplayOffsetAdjustment).toBe(5);
 });
 
 test('optimisticAddSequenceKeyframe adds a missing prop before keyframing it', () => {

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -13,6 +13,7 @@ test('optimisticDeleteSequenceKeyframe removes the matching keyframe and an easi
 		props: {
 			'style.opacity': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},
@@ -56,6 +57,7 @@ test('optimisticDeleteSequenceKeyframe preserves the left segment easing when re
 		props: {
 			'style.opacity': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},
@@ -138,6 +140,7 @@ test('optimisticDeleteSequenceKeyframe is a no-op when no keyframe matches', () 
 		props: {
 			'style.opacity': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 0}],
 				easing: [],
@@ -181,6 +184,7 @@ test('optimisticDeleteSequenceKeyframes deletes multiple keyframes in one pass',
 		props: {
 			width: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 100},
@@ -223,6 +227,7 @@ test('optimisticDeleteSequenceKeyframes uses the playhead value when deleting al
 		props: {
 			width: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 100},
@@ -255,6 +260,7 @@ test('optimisticDeleteSequenceKeyframes uses the playhead value when deleting al
 
 	expect(updated.canUpdate && updated.props.width).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 150,
 	});
 });
@@ -272,6 +278,7 @@ test('optimisticDeleteEffectKeyframe removes the matching keyframe on the target
 				props: {
 					amount: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -325,6 +332,7 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 				props: {
 					amount: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [{frame: 40, value: 0.6}],
 						easing: [],
@@ -355,6 +363,7 @@ test('optimisticDeleteEffectKeyframe converts the last keyframe on the target ef
 
 	expect(effect.props.amount).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.6,
 	});
 });
@@ -389,6 +398,7 @@ test('optimisticDeleteEffectKeyframes deletes multiple keyframes in one pass', (
 				props: {
 					amount: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -444,6 +454,7 @@ test('optimisticDeleteEffectKeyframes uses the playhead value when deleting all 
 				props: {
 					amount: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 0, value: 0},
@@ -480,6 +491,7 @@ test('optimisticDeleteEffectKeyframes uses the playhead value when deleting all 
 	const effect = updated.canUpdate ? updated.effects[0] : null;
 	expect(effect?.canUpdate && effect.props.amount).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.5,
 	});
 });

--- a/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-delete-keyframe.test.ts
@@ -103,6 +103,7 @@ test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static va
 		props: {
 			width: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: 5,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 12, value: 320}],
 				easing: [],
@@ -127,6 +128,7 @@ test('optimisticDeleteSequenceKeyframe converts the last keyframe to a static va
 	expect(updated.props.width).toEqual({
 		status: 'static',
 		codeValue: 320,
+		keyframeDisplayOffsetAdjustment: 5,
 	});
 });
 

--- a/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
+++ b/packages/studio-shared/src/test/optimistic-move-keyframe.test.ts
@@ -11,6 +11,7 @@ const previous: CanUpdateSequencePropsResponse = {
 	props: {
 		scale: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 1},
@@ -32,6 +33,7 @@ const previous: CanUpdateSequencePropsResponse = {
 			props: {
 				amount: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0.2},

--- a/packages/studio-shared/src/test/optimistic-update-for-effect-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-effect-prop-statuses.test.ts
@@ -11,8 +11,16 @@ test('optimisticUpdateForEffectPropStatuses updates the matching effect prop', (
 				canUpdate: true,
 				effectIndex: 0,
 				props: {
-					color: {status: 'static', codeValue: 'red'},
-					opacity: {status: 'static', codeValue: 0.5},
+					color: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 'red',
+					},
+					opacity: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 0.5,
+					},
 				},
 				callee: 'tint',
 				importPath: null,
@@ -39,10 +47,12 @@ test('optimisticUpdateForEffectPropStatuses updates the matching effect prop', (
 
 	expect(effect.props.opacity).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.8,
 	});
 	expect(effect.props.color).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 'red',
 	});
 });
@@ -93,7 +103,11 @@ test('optimisticUpdateForEffectPropStatuses applies when effect props are unset 
 				callee: 'tint',
 				importPath: null,
 				props: {
-					amount: {status: 'static', codeValue: undefined},
+					amount: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: undefined,
+					},
 				},
 			},
 		],
@@ -118,6 +132,7 @@ test('optimisticUpdateForEffectPropStatuses applies when effect props are unset 
 
 	expect(effect.props.amount).toEqual({
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 0.5,
 	});
 });

--- a/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-for-prop-statuses.test.ts
@@ -9,6 +9,7 @@ test('optimisticUpdateForPropStatuses should return the correct response', () =>
 		props: {
 			'style.opacity': {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 0.5,
 			},
 		},
@@ -26,6 +27,7 @@ test('optimisticUpdateForPropStatuses should return the correct response', () =>
 		props: {
 			'style.opacity': {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 0.6,
 			},
 		},
@@ -43,6 +45,7 @@ test('optimisticUpdateForPropStatuses should return the correct response', () =>
 		props: {
 			layout: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'none',
 			},
 		},
@@ -56,6 +59,7 @@ test('optimisticUpdateForPropStatuses should use undefined for removed default v
 		props: {
 			name: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: 'hehe',
 			},
 		},
@@ -75,6 +79,7 @@ test('optimisticUpdateForPropStatuses should use undefined for removed default v
 		props: {
 			name: {
 				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: undefined,
 			},
 		},

--- a/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
@@ -10,6 +10,7 @@ const previous: CanUpdateSequencePropsResponse = {
 	props: {
 		scale: {
 			status: 'keyframed',
+			keyframeDisplayOffsetAdjustment: null,
 			interpolationFunction: 'interpolate',
 			keyframes: [
 				{frame: 0, value: 1},
@@ -31,6 +32,7 @@ const previous: CanUpdateSequencePropsResponse = {
 			props: {
 				amount: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0.2},

--- a/packages/studio-shared/src/test/schema-field-info.test.ts
+++ b/packages/studio-shared/src/test/schema-field-info.test.ts
@@ -93,10 +93,15 @@ const borderRadiusSchema = {
 const getBorderRadiusFields = (
 	props: Record<
 		string,
-		| {status: 'static'; codeValue: unknown}
+		| {
+				status: 'static';
+				keyframeDisplayOffsetAdjustment: null;
+				codeValue: unknown;
+		  }
 		| {status: 'computed'}
 		| {
 				status: 'keyframed';
+				keyframeDisplayOffsetAdjustment: null;
 				interpolationFunction: 'interpolate';
 				keyframes: {frame: number; value: number}[];
 				easing: [];
@@ -138,6 +143,7 @@ test('getEffectFieldsToShow uses the active enum variant', () => {
 						props: {
 							colorMode: {
 								status: 'static',
+								keyframeDisplayOffsetAdjustment: null,
 								codeValue: 'source',
 							},
 						},
@@ -204,6 +210,7 @@ test('getEffectFieldsToShow sizes array fields from the current value', () => {
 						props: {
 							colors: {
 								status: 'static',
+								keyframeDisplayOffsetAdjustment: null,
 								codeValue: ['red', 'green', 'blue'],
 							},
 						},
@@ -417,20 +424,60 @@ test('getFieldsToShow selects one border radius representation', () => {
 	expect(getBorderRadiusFields({})).toEqual(['style.borderRadius']);
 	expect(
 		getBorderRadiusFields({
-			'style.borderRadius': {status: 'static', codeValue: 12},
-			'style.borderTopLeftRadius': {status: 'static', codeValue: 12},
-			'style.borderTopRightRadius': {status: 'static', codeValue: 12},
-			'style.borderBottomRightRadius': {status: 'static', codeValue: 12},
-			'style.borderBottomLeftRadius': {status: 'static', codeValue: 12},
+			'style.borderRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
+			'style.borderTopLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
+			'style.borderTopRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
+			'style.borderBottomRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
+			'style.borderBottomLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
 		}),
 	).toEqual(['style.borderRadius']);
 	expect(
 		getBorderRadiusFields({
-			'style.borderRadius': {status: 'static', codeValue: undefined},
-			'style.borderTopLeftRadius': {status: 'static', codeValue: 4},
-			'style.borderTopRightRadius': {status: 'static', codeValue: 8},
-			'style.borderBottomRightRadius': {status: 'static', codeValue: 12},
-			'style.borderBottomLeftRadius': {status: 'static', codeValue: 16},
+			'style.borderRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: undefined,
+			},
+			'style.borderTopLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 4,
+			},
+			'style.borderTopRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 8,
+			},
+			'style.borderBottomRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
+			'style.borderBottomLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 16,
+			},
 		}),
 	).toEqual([
 		'style.borderTopLeftRadius',
@@ -442,6 +489,7 @@ test('getFieldsToShow selects one border radius representation', () => {
 		getBorderRadiusFields({
 			'style.borderRadius': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 0},

--- a/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
+++ b/packages/studio/src/components/InspectorPanel/AlignmentControls.tsx
@@ -15,6 +15,7 @@ import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {getSelectedOutlineActiveSchema} from '../selected-outline-drag';
 import {translateFieldKey} from '../selected-outline-types';
 import {callAddSequenceKeyframe} from '../Timeline/call-add-keyframe';
+import {getKeyframeDisplayOffset} from '../Timeline/get-timeline-keyframes';
 import {saveSequenceProps} from '../Timeline/save-sequence-prop';
 import {
 	parseTranslate,
@@ -115,7 +116,15 @@ export const AlignmentControls: React.FC<{
 				propStatuses,
 				nodePath,
 			);
-			const sourceFrame = timelinePosition - track.keyframeDisplayOffset;
+			const firstKeyframedStatus = Object.values(nodePropStatuses ?? {}).find(
+				(status) => status.status === 'keyframed',
+			);
+			const sourceFrame =
+				timelinePosition -
+				getKeyframeDisplayOffset({
+					propStatus: firstKeyframedStatus,
+					keyframeDisplayOffset: track.keyframeDisplayOffset,
+				});
 			const dragOverrides = getDragOverrides(nodePath) ?? {};
 
 			const activeSchema = getSelectedOutlineActiveSchema({
@@ -256,7 +265,15 @@ export const AlignmentControls: React.FC<{
 		propStatuses,
 		renderNodePath,
 	);
-	const renderSourceFrame = timelinePosition - track.keyframeDisplayOffset;
+	const firstRenderKeyframedStatus = Object.values(
+		renderNodePropStatuses ?? {},
+	).find((status) => status.status === 'keyframed');
+	const renderSourceFrame =
+		timelinePosition -
+		getKeyframeDisplayOffset({
+			propStatus: firstRenderKeyframedStatus,
+			keyframeDisplayOffset: track.keyframeDisplayOffset,
+		});
 	const renderDragOverrides = getDragOverrides(renderNodePath) ?? {};
 
 	const renderActiveSchema = getSelectedOutlineActiveSchema({

--- a/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
@@ -15,6 +15,7 @@ import {
 	callAddSequenceKeyframe,
 } from '../Timeline/call-add-keyframe';
 import {EasingEditor} from '../Timeline/EasingEditorModal';
+import {getKeyframeDisplayOffset} from '../Timeline/get-timeline-keyframes';
 import {
 	getTimelineSelectionFromNodePathInfo,
 	getTimelineSelectionKey,
@@ -176,6 +177,13 @@ export const EasingInspector: React.FC<{
 			segmentIndex: easingUpdate.segmentIndex,
 		});
 	}, [easingUpdate, selection.nodePathInfo, track]);
+	const easingKeyframeDisplayOffset =
+		easingUpdate === null || track === null
+			? 0
+			: getKeyframeDisplayOffset({
+					propStatus: easingUpdate.propStatus,
+					keyframeDisplayOffset: track.keyframeDisplayOffset,
+				});
 
 	const state = useMemo(() => {
 		if (initialEasing === null || currentEasingSelection === null) {
@@ -223,7 +231,7 @@ export const EasingInspector: React.FC<{
 				return;
 			}
 
-			const sourceFrame = timelinePosition - track.keyframeDisplayOffset;
+			const sourceFrame = timelinePosition - easingKeyframeDisplayOffset;
 			const value = Internals.getEffectiveVisualModeValue({
 				propStatus: easingUpdate.propStatus,
 				dragOverrideValue: easingDetails.dragOverrideValue,
@@ -274,6 +282,7 @@ export const EasingInspector: React.FC<{
 			setPropStatuses,
 			timelinePosition,
 			track,
+			easingKeyframeDisplayOffset,
 		],
 	);
 
@@ -294,7 +303,7 @@ export const EasingInspector: React.FC<{
 						includeEasings
 						keyframes={easingUpdate.propStatus.keyframes.map((keyframe) => ({
 							...keyframe,
-							frame: keyframe.frame + track.keyframeDisplayOffset,
+							frame: keyframe.frame + easingKeyframeDisplayOffset,
 						}))}
 						nodePathInfo={selection.nodePathInfo}
 					/>
@@ -309,6 +318,7 @@ export const EasingInspector: React.FC<{
 			parentSelection,
 			selection,
 			track,
+			easingKeyframeDisplayOffset,
 		],
 	);
 

--- a/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
@@ -33,6 +33,7 @@ import {
 } from '../Timeline/call-delete-keyframe';
 import {callMoveKeyframes} from '../Timeline/call-move-keyframe';
 import {getEasingSelectionAfterKeyframeDelete} from '../Timeline/get-easing-selection-after-keyframe-delete';
+import {getKeyframeDisplayOffset} from '../Timeline/get-timeline-keyframes';
 import {getCurrentFrame} from '../Timeline/imperative-state';
 import {parseKeyframeFieldFromNodePath} from '../Timeline/parse-keyframe-field-from-node-path';
 import {TimelineEffectPropValue} from '../Timeline/TimelineEffectPropItem';
@@ -184,7 +185,6 @@ export const KeyframeInspector: React.FC<{
 
 		const nodePath = selection.nodePathInfo.sequenceSubscriptionKey;
 		const {keyframeDisplayOffset} = track;
-		const sourceFrame = selection.frame - keyframeDisplayOffset;
 
 		if (keyframeField.type === 'sequence') {
 			const sequenceFields = getFieldsToShow({
@@ -213,11 +213,19 @@ export const KeyframeInspector: React.FC<{
 				field: sequenceField,
 				fieldLabel: sequenceField.description ?? sequenceField.key,
 				fileName: nodePath.absolutePath,
-				keyframeDisplayOffset,
+				keyframeDisplayOffset: getKeyframeDisplayOffset({
+					propStatus: sequencePropStatus,
+					keyframeDisplayOffset,
+				}),
 				nodePath,
 				propStatus: sequencePropStatus,
 				schema: track.sequence.controls.schema,
-				sourceFrame,
+				sourceFrame:
+					selection.frame -
+					getKeyframeDisplayOffset({
+						propStatus: sequencePropStatus,
+						keyframeDisplayOffset,
+					}),
 			};
 		}
 
@@ -257,11 +265,19 @@ export const KeyframeInspector: React.FC<{
 			field: effectField,
 			fieldLabel: effectField.description ?? effectField.key,
 			fileName: nodePath.absolutePath,
-			keyframeDisplayOffset,
+			keyframeDisplayOffset: getKeyframeDisplayOffset({
+				propStatus: effectPropStatus,
+				keyframeDisplayOffset,
+			}),
 			nodePath,
 			propStatus: effectPropStatus,
 			schema: effect.schema,
-			sourceFrame,
+			sourceFrame:
+				selection.frame -
+				getKeyframeDisplayOffset({
+					propStatus: effectPropStatus,
+					keyframeDisplayOffset,
+				}),
 			validatedLocation: {
 				source: nodePath.absolutePath,
 				line: 1,

--- a/packages/studio/src/components/InspectorPanel/easing-inspector-selection.ts
+++ b/packages/studio/src/components/InspectorPanel/easing-inspector-selection.ts
@@ -1,5 +1,6 @@
 import type {CanUpdateSequencePropStatusKeyframed} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {getKeyframeDisplayOffset as resolveKeyframeDisplayOffset} from '../Timeline/get-timeline-keyframes';
 import type {TimelineEasingSelection} from '../Timeline/TimelineSelection';
 
 export const getEasingSelectionFromCurrentKeyframes = ({
@@ -19,11 +20,16 @@ export const getEasingSelectionFromCurrentKeyframes = ({
 		return null;
 	}
 
+	const resolvedKeyframeDisplayOffset = resolveKeyframeDisplayOffset({
+		propStatus,
+		keyframeDisplayOffset,
+	});
+
 	return {
 		type: 'easing',
 		nodePathInfo,
-		fromFrame: fromKeyframe.frame + keyframeDisplayOffset,
-		toFrame: toKeyframe.frame + keyframeDisplayOffset,
+		fromFrame: fromKeyframe.frame + resolvedKeyframeDisplayOffset,
+		toFrame: toKeyframe.frame + resolvedKeyframeDisplayOffset,
 		segmentIndex,
 	};
 };

--- a/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
+++ b/packages/studio/src/components/InspectorPanel/inspector-section-collapse.ts
@@ -10,7 +10,11 @@ export type SmartCollapsibleInspectorGroup = Extract<
 export type InspectorSectionActivity = 'active' | 'inactive' | 'unknown';
 
 type InspectorSectionPropStatus =
-	| {readonly status: 'static'; readonly codeValue: unknown}
+	| {
+			readonly status: 'static';
+			readonly keyframeDisplayOffsetAdjustment: number | null;
+			readonly codeValue: unknown;
+	  }
 	| {readonly status: 'computed' | 'keyframed'};
 
 const BORDER_KEYS = [

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -55,6 +55,7 @@ import {
 } from './selected-outline-types';
 import {SelectedOutlineKeyboardControls} from './SelectedOutlineKeyboardControls';
 import {SelectedOutlineRenderer} from './SelectedOutlineRenderer';
+import {getKeyframeDisplayOffset} from './Timeline/get-timeline-keyframes';
 import {
 	useTimelineSelection,
 	type TimelineSelection,
@@ -305,7 +306,14 @@ const calculateOutlineTargets = ({
 			propStatuses,
 			nodePath,
 		);
-		const sourceFrame = targetTimelinePosition - keyframeDisplayOffset;
+		const firstKeyframedStatus = Object.values(nodePropStatuses ?? {}).find(
+			(status) => status.status === 'keyframed',
+		);
+		const nodeKeyframeDisplayOffset = getKeyframeDisplayOffset({
+			propStatus: firstKeyframedStatus,
+			keyframeDisplayOffset,
+		});
+		const sourceFrame = targetTimelinePosition - nodeKeyframeDisplayOffset;
 		const dragOverrides = getDragOverrides(nodePath) ?? {};
 		const runtimeValues = controls
 			? (runtimeValuesByStore.get(controls.runtimeValues) ??
@@ -387,7 +395,7 @@ const calculateOutlineTargets = ({
 			key,
 			containsSelection,
 			crop,
-			keyframeDisplayOffset,
+			keyframeDisplayOffset: nodeKeyframeDisplayOffset,
 			nodePathInfo,
 			ref: sequence.refForOutline,
 			selected,
@@ -457,7 +465,11 @@ const calculateOutlineTargets = ({
 			selectedTransformOriginInfo?.displayFrame === null ||
 			selectedTransformOriginInfo?.displayFrame === undefined
 				? sourceFrame
-				: selectedTransformOriginInfo.displayFrame - keyframeDisplayOffset;
+				: selectedTransformOriginInfo.displayFrame -
+					getKeyframeDisplayOffset({
+						propStatus: transformOriginPropStatus,
+						keyframeDisplayOffset,
+					});
 		const canTransformOriginStatus =
 			transformOriginPropStatus?.status === 'static' ||
 			(transformOriginPropStatus?.status === 'keyframed' &&
@@ -478,7 +490,7 @@ const calculateOutlineTargets = ({
 			selectedCropInfo?.displayFrame === null ||
 			selectedCropInfo?.displayFrame === undefined
 				? sourceFrame
-				: selectedCropInfo.displayFrame - keyframeDisplayOffset;
+				: selectedCropInfo.displayFrame - nodeKeyframeDisplayOffset;
 		const canCropDrag =
 			previewInteractive &&
 			selectedForCrop &&
@@ -511,7 +523,10 @@ const calculateOutlineTargets = ({
 							propStatus,
 							clientId: connectedClientId,
 							fieldDefault: fieldSchema.default,
-							keyframeDisplayOffset,
+							keyframeDisplayOffset: getKeyframeDisplayOffset({
+								propStatus,
+								keyframeDisplayOffset,
+							}),
 							nodePath,
 							schema: controls.schema,
 						}
@@ -522,7 +537,10 @@ const calculateOutlineTargets = ({
 							clientId: connectedClientId,
 							fieldDefault: scaleFieldSchema.default,
 							fieldSchema: scaleFieldSchema,
-							keyframeDisplayOffset,
+							keyframeDisplayOffset: getKeyframeDisplayOffset({
+								propStatus: scalePropStatus,
+								keyframeDisplayOffset,
+							}),
 							linked: getScaleLockState({
 								nodePath,
 								fieldKey: scaleFieldKey,
@@ -549,7 +567,10 @@ const calculateOutlineTargets = ({
 							clientId: connectedClientId,
 							fieldDefault: rotationFieldSchema.default,
 							fieldSchema: rotationFieldSchema,
-							keyframeDisplayOffset,
+							keyframeDisplayOffset: getKeyframeDisplayOffset({
+								propStatus: rotationPropStatus,
+								keyframeDisplayOffset,
+							}),
 							nodePath,
 							schema: controls.schema,
 							transform3DMode,
@@ -559,7 +580,10 @@ const calculateOutlineTargets = ({
 				transformOriginDrag: canTransformOriginDrag
 					? {
 							clientId: connectedClientId,
-							keyframeDisplayOffset,
+							keyframeDisplayOffset: getKeyframeDisplayOffset({
+								propStatus: transformOriginPropStatus,
+								keyframeDisplayOffset,
+							}),
 							nodePath,
 							originDefault: transformOriginFieldSchema.default,
 							originPropStatus: transformOriginPropStatus,

--- a/packages/studio/src/components/Timeline/TimelineArrayField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineArrayField.tsx
@@ -236,6 +236,7 @@ const ItemEditor: React.FC<{
 	const propStatus = useMemo<CanUpdateSequencePropStatusStatic>(
 		() => ({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: value,
 		}),
 		[value],

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -19,7 +19,10 @@ import {callApi} from '../call-api';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddEffectKeyframe} from './call-add-keyframe';
-import {getComputedStatusLabel} from './get-timeline-keyframes';
+import {
+	getComputedStatusLabel,
+	getKeyframeDisplayOffset,
+} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
@@ -408,6 +411,10 @@ export const TimelineEffectPropItem: React.FC<{
 		effectStatus.type === 'can-update-effect'
 			? (effectStatus.props?.[field.key] ?? null)
 			: null;
+	const resolvedKeyframeDisplayOffset = getKeyframeDisplayOffset({
+		propStatus,
+		keyframeDisplayOffset,
+	});
 
 	const dragOverrideValue = useMemo(() => {
 		const overrides = getEffectDragOverrides(nodePath, field.effectIndex);
@@ -567,7 +574,7 @@ export const TimelineEffectPropItem: React.FC<{
 					field={field}
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
-					keyframeDisplayOffset={keyframeDisplayOffset}
+					keyframeDisplayOffset={resolvedKeyframeDisplayOffset}
 				/>
 			</TimelineFieldRowContent>
 		</TimelineRowChrome>

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -38,7 +38,10 @@ import {
 	getPreviousKeyframeDisplayFrame,
 	hasKeyframeAtSourceFrame,
 } from './get-keyframe-navigation';
-import {getTimelineKeyframes} from './get-timeline-keyframes';
+import {
+	getKeyframeDisplayOffset,
+	getTimelineKeyframes,
+} from './get-timeline-keyframes';
 import {TimelineKeyframeDiamondIcon} from './TimelineKeyframeDiamondIcon';
 import {useTimelineKeyframeTracks} from './TimelineKeyframeTracksContext';
 import {
@@ -271,8 +274,16 @@ const resolveKeyframeControlTarget = ({
 			propStatus: sequenceSelectedPropStatus,
 			nodePath,
 			fileName: nodePath.absolutePath,
-			keyframeDisplayOffset: track.keyframeDisplayOffset,
-			sourceFrame: timelinePosition - track.keyframeDisplayOffset,
+			keyframeDisplayOffset: getKeyframeDisplayOffset({
+				propStatus: sequenceSelectedPropStatus,
+				keyframeDisplayOffset: track.keyframeDisplayOffset,
+			}),
+			sourceFrame:
+				timelinePosition -
+				getKeyframeDisplayOffset({
+					propStatus: sequenceSelectedPropStatus,
+					keyframeDisplayOffset: track.keyframeDisplayOffset,
+				}),
 			defaultValue: fieldNode.field.fieldSchema.default,
 			dragOverrideValue: (getDragOverrides(nodePath) ?? {})[
 				fieldNode.field.key
@@ -301,8 +312,16 @@ const resolveKeyframeControlTarget = ({
 		propStatus: effectSelectedPropStatus,
 		nodePath,
 		fileName: nodePath.absolutePath,
-		keyframeDisplayOffset: track.keyframeDisplayOffset,
-		sourceFrame: timelinePosition - track.keyframeDisplayOffset,
+		keyframeDisplayOffset: getKeyframeDisplayOffset({
+			propStatus: effectSelectedPropStatus,
+			keyframeDisplayOffset: track.keyframeDisplayOffset,
+		}),
+		sourceFrame:
+			timelinePosition -
+			getKeyframeDisplayOffset({
+				propStatus: effectSelectedPropStatus,
+				keyframeDisplayOffset: track.keyframeDisplayOffset,
+			}),
 		defaultValue: fieldNode.field.fieldSchema.default,
 		dragOverrideValue: getEffectDragOverrides(
 			nodePath,
@@ -512,7 +531,11 @@ export const TimelineKeyframeControls: React.FC<{
 			? previewServerState.clientId
 			: null;
 
-	const jsxFrame = timelinePosition - keyframeDisplayOffset;
+	const resolvedKeyframeDisplayOffset = getKeyframeDisplayOffset({
+		propStatus,
+		keyframeDisplayOffset,
+	});
+	const jsxFrame = timelinePosition - resolvedKeyframeDisplayOffset;
 	const keyframes = useMemo(
 		() => getTimelineKeyframes(propStatus, keyframeDisplayOffset),
 		[propStatus, keyframeDisplayOffset],
@@ -590,7 +613,7 @@ export const TimelineKeyframeControls: React.FC<{
 			propStatus,
 			nodePath,
 			fileName,
-			keyframeDisplayOffset,
+			keyframeDisplayOffset: resolvedKeyframeDisplayOffset,
 			sourceFrame: jsxFrame,
 			defaultValue,
 			dragOverrideValue,
@@ -604,7 +627,7 @@ export const TimelineKeyframeControls: React.FC<{
 			fieldKey,
 			fileName,
 			jsxFrame,
-			keyframeDisplayOffset,
+			resolvedKeyframeDisplayOffset,
 			nodePath,
 			nodePathInfo,
 			propStatus,

--- a/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframedValue.tsx
@@ -52,6 +52,7 @@ export const TimelineKeyframedValue: React.FC<{
 	const fakeStatus: CanUpdateSequencePropStatusStatic = useMemo(
 		() => ({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: computedValue,
 		}),
 		[computedValue],

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -25,6 +25,7 @@ import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getSequencePropResetChanges} from './get-sequence-prop-reset-changes';
+import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {saveSequenceProps} from './save-sequence-prop';
 import {isTimelineFieldStacked} from './timeline-field-row-layout';
 import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
@@ -291,11 +292,15 @@ const TimelineSequenceKeyframedValueAtCurrentFrame: React.FC<
 	}
 > = ({keyframeDisplayOffset, ...props}) => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
+	const resolvedKeyframeDisplayOffset = getKeyframeDisplayOffset({
+		propStatus: props.propStatus,
+		keyframeDisplayOffset,
+	});
 
 	return (
 		<TimelineSequenceKeyframedValueAtSourceFrame
 			{...props}
-			sourceFrame={timelinePosition - keyframeDisplayOffset}
+			sourceFrame={timelinePosition - resolvedKeyframeDisplayOffset}
 		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -89,7 +89,10 @@ export type TimelineSequenceFromDragTarget = {
 };
 
 type TimelineSequenceKeyframeDragTarget = {
+	readonly fileName: string;
 	readonly fieldKey: string;
+	readonly isDescendant: boolean;
+	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: InteractivitySchema;
 	readonly status: CanUpdateSequencePropStatusKeyframed;
 };
@@ -103,10 +106,12 @@ const getKeyframedSequenceDragTargets = ({
 	nodePath,
 	sequence,
 	propStatuses,
+	isDescendant,
 }: {
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly sequence: TSequence;
 	readonly propStatuses: PropStatuses;
+	readonly isDescendant: boolean;
 }): {
 	readonly effectKeyframes: TimelineSequenceEffectKeyframeDragTarget[];
 	readonly sequenceKeyframes: TimelineSequenceKeyframeDragTarget[];
@@ -122,8 +127,18 @@ const getKeyframedSequenceDragTargets = ({
 		sequenceSchema === undefined
 			? []
 			: Object.entries(status.props).flatMap(([fieldKey, propStatus]) =>
-					propStatus.status === 'keyframed'
-						? [{fieldKey, schema: sequenceSchema, status: propStatus}]
+					propStatus.status === 'keyframed' &&
+					(!isDescendant || propStatus.keyframeDisplayOffsetAdjustment !== null)
+						? [
+								{
+									fileName: nodePath.absolutePath,
+									fieldKey,
+									isDescendant,
+									nodePath,
+									schema: sequenceSchema,
+									status: propStatus,
+								},
+							]
 						: [],
 				);
 
@@ -139,11 +154,15 @@ const getKeyframedSequenceDragTargets = ({
 
 		return Object.entries(effectStatus.props).flatMap(
 			([fieldKey, propStatus]) =>
-				propStatus.status === 'keyframed'
+				propStatus.status === 'keyframed' &&
+				(!isDescendant || propStatus.keyframeDisplayOffsetAdjustment !== null)
 					? [
 							{
 								effectIndex: effectStatus.effectIndex,
+								fileName: nodePath.absolutePath,
 								fieldKey,
+								isDescendant,
+								nodePath,
 								schema: effectSchema,
 								status: propStatus,
 							},
@@ -158,10 +177,30 @@ const getKeyframedSequenceDragTargets = ({
 const shiftKeyframedStatus = ({
 	status,
 	deltaFrames,
+	isDescendant,
 }: {
 	readonly status: CanUpdateSequencePropStatusKeyframed;
 	readonly deltaFrames: number;
+	readonly isDescendant: boolean;
 }): CanUpdateSequencePropStatusKeyframed => {
+	if (isDescendant) {
+		const adjustment = status.keyframeDisplayOffsetAdjustment;
+		if (adjustment === null) {
+			throw new Error(
+				'Expected descendant keyframes to use an outer frame clock',
+			);
+		}
+
+		return {
+			...status,
+			keyframeDisplayOffsetAdjustment: null,
+			keyframes: status.keyframes.map((keyframe) => ({
+				...keyframe,
+				frame: keyframe.frame + adjustment,
+			})),
+		};
+	}
+
 	return {
 		...status,
 		keyframes: status.keyframes.map((keyframe) => ({
@@ -585,25 +624,31 @@ export const getTimelineSequenceFromDragKeyframeMoves = ({
 		sequenceKeyframes: targets.flatMap((target) =>
 			target.sequenceKeyframes.flatMap((keyframeTarget) =>
 				keyframeTarget.status.keyframes.map((keyframe) => ({
-					fileName: target.fileName,
-					nodePath: target.nodePath,
+					fileName: keyframeTarget.fileName,
+					nodePath: keyframeTarget.nodePath,
 					fieldKey: keyframeTarget.fieldKey,
 					fromFrame: keyframe.frame,
 					toFrame: keyframe.frame + deltaFrames,
 					schema: keyframeTarget.schema,
+					keyframeDisplayOffsetAdjustmentDelta: keyframeTarget.isDescendant
+						? -deltaFrames
+						: undefined,
 				})),
 			),
 		),
 		effectKeyframes: targets.flatMap((target) =>
 			target.effectKeyframes.flatMap((keyframeTarget) =>
 				keyframeTarget.status.keyframes.map((keyframe) => ({
-					fileName: target.fileName,
-					nodePath: target.nodePath,
+					fileName: keyframeTarget.fileName,
+					nodePath: keyframeTarget.nodePath,
 					effectIndex: keyframeTarget.effectIndex,
 					fieldKey: keyframeTarget.fieldKey,
 					fromFrame: keyframe.frame,
 					toFrame: keyframe.frame + deltaFrames,
 					schema: keyframeTarget.schema,
+					keyframeDisplayOffsetAdjustmentDelta: keyframeTarget.isDescendant
+						? -deltaFrames
+						: undefined,
 				})),
 			),
 		),
@@ -857,6 +902,10 @@ export const getTimelineSequenceFromDragTargets = ({
 			: [draggedNodePathInfo];
 	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
 	const targets = new Map<string, TimelineSequenceFromDragTarget>();
+	const includedKeyframeNodePaths = new Set<string>();
+	const sequencesById = new Map(
+		sequences.map((sequence) => [sequence.id, sequence]),
+	);
 
 	for (const nodePathInfo of targetNodePathInfos) {
 		const track = findSequenceTrack({tracks, nodePathInfo});
@@ -879,12 +928,49 @@ export const getTimelineSequenceFromDragTargets = ({
 
 		const key = stringifySequenceSubscriptionKey(nodePath);
 		if (!targets.has(key)) {
-			const {effectKeyframes, sequenceKeyframes} =
-				getKeyframedSequenceDragTargets({
-					nodePath,
-					sequence: originalSequence,
-					propStatuses,
-				});
+			const descendants = sequences.filter((candidate) => {
+				let parentId: string | null = candidate.id;
+				while (parentId !== null) {
+					if (parentId === originalSequence.id) {
+						return true;
+					}
+
+					parentId = sequencesById.get(parentId)?.parent ?? null;
+				}
+
+				return false;
+			});
+			const descendantKeyframes = descendants.flatMap((sequence) => {
+				const overrideId = sequence.controls?.overrideId;
+				const descendantNodePath = overrideId
+					? overrideIdsToNodePaths[overrideId]
+					: undefined;
+				if (descendantNodePath === undefined) {
+					return [];
+				}
+
+				const descendantNodePathKey =
+					stringifySequenceSubscriptionKey(descendantNodePath);
+				if (includedKeyframeNodePaths.has(descendantNodePathKey)) {
+					return [];
+				}
+
+				includedKeyframeNodePaths.add(descendantNodePathKey);
+				return [
+					getKeyframedSequenceDragTargets({
+						nodePath: descendantNodePath,
+						sequence,
+						propStatuses,
+						isDescendant: sequence.id !== originalSequence.id,
+					}),
+				];
+			});
+			const effectKeyframes = descendantKeyframes.flatMap(
+				(descendant) => descendant.effectKeyframes,
+			);
+			const sequenceKeyframes = descendantKeyframes.flatMap(
+				(descendant) => descendant.sequenceKeyframes,
+			);
 			targets.set(key, {
 				canSnapToTimelineStart: originalSequence.parent === null,
 				effectKeyframes,
@@ -937,11 +1023,22 @@ const clearFromDragOverrides = ({
 }) => {
 	for (const target of targets) {
 		clearDragOverrides(target.nodePath);
-		const effectIndexes = new Set(
-			target.effectKeyframes.map((keyframe) => keyframe.effectIndex),
-		);
-		for (const effectIndex of effectIndexes) {
-			clearEffectDragOverrides(target.nodePath, effectIndex);
+		for (const keyframeTarget of target.sequenceKeyframes) {
+			clearDragOverrides(keyframeTarget.nodePath);
+		}
+
+		const clearedEffects = new Set<string>();
+		for (const keyframeTarget of target.effectKeyframes) {
+			const key = `${stringifySequenceSubscriptionKey(keyframeTarget.nodePath)}:${keyframeTarget.effectIndex}`;
+			if (clearedEffects.has(key)) {
+				continue;
+			}
+
+			clearedEffects.add(key);
+			clearEffectDragOverrides(
+				keyframeTarget.nodePath,
+				keyframeTarget.effectIndex,
+			);
 		}
 	}
 };
@@ -1450,13 +1547,14 @@ export const useTimelineSequenceFromDrag = ({
 				);
 				for (const keyframeTarget of target.sequenceKeyframes) {
 					latestRef.current.setDragOverrides(
-						target.nodePath,
+						keyframeTarget.nodePath,
 						keyframeTarget.fieldKey,
 						{
 							type: 'keyframed',
 							status: shiftKeyframedStatus({
 								status: keyframeTarget.status,
 								deltaFrames,
+								isDescendant: keyframeTarget.isDescendant,
 							}),
 						},
 					);
@@ -1464,7 +1562,7 @@ export const useTimelineSequenceFromDrag = ({
 
 				for (const keyframeTarget of target.effectKeyframes) {
 					latestRef.current.setEffectDragOverrides(
-						target.nodePath,
+						keyframeTarget.nodePath,
 						keyframeTarget.effectIndex,
 						keyframeTarget.fieldKey,
 						{
@@ -1472,6 +1570,7 @@ export const useTimelineSequenceFromDrag = ({
 							status: shiftKeyframedStatus({
 								status: keyframeTarget.status,
 								deltaFrames,
+								isDescendant: keyframeTarget.isDescendant,
 							}),
 						},
 					);

--- a/packages/studio/src/components/Timeline/call-move-keyframe.ts
+++ b/packages/studio/src/components/Timeline/call-move-keyframe.ts
@@ -2,7 +2,11 @@ import {
 	optimisticMoveEffectKeyframes,
 	optimisticMoveSequenceKeyframes,
 } from '@remotion/studio-shared';
-import type {SequencePropsSubscriptionKey, InteractivitySchema} from 'remotion';
+import type {
+	CanUpdateSequencePropStatus,
+	InteractivitySchema,
+	SequencePropsSubscriptionKey,
+} from 'remotion';
 import {callApi} from '../call-api';
 import type {SetPropStatuses} from './save-sequence-prop';
 
@@ -13,6 +17,7 @@ export type MoveSequenceKeyframeChange = {
 	fromFrame: number;
 	toFrame: number;
 	schema: InteractivitySchema;
+	keyframeDisplayOffsetAdjustmentDelta?: number;
 };
 
 export type MoveEffectKeyframeChange = MoveSequenceKeyframeChange & {
@@ -31,6 +36,43 @@ const groupByNodePath = <T extends {nodePath: SequencePropsSubscriptionKey}>(
 	}
 
 	return [...groups.values()];
+};
+
+const applyKeyframeDisplayOffsetAdjustmentDeltas = ({
+	props,
+	keyframes,
+}: {
+	readonly props: Record<string, CanUpdateSequencePropStatus>;
+	readonly keyframes: readonly MoveSequenceKeyframeChange[];
+}) => {
+	const nextProps = {...props};
+	const deltas = new Map<string, number>();
+	for (const keyframe of keyframes) {
+		if (keyframe.keyframeDisplayOffsetAdjustmentDelta !== undefined) {
+			deltas.set(
+				keyframe.fieldKey,
+				keyframe.keyframeDisplayOffsetAdjustmentDelta,
+			);
+		}
+	}
+
+	for (const [fieldKey, delta] of deltas) {
+		const status = nextProps[fieldKey];
+		if (
+			status?.status !== 'keyframed' ||
+			status.keyframeDisplayOffsetAdjustment === null
+		) {
+			continue;
+		}
+
+		nextProps[fieldKey] = {
+			...status,
+			keyframeDisplayOffsetAdjustment:
+				status.keyframeDisplayOffsetAdjustment + delta,
+		};
+	}
+
+	return nextProps;
 };
 
 export const applyOptimisticKeyframeMoves = ({
@@ -52,16 +94,27 @@ export const applyOptimisticKeyframeMoves = ({
 			continue;
 		}
 
-		setPropStatuses(firstKeyframe.nodePath, (prev) =>
-			optimisticMoveSequenceKeyframes({
+		setPropStatuses(firstKeyframe.nodePath, (prev) => {
+			const moved = optimisticMoveSequenceKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({
 					fieldKey: keyframe.fieldKey,
 					fromFrame: keyframe.fromFrame,
 					toFrame: keyframe.toFrame,
 				})),
-			}),
-		);
+			});
+			if (!moved.canUpdate) {
+				return moved;
+			}
+
+			return {
+				...moved,
+				props: applyKeyframeDisplayOffsetAdjustmentDeltas({
+					props: moved.props,
+					keyframes,
+				}),
+			};
+		});
 	}
 
 	for (const keyframes of groupByNodePath(effectKeyframes)) {
@@ -70,8 +123,8 @@ export const applyOptimisticKeyframeMoves = ({
 			continue;
 		}
 
-		setPropStatuses(firstKeyframe.nodePath, (prev) =>
-			optimisticMoveEffectKeyframes({
+		setPropStatuses(firstKeyframe.nodePath, (prev) => {
+			const moved = optimisticMoveEffectKeyframes({
 				previous: prev,
 				keyframes: keyframes.map((keyframe) => ({
 					effectIndex: keyframe.effectIndex,
@@ -79,8 +132,30 @@ export const applyOptimisticKeyframeMoves = ({
 					fromFrame: keyframe.fromFrame,
 					toFrame: keyframe.toFrame,
 				})),
-			}),
-		);
+			});
+			if (!moved.canUpdate) {
+				return moved;
+			}
+
+			return {
+				...moved,
+				effects: moved.effects.map((effect) => {
+					if (!effect.canUpdate) {
+						return effect;
+					}
+
+					return {
+						...effect,
+						props: applyKeyframeDisplayOffsetAdjustmentDeltas({
+							props: effect.props,
+							keyframes: keyframes.filter(
+								(keyframe) => keyframe.effectIndex === effect.effectIndex,
+							),
+						}),
+					};
+				}),
+			};
+		});
 	}
 };
 

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -7,9 +7,7 @@ import type {
 import {Internals} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
-	callDeleteEffectKeyframe,
 	callDeleteKeyframes,
-	callDeleteSequenceKeyframe,
 	type DeleteEffectKeyframeChange,
 	type DeleteSequenceKeyframeChange,
 } from './call-delete-keyframe';
@@ -27,9 +25,9 @@ const getValueWhenLastKeyframeDeleted = ({
 	playheadSourceFrame,
 }: {
 	propStatus: CanUpdateSequencePropStatus | null | undefined;
-	playheadSourceFrame: number | null;
+	playheadSourceFrame: number;
 }): unknown | null => {
-	if (propStatus?.status !== 'keyframed' || playheadSourceFrame === null) {
+	if (propStatus?.status !== 'keyframed') {
 		return null;
 	}
 
@@ -54,8 +52,8 @@ const getSelectedKeyframeDeletion = ({
 	frame: number;
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	propStatuses: PropStatuses | null;
-	timelinePosition: number | null;
+	propStatuses: PropStatuses;
+	timelinePosition: number;
 }): SelectedKeyframeDeletion | null => {
 	const field = parseKeyframeFieldFromNodePath(nodePathInfo.auxiliaryKeys);
 	if (field === null) {
@@ -81,14 +79,11 @@ const getSelectedKeyframeDeletion = ({
 			return null;
 		}
 
-		const effectStatus =
-			propStatuses !== null
-				? Internals.getEffectPropStatusesCtx({
-						propStatuses,
-						nodePath,
-						effectIndex: field.effectIndex,
-					})
-				: null;
+		const effectStatus = Internals.getEffectPropStatusesCtx({
+			propStatuses,
+			nodePath,
+			effectIndex: field.effectIndex,
+		});
 		const effectPropStatus =
 			effectStatus?.type === 'can-update-effect'
 				? effectStatus.props[field.fieldKey]
@@ -99,9 +94,7 @@ const getSelectedKeyframeDeletion = ({
 		});
 		const effectSourceFrame = frame - effectKeyframeDisplayOffset;
 		const effectPlayheadSourceFrame =
-			timelinePosition === null
-				? null
-				: timelinePosition - effectKeyframeDisplayOffset;
+			timelinePosition - effectKeyframeDisplayOffset;
 		const effectValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
 			propStatus: effectPropStatus,
 			playheadSourceFrame: effectPlayheadSourceFrame,
@@ -119,17 +112,16 @@ const getSelectedKeyframeDeletion = ({
 		};
 	}
 
-	const sequencePropStatus =
-		propStatuses !== null
-			? Internals.getPropStatusesCtx(propStatuses, nodePath)?.[field.fieldKey]
-			: null;
+	const sequencePropStatus = Internals.getPropStatusesCtx(
+		propStatuses,
+		nodePath,
+	)?.[field.fieldKey];
 	const keyframeDisplayOffset = getKeyframeDisplayOffset({
 		propStatus: sequencePropStatus,
 		keyframeDisplayOffset: track?.keyframeDisplayOffset ?? 0,
 	});
 	const sourceFrame = frame - keyframeDisplayOffset;
-	const playheadSourceFrame =
-		timelinePosition === null ? null : timelinePosition - keyframeDisplayOffset;
+	const playheadSourceFrame = timelinePosition - keyframeDisplayOffset;
 	const sequenceValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
 		propStatus: sequencePropStatus,
 		playheadSourceFrame,
@@ -144,48 +136,6 @@ const getSelectedKeyframeDeletion = ({
 		schema: sequence.controls.schema,
 		valueWhenLastKeyframeDeleted: sequenceValueWhenLastKeyframeDeleted,
 	};
-};
-
-export const deleteSelectedKeyframe = ({
-	nodePathInfo,
-	frame,
-	sequences,
-	overrideIdsToNodePaths,
-	setPropStatuses,
-	clientId,
-}: {
-	nodePathInfo: SequenceNodePathInfo;
-	frame: number;
-	sequences: TSequence[];
-	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setPropStatuses: SetPropStatuses;
-	clientId: string;
-}): Promise<void> | null => {
-	const deletion = getSelectedKeyframeDeletion({
-		nodePathInfo,
-		frame,
-		sequences,
-		overrideIdsToNodePaths,
-		propStatuses: null,
-		timelinePosition: null,
-	});
-	if (deletion === null) {
-		return null;
-	}
-
-	if (deletion.type === 'effect') {
-		return callDeleteEffectKeyframe({
-			...deletion,
-			setPropStatuses,
-			clientId,
-		});
-	}
-
-	return callDeleteSequenceKeyframe({
-		...deletion,
-		setPropStatuses,
-		clientId,
-	});
 };
 
 export const deleteSelectedKeyframes = ({

--- a/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-keyframe.ts
@@ -14,6 +14,7 @@ import {
 	type DeleteSequenceKeyframeChange,
 } from './call-delete-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
 import type {SetPropStatuses} from './save-sequence-prop';
 
@@ -71,11 +72,6 @@ const getSelectedKeyframeDeletion = ({
 		return null;
 	}
 
-	const sourceFrame = frame - (track?.keyframeDisplayOffset ?? 0);
-	const playheadSourceFrame =
-		timelinePosition === null
-			? null
-			: timelinePosition - (track?.keyframeDisplayOffset ?? 0);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
 	const fileName = nodePath.absolutePath;
 
@@ -97,9 +93,18 @@ const getSelectedKeyframeDeletion = ({
 			effectStatus?.type === 'can-update-effect'
 				? effectStatus.props[field.fieldKey]
 				: null;
+		const effectKeyframeDisplayOffset = getKeyframeDisplayOffset({
+			propStatus: effectPropStatus,
+			keyframeDisplayOffset: track?.keyframeDisplayOffset ?? 0,
+		});
+		const effectSourceFrame = frame - effectKeyframeDisplayOffset;
+		const effectPlayheadSourceFrame =
+			timelinePosition === null
+				? null
+				: timelinePosition - effectKeyframeDisplayOffset;
 		const effectValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
 			propStatus: effectPropStatus,
-			playheadSourceFrame,
+			playheadSourceFrame: effectPlayheadSourceFrame,
 		});
 
 		return {
@@ -108,7 +113,7 @@ const getSelectedKeyframeDeletion = ({
 			nodePath,
 			effectIndex: field.effectIndex,
 			fieldKey: field.fieldKey,
-			sourceFrame,
+			sourceFrame: effectSourceFrame,
 			schema: effect.schema,
 			valueWhenLastKeyframeDeleted: effectValueWhenLastKeyframeDeleted,
 		};
@@ -118,6 +123,13 @@ const getSelectedKeyframeDeletion = ({
 		propStatuses !== null
 			? Internals.getPropStatusesCtx(propStatuses, nodePath)?.[field.fieldKey]
 			: null;
+	const keyframeDisplayOffset = getKeyframeDisplayOffset({
+		propStatus: sequencePropStatus,
+		keyframeDisplayOffset: track?.keyframeDisplayOffset ?? 0,
+	});
+	const sourceFrame = frame - keyframeDisplayOffset;
+	const playheadSourceFrame =
+		timelinePosition === null ? null : timelinePosition - keyframeDisplayOffset;
 	const sequenceValueWhenLastKeyframeDeleted = getValueWhenLastKeyframeDeleted({
 		propStatus: sequencePropStatus,
 		playheadSourceFrame,

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -4,10 +4,7 @@ import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sor
 import {callApi} from '../call-api';
 import type {ConfirmationDialogFunction} from '../ConfirmationDialog-types';
 import {showNotification} from '../Notifications/NotificationCenter';
-import {
-	deleteSelectedKeyframe,
-	deleteSelectedKeyframes,
-} from './delete-selected-keyframe';
+import {deleteSelectedKeyframes} from './delete-selected-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {getEasingSelectionAfterKeyframeDelete} from './get-easing-selection-after-keyframe-delete';
 import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
@@ -129,61 +126,6 @@ const deleteEffects = (
 			showNotification((err as Error).message, 4000);
 			return false;
 		});
-};
-
-export const deleteSelectedTimelineItem = ({
-	selection,
-	sequences,
-	overrideIdsToNodePaths,
-	setPropStatuses,
-	clientId,
-	confirm,
-}: {
-	selection: TimelineSelection;
-	sequences: TSequence[];
-	overrideIdsToNodePaths: OverrideIdToNodePaths;
-	setPropStatuses: SetPropStatuses;
-	clientId: string;
-	confirm: ConfirmationDialogFunction;
-}): Promise<boolean> | null => {
-	if (selection.type === 'keyframe') {
-		const promise = deleteSelectedKeyframe({
-			nodePathInfo: selection.nodePathInfo,
-			frame: selection.frame,
-			sequences,
-			overrideIdsToNodePaths,
-			setPropStatuses,
-			clientId,
-		});
-		return promise?.then(() => true) ?? null;
-	}
-
-	switch (selection.type) {
-		case 'guide':
-			return null;
-		case 'sequence':
-			return deleteSequencesFromSource([selection.nodePathInfo], confirm);
-		case 'sequence-effect':
-			return deleteEffects([
-				{
-					type: 'single-effect',
-					nodePathInfo: selection.nodePathInfo,
-					effectIndex: selection.i,
-				},
-			]);
-		case 'sequence-prop':
-		case 'sequence-effect-prop':
-		case 'easing':
-			return null;
-		case 'sequence-all-effects':
-			return deleteEffects([
-				{type: 'all-effects', nodePathInfo: selection.nodePathInfo},
-			]);
-		default:
-			throw new Error(
-				`Unexpected timeline selection type: ${selection satisfies never}`,
-			);
-	}
 };
 
 const isSequenceRowSelection = (

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -10,6 +10,7 @@ import {
 } from './delete-selected-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {getEasingSelectionAfterKeyframeDelete} from './get-easing-selection-after-keyframe-delete';
+import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
 import type {SetPropStatuses} from './save-sequence-prop';
 import {
@@ -277,8 +278,6 @@ const getEasingSelectionAfterDeletingKeyframes = ({
 	}
 
 	const nodePath = selection.nodePathInfo.sequenceSubscriptionKey;
-	const sourceFrame = selection.frame - track.keyframeDisplayOffset;
-
 	if (field.type === 'sequence') {
 		const sequencePropStatus = Internals.getPropStatusesCtx(
 			propStatuses,
@@ -294,7 +293,13 @@ const getEasingSelectionAfterDeletingKeyframes = ({
 		}
 
 		return getEasingSelectionAfterKeyframeDelete({
-			deletedSourceFrames: [sourceFrame],
+			deletedSourceFrames: [
+				selection.frame -
+					getKeyframeDisplayOffset({
+						propStatus: sequencePropStatus,
+						keyframeDisplayOffset: track.keyframeDisplayOffset,
+					}),
+			],
 			keyframeDisplayOffset: track.keyframeDisplayOffset,
 			nodePathInfo: selection.nodePathInfo,
 			propStatus: sequencePropStatus,
@@ -321,7 +326,13 @@ const getEasingSelectionAfterDeletingKeyframes = ({
 	}
 
 	return getEasingSelectionAfterKeyframeDelete({
-		deletedSourceFrames: [sourceFrame],
+		deletedSourceFrames: [
+			selection.frame -
+				getKeyframeDisplayOffset({
+					propStatus: effectPropStatus,
+					keyframeDisplayOffset: track.keyframeDisplayOffset,
+				}),
+		],
 		keyframeDisplayOffset: track.keyframeDisplayOffset,
 		nodePathInfo: selection.nodePathInfo,
 		propStatus: effectPropStatus,

--- a/packages/studio/src/components/Timeline/get-easing-selection-after-keyframe-delete.ts
+++ b/packages/studio/src/components/Timeline/get-easing-selection-after-keyframe-delete.ts
@@ -1,5 +1,6 @@
 import type {CanUpdateSequencePropStatusKeyframed} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
+import {getKeyframeDisplayOffset as resolveKeyframeDisplayOffset} from './get-timeline-keyframes';
 import type {TimelineEasingSelection} from './TimelineSelection';
 
 export const getEasingSelectionAfterKeyframeDelete = ({
@@ -15,11 +16,15 @@ export const getEasingSelectionAfterKeyframeDelete = ({
 	readonly propStatus: CanUpdateSequencePropStatusKeyframed;
 	readonly timelinePosition: number;
 }): TimelineEasingSelection | null => {
+	const resolvedKeyframeDisplayOffset = resolveKeyframeDisplayOffset({
+		propStatus,
+		keyframeDisplayOffset,
+	});
 	const deletedSourceFrameSet = new Set(deletedSourceFrames);
 	const remainingKeyframes = propStatus.keyframes.filter(
 		(keyframe) => !deletedSourceFrameSet.has(keyframe.frame),
 	);
-	const sourceFrame = timelinePosition - keyframeDisplayOffset;
+	const sourceFrame = timelinePosition - resolvedKeyframeDisplayOffset;
 
 	for (let i = 0; i < remainingKeyframes.length - 1; i++) {
 		const keyframe = remainingKeyframes[i];
@@ -32,8 +37,8 @@ export const getEasingSelectionAfterKeyframeDelete = ({
 			return {
 				type: 'easing',
 				nodePathInfo,
-				fromFrame: keyframe.frame + keyframeDisplayOffset,
-				toFrame: nextKeyframe.frame + keyframeDisplayOffset,
+				fromFrame: keyframe.frame + resolvedKeyframeDisplayOffset,
+				toFrame: nextKeyframe.frame + resolvedKeyframeDisplayOffset,
 				segmentIndex: i,
 			};
 		}

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -52,7 +52,9 @@ export const getKeyframeDisplayOffset = ({
 	return (
 		keyframeDisplayOffset +
 		(propStatus?.status === 'keyframed' || propStatus?.status === 'static'
-			? (propStatus.keyframeDisplayOffsetAdjustment ?? 0)
+			? propStatus.keyframeDisplayOffsetAdjustment === null
+				? 0
+				: propStatus.keyframeDisplayOffsetAdjustment
 			: 0)
 	);
 };

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -28,12 +28,31 @@ export const getTimelineKeyframes = (
 	}
 
 	const {keyframes} = propStatus;
-	if (keyframeDisplayOffset === 0) {
+	const resolvedKeyframeDisplayOffset = getKeyframeDisplayOffset({
+		propStatus,
+		keyframeDisplayOffset,
+	});
+	if (resolvedKeyframeDisplayOffset === 0) {
 		return keyframes;
 	}
 
 	return keyframes.map((keyframe) => ({
 		...keyframe,
-		frame: keyframe.frame + keyframeDisplayOffset,
+		frame: keyframe.frame + resolvedKeyframeDisplayOffset,
 	}));
+};
+
+export const getKeyframeDisplayOffset = ({
+	propStatus,
+	keyframeDisplayOffset,
+}: {
+	propStatus: CanUpdateSequencePropStatus | null | undefined;
+	keyframeDisplayOffset: number;
+}): number => {
+	return (
+		keyframeDisplayOffset +
+		(propStatus?.status === 'keyframed' || propStatus?.status === 'static'
+			? (propStatus.keyframeDisplayOffsetAdjustment ?? 0)
+			: 0)
+	);
 };

--- a/packages/studio/src/components/Timeline/keyframe-clipboard.ts
+++ b/packages/studio/src/components/Timeline/keyframe-clipboard.ts
@@ -16,6 +16,7 @@ import {
 	type TSequence,
 } from 'remotion';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
+import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
 import type {TimelineSelection} from './TimelineSelection';
 
@@ -133,7 +134,10 @@ const resolveKeyframeField = ({
 				fieldKey: identity.fieldKey,
 			}),
 			propStatus: sequencePropStatus,
-			keyframeDisplayOffset: track.keyframeDisplayOffset,
+			keyframeDisplayOffset: getKeyframeDisplayOffset({
+				propStatus: sequencePropStatus,
+				keyframeDisplayOffset: track.keyframeDisplayOffset,
+			}),
 		};
 	}
 
@@ -161,7 +165,10 @@ const resolveKeyframeField = ({
 			fieldKey: identity.fieldKey,
 		}),
 		propStatus: effectPropStatus,
-		keyframeDisplayOffset: track.keyframeDisplayOffset,
+		keyframeDisplayOffset: getKeyframeDisplayOffset({
+			propStatus: effectPropStatus,
+			keyframeDisplayOffset: track.keyframeDisplayOffset,
+		}),
 	};
 };
 

--- a/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-keyframe-drag.ts
@@ -21,6 +21,7 @@ import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {callMoveKeyframes} from './call-move-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
 import {getBoundedKeyframeDragDelta} from './get-bounded-keyframe-drag-delta';
+import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {parseKeyframeFieldFromNodePath} from './parse-keyframe-field-from-node-path';
 import {
 	getTimelineKeyframeDragKey,
@@ -231,7 +232,6 @@ const getTimelineKeyframeDragTarget = ({
 		return null;
 	}
 
-	const sourceFrame = displayFrame - (track?.keyframeDisplayOffset ?? 0);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
 	const fileName = nodePath.absolutePath;
 	const sequenceStatus = getCodeValueForTarget({propStatuses, nodePath});
@@ -253,9 +253,16 @@ const getTimelineKeyframeDragTarget = ({
 			return null;
 		}
 
+		const effectSourceFrame =
+			displayFrame -
+			getKeyframeDisplayOffset({
+				propStatus: effectPropStatus,
+				keyframeDisplayOffset: track?.keyframeDisplayOffset ?? 0,
+			});
+
 		if (
 			!effectPropStatus.keyframes.some(
-				(keyframe) => keyframe.frame === sourceFrame,
+				(keyframe) => keyframe.frame === effectSourceFrame,
 			)
 		) {
 			return null;
@@ -271,7 +278,7 @@ const getTimelineKeyframeDragTarget = ({
 			nodePathInfo,
 			propStatus: effectPropStatus,
 			schema: effect.schema,
-			sourceFrame,
+			sourceFrame: effectSourceFrame,
 		};
 	}
 
@@ -279,6 +286,13 @@ const getTimelineKeyframeDragTarget = ({
 	if (sequencePropStatus?.status !== 'keyframed') {
 		return null;
 	}
+
+	const sourceFrame =
+		displayFrame -
+		getKeyframeDisplayOffset({
+			propStatus: sequencePropStatus,
+			keyframeDisplayOffset: track?.keyframeDisplayOffset ?? 0,
+		});
 
 	if (
 		!sequencePropStatus.keyframes.some(

--- a/packages/studio/src/test/border-radius-representation.test.ts
+++ b/packages/studio/src/test/border-radius-representation.test.ts
@@ -14,7 +14,11 @@ import {
 
 test('a static shorthand can be converted to individual corners', () => {
 	const conversion = getBorderRadiusConversion({
-		'style.borderRadius': {status: 'static', codeValue: 12},
+		'style.borderRadius': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 12,
+		},
 	});
 	expect(conversion).toEqual({type: 'individual', value: 12});
 	if (conversion === null) {
@@ -33,11 +37,19 @@ test('a static shorthand can be converted to individual corners', () => {
 	const initial: CanUpdateSequencePropsResponse = {
 		canUpdate: true,
 		props: {
-			[BORDER_RADIUS_SHORTHAND_KEY]: {status: 'static', codeValue: 12},
+			[BORDER_RADIUS_SHORTHAND_KEY]: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 12,
+			},
 			...Object.fromEntries(
 				BORDER_RADIUS_LONGHAND_KEYS.map((key) => [
 					key,
-					{status: 'static', codeValue: 12},
+					{
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 12,
+					},
 				]),
 			),
 		},
@@ -58,6 +70,7 @@ test('a static shorthand can be converted to individual corners', () => {
 	if (optimistic.canUpdate) {
 		expect(optimistic.props[BORDER_RADIUS_SHORTHAND_KEY]).toEqual({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: undefined,
 		});
 	}
@@ -70,12 +83,17 @@ test('an unauthored border radius can be converted to zero-valued corners', () =
 		{
 			[BORDER_RADIUS_SHORTHAND_KEY]: {
 				status: 'static' as const,
+				keyframeDisplayOffsetAdjustment: null,
 				codeValue: undefined,
 			},
 			...Object.fromEntries(
 				BORDER_RADIUS_LONGHAND_KEYS.map((key) => [
 					key,
-					{status: 'static' as const, codeValue: undefined},
+					{
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: undefined,
+					},
 				]),
 			),
 		},
@@ -102,7 +120,11 @@ test('four equal static longhands can be converted to a shorthand', () => {
 			Object.fromEntries(
 				BORDER_RADIUS_LONGHAND_KEYS.map((key) => [
 					key,
-					{status: 'static', codeValue: 8},
+					{
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 8,
+					},
 				]),
 			) as Record<string, CanUpdateSequencePropStatus>,
 		),
@@ -115,6 +137,7 @@ test('static drag overrides determine the border radius conversion', () => {
 			{
 				[BORDER_RADIUS_SHORTHAND_KEY]: {
 					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
 					codeValue: 12,
 				},
 			},
@@ -127,7 +150,11 @@ test('static drag overrides determine the border radius conversion', () => {
 	const unequalLonghands = Object.fromEntries(
 		BORDER_RADIUS_LONGHAND_KEYS.map((key, index) => [
 			key,
-			{status: 'static' as const, codeValue: index},
+			{
+				status: 'static' as const,
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: index,
+			},
 		]),
 	);
 	expect(
@@ -147,7 +174,11 @@ test('static drag overrides determine the border radius conversion', () => {
 			Object.fromEntries(
 				BORDER_RADIUS_LONGHAND_KEYS.map((key) => [
 					key,
-					{status: 'static' as const, codeValue: 8},
+					{
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 8,
+					},
 				]),
 			),
 			{
@@ -160,10 +191,26 @@ test('static drag overrides determine the border radius conversion', () => {
 test('unequal, keyframed, and computed radii cannot be converted', () => {
 	expect(
 		getBorderRadiusConversion({
-			'style.borderTopLeftRadius': {status: 'static', codeValue: 1},
-			'style.borderTopRightRadius': {status: 'static', codeValue: 2},
-			'style.borderBottomRightRadius': {status: 'static', codeValue: 1},
-			'style.borderBottomLeftRadius': {status: 'static', codeValue: 2},
+			'style.borderTopLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 1,
+			},
+			'style.borderTopRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 2,
+			},
+			'style.borderBottomRightRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 1,
+			},
+			'style.borderBottomLeftRadius': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 2,
+			},
 		}),
 	).toBe(null);
 	expect(
@@ -175,6 +222,7 @@ test('unequal, keyframed, and computed radii cannot be converted', () => {
 		getBorderRadiusConversion({
 			'style.borderRadius': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 0}],
 				easing: [],

--- a/packages/studio/src/test/browser-studio-sequence-props.test.ts
+++ b/packages/studio/src/test/browser-studio-sequence-props.test.ts
@@ -39,12 +39,24 @@ test('routes sequence prop operations through Browser Studio', async () => {
 			calls.push(`save:${request.clientId}:${request.edits[0]?.fileName}`);
 			return Promise.resolve({
 				canUpdate: true,
-				props: {from: {status: 'static', codeValue: 15}},
+				props: {
+					from: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 15,
+					},
+				},
 				results: [
 					{
 						fileName: 'src/Composition.tsx',
 						nodePath,
-						props: {from: {status: 'static', codeValue: 15}},
+						props: {
+							from: {
+								status: 'static',
+								keyframeDisplayOffsetAdjustment: null,
+								codeValue: 15,
+							},
+						},
 					},
 				],
 			});
@@ -56,7 +68,13 @@ test('routes sequence prop operations through Browser Studio', async () => {
 				nodePath,
 				status: {
 					canUpdate: true,
-					props: {from: {status: 'static', codeValue: 10}},
+					props: {
+						from: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 10,
+						},
+					},
 					effects: [],
 				},
 			});
@@ -152,7 +170,13 @@ test('batches server sequence prop subscriptions into one request', async () => 
 							},
 							status: {
 								canUpdate: true,
-								props: {from: {status: 'static', codeValue: request.line}},
+								props: {
+									from: {
+										status: 'static',
+										keyframeDisplayOffsetAdjustment: null,
+										codeValue: request.line,
+									},
+								},
 								effects: [],
 							},
 						})),
@@ -192,10 +216,12 @@ test('batches server sequence prop subscriptions into one request', async () => 
 		const last = results.at(-1);
 		expect(first.success && first.status.props.from).toEqual({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: 2,
 		});
 		expect(last?.success && last.status.props.from).toEqual({
 			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
 			codeValue: 1001,
 		});
 	} finally {
@@ -227,7 +253,13 @@ test('handles a legacy single-subscription response to a batched request', async
 						nodePath,
 						status: {
 							canUpdate: true,
-							props: {from: {status: 'static', codeValue: 10}},
+							props: {
+								from: {
+									status: 'static',
+									keyframeDisplayOffsetAdjustment: null,
+									codeValue: 10,
+								},
+							},
 							effects: [],
 						},
 					},
@@ -257,7 +289,13 @@ test('handles a legacy single-subscription response to a batched request', async
 				nodePath,
 				status: {
 					canUpdate: true,
-					props: {from: {status: 'static', codeValue: 10}},
+					props: {
+						from: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 10,
+						},
+					},
 					effects: [],
 				},
 			},

--- a/packages/studio/src/test/easing-inspector-selection.test.ts
+++ b/packages/studio/src/test/easing-inspector-selection.test.ts
@@ -28,6 +28,7 @@ const makeKeyframedStatus = (
 	keyframes: {readonly frame: number; readonly value: number}[],
 ): CanUpdateSequencePropStatusKeyframed => ({
 	status: 'keyframed',
+	keyframeDisplayOffsetAdjustment: null,
 	interpolationFunction: 'interpolate',
 	keyframes,
 	easing: [{type: 'linear'}, {type: 'linear'}],

--- a/packages/studio/src/test/easing-selection-after-keyframe-delete.test.ts
+++ b/packages/studio/src/test/easing-selection-after-keyframe-delete.test.ts
@@ -26,6 +26,7 @@ const makeNodePathInfo = (
 
 const keyframedStatus = {
 	status: 'keyframed',
+	keyframeDisplayOffsetAdjustment: null,
 	interpolationFunction: 'interpolate',
 	keyframes: [
 		{frame: 0, value: 0},

--- a/packages/studio/src/test/inspector-section-collapse.test.ts
+++ b/packages/studio/src/test/inspector-section-collapse.test.ts
@@ -9,7 +9,11 @@ const staticStatuses = (values: Record<string, unknown>) => {
 	return Object.fromEntries(
 		Object.entries(values).map(([key, codeValue]) => [
 			key,
-			{status: 'static' as const, codeValue},
+			{
+				status: 'static' as const,
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue,
+			},
 		]),
 	);
 };
@@ -251,6 +255,7 @@ test('uses the component schema defaults to determine layout activity', () => {
 					...defaultStatuses,
 					layout: {
 						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
 						codeValue: defaults.layout === 'none' ? 'absolute-fill' : 'none',
 					},
 				},
@@ -264,6 +269,7 @@ test('uses the component schema defaults to determine layout activity', () => {
 					...defaultStatuses,
 					premountFor: {
 						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
 						codeValue: defaults.premountFor + 1,
 					},
 				},

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -68,6 +68,7 @@ const makeSequence = (overrides: Partial<TSequence> = {}): TSequence =>
 
 const staticNumber = (value: number): CanUpdateSequencePropStatus => ({
 	status: 'static',
+	keyframeDisplayOffsetAdjustment: null,
 	codeValue: value,
 });
 

--- a/packages/studio/src/test/timeline-keyframe-navigation.test.ts
+++ b/packages/studio/src/test/timeline-keyframe-navigation.test.ts
@@ -73,10 +73,12 @@ test('hasKeyframeAtSourceFrame checks source frame membership', () => {
 test('timeline keyframe controls visibility follows property selection or keyframed status', () => {
 	const staticStatus: CanUpdateSequencePropStatus = {
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 1,
 	};
 	const keyframedStatus: CanUpdateSequencePropStatus = {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 10, value: 1}],
 		easing: [],
@@ -118,10 +120,12 @@ test('timeline keyframe controls visibility follows property selection or keyfra
 test('keyframe navigation visibility follows property selection or keyframed status', () => {
 	const staticStatus: CanUpdateSequencePropStatus = {
 		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
 		codeValue: 1,
 	};
 	const keyframedStatus: CanUpdateSequencePropStatus = {
 		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
 		interpolationFunction: 'interpolate',
 		keyframes: [{frame: 10, value: 1}],
 		easing: [],

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -337,6 +337,22 @@ test('keyframe display offsets account for parent trimBefore', () => {
 	]);
 });
 
+test('keyframe display offsets respect the useCurrentFrame coordinate space', () => {
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		...makeKeyframedStatus(),
+		keyframeDisplayOffsetAdjustment: 5,
+		keyframes: [
+			{frame: 10, value: '0px 0px'},
+			{frame: 20, value: '500px 0px'},
+		],
+	};
+
+	expect(getTimelineKeyframes(status, -5)).toEqual([
+		{frame: 10, value: '0px 0px'},
+		{frame: 20, value: '500px 0px'},
+	]);
+});
+
 test('timeline easing segments connect adjacent display keyframes', () => {
 	const status: CanUpdateSequencePropStatusKeyframed = {
 		...makeKeyframedStatus(),

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -341,6 +341,36 @@ test('keyframe display offsets account for parent trimBefore', () => {
 });
 
 test('keyframe display offsets respect the useCurrentFrame coordinate space', () => {
+	const timeline = calculateTimeline({
+		sequences: [
+			makeSequence({
+				id: 'timing-wrapper',
+				from: -5,
+				trimBefore: null,
+				nonce: 0,
+			}),
+			makeSequence({
+				id: 'controlled-element',
+				from: 0,
+				trimBefore: null,
+				parent: 'timing-wrapper',
+				overrideId: 'controlled-element',
+				nonce: 1,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			'controlled-element': makeNodePath('controlled-element'),
+		},
+	});
+	const controlledElement = timeline.find(
+		(track) => track.sequence.id === 'controlled-element',
+	);
+	if (!controlledElement) {
+		throw new Error('Could not find controlled element');
+	}
+
+	expect(controlledElement.keyframeDisplayOffset).toBe(-5);
+
 	const status: CanUpdateSequencePropStatusKeyframed = {
 		...makeKeyframedStatus(),
 		keyframeDisplayOffsetAdjustment: 5,
@@ -350,7 +380,9 @@ test('keyframe display offsets respect the useCurrentFrame coordinate space', ()
 		],
 	};
 
-	expect(getTimelineKeyframes(status, -5)).toEqual([
+	expect(
+		getTimelineKeyframes(status, controlledElement.keyframeDisplayOffset),
+	).toEqual([
 		{frame: 10, value: '0px 0px'},
 		{frame: 20, value: '500px 0px'},
 	]);

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -91,6 +91,7 @@ const numberFieldSchema = {
 
 const makeKeyframedStatus = (): CanUpdateSequencePropStatusKeyframed => ({
 	status: 'keyframed',
+	keyframeDisplayOffsetAdjustment: null,
 	interpolationFunction: 'interpolate',
 	keyframes: [
 		{frame: 0, value: 2},
@@ -239,6 +240,7 @@ test('keyframe display offsets follow the parent sequence context', () => {
 		getTimelineKeyframes(
 			{
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: 2},
@@ -319,6 +321,7 @@ test('keyframe display offsets account for parent trimBefore', () => {
 		getTimelineKeyframes(
 			{
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 20, value: 2},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -300,7 +300,11 @@ const makeDurationPropStatuses = (
 		propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 			canUpdate: true,
 			props: {
-				durationInFrames: {status: 'static', codeValue: 100},
+				durationInFrames: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 100,
+				},
 			},
 			effects: [],
 		};
@@ -317,7 +321,11 @@ const makeFromPropStatuses = (
 		propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 			canUpdate: true,
 			props: {
-				from: {status: 'static', codeValue: 0},
+				from: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0,
+				},
 			},
 			effects: [],
 		};
@@ -338,12 +346,26 @@ const makeLeftEdgePropStatuses = (
 			props: {
 				...(includeTimelineRange
 					? {
-							durationInFrames: {status: 'static' as const, codeValue: 100},
-							from: {status: 'static' as const, codeValue: 0},
+							durationInFrames: {
+								status: 'static' as const,
+								keyframeDisplayOffsetAdjustment: null,
+								codeValue: 100,
+							},
+							from: {
+								status: 'static' as const,
+								keyframeDisplayOffsetAdjustment: null,
+								codeValue: 0,
+							},
 						}
 					: {}),
 				...(includeTrimBefore
-					? {trimBefore: {status: 'static' as const, codeValue: 0}}
+					? {
+							trimBefore: {
+								status: 'static' as const,
+								keyframeDisplayOffsetAdjustment: null,
+								codeValue: 0,
+							},
+						}
 					: {}),
 			},
 			effects: [],
@@ -751,6 +773,7 @@ test('copying a keyframed effect creates a structured snapshot', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -849,6 +872,7 @@ test('copying a selected effect prop creates an effect prop payload', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -909,6 +933,7 @@ test('copying selected keyframes preserves their frame deltas', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 10, value: 0.4},
@@ -968,7 +993,11 @@ test('pasting keyframes onto a sequence targets the copied property', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				'style.translate': {status: 'static', codeValue: 'none'},
+				'style.translate': {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 'none',
+				},
 			},
 			effects: [],
 		},
@@ -1026,6 +1055,7 @@ test('copies a keyframed sequence prop between components with matching schemas'
 			props: {
 				'style.rotate': {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: '0deg'},
@@ -1042,7 +1072,11 @@ test('copies a keyframed sequence prop between components with matching schemas'
 		[Internals.makeSequencePropsSubscriptionKey(targetNodePath)]: {
 			canUpdate: true,
 			props: {
-				'style.rotate': {status: 'static', codeValue: undefined},
+				'style.rotate': {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: undefined,
+				},
 			},
 			effects: [],
 		},
@@ -1110,6 +1144,7 @@ test('copying selected keyframes requires one property', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [{frame: 10, value: 0.4}],
 					easing: [],
@@ -1119,6 +1154,7 @@ test('copying selected keyframes requires one property', () => {
 				},
 				otherOpacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [{frame: 30, value: 2}],
 					easing: [],
@@ -1154,7 +1190,11 @@ test('pasting keyframes targets one selected property at the playhead', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				opacity: {status: 'static', codeValue: 1},
+				opacity: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 1,
+				},
 			},
 			effects: [],
 		},
@@ -1212,6 +1252,7 @@ test('pasting keyframes replaces the destination range and preserves easing', ()
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 40, value: 0},
@@ -1285,7 +1326,11 @@ test('pasting a keyframe rejects an incompatible property', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				background: {status: 'static', codeValue: '#ffffff'},
+				background: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '#ffffff',
+				},
 			},
 			effects: [],
 		},
@@ -1339,6 +1384,7 @@ test('copying a selected sequence easing creates an easing payload', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -1400,6 +1446,7 @@ test('copying a selected effect easing creates an easing payload', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolateColors',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -1464,7 +1511,11 @@ test('pasting an effect prop targets a matching selected effect', () => {
 					importPath: '@remotion/effects/halftone',
 					effectIndex: 1,
 					props: {
-						intensity: {status: 'static', codeValue: 0},
+						intensity: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 0,
+						},
 					},
 				},
 			],
@@ -1535,7 +1586,11 @@ test('pasting an effect prop targets multiple matching selected effects', () => 
 		importPath: '@remotion/effects/halftone',
 		effectIndex: 0,
 		props: {
-			intensity: {status: 'static', codeValue: 0},
+			intensity: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 0,
+			},
 		},
 	} as const;
 	const propStatuses = {
@@ -1643,8 +1698,16 @@ test('pasting an effect prop requires the same effect type and prop key', () => 
 					importPath: '@remotion/effects/blur',
 					effectIndex: 0,
 					props: {
-						opacity: {status: 'static', codeValue: 1},
-						intensity: {status: 'static', codeValue: 0},
+						opacity: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 1,
+						},
+						intensity: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 0,
+						},
 					},
 				},
 			],
@@ -1838,7 +1901,11 @@ test('Timeline duration drag rejects media without an explicit duration', () => 
 				[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 					canUpdate: true,
 					props: {
-						durationInFrames: {status: 'static', codeValue: undefined},
+						durationInFrames: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: undefined,
+						},
 					},
 					effects: [],
 				},
@@ -2040,6 +2107,7 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 		props: {
 			durationInFrames: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [{frame: 0, value: 15}],
 				easing: [{type: 'linear'}],
@@ -2211,8 +2279,16 @@ test('TransitionSeries.Sequence left edge drag leaves its calculated position un
 			[Internals.makeSequencePropsSubscriptionKey(subscriptionKey)]: {
 				canUpdate: true,
 				props: {
-					durationInFrames: {status: 'static', codeValue: 40},
-					trimBefore: {status: 'static', codeValue: 3},
+					durationInFrames: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 40,
+					},
+					trimBefore: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 3,
+					},
 				},
 				effects: [],
 			},
@@ -2260,8 +2336,16 @@ test('Series.Sequence left edge drag leaves its calculated position unchanged', 
 			[Internals.makeSequencePropsSubscriptionKey(subscriptionKey)]: {
 				canUpdate: true,
 				props: {
-					durationInFrames: {status: 'static', codeValue: 40},
-					trimBefore: {status: 'static', codeValue: 3},
+					durationInFrames: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 40,
+					},
+					trimBefore: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 3,
+					},
 				},
 				effects: [],
 			},
@@ -2522,9 +2606,14 @@ test('Timeline from drag moves all owned sequence keyframes by the same delta', 
 	propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 		canUpdate: true,
 		props: {
-			from: {status: 'static', codeValue: 0},
+			from: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 0,
+			},
 			'style.translate': {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: '0px 0px'},
@@ -2537,6 +2626,7 @@ test('Timeline from drag moves all owned sequence keyframes by the same delta', 
 			},
 			opacity: {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 10, value: 0},
@@ -2594,7 +2684,11 @@ test('Timeline from drag moves owned effect keyframes by the same delta', () => 
 	propStatuses[Internals.makeSequencePropsSubscriptionKey(nodePath)] = {
 		canUpdate: true,
 		props: {
-			from: {status: 'static', codeValue: 0},
+			from: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: 0,
+			},
 		},
 		effects: [
 			{
@@ -2605,6 +2699,7 @@ test('Timeline from drag moves owned effect keyframes by the same delta', () => 
 				props: {
 					intensity: {
 						status: 'keyframed',
+						keyframeDisplayOffsetAdjustment: null,
 						interpolationFunction: 'interpolate',
 						keyframes: [
 							{frame: 5, value: 10},
@@ -3753,10 +3848,26 @@ test('Crop is only available when all crop fields can be edited', () => {
 		cropBottom: numberField,
 	} satisfies InteractivitySchema;
 	const propStatuses = {
-		cropLeft: {status: 'static' as const, codeValue: 0},
-		cropRight: {status: 'static' as const, codeValue: 0},
-		cropTop: {status: 'static' as const, codeValue: 0},
-		cropBottom: {status: 'static' as const, codeValue: 0},
+		cropLeft: {
+			status: 'static' as const,
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0,
+		},
+		cropRight: {
+			status: 'static' as const,
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0,
+		},
+		cropTop: {
+			status: 'static' as const,
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0,
+		},
+		cropBottom: {
+			status: 'static' as const,
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0,
+		},
 	};
 
 	expect(canEditSelectedOutlineCrop({schema, propStatuses})).toBe(true);
@@ -3812,7 +3923,11 @@ test('Crop handle changes preserve static and keyframed field behavior', () => {
 	const staticField = (value: number) => ({
 		defaultValue: 0,
 		fieldSchema: schema.cropLeft,
-		propStatus: {status: 'static' as const, codeValue: value},
+		propStatus: {
+			status: 'static' as const,
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: value,
+		},
 		value,
 	});
 	const target = {
@@ -3824,6 +3939,7 @@ test('Crop handle changes preserve static and keyframed field behavior', () => {
 				fieldSchema: schema.cropRight,
 				propStatus: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0.2},
@@ -3885,7 +4001,11 @@ test('Crop handle changes preserve static and keyframed field behavior', () => {
 				...target,
 				transformOrigin: {
 					defaultValue: '50% 50%',
-					propStatus: {status: 'static', codeValue: undefined},
+					propStatus: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: undefined,
+					},
 					value: '50% 50%',
 				},
 			},
@@ -3935,7 +4055,11 @@ test('Crop follows an absent or crop-centered static transform origin', () => {
 			nextCrop,
 			transformOrigin: {
 				defaultValue: '50% 50%',
-				propStatus: {status: 'static', codeValue: undefined},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: undefined,
+				},
 				value: '50% 50%',
 			},
 		}),
@@ -3947,7 +4071,11 @@ test('Crop follows an absent or crop-centered static transform origin', () => {
 			nextCrop,
 			transformOrigin: {
 				defaultValue: '50% 50%',
-				propStatus: {status: 'static', codeValue: '23.5% 41.5% 10px'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '23.5% 41.5% 10px',
+				},
 				value: '23.5% 41.5% 10px',
 			},
 		}),
@@ -3972,7 +4100,11 @@ test('Crop leaves custom, keyframed and computed transform origins alone', () =>
 			...base,
 			transformOrigin: {
 				defaultValue: '50% 50%',
-				propStatus: {status: 'static', codeValue: '50% 50%'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '50% 50%',
+				},
 				value: '50% 50%',
 			},
 		}),
@@ -3984,6 +4116,7 @@ test('Crop leaves custom, keyframed and computed transform origins alone', () =>
 				defaultValue: '50% 50%',
 				propStatus: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [{frame: 0, value: '23.5% 41.5%'}],
 					easing: [],
@@ -4087,6 +4220,7 @@ const makeTransformOriginDragTarget = ({
 	originPropStatus: originKeyframed
 		? {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: '50% 50%'},
@@ -4097,7 +4231,11 @@ const makeTransformOriginDragTarget = ({
 				posterize: undefined,
 				output: undefined,
 			}
-		: {status: 'static', codeValue: '50% 50%'},
+		: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: '50% 50%',
+			},
 	originValue: '50% 50%',
 	rotateValue: '0deg',
 	scaleValue: 1,
@@ -4107,6 +4245,7 @@ const makeTransformOriginDragTarget = ({
 	translatePropStatus: translateKeyframed
 		? {
 				status: 'keyframed',
+				keyframeDisplayOffsetAdjustment: null,
 				interpolationFunction: 'interpolate',
 				keyframes: [
 					{frame: 0, value: '0px 0px'},
@@ -4117,7 +4256,11 @@ const makeTransformOriginDragTarget = ({
 				posterize: undefined,
 				output: undefined,
 			}
-		: {status: 'static', codeValue: '10px 20px'},
+		: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: '10px 20px',
+			},
 	translateValue: '10px 20px',
 });
 
@@ -4785,28 +4928,44 @@ test('UV ellipse interactive controls expose resize and rotation handles', () =>
 				fieldKey: 'width',
 				fieldSchema: schema.width,
 				fieldDefault: schema.width.default,
-				propStatus: {status: 'static', codeValue: 0.6},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.6,
+				},
 				value: 0.6,
 			},
 			height: {
 				fieldKey: 'height',
 				fieldSchema: schema.height,
 				fieldDefault: schema.height.default,
-				propStatus: {status: 'static', codeValue: 0.4},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.4,
+				},
 				value: 0.4,
 			},
 			rotation: {
 				fieldKey: 'rotation',
 				fieldSchema: schema.rotation,
 				fieldDefault: schema.rotation.default,
-				propStatus: {status: 'static', codeValue: 90},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 90,
+				},
 				value: 90,
 			},
 			start: {
 				fieldKey: 'start',
 				fieldSchema: schema.start,
 				fieldDefault: schema.start.default,
-				propStatus: {status: 'static', codeValue: 0.5},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.5,
+				},
 				value: 0.5,
 			},
 		},
@@ -4815,7 +4974,11 @@ test('UV ellipse interactive controls expose resize and rotation handles', () =>
 		fieldSchema: schema.center,
 		isSelected: true,
 		nodePath,
-		propStatus: {status: 'static', codeValue: [0.5, 0.5]},
+		propStatus: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: [0.5, 0.5],
+		},
 		schema,
 		sourceFrame: 0,
 		value: [0.5, 0.5],
@@ -4895,28 +5058,44 @@ test('UV ellipse interactive controls rotate numeric fields in pixel space', () 
 				fieldKey: 'width',
 				fieldSchema: schema.width,
 				fieldDefault: schema.width.default,
-				propStatus: {status: 'static', codeValue: 0.6},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.6,
+				},
 				value: 0.6,
 			},
 			height: {
 				fieldKey: 'height',
 				fieldSchema: schema.height,
 				fieldDefault: schema.height.default,
-				propStatus: {status: 'static', codeValue: 0.4},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.4,
+				},
 				value: 0.4,
 			},
 			rotation: {
 				fieldKey: 'rotation',
 				fieldSchema: schema.rotation,
 				fieldDefault: schema.rotation.default,
-				propStatus: {status: 'static', codeValue: 90},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 90,
+				},
 				value: 90,
 			},
 			start: {
 				fieldKey: 'start',
 				fieldSchema: schema.start,
 				fieldDefault: schema.start.default,
-				propStatus: {status: 'static', codeValue: 0.5},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.5,
+				},
 				value: 0.5,
 			},
 		},
@@ -4925,7 +5104,11 @@ test('UV ellipse interactive controls rotate numeric fields in pixel space', () 
 		fieldSchema: schema.center,
 		isSelected: true,
 		nodePath,
-		propStatus: {status: 'static', codeValue: [0.5, 0.5]},
+		propStatus: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: [0.5, 0.5],
+		},
 		schema,
 		sourceFrame: 0,
 		value: [0.5, 0.5],
@@ -4985,14 +5168,17 @@ const getUvHandlesForSelectedEffectChild = (selectedFieldKey: string) => {
 					props: {
 						start: {
 							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
 							codeValue: [0.2, 0.3],
 						},
 						end: {
 							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
 							codeValue: [0.8, 0.7],
 						},
 						dotSize: {
 							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
 							codeValue: 10,
 						},
 					},
@@ -5174,6 +5360,7 @@ test('UV handles are requested for keyframed selected effect props', () => {
 					props: {
 						position: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: [0, 0]},
@@ -5406,6 +5593,7 @@ test('Derived selectable timeline items follow expanded timeline order', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 10, value: 0},
@@ -5535,8 +5723,16 @@ test('Backspace reset targets multiple selected sequence props', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				opacity: {status: 'static', codeValue: 0.5},
-				'style.rotate': {status: 'static', codeValue: '45deg'},
+				opacity: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.5,
+				},
+				'style.rotate': {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '45deg',
+				},
 			},
 			effects: [],
 		},
@@ -5580,7 +5776,11 @@ test('Backspace reset targets stroke with the SVG default', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				stroke: {status: 'static', codeValue: '#ff0000'},
+				stroke: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '#ff0000',
+				},
 			},
 			effects: [],
 		},
@@ -5622,7 +5822,11 @@ test('Backspace reset targets border radius with the CSS default', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				'style.borderRadius': {status: 'static', codeValue: 24},
+				'style.borderRadius': {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 24,
+				},
 			},
 			effects: [],
 		},
@@ -5671,6 +5875,7 @@ test('Backspace reset targets selected keyframed sequence props', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -5761,6 +5966,7 @@ test('Backspace reset targets flattened built-in keyframed sequence style props'
 			props: {
 				'style.opacity': {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -5819,6 +6025,7 @@ test('Backspace reset skips keyframed sequence props without defaults', () => {
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -5866,7 +6073,11 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startZ: 30,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '10px 20px 30px'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '10px 20px 30px',
+				},
 				fieldDefault: '0px 0px',
 				keyframeDisplayOffset: 30,
 				nodePath: firstNodePath,
@@ -5882,7 +6093,11 @@ test('Selected outline dragging applies the same delta to all selected sequences
 			startZ: null,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '-5px 3px'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '-5px 3px',
+				},
 				fieldDefault: '0px 0px',
 				keyframeDisplayOffset: 30,
 				nodePath: secondNodePath,
@@ -5935,8 +6150,16 @@ test('Selected outline active schema exposes default Sequence translate controls
 		},
 		dragOverrides: {},
 		propStatus: {
-			layout: {status: 'static', codeValue: undefined},
-			'style.translate': {status: 'static', codeValue: undefined},
+			layout: {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: undefined,
+			},
+			'style.translate': {
+				status: 'static',
+				keyframeDisplayOffsetAdjustment: null,
+				codeValue: undefined,
+			},
 		},
 		frame: 0,
 	});
@@ -5989,7 +6212,11 @@ test('Selected outline keyboard nudging moves by one or ten pixels', () => {
 			startZ: null,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '10px 20px'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '10px 20px',
+				},
 				fieldDefault: '0px 0px',
 				keyframeDisplayOffset: 30,
 				nodePath,
@@ -6135,6 +6362,7 @@ test('Selected outline dragging keyframed translate adds a keyframe at the sourc
 				clientId: 'client',
 				propStatus: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: '0px 0px 15px'},
@@ -6200,7 +6428,11 @@ test('Selected outline edge dragging scales one axis when scale is unlinked', ()
 			startZ: 1,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '2 3'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '2 3',
+				},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
 				keyframeDisplayOffset: 0,
@@ -6259,7 +6491,11 @@ test('Selected outline edge dragging rounds scale values', () => {
 			startZ: 1,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '2 3'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '2 3',
+				},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
 				keyframeDisplayOffset: 0,
@@ -6294,7 +6530,11 @@ test('Selected outline edge dragging preserves aspect ratio when scale is linked
 			startZ: 1,
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '2 3'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '2 3',
+				},
 				fieldDefault: 1,
 				fieldSchema: schema['style.scale'],
 				keyframeDisplayOffset: 0,
@@ -6330,7 +6570,11 @@ test('Selected outline corner dragging rotates selected sequences', () => {
 			startValue: '45deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '45deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '45deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6349,7 +6593,11 @@ test('Selected outline corner dragging rotates selected sequences', () => {
 			startValue: '-10deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '-10deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '-10deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6410,7 +6658,11 @@ test('Selected outline corner dragging rounds rotation values', () => {
 			startValue: '32deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '32deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '32deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6447,6 +6699,7 @@ test('Selected outline canvas dragging changes X and Y rotation while preserving
 				clientId: 'client',
 				propStatus: {
 					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
 					codeValue: '0.386017 0.438014 0.811871 38.630009deg',
 				},
 				fieldDefault: '0deg',
@@ -6489,6 +6742,7 @@ test('Selected outline corner dragging changes Z rotation while preserving X and
 				clientId: 'client',
 				propStatus: {
 					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
 					codeValue: '0.386017 0.438014 0.811871 38.630009deg',
 				},
 				fieldDefault: '0deg',
@@ -6534,7 +6788,11 @@ test('Selected outline corner dragging snaps rotation to 15 degree increments', 
 			startValue: '32deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '32deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '32deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6575,7 +6833,11 @@ test('Selected outline corner dragging snaps selected rotations from the first d
 			startValue: '32deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '32deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '32deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6594,7 +6856,11 @@ test('Selected outline corner dragging snaps selected rotations from the first d
 			startValue: '-10deg',
 			target: {
 				clientId: 'client',
-				propStatus: {status: 'static', codeValue: '-10deg'},
+				propStatus: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: '-10deg',
+				},
 				fieldDefault: '0deg',
 				fieldSchema: schema['style.rotate'],
 				keyframeDisplayOffset: 30,
@@ -6637,6 +6903,7 @@ test('Selected outline corner dragging keyframed rotation adds a keyframe at the
 				clientId: 'client',
 				propStatus: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: '0deg'},
@@ -6915,7 +7182,11 @@ test('Backspace reset targets selected effect props', () => {
 					importPath: null,
 					effectIndex: 0,
 					props: {
-						intensity: {status: 'static', codeValue: 10},
+						intensity: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 10,
+						},
 					},
 				},
 			],
@@ -6988,8 +7259,16 @@ test('Backspace reset targets active enum variant effect props', () => {
 					importPath: null,
 					effectIndex: 0,
 					props: {
-						colorMode: {status: 'static', codeValue: 'solid'},
-						dotColor: {status: 'static', codeValue: 'blue'},
+						colorMode: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 'solid',
+						},
+						dotColor: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 'blue',
+						},
 					},
 				},
 			],
@@ -7050,7 +7329,11 @@ test('Backspace reset targets selected static blur radius with default', () => {
 					importPath: null,
 					effectIndex: 0,
 					props: {
-						radius: {status: 'static', codeValue: 24},
+						radius: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 24,
+						},
 					},
 				},
 			],
@@ -7113,6 +7396,7 @@ test('Backspace reset targets selected keyframed effect props', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -7185,6 +7469,7 @@ test('Backspace reset skips keyframed effect props without defaults', () => {
 					props: {
 						intensity: {
 							status: 'keyframed',
+							keyframeDisplayOffsetAdjustment: null,
 							interpolationFunction: 'interpolate',
 							keyframes: [
 								{frame: 0, value: 10},
@@ -7243,7 +7528,11 @@ test('Backspace reset targets mixed selected sequence and effect props', () => {
 		[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
 			canUpdate: true,
 			props: {
-				opacity: {status: 'static', codeValue: 0.5},
+				opacity: {
+					status: 'static',
+					keyframeDisplayOffsetAdjustment: null,
+					codeValue: 0.5,
+				},
 			},
 			effects: [
 				{
@@ -7252,7 +7541,11 @@ test('Backspace reset targets mixed selected sequence and effect props', () => {
 					importPath: null,
 					effectIndex: 0,
 					props: {
-						intensity: {status: 'static', codeValue: 10},
+						intensity: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: 10,
+						},
 					},
 				},
 			],
@@ -7424,6 +7717,7 @@ test('Deleting selected keyframe selects remaining easing under playhead', () =>
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -7480,6 +7774,7 @@ test('Deleting selected keyframe clears selection when playhead is not between r
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},
@@ -7603,6 +7898,7 @@ test('Deleting all selected keyframes preserves the value at the playhead', asyn
 			props: {
 				opacity: {
 					status: 'keyframed',
+					keyframeDisplayOffsetAdjustment: null,
 					interpolationFunction: 'interpolate',
 					keyframes: [
 						{frame: 0, value: 0},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2671,6 +2671,112 @@ test('Timeline from drag moves all owned sequence keyframes by the same delta', 
 	]);
 });
 
+test('Timeline from drag moves only descendant keyframes tied to an outer frame clock', () => {
+	const parentNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const parentNodePath = parentNodePathInfo.sequenceSubscriptionKey;
+	const outerFrameDescendantNodePath = makeNodePathInfo(
+		['body', 0, 'children', 0],
+		[],
+	).sequenceSubscriptionKey;
+	const localFrameDescendantNodePath = makeNodePathInfo(
+		['body', 1],
+		[],
+	).sequenceSubscriptionKey;
+	const propStatuses = makeFromPropStatuses([parentNodePath]);
+	const keyframedColorStatus = {
+		status: 'keyframed' as const,
+		interpolationFunction: 'interpolateColors' as const,
+		keyframes: [
+			{frame: 0, value: '#0b84f3'},
+			{frame: 100, value: '#f43b00'},
+		],
+		easing: [{type: 'linear' as const}],
+		clamping: {left: 'extend' as const, right: 'extend' as const},
+		posterize: undefined,
+		output: undefined,
+	};
+	propStatuses[
+		Internals.makeSequencePropsSubscriptionKey(outerFrameDescendantNodePath)
+	] = {
+		canUpdate: true,
+		props: {
+			color: {
+				...keyframedColorStatus,
+				keyframeDisplayOffsetAdjustment: 0,
+			},
+		},
+		effects: [],
+	};
+	propStatuses[
+		Internals.makeSequencePropsSubscriptionKey(localFrameDescendantNodePath)
+	] = {
+		canUpdate: true,
+		props: {
+			color: {
+				...keyframedColorStatus,
+				keyframeDisplayOffsetAdjustment: null,
+			},
+		},
+		effects: [],
+	};
+
+	const targets = getTimelineSequenceFromDragTargets({
+		draggedNodePathInfo: parentNodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo: parentNodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema: {},
+				id: 'parent',
+				overrideId: 'parent-override',
+			}),
+			makeTimelineSequence({
+				schema: {color: {type: 'color', default: '#000000'}},
+				id: 'outer-frame-descendant',
+				overrideId: 'outer-frame-descendant-override',
+				parentId: 'parent',
+			}),
+			makeTimelineSequence({
+				schema: {color: {type: 'color', default: '#000000'}},
+				id: 'local-frame-descendant',
+				overrideId: 'local-frame-descendant-override',
+				parentId: 'parent',
+			}),
+		],
+		overrideIdsToNodePaths: {
+			'parent-override': parentNodePath,
+			'outer-frame-descendant-override': outerFrameDescendantNodePath,
+			'local-frame-descendant-override': localFrameDescendantNodePath,
+		},
+		propStatuses,
+	});
+
+	expect(
+		getTimelineSequenceFromDragKeyframeMoves({
+			targets: targets ?? [],
+			deltaFrames: 10,
+		}).sequenceKeyframes.map((keyframe) => ({
+			nodePath: keyframe.nodePath,
+			fromFrame: keyframe.fromFrame,
+			toFrame: keyframe.toFrame,
+			keyframeDisplayOffsetAdjustmentDelta:
+				keyframe.keyframeDisplayOffsetAdjustmentDelta,
+		})),
+	).toEqual([
+		{
+			nodePath: outerFrameDescendantNodePath,
+			fromFrame: 0,
+			toFrame: 10,
+			keyframeDisplayOffsetAdjustmentDelta: -10,
+		},
+		{
+			nodePath: outerFrameDescendantNodePath,
+			fromFrame: 100,
+			toFrame: 110,
+			keyframeDisplayOffsetAdjustmentDelta: -10,
+		},
+	]);
+});
+
 test('Timeline from drag moves owned effect keyframes by the same delta', () => {
 	const schema = {} satisfies InteractivitySchema;
 	const effectSchema = {

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -405,8 +405,16 @@ test('TransitionSeries.Sequence timing overrides cascade to later sequences', as
 			[subscriptionKey]: {
 				canUpdate: true as const,
 				props: {
-					durationInFrames: {status: 'static' as const, codeValue: 10},
-					trimBefore: {status: 'static' as const, codeValue: 2},
+					durationInFrames: {
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 10,
+					},
+					trimBefore: {
+						status: 'static' as const,
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: 2,
+					},
 				},
 				effects: [],
 			},


### PR DESCRIPTION
## Summary

- Detect whether an interpolation uses a composition-frame or sequence-local `useCurrentFrame()` binding.
- Carry the resulting display offset through Studio timeline rendering, inspectors, and keyframe editing operations.
- Add regression coverage and a `sequence-shift-repro` composition to the example testbed.

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx tsc --noEmit`
- `cd packages/example && bun run comps`
