### PR TITLE
`@remotion/studio`: Standardize opening files in installed editors

### DIFF
--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -150,7 +150,7 @@ test.describe('error overlay dismissal', () => {
 		// 1. Introduce the bug: remove the `radius: 24` argument.
 		await writeAndWaitForRebuild(buggyContent, 'introducing the bug');
 		await expect(errorMessage).toBeVisible({timeout: 15_000});
-		await page.getByRole('button', {name: 'Open in Zed'}).click();
+		await page.getByRole('button', {name: 'Open in Zed', exact: true}).click();
 		await expect
 			.poll(() => openInEditorRequests)
 			.toEqual([expect.objectContaining({editorId: 'zed'})]);

--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -43,6 +43,36 @@ test.describe('error overlay dismissal', () => {
 		expect(buggyContent).not.toBe(originalContent);
 
 		const errorMessage = page.getByText('"radius" must be a finite number');
+		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultEditor: null,
+						installedEditors: [{id: 'zed', name: 'Zed', nameWithType: 'Zed'}],
+					},
+				},
+			});
+		});
+		await page.route('**/api/default-coding-agent-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultCodingAgent: null,
+						installedCodingAgents: [],
+						installedTerminals: [],
+					},
+				},
+			});
+		});
+		await page.route('**/api/open-in-editor', async (route) => {
+			openInEditorRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {success: true, data: {success: true}},
+			});
+		});
 
 		const writeAndWaitForRebuild = async (
 			content: string,
@@ -120,6 +150,10 @@ test.describe('error overlay dismissal', () => {
 		// 1. Introduce the bug: remove the `radius: 24` argument.
 		await writeAndWaitForRebuild(buggyContent, 'introducing the bug');
 		await expect(errorMessage).toBeVisible({timeout: 15_000});
+		await page.getByRole('button', {name: 'Open in Zed'}).click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([expect.objectContaining({editorId: 'zed'})]);
 
 		// 2. Fix the bug: restore the `radius: 24` argument. The error UI should
 		//    dismiss once HMR applies the fix.

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -914,6 +914,55 @@ test.describe('visual mode', () => {
 					editorId: 'zed',
 				}),
 			]);
+
+		const timelineGridline = page.locator(
+			'[data-timeline-marquee-item][title="0% gridline"]',
+		);
+		await timelineGridline.click();
+		await page.locator('[data-sidebar-toggle="right"]').click();
+		const sourceLocation = page
+			.getByRole('group', {name: 'Inspector source location'})
+			.first();
+		await expect(sourceLocation).toBeVisible();
+		const sourceLink = sourceLocation.getByRole('button', {
+			name: /BarChart\.tsx:\d+/,
+		});
+		await expect(sourceLink).toBeEnabled();
+		await sourceLink.click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+			]);
+
+		await timelineGridline.click({button: 'right'});
+		const sequenceContextMenu = page
+			.locator('[data-remotion-menu-tree-id]')
+			.last();
+		const contextMenuOpenInZed = sequenceContextMenu.getByRole('button', {
+			name: 'Open in Zed',
+			exact: true,
+		});
+		await expect(contextMenuOpenInZed).toBeEnabled();
+		await contextMenuOpenInZed.click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+				expect.objectContaining({
+					editorId: 'zed',
+				}),
+			]);
 	});
 
 	test('should use standalone and contextual app names in portaled context menus', async ({

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -303,6 +303,23 @@ test.describe('visual mode', () => {
 				set: () => undefined,
 			});
 		});
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultEditor: 'vscode',
+						installedEditors: [
+							{
+								id: 'vscode',
+								name: 'Test editor',
+								nameWithType: 'Test editor',
+							},
+						],
+					},
+				},
+			});
+		});
 		const openInEditorRequests: unknown[] = [];
 		await page.route('**/api/open-in-editor', async (route) => {
 			openInEditorRequests.push(route.request().postDataJSON());

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -831,7 +831,7 @@ test.describe('visual mode', () => {
 		).toEqual([]);
 	});
 
-	test('should fall back to the preferred installed editor if no editor is running', async ({
+	test('should use an explicit editor or fall back to an installed editor', async ({
 		page,
 	}) => {
 		await page.addInitScript(() => {
@@ -902,7 +902,14 @@ test.describe('visual mode', () => {
 			page.getByRole('button', {name: 'Zed', exact: true}),
 		).toHaveCount(0);
 
-		await page.keyboard.press('Escape');
+		await page.getByRole('button', {name: 'Code', exact: true}).click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([
+				expect.objectContaining({
+					editorId: 'vscode',
+				}),
+			]);
 		await expect(
 			page.getByRole('button', {name: 'Cursor', exact: true}),
 		).toBeHidden();
@@ -910,6 +917,9 @@ test.describe('visual mode', () => {
 		await expect
 			.poll(() => openInEditorRequests)
 			.toEqual([
+				expect.objectContaining({
+					editorId: 'vscode',
+				}),
 				expect.objectContaining({
 					editorId: 'zed',
 				}),
@@ -933,6 +943,9 @@ test.describe('visual mode', () => {
 			.poll(() => openInEditorRequests)
 			.toEqual([
 				expect.objectContaining({
+					editorId: 'vscode',
+				}),
+				expect.objectContaining({
 					editorId: 'zed',
 				}),
 				expect.objectContaining({
@@ -954,6 +967,9 @@ test.describe('visual mode', () => {
 			.poll(() => openInEditorRequests)
 			.toEqual([
 				expect.objectContaining({
+					editorId: 'vscode',
+				}),
+				expect.objectContaining({
 					editorId: 'zed',
 				}),
 				expect.objectContaining({
@@ -963,6 +979,57 @@ test.describe('visual mode', () => {
 					editorId: 'zed',
 				}),
 			]);
+	});
+
+	test('should disable opening when no editor is installed', async ({page}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'remotion_editorName', {
+				configurable: true,
+				get: () => null,
+				set: () => undefined,
+			});
+		});
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {defaultEditor: null, installedEditors: []},
+				},
+			});
+		});
+		await page.route('**/api/default-coding-agent-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultCodingAgent: null,
+						installedCodingAgents: [],
+						installedTerminals: [],
+					},
+				},
+			});
+		});
+
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+		const projectLocation = page.getByTitle(exampleDir);
+		await projectLocation.hover();
+		await expect(
+			projectLocation.getByRole('button', {
+				name: 'Open in default editor',
+				exact: true,
+			}),
+		).toBeDisabled({timeout: 15_000});
+
+		if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
+			await page.locator('[data-sidebar-toggle="right"]').click();
+		}
+		const sourceLocation = page
+			.getByRole('group', {name: 'Inspector source location'})
+			.first();
+		await expect(sourceLocation).toBeVisible();
+		await expect(
+			sourceLocation.getByRole('button', {name: /\.tsx:\d+/}).first(),
+		).toBeDisabled();
 	});
 
 	test('should use standalone and contextual app names in portaled context menus', async ({

--- a/packages/studio-server/src/preview-server/routes/default-editor.ts
+++ b/packages/studio-server/src/preview-server/routes/default-editor.ts
@@ -2,6 +2,7 @@ import type {
 	GetDefaultEditorInfoRequest,
 	GetDefaultEditorInfoResponse,
 } from '@remotion/studio-shared';
+import {resolveCustomEditorExecutable} from '../../helpers/custom-editor';
 import {getAvailableEditors} from '../../helpers/editor-registry';
 import type {ApiHandler} from '../api-types';
 
@@ -12,7 +13,9 @@ export const getDefaultEditorInfoHandler: ApiHandler<
 	const installedEditors = await getAvailableEditors();
 	const configuredEditor = getDefaultEditor();
 	const customEditor =
-		configuredEditor && typeof configuredEditor === 'object'
+		configuredEditor &&
+		typeof configuredEditor === 'object' &&
+		resolveCustomEditorExecutable(configuredEditor)
 			? configuredEditor
 			: null;
 	return {

--- a/packages/studio-server/src/test/default-editor-route.test.ts
+++ b/packages/studio-server/src/test/default-editor-route.test.ts
@@ -1,18 +1,14 @@
 import {expect, test} from 'bun:test';
+import type {DefaultEditor} from '@remotion/renderer';
 import {getDefaultEditorInfoHandler} from '../preview-server/routes/default-editor';
 
-test('exposes only an opaque ID and name for a configured custom editor', async () => {
-	const response = await getDefaultEditorInfoHandler({
+const getEditorInfo = (defaultEditor: DefaultEditor | null) => {
+	return getDefaultEditorInfoHandler({
 		binariesDirectory: null,
 		configFile: null,
 		entryPoint: '',
 		getDefaultCodingAgent: () => null,
-		getDefaultEditor: () => ({
-			type: 'custom',
-			name: 'Acme Editor',
-			executable: '/private/acme/editor',
-			arguments: ['--goto', '%TARGET_PATH%'],
-		}),
+		getDefaultEditor: () => defaultEditor,
 		input: {},
 		logLevel: 'error',
 		methods: {
@@ -25,6 +21,15 @@ test('exposes only an opaque ID and name for a configured custom editor', async 
 		request: {} as never,
 		response: {} as never,
 	});
+};
+
+test('exposes only an opaque ID and name for an installed custom editor', async () => {
+	const response = await getEditorInfo({
+		type: 'custom',
+		name: 'Acme Editor',
+		executable: process.execPath,
+		arguments: ['--goto', '%TARGET_PATH%'],
+	});
 
 	expect(response.defaultEditor).toBe('custom');
 	expect(response.installedEditors).toContainEqual({
@@ -32,6 +37,20 @@ test('exposes only an opaque ID and name for a configured custom editor', async 
 		name: 'Acme Editor',
 		nameWithType: 'Acme Editor',
 	});
-	expect(JSON.stringify(response)).not.toContain('/private/acme/editor');
+	expect(JSON.stringify(response)).not.toContain(process.execPath);
 	expect(JSON.stringify(response)).not.toContain('%TARGET_PATH%');
+});
+
+test('does not expose a custom editor whose executable is unavailable', async () => {
+	const response = await getEditorInfo({
+		type: 'custom',
+		name: 'Missing Editor',
+		executable: '/missing/remotion-editor',
+		arguments: ['%TARGET_PATH%'],
+	});
+
+	expect(response.defaultEditor).toBe('custom');
+	expect(response.installedEditors).not.toContainEqual(
+		expect.objectContaining({id: 'custom'}),
+	);
 });

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -38,6 +38,7 @@ import {showNotification} from './Notifications/NotificationCenter';
 import {applyCodemod} from './RenderQueue/actions';
 import {SidebarRenderButton} from './SidebarRenderButton';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
+import {useEditorOpening} from './use-default-editor-info';
 
 const itemStyle: React.CSSProperties = {
 	paddingRight: 2,
@@ -192,6 +193,9 @@ export const CompositionSelectorItem: React.FC<{
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const connectionStatus = useContext(StudioServerConnectionCtx)
 		.previewServerState.type;
+	const {defaultEditorId, defaultEditorName} = useEditorOpening(
+		connectionStatus === 'connected',
+	);
 	const resolvedLocation = useResolvedStack(
 		item.type === 'composition' ? item.composition.stack : item.folder.stack,
 	);
@@ -202,6 +206,8 @@ export const CompositionSelectorItem: React.FC<{
 				closeMenu: noop,
 				composition: item.composition,
 				connectionStatus,
+				editorId: defaultEditorId,
+				editorName: defaultEditorName,
 				includeCompositionManagementItems: true,
 				resolvedLocation,
 				setSelectedModal,
@@ -212,12 +218,21 @@ export const CompositionSelectorItem: React.FC<{
 		return getFolderMenuItems({
 			closeMenu: noop,
 			connectionStatus,
+			editorId: defaultEditorId,
+			editorName: defaultEditorName,
 			folder: item.folder,
 			resolvedLocation,
 			setSelectedModal,
 			readOnlyStudio: window.remotion_isReadOnlyStudio,
 		});
-	}, [connectionStatus, item, resolvedLocation, setSelectedModal]);
+	}, [
+		connectionStatus,
+		defaultEditorId,
+		defaultEditorName,
+		item,
+		resolvedLocation,
+		setSelectedModal,
+	]);
 
 	const onCompositionDragStart = useCallback(
 		(event: DragEvent<HTMLElement>) => {

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -26,10 +26,8 @@ import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {openInFileExplorer} from './RenderQueue/actions';
 import {
-	canUseEditorPicker,
-	getPreferredEditorId,
 	useDefaultCodingAgentInfo,
-	useDefaultEditorInfo,
+	useEditorOpening,
 } from './use-default-editor-info';
 
 const splitButton: React.CSSProperties = {
@@ -73,14 +71,17 @@ export const InspectorOpenInEditor: React.FC<{
 	const [hovered, setHovered] = useState(false);
 	const [dropdownOpened, setDropdownOpened] = useState(false);
 	const ignorePointerEnter = useRef(false);
-	const editorPickerAvailable = canUseEditorPicker(
-		previewServerState.type === 'connected',
-	);
-	const editorInfo = useDefaultEditorInfo(editorPickerAvailable);
-	const codingAgentInfo = useDefaultCodingAgentInfo(editorPickerAvailable);
+	const {
+		canConfigureApps,
+		canOpenInEditor,
+		defaultEditorId,
+		defaultEditorName,
+		editorInfo,
+	} = useEditorOpening(previewServerState.type === 'connected');
+	const codingAgentInfo = useDefaultCodingAgentInfo(canConfigureApps);
 
 	const openWithEditor = useCallback(
-		async (editorId: EditorPickerId | null) => {
+		async (editorId: EditorPickerId) => {
 			if (!location) {
 				return;
 			}
@@ -94,10 +95,6 @@ export const InspectorOpenInEditor: React.FC<{
 		[location],
 	);
 
-	const preferredEditorId = getPreferredEditorId(editorInfo);
-	const preferredEditor = editorInfo?.installedEditors.find(
-		(editor) => editor.id === preferredEditorId,
-	);
 	const openWithCodingAgent = useCallback(
 		async (codingAgentId: DefaultCodingAgent, codingAgentName: string) => {
 			try {
@@ -114,21 +111,16 @@ export const InspectorOpenInEditor: React.FC<{
 		},
 		[contextForAgents],
 	);
-	const editorName =
-		window.remotion_editorName ??
-		preferredEditor?.nameWithType ??
-		'default editor';
-	const canOpenDefault =
-		location !== null &&
-		(window.remotion_editorName !== null || preferredEditorId !== null);
+	const editorName = defaultEditorName ?? 'default editor';
+	const canOpenDefault = location !== null && canOpenInEditor;
 	const onOpenDefault: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(event) => {
 			event.stopPropagation();
-			openWithEditor(
-				window.remotion_editorName === null ? preferredEditorId : null,
-			).catch(() => undefined);
+			if (defaultEditorId) {
+				openWithEditor(defaultEditorId).catch(() => undefined);
+			}
 		},
-		[openWithEditor, preferredEditorId],
+		[defaultEditorId, openWithEditor],
 	);
 	const onDropdownOpenChange = useCallback((open: boolean) => {
 		setDropdownOpened(open);
@@ -171,18 +163,20 @@ export const InspectorOpenInEditor: React.FC<{
 			editorDisabled: location === null,
 			editorInfo,
 			excludeCodingAgentId: null,
-			excludeEditorId: preferredEditorId,
+			excludeEditorId: defaultEditorId,
 			fileManagerDisabled: !location?.source,
 			folder: locationType === 'folder',
 			location,
-			onConfigureApps: () => {
-				setSelectedModal({
-					type: 'settings',
-					initialTab: 'apps',
-					initialPublicLicenseKey:
-						window.remotion_renderDefaults?.publicLicenseKey ?? null,
-				});
-			},
+			onConfigureApps: canConfigureApps
+				? () => {
+						setSelectedModal({
+							type: 'settings',
+							initialTab: 'apps',
+							initialPublicLicenseKey:
+								window.remotion_renderDefaults?.publicLicenseKey ?? null,
+						});
+					}
+				: null,
 			onOpenInCodingAgent: (codingAgentId, codingAgentName) => {
 				openWithCodingAgent(codingAgentId, codingAgentName).catch(
 					() => undefined,
@@ -235,16 +229,17 @@ export const InspectorOpenInEditor: React.FC<{
 		});
 	}, [
 		codingAgentInfo,
+		canConfigureApps,
+		defaultEditorId,
 		editorInfo,
 		location,
 		locationType,
 		openWithCodingAgent,
 		openWithEditor,
-		preferredEditorId,
 		setSelectedModal,
 	]);
 
-	if (!editorPickerAvailable) {
+	if (previewServerState.type !== 'connected') {
 		return null;
 	}
 
@@ -271,7 +266,7 @@ export const InspectorOpenInEditor: React.FC<{
 				type="button"
 			>
 				{label}
-				<EditorIcon editorId={preferredEditorId} size={editorButtonIconSize} />
+				<EditorIcon editorId={defaultEditorId} size={editorButtonIconSize} />
 			</button>
 			<InlineDropdown
 				onOpenChange={onDropdownOpenChange}

--- a/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import {Internals} from 'remotion';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {
 	openOriginalPositionInEditor,
@@ -23,6 +24,7 @@ import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {COMPACT_INLINE_ROW_HEIGHT} from '../layout';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
+import {useEditorOpening} from '../use-default-editor-info';
 
 const COMPOSITION_INSPECTOR_HEADER_HEIGHT = 66;
 
@@ -44,6 +46,10 @@ const renderReactIcon = (color: string) => {
 export const CompositionInspectorHeader = () => {
 	const video = Internals.useVideo();
 	const {compositions} = useContext(Internals.CompositionManager);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canOpenInEditor, defaultEditorId} = useEditorOpening(
+		previewServerState.type === 'connected',
+	);
 
 	const currentComposition = useMemo(() => {
 		if (!video) {
@@ -92,23 +98,27 @@ export const CompositionInspectorHeader = () => {
 	}, [compositionFile, compositionId]);
 
 	const openFileLocation = useCallback(() => {
-		if (!validatedLocation) {
+		if (!validatedLocation || !defaultEditorId || !canOpenInEditor) {
 			return;
 		}
 
-		openOriginalPositionInEditor(validatedLocation, null).catch((err) => {
-			showNotification((err as Error).message, 2000);
-		});
-	}, [validatedLocation]);
+		openOriginalPositionInEditor(validatedLocation, defaultEditorId).catch(
+			(err) => {
+				showNotification((err as Error).message, 2000);
+			},
+		);
+	}, [canOpenInEditor, defaultEditorId, validatedLocation]);
 	const openComponentLocation = useCallback(() => {
-		if (!componentLocation) {
+		if (!componentLocation || !defaultEditorId || !canOpenInEditor) {
 			return;
 		}
 
-		openOriginalPositionInEditor(componentLocation, null).catch((err) => {
-			showNotification((err as Error).message, 2000);
-		});
-	}, [componentLocation]);
+		openOriginalPositionInEditor(componentLocation, defaultEditorId).catch(
+			(err) => {
+				showNotification((err as Error).message, 2000);
+			},
+		);
+	}, [canOpenInEditor, componentLocation, defaultEditorId]);
 	const renderCompositionIcon = useCallback(
 		(color: string) => {
 			if (!video) {
@@ -143,7 +153,7 @@ export const CompositionInspectorHeader = () => {
 					/>
 					<InspectorSourceLocation
 						location={validatedLocation}
-						canOpen={validatedLocation !== null}
+						canOpen={validatedLocation !== null && canOpenInEditor}
 						onOpen={openFileLocation}
 						renderIcon={renderCompositionIcon}
 						size="inline-action"
@@ -155,7 +165,7 @@ export const CompositionInspectorHeader = () => {
 					) : (
 						<InspectorSourceLocation
 							location={componentLocation}
-							canOpen={componentLocation !== null}
+							canOpen={componentLocation !== null && canOpenInEditor}
 							onOpen={openComponentLocation}
 							renderIcon={renderReactIcon}
 							size="inline-action"

--- a/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
+++ b/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
@@ -11,6 +11,7 @@ import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
 import {ContextMenu} from '../ContextMenu';
 import {useSelectComposition} from '../InitialCompositionLoader';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
+import {useEditorOpening} from '../use-default-editor-info';
 import {InspectorInlineAction} from './common';
 
 const compositionIconStyle: React.CSSProperties = {
@@ -66,6 +67,9 @@ const ConnectedCompositionRow: React.FC<{
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const connectionStatus = useContext(StudioServerConnectionCtx)
 		.previewServerState.type;
+	const {defaultEditorId, defaultEditorName} = useEditorOpening(
+		connectionStatus === 'connected',
+	);
 	const resolvedLocation = useResolvedStack(composition.stack);
 	const getContextMenuItems = useCallback(
 		() =>
@@ -73,12 +77,21 @@ const ConnectedCompositionRow: React.FC<{
 				closeMenu: noop,
 				composition,
 				connectionStatus,
+				editorId: defaultEditorId,
+				editorName: defaultEditorName,
 				includeCompositionManagementItems: false,
 				readOnlyStudio: window.remotion_isReadOnlyStudio,
 				resolvedLocation,
 				setSelectedModal,
 			}),
-		[composition, connectionStatus, resolvedLocation, setSelectedModal],
+		[
+			composition,
+			connectionStatus,
+			defaultEditorId,
+			defaultEditorName,
+			resolvedLocation,
+			setSelectedModal,
+		],
 	);
 
 	return (

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -48,10 +48,8 @@ import {
 } from './Timeline/TimelineSelection';
 import {getOriginalLocationFromStack} from './Timeline/TimelineStack/get-stack';
 import {
-	canUseEditorPicker,
-	getPreferredEditorId,
 	useDefaultCodingAgentInfo,
-	useDefaultEditorInfo,
+	useEditorOpening,
 } from './use-default-editor-info';
 import {useSelectAsset} from './use-select-asset';
 type SelectedOutlineElementProps = {
@@ -99,12 +97,13 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	scale,
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const canConfigureApps = canUseEditorPicker(
-		previewServerState.type === 'connected',
-	);
-	const editorInfo = useDefaultEditorInfo(canConfigureApps);
+	const {
+		canConfigureApps,
+		canOpenInEditor: editorAvailable,
+		defaultEditorId,
+		editorInfo,
+	} = useEditorOpening(previewServerState.type === 'connected');
 	const codingAgentInfo = useDefaultCodingAgentInfo(canConfigureApps);
-	const preferredEditorId = getPreferredEditorId(editorInfo);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const updateResolvedStackTrace = useContext(
 		Internals.SequenceStackTracesUpdateContext,
@@ -202,9 +201,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 			});
 			const action = getSequenceDoubleClickAction({
 				button,
-				canOpenInEditor:
-					previewServerState.type === 'connected' &&
-					(window.remotion_editorName !== null || preferredEditorId !== null),
+				canOpenInEditor: editorAvailable,
 				numberOfConnectedCompositions: connectedCompositions.length,
 			});
 
@@ -220,14 +217,11 @@ const SelectedOutlineElementUnmemoized: React.FC<
 			const openTargetInEditor = async () => {
 				const originalLocation =
 					await resolveOriginalLocation(doubleClickTarget);
-				if (originalLocation === null) {
+				if (originalLocation === null || defaultEditorId === null) {
 					return;
 				}
 
-				await openOriginalPositionInEditor(
-					originalLocation,
-					window.remotion_editorName === null ? preferredEditorId : null,
-				);
+				await openOriginalPositionInEditor(originalLocation, defaultEditorId);
 			};
 
 			openTargetInEditor().catch((err) => {
@@ -238,8 +232,8 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		},
 		[
 			compositions,
-			preferredEditorId,
-			previewServerState.type,
+			defaultEditorId,
+			editorAvailable,
 			resolveOriginalLocation,
 			selectComposition,
 		],
@@ -268,10 +262,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				? contextMenuTarget.sequence.src
 				: null;
 		const assetLinkInfo = mediaSrc ? getTimelineAssetLinkInfo(mediaSrc) : null;
-		const canOpenInEditor = Boolean(
-			originalLocation &&
-			(window.remotion_editorName !== null || preferredEditorId !== null),
-		);
+		const canOpenInEditor = Boolean(originalLocation && editorAvailable);
 		const sourceEditingEnabled = isStudioInteractivityEnabled();
 		const disableInteractivityDisabled =
 			!sourceEditingEnabled || !contextMenuTarget.sequence.showInTimeline;
@@ -382,17 +373,16 @@ const SelectedOutlineElementUnmemoized: React.FC<
 					});
 			},
 			openInEditor: (editorId) => {
-				if (!originalLocation) {
+				const resolvedEditorId = editorId ?? defaultEditorId;
+				if (!originalLocation || !resolvedEditorId || !editorAvailable) {
 					return;
 				}
 
-				openOriginalPositionInEditor(
-					originalLocation,
-					editorId ??
-						(window.remotion_editorName === null ? preferredEditorId : null),
-				).catch((err) => {
-					showNotification((err as Error).message, 2000);
-				});
+				openOriginalPositionInEditor(originalLocation, resolvedEditorId).catch(
+					(err) => {
+						showNotification((err as Error).message, 2000);
+					},
+				);
 			},
 			originalLocation,
 			selectAsset,
@@ -505,7 +495,8 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		editorInfo,
 		getTarget,
 		onSelect,
-		preferredEditorId,
+		defaultEditorId,
+		editorAvailable,
 		previewServerState,
 		resolveOriginalLocation,
 		setManuallyEnabled,

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -49,6 +49,7 @@ import {
 import {getOriginalLocationFromStack} from './Timeline/TimelineStack/get-stack';
 import {
 	canUseEditorPicker,
+	getPreferredEditorId,
 	useDefaultCodingAgentInfo,
 	useDefaultEditorInfo,
 } from './use-default-editor-info';
@@ -103,6 +104,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	);
 	const editorInfo = useDefaultEditorInfo(canConfigureApps);
 	const codingAgentInfo = useDefaultCodingAgentInfo(canConfigureApps);
+	const preferredEditorId = getPreferredEditorId(editorInfo);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const updateResolvedStackTrace = useContext(
 		Internals.SequenceStackTracesUpdateContext,
@@ -202,7 +204,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				button,
 				canOpenInEditor:
 					previewServerState.type === 'connected' &&
-					Boolean(window.remotion_editorName),
+					(window.remotion_editorName !== null || preferredEditorId !== null),
 				numberOfConnectedCompositions: connectedCompositions.length,
 			});
 
@@ -222,7 +224,10 @@ const SelectedOutlineElementUnmemoized: React.FC<
 					return;
 				}
 
-				await openOriginalPositionInEditor(originalLocation, null);
+				await openOriginalPositionInEditor(
+					originalLocation,
+					window.remotion_editorName === null ? preferredEditorId : null,
+				);
 			};
 
 			openTargetInEditor().catch((err) => {
@@ -233,6 +238,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		},
 		[
 			compositions,
+			preferredEditorId,
 			previewServerState.type,
 			resolveOriginalLocation,
 			selectComposition,
@@ -263,7 +269,8 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				: null;
 		const assetLinkInfo = mediaSrc ? getTimelineAssetLinkInfo(mediaSrc) : null;
 		const canOpenInEditor = Boolean(
-			window.remotion_editorName && originalLocation,
+			originalLocation &&
+			(window.remotion_editorName !== null || preferredEditorId !== null),
 		);
 		const sourceEditingEnabled = isStudioInteractivityEnabled();
 		const disableInteractivityDisabled =
@@ -379,11 +386,13 @@ const SelectedOutlineElementUnmemoized: React.FC<
 					return;
 				}
 
-				openOriginalPositionInEditor(originalLocation, editorId).catch(
-					(err) => {
-						showNotification((err as Error).message, 2000);
-					},
-				);
+				openOriginalPositionInEditor(
+					originalLocation,
+					editorId ??
+						(window.remotion_editorName === null ? preferredEditorId : null),
+				).catch((err) => {
+					showNotification((err as Error).message, 2000);
+				});
 			},
 			originalLocation,
 			selectAsset,
@@ -496,6 +505,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		editorInfo,
 		getTarget,
 		onSelect,
+		preferredEditorId,
 		previewServerState,
 		resolveOriginalLocation,
 		setManuallyEnabled,

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -18,6 +18,7 @@ import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
 import {callApi} from '../call-api';
 import {ContextMenu} from '../ContextMenu';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {useEditorOpening} from '../use-default-editor-info';
 import {callAddEffectKeyframe} from './call-add-keyframe';
 import {getComputedStatusLabel} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
@@ -382,6 +383,9 @@ export const TimelineEffectPropItem: React.FC<{
 	keyframeControlsMode = 'timeline',
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canOpenInEditor, defaultEditorId} = useEditorOpening(
+		previewServerState.type === 'connected',
+	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {getEffectDragOverrides} = useContext(
@@ -524,20 +528,18 @@ export const TimelineEffectPropItem: React.FC<{
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
-			if (
-				!window.remotion_editorName ||
-				previewServerState.type !== 'connected'
-			) {
+			if (!canOpenInEditor || !defaultEditorId) {
 				return;
 			}
 
 			event.stopPropagation();
 			openOriginalPositionInEditorAtProperty({
+				editorId: defaultEditorId,
 				originalPosition: validatedLocation,
 				property: field.key,
 			}).catch(() => undefined);
 		},
-		[field.key, previewServerState.type, validatedLocation],
+		[canOpenInEditor, defaultEditorId, field.key, validatedLocation],
 	);
 
 	const row = (

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -23,6 +23,7 @@ import type {
 import {ContextMenu} from '../ContextMenu';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {useEditorOpening} from '../use-default-editor-info';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
 import {getSequencePropResetChanges} from './get-sequence-prop-reset-changes';
 import {saveSequenceProps} from './save-sequence-prop';
@@ -419,6 +420,9 @@ export const TimelineSequencePropItem: React.FC<{
 	);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canOpenInEditor, defaultEditorId} = useEditorOpening(
+		previewServerState.type === 'connected',
+	);
 	const selection = useTimelineRowSelection(nodePathInfo);
 	const transform3DMode = useContext(Transform3DModeContext);
 	const propStatusesForOverride = Internals.getPropStatusesCtx(
@@ -554,20 +558,18 @@ export const TimelineSequencePropItem: React.FC<{
 		React.MouseEventHandler<HTMLDivElement>
 	>(
 		(event) => {
-			if (
-				!window.remotion_editorName ||
-				previewServerState.type !== 'connected'
-			) {
+			if (!canOpenInEditor || !defaultEditorId) {
 				return;
 			}
 
 			event.stopPropagation();
 			openOriginalPositionInEditorAtProperty({
+				editorId: defaultEditorId,
 				originalPosition: validatedLocation,
 				property: field.key.split('.').at(-1) ?? field.key,
 			}).catch(() => undefined);
 		},
-		[field.key, previewServerState.type, validatedLocation],
+		[canOpenInEditor, defaultEditorId, field.key, validatedLocation],
 	);
 
 	if (propStatus === null) {

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -11,6 +11,7 @@ import {getOpenInMenuItems} from '../get-open-in-menu-items';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {openInFileExplorer} from '../RenderQueue/actions';
+import {getPreferredEditorId} from '../use-default-editor-info';
 import type {TimelineAssetLinkInfo} from './timeline-asset-link';
 import {openTimelineAssetLink} from './timeline-asset-link';
 
@@ -82,13 +83,15 @@ export const getSequenceContextMenuItems = ({
 	readonly sequence: TSequence;
 	readonly sourceActions?: readonly ComboboxValue[];
 }): ComboboxValue[] => {
-	const editorName = window.remotion_editorName;
 	const isInteractiveSvg =
 		sequence.controls?.componentIdentity === interactiveSvgComponentIdentity;
 	const installedEditors = editorInfo?.installedEditors ?? [];
-	const defaultEditorId =
-		installedEditors.find((editor) => editor.nameWithType === editorName)?.id ??
-		null;
+	const defaultEditorId = getPreferredEditorId(editorInfo);
+	const defaultEditor = installedEditors.find(
+		(editor) => editor.id === defaultEditorId,
+	);
+	const editorName =
+		window.remotion_editorName ?? defaultEditor?.nameWithType ?? null;
 	const defaultCodingAgent = codingAgentInfo?.installedCodingAgents.find(
 		(codingAgent) => codingAgent.id === codingAgentInfo.defaultCodingAgent,
 	);
@@ -111,7 +114,7 @@ export const getSequenceContextMenuItems = ({
 	const openInMenuItems = onConfigureApps
 		? getOpenInMenuItems({
 				codingAgentInfo,
-				editorDisabled: !canOpenInEditor || !originalLocation,
+				editorDisabled: !originalLocation,
 				editorInfo,
 				excludeCodingAgentId: defaultCodingAgent?.id ?? null,
 				excludeEditorId: defaultEditorId,

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -90,8 +90,7 @@ export const getSequenceContextMenuItems = ({
 	const defaultEditor = installedEditors.find(
 		(editor) => editor.id === defaultEditorId,
 	);
-	const editorName =
-		window.remotion_editorName ?? defaultEditor?.nameWithType ?? null;
+	const editorName = defaultEditor?.nameWithType ?? null;
 	const defaultCodingAgent = codingAgentInfo?.installedCodingAgents.find(
 		(codingAgent) => codingAgent.id === codingAgentInfo.defaultCodingAgent,
 	);
@@ -114,7 +113,7 @@ export const getSequenceContextMenuItems = ({
 	const openInMenuItems = onConfigureApps
 		? getOpenInMenuItems({
 				codingAgentInfo,
-				editorDisabled: !originalLocation,
+				editorDisabled: !canOpenInEditor || !originalLocation,
 				editorInfo,
 				excludeCodingAgentId: defaultCodingAgent?.id ?? null,
 				excludeEditorId: defaultEditorId,

--- a/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
+++ b/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
@@ -10,6 +10,7 @@ import {
 import {showNotification} from '../Notifications/NotificationCenter';
 import {
 	canUseEditorPicker,
+	getPreferredEditorId,
 	useDefaultCodingAgentInfo,
 	useDefaultEditorInfo,
 } from '../use-default-editor-info';
@@ -25,13 +26,15 @@ export const useOpenSequenceInApps = (sequence: TSequence) => {
 	const editorPickerAvailable = canUseEditorPicker(previewConnected);
 	const editorInfo = useDefaultEditorInfo(editorPickerAvailable);
 	const codingAgentInfo = useDefaultCodingAgentInfo(editorPickerAvailable);
-
+	const preferredEditorId = getPreferredEditorId(editorInfo);
 	const canOpenInEditor = useMemo(
 		() =>
 			Boolean(
-				window.remotion_editorName && previewConnected && originalLocation,
+				previewConnected &&
+				originalLocation &&
+				(window.remotion_editorName !== null || preferredEditorId !== null),
 			),
-		[originalLocation, previewConnected],
+		[originalLocation, preferredEditorId, previewConnected],
 	);
 
 	const openInEditor = useCallback(
@@ -41,12 +44,16 @@ export const useOpenSequenceInApps = (sequence: TSequence) => {
 			}
 
 			try {
-				await openOriginalPositionInEditor(originalLocation, editorId);
+				await openOriginalPositionInEditor(
+					originalLocation,
+					editorId ??
+						(window.remotion_editorName === null ? preferredEditorId : null),
+				);
 			} catch (err) {
 				showNotification((err as Error).message, 2000);
 			}
 		},
-		[canOpenInEditor, originalLocation],
+		[canOpenInEditor, originalLocation, preferredEditorId],
 	);
 	const openInCodingAgent = useCallback(
 		async (

--- a/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
+++ b/packages/studio/src/components/Timeline/use-open-sequence-in-apps.ts
@@ -9,10 +9,8 @@ import {
 } from '../../helpers/open-in-editor';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {
-	canUseEditorPicker,
-	getPreferredEditorId,
 	useDefaultCodingAgentInfo,
-	useDefaultEditorInfo,
+	useEditorOpening,
 } from '../use-default-editor-info';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
 
@@ -23,37 +21,32 @@ export const useOpenSequenceInApps = (sequence: TSequence) => {
 		sequence.getStack,
 		sequence.controls?.overrideId ?? sequence.id,
 	);
-	const editorPickerAvailable = canUseEditorPicker(previewConnected);
-	const editorInfo = useDefaultEditorInfo(editorPickerAvailable);
-	const codingAgentInfo = useDefaultCodingAgentInfo(editorPickerAvailable);
-	const preferredEditorId = getPreferredEditorId(editorInfo);
+	const {
+		canConfigureApps,
+		canOpenInEditor: editorAvailable,
+		defaultEditorId,
+		editorInfo,
+	} = useEditorOpening(previewConnected);
+	const codingAgentInfo = useDefaultCodingAgentInfo(canConfigureApps);
 	const canOpenInEditor = useMemo(
-		() =>
-			Boolean(
-				previewConnected &&
-				originalLocation &&
-				(window.remotion_editorName !== null || preferredEditorId !== null),
-			),
-		[originalLocation, preferredEditorId, previewConnected],
+		() => Boolean(editorAvailable && originalLocation),
+		[editorAvailable, originalLocation],
 	);
 
 	const openInEditor = useCallback(
 		async (editorId: EditorPickerId | null) => {
-			if (!canOpenInEditor || !originalLocation) {
+			const resolvedEditorId = editorId ?? defaultEditorId;
+			if (!canOpenInEditor || !originalLocation || !resolvedEditorId) {
 				return;
 			}
 
 			try {
-				await openOriginalPositionInEditor(
-					originalLocation,
-					editorId ??
-						(window.remotion_editorName === null ? preferredEditorId : null),
-				);
+				await openOriginalPositionInEditor(originalLocation, resolvedEditorId);
 			} catch (err) {
 				showNotification((err as Error).message, 2000);
 			}
 		},
-		[canOpenInEditor, originalLocation, preferredEditorId],
+		[canOpenInEditor, defaultEditorId, originalLocation],
 	);
 	const openInCodingAgent = useCallback(
 		async (
@@ -78,7 +71,7 @@ export const useOpenSequenceInApps = (sequence: TSequence) => {
 
 	return {
 		canOpenInEditor,
-		canConfigureApps: editorPickerAvailable,
+		canConfigureApps,
 		codingAgentInfo,
 		editorInfo,
 		openInCodingAgent,

--- a/packages/studio/src/components/VisualControls/ClickableFileName.tsx
+++ b/packages/studio/src/components/VisualControls/ClickableFileName.tsx
@@ -1,10 +1,12 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useContext, useMemo, useState} from 'react';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {BORDER_WHITE, LIGHT_COLOR, WHITE_HEX} from '../../helpers/colors';
 import {openOriginalPositionInEditor} from '../../helpers/open-in-editor';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {getSchemaEditorFieldsetPadding} from '../RenderModal/SchemaEditor/Fieldset';
 import {getOriginalSourceAttribution} from '../Timeline/TimelineStack/source-attribution';
+import {useEditorOpening} from '../use-default-editor-info';
 
 export type OriginalFileNameState =
 	| {
@@ -30,7 +32,15 @@ export const ClickableFileName = ({
 	readonly originalFileName: OriginalFileNameState;
 }) => {
 	const [titleHovered, setTitleHovered] = useState(false);
-	const hoverEffect = titleHovered && originalFileName.type === 'loaded';
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canOpenInEditor, defaultEditorId} = useEditorOpening(
+		previewServerState.type === 'connected',
+	);
+	const canOpen =
+		canOpenInEditor &&
+		defaultEditorId !== null &&
+		originalFileName.type === 'loaded';
+	const hoverEffect = titleHovered && canOpen;
 
 	const onTitlePointerEnter = useCallback(() => {
 		setTitleHovered(true);
@@ -43,23 +53,24 @@ export const ClickableFileName = ({
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			fontSize: 12,
-			cursor: originalFileName.type === 'loaded' ? 'pointer' : undefined,
+			cursor: canOpen ? 'pointer' : undefined,
 			borderBottom: hoverEffect ? BORDER_WHITE : 'none',
 			color: hoverEffect ? WHITE_HEX : LIGHT_COLOR,
 		};
-	}, [originalFileName, hoverEffect]);
+	}, [canOpen, hoverEffect]);
 
 	const onClick = useCallback(() => {
-		if (originalFileName.type !== 'loaded') {
+		if (originalFileName.type !== 'loaded' || !canOpen || !defaultEditorId) {
 			return;
 		}
 
-		openOriginalPositionInEditor(originalFileName.originalFileName, null).catch(
-			(err) => {
-				showNotification((err as Error).message, 2000);
-			},
-		);
-	}, [originalFileName]);
+		openOriginalPositionInEditor(
+			originalFileName.originalFileName,
+			defaultEditorId,
+		).catch((err) => {
+			showNotification((err as Error).message, 2000);
+		});
+	}, [canOpen, defaultEditorId, originalFileName]);
 
 	return (
 		<div style={container}>

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -1,3 +1,4 @@
+import type {EditorPickerId} from '@remotion/studio-shared';
 import type {SetStateAction} from 'react';
 import type {ResolvedStackLocation, _InternalTypes} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -20,6 +21,8 @@ export const getCompositionMenuItems = ({
 	closeMenu,
 	readOnlyStudio,
 	includeCompositionManagementItems,
+	editorId,
+	editorName,
 }: {
 	composition: _InternalTypes['AnyComposition'] | null;
 	connectionStatus: PreviewServerConnectionState['type'];
@@ -28,14 +31,18 @@ export const getCompositionMenuItems = ({
 	closeMenu: () => void;
 	readOnlyStudio: boolean;
 	includeCompositionManagementItems: boolean;
+	editorId: EditorPickerId | null;
+	editorName: string | null;
 }): ComboboxValue[] => {
-	const editorName = window.remotion_editorName;
 	const fileLocation = formatFileLocation({
 		location: resolvedLocation,
 		root: window.remotion_cwd,
 	});
 	const showInEditorDisabled =
-		!composition || connectionStatus !== 'connected' || !resolvedLocation;
+		!editorId ||
+		!composition ||
+		connectionStatus !== 'connected' ||
+		!resolvedLocation;
 	const openComponentInEditorDisabled =
 		showInEditorDisabled || !resolvedLocation?.source;
 	const copyFileLocationDisabled = !composition || !fileLocation;
@@ -49,12 +56,12 @@ export const getCompositionMenuItems = ({
 					leftItem: null,
 					onClick: async () => {
 						closeMenu();
-						if (!composition || !resolvedLocation) {
+						if (!composition || !resolvedLocation || !editorId) {
 							return;
 						}
 
 						try {
-							await openOriginalPositionInEditor(resolvedLocation, null);
+							await openOriginalPositionInEditor(resolvedLocation, editorId);
 						} catch (err) {
 							showNotification((err as Error).message, 2000);
 						}
@@ -74,7 +81,7 @@ export const getCompositionMenuItems = ({
 					leftItem: null,
 					onClick: async () => {
 						closeMenu();
-						if (!composition || !resolvedLocation?.source) {
+						if (!composition || !resolvedLocation?.source || !editorId) {
 							return;
 						}
 
@@ -82,6 +89,7 @@ export const getCompositionMenuItems = ({
 							await openCompositionComponentInEditor({
 								compositionFile: resolvedLocation.source,
 								compositionId: composition.id,
+								editorId,
 							});
 						} catch (err) {
 							showNotification((err as Error).message, 2000);

--- a/packages/studio/src/components/folder-menu-items.ts
+++ b/packages/studio/src/components/folder-menu-items.ts
@@ -1,3 +1,4 @@
+import type {EditorPickerId} from '@remotion/studio-shared';
 import type {SetStateAction} from 'react';
 import type {ResolvedStackLocation, _InternalTypes} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -16,6 +17,8 @@ export const getFolderMenuItems = ({
 	readOnlyStudio,
 	resolvedLocation,
 	setSelectedModal,
+	editorId,
+	editorName,
 }: {
 	closeMenu: () => void;
 	connectionStatus: PreviewServerConnectionState['type'];
@@ -23,8 +26,9 @@ export const getFolderMenuItems = ({
 	readOnlyStudio: boolean;
 	resolvedLocation: ResolvedStackLocation | null;
 	setSelectedModal: (value: SetStateAction<ModalState | null>) => void;
+	editorId: EditorPickerId | null;
+	editorName: string | null;
 }): ComboboxValue[] => {
-	const editorName = window.remotion_editorName;
 	const folderId = getFolderId({
 		folderName: folder.name,
 		parentName: folder.parent,
@@ -34,7 +38,7 @@ export const getFolderMenuItems = ({
 		root: window.remotion_cwd,
 	});
 	const showInEditorDisabled =
-		connectionStatus !== 'connected' || !resolvedLocation;
+		!editorId || connectionStatus !== 'connected' || !resolvedLocation;
 	const copyFileLocationDisabled = !fileLocation;
 	const codemodDisabled = readOnlyStudio || !folder.stack;
 
@@ -47,12 +51,12 @@ export const getFolderMenuItems = ({
 					leftItem: null,
 					onClick: async () => {
 						closeMenu();
-						if (!resolvedLocation) {
+						if (!resolvedLocation || !editorId) {
 							return;
 						}
 
 						try {
-							await openOriginalPositionInEditor(resolvedLocation, null);
+							await openOriginalPositionInEditor(resolvedLocation, editorId);
 						} catch (err) {
 							showNotification((err as Error).message, 2000);
 						}

--- a/packages/studio/src/components/get-open-in-menu-items.tsx
+++ b/packages/studio/src/components/get-open-in-menu-items.tsx
@@ -52,7 +52,7 @@ export const getOpenInMenuItems = ({
 	readonly fileManagerDisabled: boolean;
 	readonly folder: boolean;
 	readonly location: OriginalPosition | null;
-	readonly onConfigureApps: () => void;
+	readonly onConfigureApps: (() => void) | null;
 	readonly onOpenInCodingAgent: (
 		codingAgentId: DefaultCodingAgent,
 		codingAgentName: string,
@@ -228,19 +228,21 @@ export const getOpenInMenuItems = ({
 					...systemApps,
 				]
 			: []),
-		...(hasCategorizedApps || systemApps.length > 0
+		...(onConfigureApps && (hasCategorizedApps || systemApps.length > 0)
 			? [{type: 'divider' as const, id: 'open-in-settings-divider'}]
 			: []),
-		{
-			id: 'change-default-apps',
-			keyHint: null,
-			label: <span style={menuLabel}>Change default apps...</span>,
-			leftItem: null,
-			onClick: onConfigureApps,
-			quickSwitcherLabel: null,
-			subMenu: null,
-			type: 'item' as const,
-			value: 'change-default-apps',
-		},
-	];
+		onConfigureApps
+			? {
+					id: 'change-default-apps',
+					keyHint: null,
+					label: <span style={menuLabel}>Change default apps...</span>,
+					leftItem: null,
+					onClick: onConfigureApps,
+					quickSwitcherLabel: null,
+					subMenu: null,
+					type: 'item' as const,
+					value: 'change-default-apps',
+				}
+			: null,
+	].filter(NoReactInternals.truthy);
 };

--- a/packages/studio/src/components/use-default-editor-info.ts
+++ b/packages/studio/src/components/use-default-editor-info.ts
@@ -13,6 +13,10 @@ export const canUseEditorPicker = (previewServerConnected: boolean) => {
 	);
 };
 
+export const canOpenInEditor = (previewServerConnected: boolean) => {
+	return previewServerConnected && getBrowserStudioOperations() === null;
+};
+
 const preferredFallbackEditorIds: EditorPickerId[] = [
 	'zed',
 	'vscode',
@@ -22,22 +26,18 @@ const preferredFallbackEditorIds: EditorPickerId[] = [
 export const getPreferredEditorId = (
 	editorInfo: GetDefaultEditorInfoResponse | null,
 ): EditorPickerId | null => {
-	const runningEditorId = editorInfo?.installedEditors.find(
-		(editor) => editor.nameWithType === window.remotion_editorName,
-	)?.id;
-	if (runningEditorId) {
-		return runningEditorId;
-	}
-
-	if (window.remotion_editorName !== null) {
-		return null;
-	}
-
 	const configuredEditorId = editorInfo?.installedEditors.find(
 		(editor) => editor.id === editorInfo.defaultEditor,
 	)?.id;
 	if (configuredEditorId) {
 		return configuredEditorId;
+	}
+
+	const runningEditorId = editorInfo?.installedEditors.find(
+		(editor) => editor.nameWithType === window.remotion_editorName,
+	)?.id;
+	if (runningEditorId) {
+		return runningEditorId;
 	}
 
 	return (
@@ -59,6 +59,23 @@ export const getPreferredEditorId = (
 			})
 			.at(0)?.id ?? null
 	);
+};
+
+export const useEditorOpening = (previewServerConnected: boolean) => {
+	const editorConnectionAvailable = canOpenInEditor(previewServerConnected);
+	const editorInfo = useDefaultEditorInfo(editorConnectionAvailable);
+	const defaultEditorId = getPreferredEditorId(editorInfo);
+	const defaultEditor = editorInfo?.installedEditors.find(
+		(editor) => editor.id === defaultEditorId,
+	);
+
+	return {
+		canConfigureApps: canUseEditorPicker(previewServerConnected),
+		canOpenInEditor: editorConnectionAvailable && defaultEditorId !== null,
+		defaultEditorId,
+		defaultEditorName: defaultEditor?.nameWithType ?? null,
+		editorInfo,
+	};
 };
 
 export const useDefaultEditorInfo = (enabled: boolean) => {

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
@@ -1,8 +1,10 @@
 import {getLocationFromBuildError} from '@remotion/studio-shared';
-import React, {useMemo} from 'react';
+import React, {useContext, useMemo} from 'react';
 import {MediaPlaybackError} from 'remotion';
 import {Spacing} from '../../components/layout';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../../components/Menu/is-menu-item';
+import {useEditorOpening} from '../../components/use-default-editor-info';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
 	ERROR_CODE_FRAME_BACKGROUND,
 	WHITE,
@@ -73,6 +75,9 @@ export const ErrorDisplay: React.FC<{
 	calculateMetadata,
 	symbolicationFailure,
 }) => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {canOpenInEditor, defaultEditorId, defaultEditorName} =
+		useEditorOpening(previewServerState.type === 'connected');
 	const highestLineNumber = Math.max(
 		0,
 		...display.stackFrames
@@ -132,10 +137,15 @@ export const ErrorDisplay: React.FC<{
 					<div style={spacer} />
 				</>
 			) : null}
-			{display.stackFrames.length > 0 && window.remotion_editorName ? (
+			{display.stackFrames.length > 0 &&
+			canOpenInEditor &&
+			defaultEditorId &&
+			defaultEditorName ? (
 				<>
 					<OpenInEditor
 						canHaveKeyboardShortcuts={keyboardShortcuts}
+						editorId={defaultEditorId}
+						editorName={defaultEditorName}
 						stack={display.stackFrames[0]}
 					/>
 					<div style={spacer} />
@@ -183,6 +193,7 @@ export const ErrorDisplay: React.FC<{
 								s={s}
 								lineNumberWidth={lineNumberWidth}
 								defaultFunctionName={'(anonymous function)'}
+								editorId={canOpenInEditor ? defaultEditorId : null}
 							/>
 						);
 					})}

--- a/packages/studio/src/error-overlay/remotion-overlay/OpenInEditor.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/OpenInEditor.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-import type {SymbolicatedStackFrame} from '@remotion/studio-shared';
+import type {
+	EditorPickerId,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useEffect,
@@ -73,7 +76,9 @@ const reducer = (state: State, action: Action): State => {
 export const OpenInEditor: React.FC<{
 	readonly stack: SymbolicatedStackFrame;
 	readonly canHaveKeyboardShortcuts: boolean;
-}> = ({stack, canHaveKeyboardShortcuts}) => {
+	readonly editorId: EditorPickerId;
+	readonly editorName: string;
+}> = ({stack, canHaveKeyboardShortcuts, editorId, editorName}) => {
 	const isMounted = useRef(true);
 	const [state, dispatch] = useReducer(reducer, initialState);
 	const {registerKeybinding} = useKeybinding();
@@ -84,7 +89,7 @@ export const OpenInEditor: React.FC<{
 
 	const openInBrowser = useCallback(() => {
 		dispatch({type: 'start'});
-		openInEditor(stack, null)
+		openInEditor(stack, editorId)
 			.then((data) => {
 				if (data.success) {
 					dispatchIfMounted({type: 'succeed'});
@@ -101,7 +106,7 @@ export const OpenInEditor: React.FC<{
 					dispatchIfMounted({type: 'reset'});
 				}, 2000);
 			});
-	}, [dispatchIfMounted, stack]);
+	}, [dispatchIfMounted, editorId, stack]);
 
 	useEffect(() => {
 		return () => {
@@ -134,15 +139,15 @@ export const OpenInEditor: React.FC<{
 			case 'error':
 				return 'Failed to open';
 			case 'idle':
-				return `Open in ${window.remotion_editorName}`;
+				return `Open in ${editorName}`;
 			case 'success':
-				return `Opened in ${window.remotion_editorName}`;
+				return `Opened in ${editorName}`;
 			case 'load':
 				return `Opening...`;
 			default:
 				throw new Error('invalid state');
 		}
-	}, [state.type]);
+	}, [editorName, state.type]);
 
 	return (
 		<Button onClick={openInBrowser} disabled={state.type !== 'idle'}>

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -6,6 +6,8 @@ import React, {
 } from 'react';
 import {AbsoluteFill} from 'remotion';
 import {MENU_TOOLBAR_HEIGHT} from '../../components/menu-toolbar-height';
+import {SettingsProvider} from '../../components/SettingsContext';
+import {PreviewServerConnection} from '../../helpers/client-id';
 import {BACKGROUND_HEX, WHITE} from '../../helpers/colors';
 import {KeybindingContextProvider} from '../../state/keybindings';
 import {ErrorLoader} from './ErrorLoader';
@@ -67,30 +69,34 @@ export const Overlay: React.FC = () => {
 	}
 
 	return (
-		<KeybindingContextProvider>
-			<AbsoluteFill
-				style={{
-					backgroundColor: BACKGROUND_COLOR,
-					overflow: 'auto',
-					color: WHITE,
-					top: MENU_TOOLBAR_HEIGHT,
-					height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
-				}}
-			>
-				{errors.errors.map((err, i) => {
-					return (
-						<ErrorLoader
-							// eslint-disable-next-line react/no-array-index-key
-							key={(err.stack ?? '') + i}
-							keyboardShortcuts={i === 0}
-							error={err}
-							onRetry={null}
-							canHaveDismissButton
-							calculateMetadata={false}
-						/>
-					);
-				})}
-			</AbsoluteFill>
-		</KeybindingContextProvider>
+		<PreviewServerConnection>
+			<SettingsProvider>
+				<KeybindingContextProvider>
+					<AbsoluteFill
+						style={{
+							backgroundColor: BACKGROUND_COLOR,
+							overflow: 'auto',
+							color: WHITE,
+							top: MENU_TOOLBAR_HEIGHT,
+							height: `calc(100% - ${MENU_TOOLBAR_HEIGHT}px)`,
+						}}
+					>
+						{errors.errors.map((err, i) => {
+							return (
+								<ErrorLoader
+									// eslint-disable-next-line react/no-array-index-key
+									key={(err.stack ?? '') + i}
+									keyboardShortcuts={i === 0}
+									error={err}
+									onRetry={null}
+									canHaveDismissButton
+									calculateMetadata={false}
+								/>
+							);
+						})}
+					</AbsoluteFill>
+				</KeybindingContextProvider>
+			</SettingsProvider>
+		</PreviewServerConnection>
 	);
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
@@ -1,4 +1,7 @@
-import type {SymbolicatedStackFrame} from '@remotion/studio-shared';
+import type {
+	EditorPickerId,
+	SymbolicatedStackFrame,
+} from '@remotion/studio-shared';
 import React, {useCallback, useState} from 'react';
 import {Button} from '../../components/Button';
 import {
@@ -45,7 +48,8 @@ export const StackElement: React.FC<{
 	readonly lineNumberWidth: number;
 	readonly isFirst: boolean;
 	readonly defaultFunctionName: string;
-}> = ({s, lineNumberWidth, isFirst, defaultFunctionName}) => {
+	readonly editorId: EditorPickerId | null;
+}> = ({s, lineNumberWidth, isFirst, defaultFunctionName, editorId}) => {
 	const [showCodeFrame, setShowCodeFrame] = useState(
 		() =>
 			(!s.originalFileName?.includes('node_modules') &&
@@ -53,19 +57,21 @@ export const StackElement: React.FC<{
 			isFirst,
 	);
 	const [locationHovered, setLocationHovered] = useState(false);
-	const canOpenFileLocation = Boolean(
-		window.remotion_editorName && s.originalFileName,
-	);
+	const canOpenFileLocation = Boolean(editorId && s.originalFileName);
 	const onOpenFileLocation = useCallback(() => {
 		if (!canOpenFileLocation) {
 			return;
 		}
 
-		openInEditor(s, null).catch((err: unknown) => {
+		if (!editorId) {
+			return;
+		}
+
+		openInEditor(s, editorId).catch((err: unknown) => {
 			// eslint-disable-next-line no-console
 			console.log('Could not open in editor', err);
 		});
-	}, [canOpenFileLocation, s]);
+	}, [canOpenFileLocation, editorId, s]);
 	const toggleCodeFrame = useCallback(() => {
 		setShowCodeFrame((f) => !f);
 	}, []);

--- a/packages/studio/src/helpers/open-in-editor.ts
+++ b/packages/studio/src/helpers/open-in-editor.ts
@@ -16,7 +16,7 @@ import {getBrowserStudioOperations} from './browser-studio-operations';
 
 export const openInEditor = (
 	stack: SymbolicatedStackFrame,
-	editorId: EditorPickerId | null,
+	editorId: EditorPickerId,
 ) => {
 	const {
 		originalFileName,
@@ -58,7 +58,7 @@ export const openInGitClient = (gitClientId: GitClientId) => {
 
 export const openOriginalPositionInEditor = async (
 	originalPosition: OriginalPosition,
-	editorId: EditorPickerId | null,
+	editorId: EditorPickerId,
 ) => {
 	const response = await openInEditor(
 		{
@@ -76,9 +76,11 @@ export const openOriginalPositionInEditor = async (
 };
 
 export const openOriginalPositionInEditorAtProperty = async ({
+	editorId,
 	originalPosition,
 	property,
 }: {
+	editorId: EditorPickerId;
 	originalPosition: CodePosition;
 	property: string;
 }) => {
@@ -99,7 +101,7 @@ export const openOriginalPositionInEditorAtProperty = async ({
 			line: position.lineNumber,
 			column: position.columnNumber,
 		},
-		null,
+		editorId,
 	);
 };
 
@@ -259,13 +261,15 @@ export const preloadCompositionComponentInfo = ({
 export const openCompositionComponentInEditor = async ({
 	compositionFile,
 	compositionId,
+	editorId,
 }: {
 	compositionFile: string;
 	compositionId: string;
+	editorId: EditorPickerId;
 }) => {
 	const info = await loadCompositionComponentInfo({
 		compositionFile,
 		compositionId,
 	});
-	await openOriginalPositionInEditor(info.location, null);
+	await openOriginalPositionInEditor(info.location, editorId);
 };

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -1,3 +1,4 @@
+import type {EditorPickerId} from '@remotion/studio-shared';
 import {useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
@@ -16,6 +17,7 @@ import {openInFileExplorer} from '../components/RenderQueue/actions';
 import {getPreviewSizeLabel, getUniqueSizes} from '../components/SizeSelector';
 import {useResolvedStack} from '../components/Timeline/use-resolved-stack';
 import {inOutHandles} from '../components/TimelineInOutToggle';
+import {useEditorOpening} from '../components/use-default-editor-info';
 import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {Checkmark} from '../icons/Checkmark';
 import {drawRef} from '../state/canvas-ref';
@@ -56,12 +58,14 @@ const getFileMenu = ({
 	readOnlyStudio,
 	closeMenu,
 	editorName,
+	editorId,
 	previewServerState,
 	setSelectedModal,
 }: {
 	readOnlyStudio: boolean;
 	closeMenu: () => void;
 	editorName: string | null;
+	editorId: EditorPickerId | null;
 	previewServerState: 'connected' | 'init' | 'disconnected';
 	setSelectedModal: (value: React.SetStateAction<ModalState | null>) => void;
 }) => {
@@ -179,7 +183,7 @@ const getFileMenu = ({
 					id: 'open-project-divider',
 				}
 			: null,
-		editorName && !readOnlyStudio
+		editorName && editorId && !readOnlyStudio
 			? {
 					id: 'open-in-editor',
 					value: 'open-in-editor',
@@ -193,7 +197,7 @@ const getFileMenu = ({
 								originalFunctionName: null,
 								originalScriptCode: null,
 							},
-							null,
+							editorId,
 						)
 							.then(({success}) => {
 								if (!success) {
@@ -336,7 +340,9 @@ export const useMenuStructure = (
 		Internals.CompositionManager,
 	);
 	const {type} = useContext(StudioServerConnectionCtx).previewServerState;
-	const editorName = window.remotion_editorName;
+	const {defaultEditorId, defaultEditorName} = useEditorOpening(
+		type === 'connected',
+	);
 	const keyboardShortcutsDisabled = areKeyboardShortcutsDisabled();
 	const studioAskAIEnabled = getStudioAskAIEnabled();
 	const canConfigureDefaultEditor =
@@ -498,7 +504,8 @@ export const useMenuStructure = (
 			getFileMenu({
 				readOnlyStudio,
 				closeMenu,
-				editorName,
+				editorId: defaultEditorId,
+				editorName: defaultEditorName,
 				previewServerState: type,
 				setSelectedModal,
 			}),
@@ -873,6 +880,8 @@ export const useMenuStructure = (
 						closeMenu,
 						composition: currentComposition,
 						connectionStatus: type,
+						editorId: defaultEditorId,
+						editorName: defaultEditorName,
 						includeCompositionManagementItems: true,
 						resolvedLocation: resolvedCompositionLocation,
 						setSelectedModal,
@@ -1138,7 +1147,8 @@ export const useMenuStructure = (
 		isFullscreenSupported,
 		remotion_packageManager,
 		mobileLayout,
-		editorName,
+		defaultEditorId,
+		defaultEditorName,
 		keyboardShortcutsDisabled,
 		studioAskAIEnabled,
 		size.size,

--- a/packages/studio/src/test/composition-menu-items.test.ts
+++ b/packages/studio/src/test/composition-menu-items.test.ts
@@ -54,6 +54,8 @@ const commonArgs = {
 	closeMenu: () => undefined,
 	composition,
 	connectionStatus: 'connected' as const,
+	editorId: 'vscode' as const,
+	editorName: 'Code',
 	readOnlyStudio: false,
 	resolvedLocation: null,
 	setSelectedModal: () => undefined,
@@ -85,6 +87,8 @@ test('connected composition context menus omit management actions', () => {
 
 	const items = getCompositionContextMenuItems({
 		...commonArgs,
+		editorId: null,
+		editorName: null,
 		includeCompositionManagementItems: false,
 	});
 

--- a/packages/studio/src/test/default-editor-info.test.ts
+++ b/packages/studio/src/test/default-editor-info.test.ts
@@ -1,5 +1,8 @@
 import {afterEach, expect, test} from 'bun:test';
-import {getPreferredEditorId} from '../components/use-default-editor-info';
+import {
+	canOpenInEditor,
+	getPreferredEditorId,
+} from '../components/use-default-editor-info';
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
 	globalThis,
@@ -39,7 +42,7 @@ test('prefers the running editor when one is detected', () => {
 	).toBe('cursor');
 });
 
-test('does not fall back if the running editor is not in the installed list', () => {
+test('falls back if the detected editor is not in the installed list', () => {
 	installTestWindow('Custom Editor');
 
 	expect(
@@ -50,11 +53,11 @@ test('does not fall back if the running editor is not in the installed list', ()
 				{id: 'cursor', name: 'Cursor', nameWithType: 'Cursor Editor'},
 			],
 		}),
-	).toBe(null);
+	).toBe('zed');
 });
 
-test('prefers the configured default editor before fallback ordering', () => {
-	installTestWindow(null);
+test('prefers the configured default editor before the detected editor', () => {
+	installTestWindow('Zed');
 
 	expect(
 		getPreferredEditorId({
@@ -65,6 +68,24 @@ test('prefers the configured default editor before fallback ordering', () => {
 			],
 		}),
 	).toBe('cursor');
+});
+
+test('returns null when no editor is installed', () => {
+	installTestWindow('Custom Editor');
+
+	expect(
+		getPreferredEditorId({
+			defaultEditor: null,
+			installedEditors: [],
+		}),
+	).toBe(null);
+});
+
+test('requires a preview server connection', () => {
+	installTestWindow(null);
+
+	expect(canOpenInEditor(false)).toBe(false);
+	expect(canOpenInEditor(true)).toBe(true);
 });
 
 test('falls back to Zed, VS Code, Cursor, then alphabetical order', () => {

--- a/packages/studio/src/test/folder-menu-items.test.ts
+++ b/packages/studio/src/test/folder-menu-items.test.ts
@@ -36,6 +36,8 @@ test('read-only folder menus keep navigation and copy actions enabled', () => {
 	const items = getFolderMenuItems({
 		closeMenu: () => undefined,
 		connectionStatus: 'connected',
+		editorId: 'vscode',
+		editorName: 'Code',
 		folder,
 		readOnlyStudio: true,
 		resolvedLocation,


### PR DESCRIPTION
## Summary

- standardize Studio editor selection as explicit context choice, configured preference, detected installed editor, then deterministic installed-editor fallback
- require a connected preview server, a resolved source location, and a detected launchable editor across project, composition, folder, inspector, timeline, visual-control, and error-overlay entry points
- always send a concrete editor ID when opening files, without requiring a Visual Mode `nodePath`
- exclude configured custom editors whose executable cannot be resolved from the installed-editor response

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/default-editor-info.test.ts packages/studio/src/test/composition-menu-items.test.ts packages/studio/src/test/folder-menu-items.test.ts packages/studio/src/test/sequence-context-menu-items.test.ts packages/studio-server/src/test/default-editor-route.test.ts`
- `bunx playwright test e2e/studio.test.mts --grep "explicit editor|no editor is installed"`
- `bunx playwright test e2e/error-overlay.test.mts`

Closes #10388
