### PR TITLE
`@remotion/studio`: Render timeline ticks on canvas

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -459,7 +459,15 @@ const TimelineInner: React.FC = () => {
 										<TimelineList timeline={shown} showTimePadding />
 									</SplitterElement>
 									<SplitterHandle onCollapse={noop} allowToCollapse="none" />
-									<SplitterElement type="anti-flexer" sticky={null}>
+									<SplitterElement
+										type="anti-flexer"
+										sticky={
+											<>
+												<TimelineTimeIndicators />
+												<TimelineSlider />
+											</>
+										}
+									>
 										<TimelineScrollable>
 											<TimelineTracks
 												timeline={shown}
@@ -467,12 +475,10 @@ const TimelineInner: React.FC = () => {
 											/>
 											<TimelinePlayCursorSyncer />
 											<TimelineInOutPointer />
-											<TimelineTimeIndicators />
 											<TimelineDragHandler />
 											{isStudioInteractivityEnabled() ? (
 												<TimelineInOutDragHandler />
 											) : null}
-											<TimelineSlider />
 										</TimelineScrollable>
 									</SplitterElement>
 								</SplitterContainer>

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -16,6 +16,7 @@ const outer: React.CSSProperties = {
 	height: '100%',
 	overflowX: 'auto',
 	overflowY: 'hidden',
+	overscrollBehaviorX: 'none',
 	position: 'relative',
 	backgroundColor: TIMELINE_BACKGROUND,
 };

--- a/packages/studio/src/components/Timeline/TimelineSlider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSlider.tsx
@@ -1,7 +1,6 @@
 import React, {
 	createRef,
 	useContext,
-	useEffect,
 	useImperativeHandle,
 	useLayoutEffect,
 	useRef,
@@ -11,15 +10,25 @@ import {TIMELINE_PLAYHEAD_COLOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {getCurrentDuration} from './imperative-state';
-import {sliderAreaRef, timelineVerticalScroll} from './timeline-refs';
+import {scrollableRef, sliderAreaRef} from './timeline-refs';
 import {TimelineSliderHandle} from './TimelineSliderHandle';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
-const container: React.CSSProperties = {
+const clippingContainer: React.CSSProperties = {
 	position: 'absolute',
-	bottom: 0,
 	top: 0,
+	left: 0,
+	width: '100%',
+	height: '100vh',
+	overflow: 'hidden',
 	pointerEvents: 'none',
+};
+
+const slider: React.CSSProperties = {
+	position: 'absolute',
+	top: 0,
+	left: 0,
+	height: '100%',
 };
 
 const PLAYHEAD_LINE_WIDTH = 1;
@@ -36,10 +45,12 @@ const PLAYHEAD_CENTER_OFFSET = PLAYHEAD_LINE_WIDTH / 2;
 const getTimelineSliderTransform = ({
 	durationInFrames,
 	frame,
+	scrollLeft,
 	width,
 }: {
 	durationInFrames: number;
 	frame: number;
+	scrollLeft: number;
 	width: number;
 }) => {
 	const left = getXPositionOfItemInTimelineImperatively(
@@ -48,7 +59,7 @@ const getTimelineSliderTransform = ({
 		width,
 	);
 
-	return `translateX(${left - PLAYHEAD_CENTER_OFFSET}px)`;
+	return `translateX(${left - scrollLeft - PLAYHEAD_CENTER_OFFSET}px)`;
 };
 
 export const redrawTimelineSliderFast = createRef<{
@@ -85,15 +96,30 @@ const TimelineSliderInner: React.FC = () => {
 	useLayoutEffect(() => {
 		const el = ref.current;
 		const measuredWidth = sliderAreaRef.current?.clientWidth;
-		if (!el || measuredWidth === undefined || measuredWidth === 0) {
+		const scrollable = scrollableRef.current;
+		if (
+			!el ||
+			!scrollable ||
+			measuredWidth === undefined ||
+			measuredWidth === 0
+		) {
 			return;
 		}
 
-		el.style.transform = getTimelineSliderTransform({
-			durationInFrames: videoConfig.durationInFrames,
-			frame: timelinePosition,
-			width: measuredWidth,
-		});
+		const draw = () => {
+			el.style.transform = getTimelineSliderTransform({
+				durationInFrames: videoConfig.durationInFrames,
+				frame: timelinePosition,
+				scrollLeft: scrollable.scrollLeft,
+				width: measuredWidth,
+			});
+		};
+
+		draw();
+		scrollable.addEventListener('scroll', draw);
+		return () => {
+			scrollable.removeEventListener('scroll', draw);
+		};
 	}, [
 		timelinePosition,
 		videoConfig.durationInFrames,
@@ -112,37 +138,19 @@ const TimelineSliderInner: React.FC = () => {
 				current.style.transform = getTimelineSliderTransform({
 					durationInFrames: getCurrentDuration(),
 					frame,
+					scrollLeft: scrollableRef.current?.scrollLeft ?? 0,
 					width: width ?? (sliderAreaRef.current?.clientWidth as number) ?? 0,
 				});
 			},
 		};
 	}, []);
 
-	useEffect(() => {
-		const currentRef = ref.current;
-		if (!currentRef) {
-			return;
-		}
-
-		const {current} = timelineVerticalScroll;
-		if (!current) {
-			return;
-		}
-
-		const onScroll = () => {
-			currentRef.style.top = current.scrollTop + 'px';
-		};
-
-		current.addEventListener('scroll', onScroll);
-		return () => {
-			current.removeEventListener('scroll', onScroll);
-		};
-	}, []);
-
 	return (
-		<div ref={ref} style={container}>
-			<div style={line} />
-			<TimelineSliderHandle />
+		<div style={clippingContainer}>
+			<div ref={ref} style={slider}>
+				<div style={line} />
+				<TimelineSliderHandle />
+			</div>
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useMemo, useRef} from 'react';
+import React, {useContext, useLayoutEffect, useMemo, useRef} from 'react';
 import {Internals} from 'remotion';
 import {
 	BACKGROUND,
@@ -12,7 +12,7 @@ import {
 } from '../../helpers/timeline-layout';
 import {renderFrame} from '../../state/render-frame';
 import {TimeValue} from '../TimeValue';
-import {timelineVerticalScroll} from './timeline-refs';
+import {scrollableRef} from './timeline-refs';
 import {getFrameIncrementFromWidth} from './timeline-scroll-logic';
 import {TIMELINE_TICKS_BACKGROUND} from './TimelineSelection';
 import {TimelineWidthContext} from './TimelineWidthProvider';
@@ -27,18 +27,6 @@ const container: React.CSSProperties = {
 	borderBottom: `${TIMELINE_ITEM_BORDER_BOTTOM}px solid ${TIMELINE_TRACK_SEPARATOR}`,
 };
 
-const tick: React.CSSProperties = {
-	width: 1,
-	backgroundColor: WHITE_ALPHA_15,
-	height: 20,
-	position: 'absolute',
-};
-
-const secondTick: React.CSSProperties = {
-	...tick,
-	height: 15,
-};
-
 const TICK_LABEL_FONT_SIZE = 12;
 const TICK_LABEL_MARGIN_LEFT = 8;
 const TICK_LABEL_MIN_GAP = 16;
@@ -46,13 +34,6 @@ const MIN_SPACING_BETWEEN_FRAME_TICKS_PX = 5;
 const MIN_SPACING_BETWEEN_TIME_TICKS_PX = 16;
 const MIN_SPACING_BETWEEN_MEDIUM_FRAME_TICKS_PX = 24;
 const MIN_SPACING_BETWEEN_MEDIUM_TIME_TICKS_PX = 48;
-
-const tickLabel: React.CSSProperties = {
-	fontSize: TICK_LABEL_FONT_SIZE,
-	marginLeft: TICK_LABEL_MARGIN_LEFT,
-	marginTop: 7,
-	color: LIGHT_TEXT,
-};
 
 const timeValue: React.CSSProperties = {
 	height: TIMELINE_TIME_INDICATOR_HEIGHT,
@@ -82,12 +63,6 @@ export const TimelineTimePadding: React.FC = () => {
 			}}
 		/>
 	);
-};
-
-type TimelineTick = {
-	frame: number;
-	style: React.CSSProperties;
-	showTime: boolean;
 };
 
 const NICE_SECOND_INTERVALS = [
@@ -266,28 +241,156 @@ const TimelineTimeIndicatorsInner = React.memo<{
 	readonly fps: number;
 	readonly durationInFrames: number;
 }>(({windowWidth, durationInFrames, fps}) => {
-	const ref = useRef<HTMLDivElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement>(null);
 
-	useEffect(() => {
-		const currentRef = ref.current;
-		if (!currentRef) {
+	useLayoutEffect(() => {
+		const canvas = canvasRef.current;
+		const scrollable = scrollableRef.current;
+		if (!canvas || !scrollable) {
 			return;
 		}
 
-		const {current} = timelineVerticalScroll;
-		if (!current) {
+		const context = canvas.getContext('2d');
+		if (!context) {
 			return;
 		}
+
+		const frameInterval = getFrameIncrementFromWidth(
+			durationInFrames,
+			windowWidth,
+		);
+		const maxTickLabelWidth =
+			renderFrame(durationInFrames - 1, fps).length *
+			TICK_LABEL_FONT_SIZE *
+			0.6;
+		const tickScale = getTimelineTickScale({
+			fps,
+			frameInterval,
+			rawSecondMarkerEveryNth:
+				(TICK_LABEL_MARGIN_LEFT + maxTickLabelWidth + TICK_LABEL_MIN_GAP) /
+				(frameInterval * fps),
+		});
+
+		const draw = () => {
+			const {clientWidth: width, scrollLeft} = scrollable;
+			const pixelRatio = window.devicePixelRatio;
+			const canvasWidth = Math.ceil(width * pixelRatio);
+			const canvasHeight = TIMELINE_TIME_INDICATOR_HEIGHT * pixelRatio;
+
+			if (canvas.width !== canvasWidth || canvas.height !== canvasHeight) {
+				canvas.width = canvasWidth;
+				canvas.height = canvasHeight;
+				canvas.style.width = `${width}px`;
+				canvas.style.height = `${TIMELINE_TIME_INDICATOR_HEIGHT}px`;
+			}
+
+			context.resetTransform();
+			context.clearRect(0, 0, canvas.width, canvas.height);
+			context.scale(pixelRatio, pixelRatio);
+			context.fillStyle = WHITE_ALPHA_15;
+
+			const firstFrame = Math.max(
+				0,
+				Math.floor((scrollLeft - TIMELINE_PADDING) / frameInterval),
+			);
+			const lastFrame = Math.min(
+				durationInFrames - 1,
+				Math.ceil((scrollLeft + width - TIMELINE_PADDING) / frameInterval),
+			);
+			const xForFrame = (frame: number) =>
+				Math.round(frameInterval * frame + TIMELINE_PADDING - scrollLeft) + 0.5;
+			const drawTick = (frame: number, height: number) => {
+				const x = xForFrame(frame);
+				context.fillRect(x, 0, 1, height);
+			};
+
+			const firstLabelSecond =
+				Math.ceil(firstFrame / fps / tickScale.labelEverySeconds) *
+				tickScale.labelEverySeconds;
+			const seconds = Math.floor(durationInFrames / fps);
+			for (
+				let second = firstLabelSecond;
+				second < seconds && second * fps <= lastFrame;
+				second += tickScale.labelEverySeconds
+			) {
+				const frame = second * fps;
+				drawTick(frame, 15);
+				if (second > 0) {
+					context.fillStyle = LIGHT_TEXT;
+					context.font = `${TICK_LABEL_FONT_SIZE}px ${getComputedStyle(canvas).fontFamily}`;
+					context.textBaseline = 'top';
+					context.fillText(
+						renderFrame(frame, fps),
+						xForFrame(frame) + TICK_LABEL_MARGIN_LEFT,
+						7,
+					);
+					context.fillStyle = WHITE_ALPHA_15;
+				}
+			}
+
+			const {minorTickEvery, mediumTickEvery} = tickScale;
+			if (minorTickEvery?.unit === 'frames') {
+				const firstTick =
+					Math.ceil(firstFrame / minorTickEvery.interval) *
+					minorTickEvery.interval;
+				for (
+					let frame = firstTick;
+					frame <= lastFrame;
+					frame += minorTickEvery.interval
+				) {
+					if (frame % (tickScale.labelEverySeconds * fps) === 0) {
+						continue;
+					}
+
+					drawTick(
+						frame,
+						(Number.isInteger(fps) && frame % fps === 0) ||
+							(mediumTickEvery?.unit === 'frames' &&
+								frame % mediumTickEvery.interval === 0)
+							? 5
+							: 2,
+					);
+				}
+			}
+
+			if (minorTickEvery?.unit === 'seconds') {
+				const firstSecond =
+					Math.ceil(firstFrame / fps / minorTickEvery.interval) *
+					minorTickEvery.interval;
+				for (
+					let second = firstSecond;
+					second < seconds && second * fps <= lastFrame;
+					second += minorTickEvery.interval
+				) {
+					if (second % tickScale.labelEverySeconds === 0) {
+						continue;
+					}
+
+					drawTick(
+						second * fps,
+						mediumTickEvery?.unit === 'seconds' &&
+							second % mediumTickEvery.interval === 0
+							? 5
+							: 2,
+					);
+				}
+			}
+		};
 
 		const onScroll = () => {
-			currentRef.style.top = current.scrollTop + 'px';
+			draw();
 		};
 
-		current.addEventListener('scroll', onScroll);
+		const resizeObserver = new ResizeObserver(draw);
+
+		draw();
+		scrollable.addEventListener('scroll', onScroll);
+		resizeObserver.observe(scrollable);
 		return () => {
-			current.removeEventListener('scroll', onScroll);
+			scrollable.removeEventListener('scroll', onScroll);
+			resizeObserver.disconnect();
 		};
-	}, []);
+	}, [durationInFrames, fps, windowWidth]);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -298,113 +401,9 @@ const TimelineTimeIndicatorsInner = React.memo<{
 		};
 	}, [windowWidth]);
 
-	const ticks: TimelineTick[] = useMemo(() => {
-		const frameInterval = getFrameIncrementFromWidth(
-			durationInFrames,
-			windowWidth,
-		);
-
-		const maxTickLabelWidth =
-			renderFrame(durationInFrames - 1, fps).length *
-			TICK_LABEL_FONT_SIZE *
-			0.6;
-		const minSpacingBetweenTickLabelsPx =
-			TICK_LABEL_MARGIN_LEFT + maxTickLabelWidth + TICK_LABEL_MIN_GAP;
-
-		const seconds = Math.floor(durationInFrames / fps);
-		const rawSecondMarkerEveryNth =
-			minSpacingBetweenTickLabelsPx / (frameInterval * fps);
-		const tickScale = getTimelineTickScale({
-			fps,
-			frameInterval,
-			rawSecondMarkerEveryNth,
-		});
-
-		// Labeled ticks use human-friendly time intervals.
-		const secondTicks: TimelineTick[] = [];
-		for (let index = 0; index < seconds; index += tickScale.labelEverySeconds) {
-			secondTicks.push({
-				frame: index * fps,
-				style: {
-					...secondTick,
-					left: frameInterval * index * fps + TIMELINE_PADDING,
-				},
-				showTime: index > 0,
-			});
-		}
-
-		const hasSecondTick = new Set(secondTicks.map((t) => t.frame));
-		const subdivisionTicks: TimelineTick[] = [];
-		const {minorTickEvery, mediumTickEvery} = tickScale;
-
-		if (minorTickEvery?.unit === 'frames') {
-			for (
-				let frame = 0;
-				frame < durationInFrames;
-				frame += minorTickEvery.interval
-			) {
-				if (hasSecondTick.has(frame)) {
-					continue;
-				}
-
-				subdivisionTicks.push({
-					frame,
-					style: {
-						...tick,
-						left: frameInterval * frame + TIMELINE_PADDING,
-						height:
-							(Number.isInteger(fps) && frame % fps === 0) ||
-							(mediumTickEvery?.unit === 'frames' &&
-								frame % mediumTickEvery.interval === 0)
-								? 5
-								: 2,
-					},
-					showTime: false,
-				});
-			}
-		}
-
-		if (minorTickEvery?.unit === 'seconds') {
-			for (
-				let second = 0;
-				second < seconds;
-				second += minorTickEvery.interval
-			) {
-				const frame = second * fps;
-				if (hasSecondTick.has(frame)) {
-					continue;
-				}
-
-				subdivisionTicks.push({
-					frame,
-					style: {
-						...tick,
-						left: frameInterval * frame + TIMELINE_PADDING,
-						height:
-							mediumTickEvery?.unit === 'seconds' &&
-							second % mediumTickEvery.interval === 0
-								? 5
-								: 2,
-					},
-					showTime: false,
-				});
-			}
-		}
-
-		return [...secondTicks, ...subdivisionTicks];
-	}, [durationInFrames, fps, windowWidth]);
-
 	return (
-		<div ref={ref} style={style}>
-			{ticks.map((t) => {
-				return (
-					<div key={t.frame} style={t.style}>
-						{t.showTime ? (
-							<div style={tickLabel}>{renderFrame(t.frame, fps)}</div>
-						) : null}
-					</div>
-				);
-			})}
+		<div style={style}>
+			<canvas ref={canvasRef} style={{position: 'absolute', top: 0, left: 0}} />
 		</div>
 	);
 });


### PR DESCRIPTION
## Summary

- render Studio timeline ticks and labels on a viewport-sized canvas
- keep the timeline ruler and playhead in the splitter's sticky overlay
- synchronously redraw ticks and reposition the DOM playhead on horizontal scroll
- clip the playhead to the timeline pane and disable horizontal overscroll

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/timeline-nice-intervals.test.ts`
