### PR TITLE
remotion.dev/convert: Add copy to clipboard action

### DIFF
--- a/packages/convert/app/components/ConversionDone.tsx
+++ b/packages/convert/app/components/ConversionDone.tsx
@@ -17,12 +17,13 @@ export const ConversionDone: React.FC<{
 		'idle',
 	);
 	const {mimeType} = getMediabunnyOutput(container);
+	const clipboardMimeType = `web ${mimeType}`;
 	const canCopyToClipboard =
 		typeof navigator !== 'undefined' &&
 		typeof navigator.clipboard?.write === 'function' &&
 		typeof ClipboardItem !== 'undefined' &&
 		typeof ClipboardItem.supports === 'function' &&
-		ClipboardItem.supports(mimeType);
+		ClipboardItem.supports(clipboardMimeType);
 
 	if (state.type !== 'done') {
 		throw new Error('Expected state to be done');
@@ -48,7 +49,7 @@ export const ConversionDone: React.FC<{
 			const file = await state.download();
 			await navigator.clipboard.write([
 				new ClipboardItem({
-					[mimeType]: file,
+					[clipboardMimeType]: file,
 				}),
 			]);
 			setCopyStatus('success');
@@ -59,7 +60,7 @@ export const ConversionDone: React.FC<{
 			setCopyStatus('error');
 			setTimeout(() => setCopyStatus('idle'), 2000);
 		}
-	}, [mimeType, state]);
+	}, [clipboardMimeType, state]);
 
 	const useAsInput = useCallback(async () => {
 		const file = await state.download();

--- a/packages/convert/app/components/ConversionDone.tsx
+++ b/packages/convert/app/components/ConversionDone.tsx
@@ -1,14 +1,27 @@
 import {Button, Button as RemotionButton} from '@remotion/design';
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import type {ConvertState, Source} from '~/lib/convert-state';
+import {getMediabunnyOutput} from '~/lib/output-container';
+import type {OutputContainer} from '~/seo';
+import {ClipboardIcon} from './icons/ClipboardIcon';
 import {CloneIcon} from './icons/clone';
 import {UndoIcon} from './icons/undo';
 
 export const ConversionDone: React.FC<{
+	readonly container: OutputContainer;
 	readonly state: ConvertState;
 	readonly setState: React.Dispatch<React.SetStateAction<ConvertState>>;
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
-}> = ({state, setState, setSrc}) => {
+}> = ({container, state, setState, setSrc}) => {
+	const [copied, setCopied] = useState(false);
+	const {mimeType} = getMediabunnyOutput(container);
+	const canCopyToClipboard =
+		typeof navigator !== 'undefined' &&
+		typeof navigator.clipboard?.write === 'function' &&
+		typeof ClipboardItem !== 'undefined' &&
+		typeof ClipboardItem.supports === 'function' &&
+		ClipboardItem.supports(mimeType);
+
 	if (state.type !== 'done') {
 		throw new Error('Expected state to be done');
 	}
@@ -27,6 +40,23 @@ export const ConversionDone: React.FC<{
 			setState({type: 'error', error: e as Error});
 		}
 	}, [setState, state]);
+
+	const onCopy = useCallback(async () => {
+		try {
+			const file = await state.download();
+			await navigator.clipboard.write([
+				new ClipboardItem({
+					[mimeType]: file,
+				}),
+			]);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (e) {
+			// eslint-disable-next-line no-console
+			console.error(e);
+			setState({type: 'error', error: e as Error});
+		}
+	}, [mimeType, setState, state]);
 
 	const useAsInput = useCallback(async () => {
 		const file = await state.download();
@@ -48,6 +78,18 @@ export const ConversionDone: React.FC<{
 			</RemotionButton>
 			<div className="h-2" />
 			<div className="flex flex-row gap-2">
+				{canCopyToClipboard ? (
+					<Button
+						className="w-full flex-1 flex-row justify-start rounded-full text-sm h-10"
+						type="button"
+						onClick={onCopy}
+						depth={0.2}
+					>
+						<ClipboardIcon size={16} />
+						<div className="w-2" />
+						{copied ? 'Copied!' : 'Copy to clipboard'}
+					</Button>
+				) : null}
 				<Button
 					className="w-full flex-1 flex-row justify-start rounded-full text-sm h-10"
 					type="button"

--- a/packages/convert/app/components/ConversionDone.tsx
+++ b/packages/convert/app/components/ConversionDone.tsx
@@ -13,7 +13,9 @@ export const ConversionDone: React.FC<{
 	readonly setState: React.Dispatch<React.SetStateAction<ConvertState>>;
 	readonly setSrc: React.Dispatch<React.SetStateAction<Source | null>>;
 }> = ({container, state, setState, setSrc}) => {
-	const [copied, setCopied] = useState(false);
+	const [copyStatus, setCopyStatus] = useState<'idle' | 'success' | 'error'>(
+		'idle',
+	);
 	const {mimeType} = getMediabunnyOutput(container);
 	const canCopyToClipboard =
 		typeof navigator !== 'undefined' &&
@@ -49,14 +51,15 @@ export const ConversionDone: React.FC<{
 					[mimeType]: file,
 				}),
 			]);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
+			setCopyStatus('success');
+			setTimeout(() => setCopyStatus('idle'), 2000);
 		} catch (e) {
 			// eslint-disable-next-line no-console
 			console.error(e);
-			setState({type: 'error', error: e as Error});
+			setCopyStatus('error');
+			setTimeout(() => setCopyStatus('idle'), 2000);
 		}
-	}, [mimeType, setState, state]);
+	}, [mimeType, state]);
 
 	const useAsInput = useCallback(async () => {
 		const file = await state.download();
@@ -87,7 +90,11 @@ export const ConversionDone: React.FC<{
 					>
 						<ClipboardIcon size={16} />
 						<div className="w-2" />
-						{copied ? 'Copied!' : 'Copy to clipboard'}
+						{copyStatus === 'success'
+							? 'Copied!'
+							: copyStatus === 'error'
+								? 'Failed to copy'
+								: 'Copy to clipboard'}
 					</Button>
 				) : null}
 				<Button


### PR DESCRIPTION
## Summary

- add a Copy to clipboard action to completed conversions
- only show it when the Clipboard API supports the generated media MIME type
- show brief copied feedback and reuse the existing conversion error state on failure

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test test` in `packages/convert`
