### PR TITLE
Elements: Add transparency preview toggle

### DIFF
--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -1,5 +1,5 @@
 import {Player} from '@remotion/player';
-import React, {type ComponentType} from 'react';
+import React, {useState, type ComponentType} from 'react';
 
 type ElementPreviewProps = {
 	readonly component: ComponentType<Record<string, never>>;
@@ -18,6 +18,11 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	width,
 	height,
 }) => {
+	const [checkerboard, setCheckerboard] = useState(true);
+	const transparencyLabel = checkerboard
+		? 'Use light preview background'
+		: 'Show transparency as checkerboard';
+
 	return (
 		<div
 			style={{
@@ -43,7 +48,61 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 					controls
 					initiallyMuted
 					loop
+					renderCustomControls={() => (
+						<button
+							aria-label={transparencyLabel}
+							aria-pressed={checkerboard}
+							onClick={() => setCheckerboard((current) => !current)}
+							style={{
+								alignItems: 'center',
+								appearance: 'none',
+								backgroundColor: 'transparent',
+								border: 'none',
+								color: checkerboard ? '#0b84f3' : 'white',
+								cursor: 'pointer',
+								display: 'inline-flex',
+								height: 37,
+								marginRight: 12,
+								padding: '6px 0',
+							}}
+							title={transparencyLabel}
+							type="button"
+						>
+							<svg
+								aria-hidden="true"
+								fill="none"
+								focusable="false"
+								height={18}
+								viewBox="0 0 512 512"
+								width={18}
+							>
+								<path
+									d="M256 48h184c13.3 0 24 10.7 24 24v184H256V48zM48 256h208v208H72c-13.3 0-24-10.7-24-24V256z"
+									fill="currentColor"
+								/>
+								<rect
+									height="416"
+									rx="24"
+									stroke="currentColor"
+									strokeWidth="32"
+									width="416"
+									x="48"
+									y="48"
+								/>
+								<path
+									d="M256 48v416M48 256h416"
+									stroke="currentColor"
+									strokeWidth="32"
+								/>
+							</svg>
+						</button>
+					)}
 					style={{
+						backgroundColor: checkerboard ? 'white' : '#f5f6f7',
+						backgroundImage: checkerboard
+							? 'conic-gradient(rgba(0, 0, 0, 0.1) 25%, transparent 0 50%, rgba(0, 0, 0, 0.1) 0 75%, transparent 0)'
+							: undefined,
+						backgroundSize: checkerboard ? '32px 32px' : undefined,
 						height: '100%',
 						width: '100%',
 					}}


### PR DESCRIPTION
## Summary

- show transparency as a checkerboard by default in Element previews
- add a Player control to switch between checkerboard and light preview backgrounds
- use the Studio checkerboard icon and preserve the selected background in fullscreen

## Verification

- `bun run build`
- `bun run stylecheck`
- manually verified the toggle and fullscreen behavior in the Product Discount Callout preview
