### PR TITLE
`@remotion/studio`: Make Quick Switcher responsive

### DIFF
--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -467,6 +467,7 @@ export const QuickSwitcherContent: React.FC<{
 	const container: React.CSSProperties = useMemo(() => {
 		return {
 			width: showKeyboardShortcuts ? 800 : 400,
+			maxWidth: 'calc(100vw - 40px)',
 		};
 	}, [showKeyboardShortcuts]);
 


### PR DESCRIPTION
## Summary

- cap the Quick Switcher width to the available viewport
- preserve the existing preferred desktop widths
- prevent horizontal scrolling on narrow mobile screens

## Verification

- `bun run build`
- `bun run stylecheck`

Closes #10510
