### PR TITLE
`@remotion/claude-code-plugin`: Fix marketplace description placement

### DIFF
--- a/packages/claude-code-plugin/.claude-plugin/marketplace.json
+++ b/packages/claude-code-plugin/.claude-plugin/marketplace.json
@@ -5,7 +5,6 @@
 		"name": "Remotion",
 		"email": "hi@remotion.dev"
 	},
-	"description": "Plugins for building programmatic videos with Remotion",
 	"plugins": [
 		{
 			"name": "remotion",


### PR DESCRIPTION
## Summary

Remove the root-level `description` from the Claude Code marketplace manifest.

The plugin-specific description remains in `plugins[0]`, avoiding validation failures in the community marketplace while preserving the listing description.

## Testing

- `bun run build`
- `bun run stylecheck`
- Claude Code plugin manifest and package tests
