### PR TITLE
`@remotion/captions`: Fix caption pagination edge cases

### DIFF
--- a/packages/captions/src/create-tiktok-style-captions.ts
+++ b/packages/captions/src/create-tiktok-style-captions.ts
@@ -93,5 +93,10 @@ export const createTikTokStyleCaptions = ({
 		}
 	});
 
+	const lastPage = tikTokStyleCaptions[tikTokStyleCaptions.length - 1];
+	if (lastPage && lastPage.durationMs === Infinity) {
+		lastPage.durationMs = currentTo - lastPage.startMs;
+	}
+
 	return {pages: tikTokStyleCaptions};
 };

--- a/packages/captions/src/ensure-max-characters-per-line.ts
+++ b/packages/captions/src/ensure-max-characters-per-line.ts
@@ -5,7 +5,7 @@ const splitWords = (inputCaptions: Caption[]): Caption[] => {
 
 	for (let i = 0; i < inputCaptions.length; i++) {
 		const w = inputCaptions[i];
-		const words = w.text.split(' ');
+		const words = w.text.split(' ').filter(Boolean);
 
 		for (let j = 0; j < words.length; j++) {
 			const word = words[j];

--- a/packages/captions/src/test/ensure-max-characters.test.ts
+++ b/packages/captions/src/test/ensure-max-characters.test.ts
@@ -158,3 +158,28 @@ test('Ensure max characters per line', () => {
 		],
 	});
 });
+
+test('Does not emit standalone whitespace captions', () => {
+	const captions: Caption[] = [
+		{
+			confidence: 1,
+			endMs: 1000,
+			startMs: 0,
+			text: " Using Remotion's TikTok template,",
+			timestampMs: 500,
+		},
+	];
+
+	expect(ensureMaxCharactersPerLine({captions, maxCharsPerLine: 20})).toEqual({
+		segments: [
+			[
+				{...captions[0], text: ' Using'},
+				{...captions[0], text: "Remotion's"},
+			],
+			[
+				{...captions[0], text: 'TikTok'},
+				{...captions[0], text: 'template,'},
+			],
+		],
+	});
+});

--- a/packages/captions/src/test/tiktok.test.ts
+++ b/packages/captions/src/test/tiktok.test.ts
@@ -75,3 +75,47 @@ test('Should create captions', () => {
 		},
 	]);
 });
+
+test('Should finalize the duration when captions end in whitespace', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: ' one',
+				startMs: 0,
+				endMs: 500,
+				timestampMs: 0,
+				confidence: null,
+			},
+			{
+				text: ' two',
+				startMs: 500,
+				endMs: 1000,
+				timestampMs: 500,
+				confidence: null,
+			},
+			{
+				text: ' ',
+				startMs: 2000,
+				endMs: 2000,
+				timestampMs: 2000,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 200,
+	});
+
+	expect(pages).toEqual([
+		{
+			text: 'one',
+			startMs: 0,
+			durationMs: 500,
+			tokens: [{text: 'one', fromMs: 0, toMs: 500}],
+		},
+		{
+			text: 'two',
+			startMs: 500,
+			durationMs: 1500,
+			tokens: [{text: 'two', fromMs: 500, toMs: 1000}],
+		},
+	]);
+});

--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -102,7 +102,7 @@ An array of [`Caption`](/docs/captions/caption) objects.
 
 ### `combineTokensWithinMilliseconds`
 
-Words that are closer than this value will be combined into a single page.
+Controls how long captions are combined into a page. Once the current page's duration exceeds this value, the next caption that starts with a space begins a new page.
 
 ## Return value
 


### PR DESCRIPTION
## Summary

- finalize the last TikTok-style caption page when input ends with whitespace
- filter empty split results so `ensureMaxCharactersPerLine()` does not emit phantom whitespace captions
- add regression coverage for both public API behaviors
- document that `combineTokensWithinMilliseconds` measures accumulated page duration

## Testing

- `bun test` in `packages/captions`
- `bun run build`
- `bun run stylecheck`

Closes #10476

## Preview

- [`createTikTokStyleCaptions()` documentation](https://remotion-git-codex-fix-caption-pagination-bugs-remotion.vercel.app/docs/captions/create-tiktok-style-captions)
