### PR TITLE
Internal testbed: Remove WONTFIX outline selection cases

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -2852,7 +2852,7 @@ export const Index: React.FC = () => {
 					width={1920}
 					height={1080}
 					fps={30}
-					durationInFrames={2700}
+					durationInFrames={2340}
 				/>
 				<Composition
 					id="fast-updates"

--- a/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
+++ b/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
@@ -71,7 +71,7 @@ const CaseFrame: React.FC<{
 						{status}
 					</div>
 					<div style={{fontSize: 28, color: '#94a3b8'}}>
-						Case {String(caseNumber).padStart(2, '0')} / 15
+						Case {String(caseNumber).padStart(2, '0')} / 13
 					</div>
 				</div>
 				<div
@@ -615,124 +615,10 @@ export const OutlineSelectionCases: React.FC = () => {
 			<Series.Sequence
 				durationInFrames={caseDurationInFrames}
 				layout="none"
-				name="10 - Every outline reachable"
+				name="10 - Selected outline wins"
 			>
 				<CaseFrame
 					caseNumber={10}
-					status="Gap"
-					title="Every outline eventually becomes selectable"
-					summary="Completely coincident outlines cannot all be reached through the canvas when only the top hit target responds."
-					desiredBehavior="A deterministic click-through or cycling interaction must eventually select every outline at the pointer."
-					instructions="Use the future cycling gesture repeatedly on the stack. All four named outlines should become selected in a predictable order."
-				>
-					<Interactive.Div
-						name="Coincident outline A"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: '#2563eb',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					>
-						<ShapeLabel>4 coincident outlines</ShapeLabel>
-					</Interactive.Div>
-					<Interactive.Div
-						name="Coincident outline B"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: 'rgba(225, 29, 72, 0.42)',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					/>
-					<Interactive.Div
-						name="Coincident outline C"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: 'rgba(217, 119, 6, 0.36)',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					/>
-					<Interactive.Div
-						name="Coincident outline D"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: 'rgba(124, 58, 237, 0.3)',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					/>
-				</CaseFrame>
-			</Series.Sequence>
-
-			<Series.Sequence
-				durationInFrames={caseDurationInFrames}
-				layout="none"
-				name="11 - Equal-area siblings reachable"
-			>
-				<CaseFrame
-					caseNumber={11}
-					status="Gap"
-					title="Equal-area siblings are all reachable"
-					summary="Unrelated equal-area outlines retain render order, leaving the lower identical sibling inaccessible from the canvas."
-					desiredBehavior="Both siblings can be selected from the canvas; source order must not permanently lock access to one of them."
-					instructions="Cycle or click through the exact overlap. Both Equal sibling A and Equal sibling B should be reachable without using the timeline."
-				>
-					<Interactive.Div
-						name="Equal sibling A"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: '#2563eb',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					>
-						<ShapeLabel>Sibling A + B</ShapeLabel>
-					</Interactive.Div>
-					<Interactive.Div
-						name="Equal sibling B"
-						style={{
-							position: 'absolute',
-							left: 190,
-							top: 200,
-							width: 500,
-							height: 420,
-							backgroundColor: 'rgba(225, 29, 72, 0.42)',
-							borderRadius: 30,
-							translate: '0px 0px',
-						}}
-					/>
-				</CaseFrame>
-			</Series.Sequence>
-
-			<Series.Sequence
-				durationInFrames={caseDurationInFrames}
-				layout="none"
-				name="12 - Selected outline wins"
-			>
-				<CaseFrame
-					caseNumber={12}
 					status="Gap"
 					title="A selected outline always wins hit-testing"
 					summary="Area and hierarchy ordering can currently put an unselected child or smaller unrelated outline above the selected target."
@@ -775,10 +661,10 @@ export const OutlineSelectionCases: React.FC = () => {
 			<Series.Sequence
 				durationInFrames={caseDurationInFrames}
 				layout="none"
-				name="13 - Selected parent drag"
+				name="11 - Selected parent drag"
 			>
 				<CaseFrame
-					caseNumber={13}
+					caseNumber={11}
 					status="Gap"
 					title="A selected parent drags from covered areas"
 					summary="A higher-priority child can receive the event inside a selected parent, replacing the selection instead of starting the drag."
@@ -821,10 +707,10 @@ export const OutlineSelectionCases: React.FC = () => {
 			<Series.Sequence
 				durationInFrames={caseDurationInFrames}
 				layout="none"
-				name="14 - Property selection survives drag"
+				name="12 - Property selection survives drag"
 			>
 				<CaseFrame
-					caseNumber={14}
+					caseNumber={12}
 					status="Gap"
 					title="Property selection survives outline dragging"
 					summary="A selected property raises its containing sequence, but pointer-down on the polygon can promote selection to the whole sequence."
@@ -852,10 +738,10 @@ export const OutlineSelectionCases: React.FC = () => {
 			<Series.Sequence
 				durationInFrames={caseDurationInFrames}
 				layout="none"
-				name="15 - Handles above polygons"
+				name="13 - Handles above polygons"
 			>
 				<CaseFrame
-					caseNumber={15}
+					caseNumber={13}
 					status="Partial"
 					title="All selected editing handles stay on top"
 					summary="Transform-origin and UV handles are already globally raised, but scale and rotation controls can be covered by a later polygon."


### PR DESCRIPTION
## Summary

- remove outline selection cases 10 and 11 because their behavior is WONTFIX
- renumber the remaining cases from 10 through 13
- update the displayed case total and composition duration

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #10238
