### PR TITLE
Docs: Add fixed WebKit WebM audio bug

### DIFF
--- a/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
+++ b/packages/docs/docs/mediabunny/webcodecs-bugs.mdx
@@ -18,6 +18,7 @@ It serves as a tracker for overall progress and known issues.
 | [AAC AudioEncoder produces incorrect decoder config description](https://bugs.webkit.org/show_bug.cgi?id=302253)                                          | Safari  | @Vanilagy    | Open      |
 | [ArrayBuffer-backed YUV VideoFrame with visibleRect is rendered incorrectly (chroma channels are offset)](https://bugs.webkit.org/show_bug.cgi?id=317524) | Safari  | @Vanilagy    | Fixed     |
 | [AudioData.copyTo() crashes the tab with valid conversion](https://bugs.webkit.org/show_bug.cgi?id=302521)                                                | Safari  | @JonnyBurger | Fixed     |
+| [WebM audio plays back garbled when BlockGroup instead of SimpleBlock is used](https://bugs.webkit.org/show_bug.cgi?id=297781)                            | Safari  | @Vanilagy    | Fixed     |
 | [AudioEncoder emits humorous AAC bitrate suggestions in error message](https://issues.chromium.org/issues/459832207)                                      | Chrome  | @Vanilagy    | Fixed     |
 | [VideoEncoder encodeQueueSize behaves unpredictably after calling encode()](https://issues.chromium.org/issues/459838287)                                 | Chrome  | @Vanilagy    | Won't fix |
 | [AudioEncoder queue size not accurately reflected by encodeQueueSize](https://issues.chromium.org/issues/459832204)                                       | Chrome  | @Vanilagy    | Fixed     |


### PR DESCRIPTION
## Summary

- add WebKit bug 297781 to the WebCodecs browser bug tracker
- mark the Safari issue as fixed

Reported by @Vanilagy: https://bugs.webkit.org/show_bug.cgi?id=297781

## Verification

- `bun run build`
- `bun run stylecheck`

## Preview

- [WebCodecs Bugs](https://remotion-git-codex-add-fixed-webkit-webm-bug-remotion.vercel.app/docs/mediabunny/webcodecs-bugs)
