### PR TITLE
Elements: Round displayed durations

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -205,7 +205,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 							</div>
 							<div>
 								<dt>Duration</dt>
-								<dd>{durationInFrames / fps}s</dd>
+								<dd>{(durationInFrames / fps).toFixed(2)}s</dd>
 							</div>
 							<div className={styles.dependenciesMetadata}>
 								<dt>Dependencies</dt>


### PR DESCRIPTION
## Summary

- Round Element page duration values to two decimal places.

## Verification

- `bun run build`
- `bun run stylecheck`
