### PR TITLE
`@remotion/media`: Concatenate audio before resampling

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -157,8 +157,8 @@ import {
 } from './StudioApis/SaveDefaultProps';
 import {TriggerCalculateMetadata} from './StudioApis/TriggerCalculateMetadata';
 import {WriteStaticFile} from './StudioApis/WriteStaticFile';
-import {SubtitleArtifact} from './SubtitleArtifact/SubtitleArtifact';
 import './style.css';
+import {SubtitleArtifact} from './SubtitleArtifact/SubtitleArtifact';
 import {SvgFilter} from './SvgFilter';
 import {Tailwind} from './Tailwind';
 import {TenFrameTester} from './TenFrameTester';
@@ -268,6 +268,7 @@ import {
 	RoughNotationUnderline,
 } from './RoughNotation';
 import {SfxExample} from './Sfx';
+import {Repro as SfxDingTrimRepro} from './Sfx/Repro';
 import {CanvasImg} from './SimpleImg/CanvasImg';
 import {ImgEffects} from './SimpleImg/ImgEffects';
 import {SmoothTextTransition} from './SmoothTextTransition';
@@ -2776,6 +2777,14 @@ export const Index: React.FC = () => {
 				height={1080}
 				fps={30}
 				durationInFrames={60}
+			/>
+			<Composition
+				id="sfx-ding-trim-repro"
+				component={SfxDingTrimRepro}
+				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={42}
 			/>
 			<Folder name="transition-series-overlay">
 				<Composition

--- a/packages/example/src/Sfx/Repro.tsx
+++ b/packages/example/src/Sfx/Repro.tsx
@@ -1,0 +1,6 @@
+import {Audio} from '@remotion/media';
+import {ding} from '@remotion/sfx';
+
+export const Repro: React.FC = () => {
+	return <Audio src={ding} />;
+};

--- a/packages/media/src/audio-extraction/extract-audio.ts
+++ b/packages/media/src/audio-extraction/extract-audio.ts
@@ -1,15 +1,13 @@
 import {type LogLevel} from 'remotion';
 import type {MediaCache} from '../caches';
 import {combineAudioDataAndClosePrevious} from '../convert-audiodata/combine-audiodata';
-import type {PcmS16AudioData} from '../convert-audiodata/convert-audiodata';
 import {
-	convertAudioData,
+	convertAudioDataToS16,
 	fixFloatingPoint,
+	resamplePcmS16AudioData,
+	type PcmS16AudioData,
+	type UnresampledPcmS16AudioData,
 } from '../convert-audiodata/convert-audiodata';
-import {
-	TARGET_NUMBER_OF_CHANNELS,
-	getTargetSampleRate,
-} from '../convert-audiodata/resample-audiodata';
 import {getTimeInSeconds} from '../get-time-in-seconds';
 import {
 	isNetworkError,
@@ -126,7 +124,7 @@ const extractAudioInternal = async ({
 
 		mediaCache.audioManager.logOpenFrames();
 
-		const audioDataArray: PcmS16AudioData[] = [];
+		const audioDataArray: UnresampledPcmS16AudioData[] = [];
 		for (let i = 0; i < samples.length; i++) {
 			const sample = samples[i];
 
@@ -152,21 +150,23 @@ const extractAudioInternal = async ({
 			// amount of samples to shave from start and end
 			let trimStartInSeconds = 0;
 			let trimEndInSeconds = 0;
-			let leadingSilence: PcmS16AudioData | null = null;
+			let leadingSilence: UnresampledPcmS16AudioData | null = null;
 
 			if (isFirstSample) {
 				trimStartInSeconds = fixFloatingPoint(timeInSeconds - sample.timestamp);
 
 				if (trimStartInSeconds < 0) {
 					const silenceFrames = Math.ceil(
-						fixFloatingPoint(-trimStartInSeconds * getTargetSampleRate()),
+						fixFloatingPoint(-trimStartInSeconds * audioDataRaw.sampleRate),
 					);
 					leadingSilence = {
-						data: new Int16Array(silenceFrames * TARGET_NUMBER_OF_CHANNELS),
+						data: new Int16Array(silenceFrames * audioDataRaw.numberOfChannels),
+						numberOfChannels: audioDataRaw.numberOfChannels,
 						numberOfFrames: silenceFrames,
+						sampleRate: audioDataRaw.sampleRate,
 						timestamp: timeInSeconds * 1_000_000,
 						durationInMicroSeconds:
-							(silenceFrames / getTargetSampleRate()) * 1_000_000,
+							(silenceFrames / audioDataRaw.sampleRate) * 1_000_000,
 					};
 					trimStartInSeconds = 0;
 				}
@@ -183,11 +183,10 @@ const extractAudioInternal = async ({
 					);
 			}
 
-			const audioData = convertAudioData({
+			const audioData = convertAudioDataToS16({
 				audioData: audioDataRaw,
 				trimStartInSeconds,
 				trimEndInSeconds,
-				playbackRate,
 				audioDataTimestamp: sample.timestamp,
 				isLast: isLastSample,
 			});
@@ -209,8 +208,13 @@ const extractAudioInternal = async ({
 		}
 
 		const combined = combineAudioDataAndClosePrevious(audioDataArray);
+		const resampled = resamplePcmS16AudioData({
+			audioData: combined,
+			playbackRate,
+			isLast: true,
+		});
 
-		return {data: combined, durationInSeconds: mediaDurationInSeconds};
+		return {data: resampled, durationInSeconds: mediaDurationInSeconds};
 	} catch (err) {
 		const error = err as Error;
 		if (isNetworkError(error)) {

--- a/packages/media/src/convert-audiodata/combine-audiodata.ts
+++ b/packages/media/src/convert-audiodata/combine-audiodata.ts
@@ -1,19 +1,28 @@
-import {fixFloatingPoint, type PcmS16AudioData} from './convert-audiodata';
-import {TARGET_NUMBER_OF_CHANNELS} from './resample-audiodata';
+import {
+	fixFloatingPoint,
+	type UnresampledPcmS16AudioData,
+} from './convert-audiodata';
 
 export const combineAudioDataAndClosePrevious = (
-	audioDataArray: PcmS16AudioData[],
-): PcmS16AudioData => {
+	audioDataArray: UnresampledPcmS16AudioData[],
+): UnresampledPcmS16AudioData => {
 	let numberOfFrames = 0;
 	let durationInMicroSeconds = 0;
-	const {timestamp} = audioDataArray[0];
+	const {numberOfChannels, sampleRate, timestamp} = audioDataArray[0];
 
 	for (const audioData of audioDataArray) {
+		if (
+			audioData.numberOfChannels !== numberOfChannels ||
+			audioData.sampleRate !== sampleRate
+		) {
+			throw new Error('Cannot combine audio data with different formats');
+		}
+
 		numberOfFrames += audioData.numberOfFrames;
 		durationInMicroSeconds += audioData.durationInMicroSeconds;
 	}
 
-	const arr = new Int16Array(numberOfFrames * TARGET_NUMBER_OF_CHANNELS);
+	const arr = new Int16Array(numberOfFrames * numberOfChannels);
 
 	let offset = 0;
 	for (const audioData of audioDataArray) {
@@ -23,7 +32,9 @@ export const combineAudioDataAndClosePrevious = (
 
 	return {
 		data: arr,
+		numberOfChannels,
 		numberOfFrames,
+		sampleRate,
 		timestamp: fixFloatingPoint(timestamp),
 		durationInMicroSeconds: fixFloatingPoint(durationInMicroSeconds),
 	};

--- a/packages/media/src/convert-audiodata/convert-audiodata.ts
+++ b/packages/media/src/convert-audiodata/convert-audiodata.ts
@@ -22,6 +22,11 @@ export type PcmS16AudioData = {
 	durationInMicroSeconds: number;
 };
 
+export type UnresampledPcmS16AudioData = PcmS16AudioData & {
+	numberOfChannels: number;
+	sampleRate: number;
+};
+
 export const fixFloatingPoint = (value: number) => {
 	const decimal = Math.abs(value % 1);
 
@@ -41,20 +46,21 @@ const ceilButNotIfFloatingPointIssue = (value: number) => {
 	return Math.ceil(fixed);
 };
 
-export const convertAudioData = ({
+export const convertAudioDataToS16 = ({
 	audioData,
 	trimStartInSeconds,
 	trimEndInSeconds,
-	playbackRate,
 	audioDataTimestamp,
 	isLast,
-}: ConvertAudioDataOptions): PcmS16AudioData => {
+}: Omit<
+	ConvertAudioDataOptions,
+	'playbackRate'
+>): UnresampledPcmS16AudioData => {
 	const {
 		numberOfChannels: srcNumberOfChannels,
 		sampleRate: currentSampleRate,
 		numberOfFrames,
 	} = audioData;
-	const ratio = currentSampleRate / getTargetSampleRate();
 
 	// Always rounding down start timestamps and rounding up end durations
 	// to ensure there are no gaps when the samples don't align
@@ -72,16 +78,6 @@ export const convertAudioData = ({
 	const frameCount = isLast
 		? ceilButNotIfFloatingPointIssue(unroundedFrameCount)
 		: Math.round(unroundedFrameCount);
-
-	const newNumberOfFrames = isLast
-		? ceilButNotIfFloatingPointIssue(unroundedFrameCount / ratio / playbackRate)
-		: Math.round(unroundedFrameCount / ratio / playbackRate);
-
-	if (newNumberOfFrames === 0) {
-		throw new Error(
-			'Cannot resample - the given sample rate would result in less than 1 sample',
-		);
-	}
 
 	const srcChannels = new Int16Array(srcNumberOfChannels * frameCount);
 
@@ -126,32 +122,66 @@ export const convertAudioData = ({
 		});
 	}
 
-	const data = new Int16Array(newNumberOfFrames * TARGET_NUMBER_OF_CHANNELS);
-	const chunkSize = frameCount / newNumberOfFrames;
-
 	const timestampOffsetMicroseconds =
 		(frameOffset / audioData.sampleRate) * 1_000_000;
 
+	return {
+		data: srcChannels,
+		numberOfChannels: srcNumberOfChannels,
+		numberOfFrames: frameCount,
+		sampleRate: currentSampleRate,
+		timestamp:
+			audioDataTimestamp * 1_000_000 +
+			fixFloatingPoint(timestampOffsetMicroseconds),
+		durationInMicroSeconds: fixFloatingPoint(
+			(frameCount / currentSampleRate) * 1_000_000,
+		),
+	};
+};
+
+export const resamplePcmS16AudioData = ({
+	audioData,
+	playbackRate,
+	isLast,
+}: {
+	audioData: UnresampledPcmS16AudioData;
+	playbackRate: number;
+	isLast: boolean;
+}): PcmS16AudioData => {
+	const ratio = audioData.sampleRate / getTargetSampleRate();
+	const newNumberOfFrames = isLast
+		? ceilButNotIfFloatingPointIssue(
+				audioData.numberOfFrames / ratio / playbackRate,
+			)
+		: Math.round(audioData.numberOfFrames / ratio / playbackRate);
+
+	if (newNumberOfFrames === 0) {
+		throw new Error(
+			'Cannot resample - the given sample rate would result in less than 1 sample',
+		);
+	}
+
 	if (
-		newNumberOfFrames === frameCount &&
-		TARGET_NUMBER_OF_CHANNELS === srcNumberOfChannels &&
+		newNumberOfFrames === audioData.numberOfFrames &&
+		TARGET_NUMBER_OF_CHANNELS === audioData.numberOfChannels &&
 		playbackRate === 1
 	) {
 		return {
-			data: srcChannels,
+			data: audioData.data,
 			numberOfFrames: newNumberOfFrames,
-			timestamp:
-				audioDataTimestamp * 1_000_000 +
-				fixFloatingPoint(timestampOffsetMicroseconds),
+			timestamp: audioData.timestamp,
 			durationInMicroSeconds: fixFloatingPoint(
 				(newNumberOfFrames / getTargetSampleRate()) * 1_000_000,
 			),
 		};
 	}
 
+	const data = new Int16Array(newNumberOfFrames * TARGET_NUMBER_OF_CHANNELS);
+	const chunkSize = audioData.numberOfFrames / newNumberOfFrames;
+
 	resampleAudioData({
-		srcNumberOfChannels,
-		sourceChannels: srcChannels,
+		srcNumberOfChannels: audioData.numberOfChannels,
+		sourceChannels: audioData.data,
 		destination: data,
 		targetFrames: newNumberOfFrames,
 		chunkSize,
@@ -160,13 +190,23 @@ export const convertAudioData = ({
 	const newAudioData: PcmS16AudioData = {
 		data,
 		numberOfFrames: newNumberOfFrames,
-		timestamp:
-			audioDataTimestamp * 1_000_000 +
-			fixFloatingPoint(timestampOffsetMicroseconds),
+		timestamp: audioData.timestamp,
 		durationInMicroSeconds: fixFloatingPoint(
 			(newNumberOfFrames / getTargetSampleRate()) * 1_000_000,
 		),
 	};
 
 	return newAudioData;
+};
+
+export const convertAudioData = (
+	options: ConvertAudioDataOptions,
+): PcmS16AudioData => {
+	const audioData = convertAudioDataToS16(options);
+
+	return resamplePcmS16AudioData({
+		audioData,
+		playbackRate: options.playbackRate,
+		isLast: options.isLast,
+	});
 };

--- a/packages/media/src/test/browser.test.ts
+++ b/packages/media/src/test/browser.test.ts
@@ -57,8 +57,7 @@ test('Should be able to extract a frame', async () => {
 	// bits = 16
 	// sampleRate = 48000
 	// 1 / 30 * 2 * 2 * 48000 = 6400
-	// we round down start and round up duration
-	expect(audio.data.byteLength).toBe(6404);
+	expect(audio.data.byteLength).toBe(6400);
 
 	const cacheStats = keyframeManager.getCacheStats();
 	expect(cacheStats.count).toBe(1);

--- a/packages/media/src/test/resample.test.ts
+++ b/packages/media/src/test/resample.test.ts
@@ -1,5 +1,10 @@
 import {expect, test} from 'vitest';
-import {convertAudioData} from '../convert-audiodata/convert-audiodata';
+import {combineAudioDataAndClosePrevious} from '../convert-audiodata/combine-audiodata';
+import {
+	convertAudioData,
+	convertAudioDataToS16,
+	resamplePcmS16AudioData,
+} from '../convert-audiodata/convert-audiodata';
 import {generateSine, toInt16Array} from './sine';
 
 test('Should be able to convert audio that is on the verge', () => {
@@ -58,4 +63,71 @@ test('convert with playbackrate', () => {
 	for (let i = 0; i < 100; i++) {
 		expect(Math.abs(spedUp.data[i] - sineSpedupArray[i])).toBeLessThan(20);
 	}
+});
+
+test('packet boundaries do not affect resampling', () => {
+	const sampleRate = 44100;
+	const numberOfFrames = 511;
+	const splitAtFrame = 257;
+	const source = generateSine({
+		length: numberOfFrames,
+		amplitude: 4095,
+		frequency: 1000,
+		sampleRate,
+		phase: 0,
+	});
+	const sourceData = toInt16Array(source);
+	const first = new AudioData({
+		data: sourceData.slice(0, splitAtFrame * 2),
+		format: 's16',
+		numberOfChannels: 2,
+		numberOfFrames: splitAtFrame,
+		sampleRate,
+		timestamp: 0,
+	});
+	const second = new AudioData({
+		data: sourceData.slice(splitAtFrame * 2),
+		format: 's16',
+		numberOfChannels: 2,
+		numberOfFrames: numberOfFrames - splitAtFrame,
+		sampleRate,
+		timestamp: (splitAtFrame / sampleRate) * 1_000_000,
+	});
+	const playbackRate = 1.75;
+	const expected = convertAudioData({
+		audioData: source,
+		trimStartInSeconds: 0,
+		trimEndInSeconds: 0,
+		playbackRate,
+		audioDataTimestamp: 0,
+		isLast: true,
+	});
+	const combined = combineAudioDataAndClosePrevious([
+		convertAudioDataToS16({
+			audioData: first,
+			trimStartInSeconds: 0,
+			trimEndInSeconds: 0,
+			audioDataTimestamp: 0,
+			isLast: false,
+		}),
+		convertAudioDataToS16({
+			audioData: second,
+			trimStartInSeconds: 0,
+			trimEndInSeconds: 0,
+			audioDataTimestamp: second.timestamp / 1_000_000,
+			isLast: true,
+		}),
+	]);
+	const actual = resamplePcmS16AudioData({
+		audioData: combined,
+		playbackRate,
+		isLast: true,
+	});
+
+	expect(actual.numberOfFrames).toBe(expected.numberOfFrames);
+	expect(actual.data).toEqual(expected.data);
+
+	first.close();
+	second.close();
+	source.close();
 });


### PR DESCRIPTION
## Summary

- keep decoded audio chunks at their native sample rate while trimming and converting them to s16
- concatenate the native-rate PCM before applying sample-rate and playback-rate conversion
- add a testbed composition and regression coverage proving packet boundaries do not affect resampling

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx vitest src/test/resample.test.ts src/test/browser.test.ts --browser --run`
