### PR TITLE
Docs: Clarify H.264 patent licensing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -42,6 +42,10 @@ Support is provided on a best-we-can-do basis via GitHub Issues and Discord.
 
 You are required to obtain a Company License to use Remotion if you are not within the group of entities eligible for a Free License. This license will enable you to use Remotion for the allowed use cases specified in the Free License, and give you access to prioritized support (read the [Support Policy](https://www.remotion.dev/docs/support)).
 
+### Third-party patent rights
+
+A Company License grants only the rights to Remotion provided under these terms. It does not grant any license to third-party patents or other intellectual property rights, including patents that may be essential to the H.264/AVC video coding standard. Any third-party licenses, royalties, or other fees required for your use, encoding, distribution, or other exploitation of H.264/AVC are not included in the Company License and are your sole responsibility.
+
 Visit [remotion.pro](https://www.remotion.pro/license) for pricing and to buy a license.
 
 ### FAQs

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -42,10 +42,6 @@ Support is provided on a best-we-can-do basis via GitHub Issues and Discord.
 
 You are required to obtain a Company License to use Remotion if you are not within the group of entities eligible for a Free License. This license will enable you to use Remotion for the allowed use cases specified in the Free License, and give you access to prioritized support (read the [Support Policy](https://www.remotion.dev/docs/support)).
 
-### Third-party patent rights
-
-A Company License grants only the rights to Remotion provided under these terms. It does not grant any license to third-party patents or other intellectual property rights, including patents that may be essential to the H.264/AVC video coding standard. Any third-party licenses, royalties, or other fees required for your use, encoding, distribution, or other exploitation of H.264/AVC are not included in the Company License and are your sole responsibility.
-
 Visit [remotion.pro](https://www.remotion.pro/license) for pricing and to buy a license.
 
 ### FAQs

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -37,6 +37,12 @@ There is no difference between the free and paid version.
 
 We discriminate the price of the same software for various users: Remotion is free for individuals and small organizations, but paid for bigger organizations.
 
+### Does the Company License cover H.264/AVC patent fees?
+
+No. The Company License covers your use of Remotion only. It does not include licenses to third-party patents, including patents that may apply to H.264/AVC. Depending on your use case and jurisdiction, you may need additional licenses or need to pay royalties. It is your responsibility to determine whether these requirements apply to you.
+
+See the [Terms and Conditions](/docs/terms#ThirdPartyPatentRights) for the full terms.
+
 ### What does prioritized support mean?
 
 Support is provided on a best-effort basis, but we will respond first to people who own a company license. We try to reply and help everybody who files an issue or contacts us. We recommend to ask questions or get help in public channels such as GitHub Issues or Discord whenever possible where community members also have the chance to reply. See our [Support Policy](/docs/support) for more details.
@@ -66,7 +72,7 @@ See the [Terms and Conditions](/docs/terms) for the full definitions.
 
 Telemetry is a reporting mechanism that sends a small, anonymized event to Remotion each time a render is performed. It is implemented through the [`@remotion/licensing`](/docs/licensing) package and is described in detail on the [Telemetry](/docs/telemetry) page.
 
-Telemetry never throttles, blocks, or fails renders - even if the telemetry request itself fails, renders still complete successfully. 
+Telemetry never throttles, blocks, or fails renders - even if the telemetry request itself fails, renders still complete successfully.
 
 Telemetry is used to ensure accountability, and to provide you with insights into your own rendering activity in the Remotion Dashboard.
 

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -37,11 +37,11 @@ There is no difference between the free and paid version.
 
 We discriminate the price of the same software for various users: Remotion is free for individuals and small organizations, but paid for bigger organizations.
 
-### Does the Company License cover H.264/AVC patent fees?
+### Does a Remotion license cover codec patent fees?
 
-No. The Company License covers your use of Remotion only. It does not include licenses to third-party patents, including patents that may apply to H.264/AVC. Depending on your use case and jurisdiction, you may need additional licenses or need to pay royalties. It is your responsibility to determine whether these requirements apply to you.
+No. A Remotion license covers your use of Remotion only. It does not include a license to third-party patents, such as patents relating to codecs like H.264/AVC, HEVC or AAC. Depending on your use case and jurisdiction, you may need additional licenses or need to pay royalties. It is your responsibility to determine whether these requirements apply to you.
 
-See the [Terms and Conditions](/docs/terms#ThirdPartyPatentRights) for the full terms.
+See the [Terms and Conditions](/docs/terms#ThirdPartyRights) for the full terms and the [FFmpeg license](/docs/miscellaneous/ffmpeg-license) page for the components that Remotion distributes.
 
 ### What does prioritized support mean?
 

--- a/packages/docs/docs/license/faq.mdx
+++ b/packages/docs/docs/license/faq.mdx
@@ -41,7 +41,7 @@ We discriminate the price of the same software for various users: Remotion is fr
 
 No. A Remotion license covers your use of Remotion only. It does not include a license to third-party patents, such as patents relating to codecs like H.264/AVC, HEVC or AAC. Depending on your use case and jurisdiction, you may need additional licenses or need to pay royalties. It is your responsibility to determine whether these requirements apply to you.
 
-See the [Terms and Conditions](/docs/terms#ThirdPartyRights) for the full terms and the [FFmpeg license](/docs/miscellaneous/ffmpeg-license) page for the components that Remotion distributes.
+See the [Terms and Conditions](/docs/terms#ThirdPartyRights) for the full terms and the [FFmpeg license](/docs/miscellaneous/ffmpeg-license) page for the third-party software that Remotion redistributes.
 
 ### What does prioritized support mean?
 

--- a/packages/docs/docs/miscellaneous/ffmpeg-license.mdx
+++ b/packages/docs/docs/miscellaneous/ffmpeg-license.mdx
@@ -21,6 +21,12 @@ No other components in Remotion's FFmpeg binary should raise licensing concerns.
 
 Remotion has carefully verified the licensing information on this page. Concerns can be sent to [hi@remotion.dev](mailto:hi@remotion.dev).
 
+## Patents
+
+This page is about copyright licenses only. Copyright licenses do not include patent licenses, and some codecs are covered by patents that are licensed separately in some jurisdictions.
+
+Whether you need a patent license or have to pay royalties depends on your use case and jurisdiction and is not covered by a Remotion license. See "[Third-party rights](/docs/terms#ThirdPartyRights)" in the Terms and Conditions.
+
 ## See also
 
 - [Acknowledgements](/docs/acknowledgements)

--- a/packages/docs/docs/terms.mdx
+++ b/packages/docs/docs/terms.mdx
@@ -516,7 +516,7 @@ The software license grants only those rights to the Remotion Software that are 
 
 Depending on the User's use case and jurisdiction, the User's encoding, decoding, distribution, or other exploitation of media may require a license from a third party or the payment of royalties or other fees. Such licenses, royalties, and fees are not included in the software license and are the User's sole responsibility.
 
-Unless not otherwise noted, third-party components distributed by Remotion remain governed by their own license terms.
+Unless otherwise noted, third-party software redistributed by Remotion is licensed separately and remains subject to its own license terms.
 
 ### Changes to these Terms and Conditions {#ChangesToTheseTerms}
 

--- a/packages/docs/docs/terms.mdx
+++ b/packages/docs/docs/terms.mdx
@@ -516,7 +516,7 @@ The software license grants only those rights to the Remotion Software that are 
 
 Depending on the User's use case and jurisdiction, the User's encoding, decoding, distribution, or other exploitation of media may require a license from a third party or the payment of royalties or other fees. Such licenses, royalties, and fees are not included in the software license and are the User's sole responsibility.
 
-Third-party components distributed together with the Remotion Software remain governed by their own license terms. See "[FFmpeg license](/docs/miscellaneous/ffmpeg-license)" for the components contained in the FFmpeg binary that Remotion distributes.
+Unless not otherwise noted, third-party components distributed by Remotion remain governed by their own license terms.
 
 ### Changes to these Terms and Conditions {#ChangesToTheseTerms}
 

--- a/packages/docs/docs/terms.mdx
+++ b/packages/docs/docs/terms.mdx
@@ -190,10 +190,6 @@ Remotion confirms the following:
 
 The software license hereby grants using the Remotion Software in a non-commercial or commercial way for the purpose of creating media (e.g., videos and images) and modifying the Remotion Software to the User's liking for the purpose of fulfilling a User's custom use case or contributing improvements back to the Remotion Software.
 
-### Third-party patent rights {#ThirdPartyPatentRights}
-
-A Company License grants only the rights to Remotion provided under these Terms and Conditions. It does not grant any license to third-party patents or other intellectual property rights, including patents that may be essential to the H.264/AVC video coding standard. Any third-party licenses, royalties, or other fees required for the User's use, encoding, distribution, or other exploitation of H.264/AVC are not included in the Company License and are the User's sole responsibility.
-
 ### Disallowed use cases {#Disallowed}
 
 It is not allowed to copy or modify the Remotion Software for the purpose of selling, renting, licensing, relicensing, or sublicensing one's own derivative of the Remotion Software.
@@ -513,6 +509,14 @@ Additionally, the Service might not be available due to reasons outside Remotion
 Without prejudice to any more specific provision of these Terms and Conditions, any intellectual property rights, such as copyrights, trademarks, trade names, service marks, word marks, patent rights, design rights, illustrations, images and/or logos related to Remotion, are the exclusive property of Remotion and are subject to the protection granted by applicable laws or international treaties relating to intellectual property.
 
 Users hold the rights and ownership, but also the responsibilities to the media assets generated with the Remotion Software.
+
+### Third-party rights {#ThirdPartyRights}
+
+The software license grants only those rights to the Remotion Software that are set out in these Terms and Conditions. It does not include a license to patents, trademarks, or any other intellectual property rights held by third parties, such as rights relating to media formats, codecs, or fonts.
+
+Depending on the User's use case and jurisdiction, the User's encoding, decoding, distribution, or other exploitation of media may require a license from a third party or the payment of royalties or other fees. Such licenses, royalties, and fees are not included in the software license and are the User's sole responsibility.
+
+Third-party components distributed together with the Remotion Software remain governed by their own license terms. See "[FFmpeg license](/docs/miscellaneous/ffmpeg-license)" for the components contained in the FFmpeg binary that Remotion distributes.
 
 ### Changes to these Terms and Conditions {#ChangesToTheseTerms}
 

--- a/packages/docs/docs/terms.mdx
+++ b/packages/docs/docs/terms.mdx
@@ -190,6 +190,10 @@ Remotion confirms the following:
 
 The software license hereby grants using the Remotion Software in a non-commercial or commercial way for the purpose of creating media (e.g., videos and images) and modifying the Remotion Software to the User's liking for the purpose of fulfilling a User's custom use case or contributing improvements back to the Remotion Software.
 
+### Third-party patent rights {#ThirdPartyPatentRights}
+
+A Company License grants only the rights to Remotion provided under these Terms and Conditions. It does not grant any license to third-party patents or other intellectual property rights, including patents that may be essential to the H.264/AVC video coding standard. Any third-party licenses, royalties, or other fees required for the User's use, encoding, distribution, or other exploitation of H.264/AVC are not included in the Company License and are the User's sole responsibility.
+
 ### Disallowed use cases {#Disallowed}
 
 It is not allowed to copy or modify the Remotion Software for the purpose of selling, renting, licensing, relicensing, or sublicensing one's own derivative of the Remotion Software.


### PR DESCRIPTION
## Summary

- clarify in the Terms and Conditions that a Company License grants only rights to Remotion
- exclude third-party H.264/AVC patent licenses, royalties, and fees
- add a plain-language entry to the License FAQ

## Checks

- `bunx oxfmt LICENSE.md --write`
- `bun render-cards.ts` in `packages/docs`
- `bun run build`
- `bun run stylecheck`

## Preview

- [Terms and Conditions](https://remotion-git-codex-clarify-h264-patent-fees-remotion.vercel.app/docs/terms)
- [License FAQ](https://remotion-git-codex-clarify-h264-patent-fees-remotion.vercel.app/docs/license/faq)
