### PR TITLE
`remotion`: Fix InvalidStateError when the HtmlInCanvas layout effect re-runs

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -191,6 +191,31 @@ export type HtmlInCanvasOnPaintParams = {
 	readonly pixelDensity: number;
 };
 
+// `transferControlToOffscreen()` may only be called once per canvas — a second
+// call throws an `InvalidStateError`. The layout effect that needs the
+// `OffscreenCanvas` can run more than once for the same canvas element: its
+// dependencies (e.g. the paint callback) can change identity without the
+// canvas remounting, and React StrictMode intentionally double-invokes
+// effects. Cache the transferred `OffscreenCanvas` per canvas element so
+// re-runs reuse it instead of throwing.
+const transferredOffscreenCanvases = new WeakMap<
+	HTMLCanvasElement,
+	OffscreenCanvas
+>();
+
+const getTransferredOffscreenCanvas = (
+	canvas: HTMLCanvasElement,
+): OffscreenCanvas => {
+	const existing = transferredOffscreenCanvases.get(canvas);
+	if (existing) {
+		return existing;
+	}
+
+	const offscreen = canvas.transferControlToOffscreen();
+	transferredOffscreenCanvases.set(canvas, offscreen);
+	return offscreen;
+};
+
 // Memoize the support check across the session — neither the platform
 // capability nor the chrome://flags toggle can change between calls.
 // SSR results are not cached so the check runs again once `document` exists.
@@ -631,7 +656,7 @@ const HtmlInCanvasContent = forwardRef<
 
 			const paintTarget = usesDirectLayoutCanvas
 				? placeholder
-				: placeholder.transferControlToOffscreen();
+				: getTransferredOffscreenCanvas(placeholder);
 
 			paintTargetRef.current = paintTarget;
 			resizePaintTarget({

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -67,6 +67,7 @@ const stub2dContext = () => {
 };
 
 let transferControlToOffscreenCalls = 0;
+const transferredCanvases = new WeakSet<HTMLCanvasElement>();
 
 Object.defineProperties(HTMLCanvasElement.prototype, {
 	getContext: {
@@ -96,6 +97,15 @@ Object.defineProperties(HTMLCanvasElement.prototype, {
 	transferControlToOffscreen: {
 		configurable: true,
 		value(this: HTMLCanvasElement) {
+			// Real browsers only allow one transfer per canvas.
+			if (transferredCanvases.has(this)) {
+				throw new DOMException(
+					'Cannot transfer control from a canvas for more than one time.',
+					'InvalidStateError',
+				);
+			}
+
+			transferredCanvases.add(this);
 			transferControlToOffscreenCalls++;
 			let contextMode: string | null = null;
 			const webgl2Context = {
@@ -471,6 +481,27 @@ test('<HtmlInCanvas> can use a higher backing density', async () => {
 	expect(paintParams.canvas.width).toBe(100);
 	expect(paintParams.canvas.height).toBe(100);
 	expect(paintParams.pixelDensity).toBe(2);
+	expect(transferControlToOffscreenCalls).toBe(1);
+});
+
+test('<HtmlInCanvas> tolerates layout effect re-runs on the same canvas', async () => {
+	// StrictMode double-invokes effects on the same canvas element. A second
+	// transferControlToOffscreen() call throws an InvalidStateError in real
+	// browsers, so the transferred OffscreenCanvas must be reused.
+	const {container} = render(
+		<React.StrictMode>
+			<SequenceTestWrapper onRegisterSequence={() => undefined}>
+				<HtmlInCanvas width={50} height={50} onPaint={() => undefined}>
+					<div>Test</div>
+				</HtmlInCanvas>
+			</SequenceTestWrapper>
+		</React.StrictMode>,
+	);
+
+	await waitFor(() => {
+		expect(container.querySelector('canvas')).not.toBeNull();
+	});
+
 	expect(transferControlToOffscreenCalls).toBe(1);
 });
 


### PR DESCRIPTION
## Problem

`transferControlToOffscreen()` may only be called once per canvas — a second call throws:

```
InvalidStateError: Cannot transfer control from a canvas for more than one time.
```

The layout effect in `<HtmlInCanvas>` that transfers the placeholder canvas can run more than once for the same canvas element:

- Its dependencies (`onPaintCb` and what it closes over) can change identity without the size-keyed canvas remounting.
- React StrictMode intentionally double-invokes effects in development, so any app rendering `<HtmlInCanvas>` with a custom `onPaint`/`onInit` under StrictMode hits the throw immediately.

We hit this in production in Kino's editor.

## Fix

Cache the transferred `OffscreenCanvas` per canvas element in a module-level `WeakMap` and reuse it when the effect re-runs.

## Tests

- The existing test mock for `transferControlToOffscreen` now mirrors real browser behavior by throwing on a second transfer of the same canvas, which makes the existing `transferControlToOffscreenCalls` assertions meaningful.
- Added a StrictMode regression test. It fails without the fix (`InvalidStateError` surfaces through `cancelRender`) and passes with it.

All 17 tests in `packages/core/src/test/html-in-canvas.test.tsx` pass.

Made with [Cursor](https://cursor.com)