### PR TITLE
Elements: Add dedicated page drag handle

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -95,18 +95,69 @@
 	border-radius: 0 !important;
 }
 
-.useIt {
-	padding: 12px;
-	border: 1px solid var(--ifm-color-emphasis-300);
-	border-radius: 12px;
-	background: var(--ifm-background-surface-color);
-}
-
 .actionRow {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 10px;
+}
+
+.dragHandle {
+	position: relative;
+	display: flex;
+	align-items: center;
+	margin-top: 8px;
+	padding: 8px 40px;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 8px;
+	background: var(--ifm-background-surface-color);
+	color: var(--ifm-color-emphasis-800);
+	cursor: grab;
+	font-size: 0.8125rem;
+	user-select: none;
+}
+
+.dragHandle:hover {
+	background: var(--ifm-color-emphasis-100);
+}
+
+.dragHandle:active {
+	cursor: grabbing;
+}
+
+[data-theme='dark'] .dragHandle {
+	border-color: var(--ifm-color-emphasis-200);
+	color: var(--ifm-color-emphasis-700);
+}
+
+.dragHandleIcon {
+	position: absolute;
+	left: 12px;
+	top: 50%;
+	font-size: 1.5rem;
+	line-height: 1;
+	transform: translateY(-50%);
+}
+
+[data-theme='dark'] .dragHandleIcon {
+	color: var(--ifm-color-emphasis-500);
+}
+
+.dragHandleText {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	line-height: 1.3;
+	text-align: center;
+}
+
+.dragHandleText strong {
+	font-weight: 600;
+}
+
+.dragHandleText small {
+	color: var(--ifm-color-emphasis-600);
+	font-size: 0.75rem;
 }
 
 .successStatus,

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -155,11 +155,6 @@
 	font-weight: 600;
 }
 
-.dragHandleText small {
-	color: var(--ifm-color-emphasis-600);
-	font-size: 0.75rem;
-}
-
 .successStatus,
 .errorStatus {
 	margin: 12px 0 0;

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -179,7 +179,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 								</span>
 								<span className={styles.dragHandleText}>
 									<strong>Drag to your Studio tab</strong>
-									<small>Place it exactly where you want</small>
+									<small>Drop it on the canvas or timeline</small>
 								</span>
 							</div>
 							{installStatus.type === 'success' ||

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -178,8 +178,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									⠿
 								</span>
 								<span className={styles.dragHandleText}>
-									<strong>Drag to your Studio tab</strong>
-									<small>Drop it on the canvas or timeline</small>
+									<strong>Drag to your Studio canvas or timeline</strong>
 								</span>
 							</div>
 							{installStatus.type === 'success' ||

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -44,7 +44,6 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const [installStatus, setInstallStatus] = useState<InstallStatus>({
 		type: 'idle',
 	});
-	const [isDragging, setIsDragging] = useState(false);
 	const [isSourceVisible, setIsSourceVisible] = useState(false);
 	const posterRef = useRef<HTMLImageElement>(null);
 	const sourceId = useId();
@@ -146,35 +145,42 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 				aria-label="Element details and actions"
 				className={styles.actionsColumn}
 			>
-				<div className={styles.useIt}>
+				<div>
 					{elementPayload === null ? null : (
 						<>
 							<div className={styles.actionRow}>
 								<BlueButton
-									draggable
 									fullWidth
 									loading={installStatus.type === 'installing'}
 									onClick={installElement}
-									onDragEnd={() => setIsDragging(false)}
-									onDragStart={(event) => {
-										setIsDragging(true);
-										setStudioDragData({
-											dataTransfer: event.dataTransfer,
-											payload: elementPayload,
-										});
-										setElementDragImage(event.dataTransfer, posterRef.current);
-									}}
 									size="sm"
-									style={{
-										cursor: isDragging ? 'grabbing' : undefined,
-										padding: '7px 12px',
-									}}
-									title="Click to install in the most recently focused Remotion Studio, or drag onto the Studio canvas"
+									style={{padding: '7px 12px'}}
+									title="Install in the most recently focused Remotion Studio"
 								>
 									{installStatus.type === 'installing'
 										? 'Finding Studio…'
 										: 'Install in Studio'}
 								</BlueButton>
+							</div>
+							<div
+								className={styles.dragHandle}
+								draggable
+								onDragStart={(event) => {
+									setStudioDragData({
+										dataTransfer: event.dataTransfer,
+										payload: elementPayload,
+									});
+									setElementDragImage(event.dataTransfer, posterRef.current);
+								}}
+								title="Hover over your Studio browser tab, then drop on the canvas or timeline"
+							>
+								<span aria-hidden="true" className={styles.dragHandleIcon}>
+									⠿
+								</span>
+								<span className={styles.dragHandleText}>
+									<strong>Drag to your Studio tab</strong>
+									<small>Place it exactly where you want</small>
+								</span>
 							</div>
 							{installStatus.type === 'success' ||
 							installStatus.type === 'error' ? (


### PR DESCRIPTION
## Summary

- keep the Install in Studio button click-only
- add a dedicated drag handle that identifies the canvas and timeline as drop targets in an open Studio tab
- tune the drag affordance for light and dark mode

## Verification

- `bun run build`
- `bun run stylecheck`
