### PR TITLE
Skills: Remove push confirmation from pr-ready workflow

### DIFF
--- a/.agents/skills/pr-ready/SKILL.md
+++ b/.agents/skills/pr-ready/SKILL.md
@@ -18,15 +18,12 @@ Start by checking:
 3. Whether the PR branch has merge conflicts with the base branch.
 4. The current PR checks or CI failures using the `gh` CLI.
 
-If there are uncommitted changes, untracked files that look relevant, or commits that have not been pushed, stop before changing, committing, or pushing them and ask the user for confirmation.
-
 If there is a merge conflict:
 
 1. Update the local base branch reference.
 2. Rebase or merge the PR branch onto the base branch, following the repository's existing workflow.
 3. Resolve conflicts carefully and preserve both the PR intent and upstream changes.
 4. Run the relevant formatting, tests, or builds for the affected packages.
-5. Ask the user for confirmation before pushing if the conflict resolution creates unpushed commits.
 
 If there is a CI failure:
 


### PR DESCRIPTION
## Summary

- remove the general confirmation requirement for uncommitted or unpushed changes from the `pr-ready` workflow
- remove the conflict-resolution push confirmation step

## Testing

- `bun run build`
- `bun run stylecheck`
