### PR TITLE
`@remotion/browser-studio`: Support deleting canvas items

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test';
 
-test('loads the Browser Studio canvas and enables Visual Mode', async ({
+test('loads the Browser Studio canvas and can add and delete items', async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -58,8 +58,24 @@ test('loads the Browser Studio canvas and enables Visual Mode', async ({
 				studio.getByRole('button', {name: 'Inspector'}),
 			).toBeVisible();
 			await studio.getByRole('button', {name: 'Add Solid'}).click();
-			await expect(studio.getByText('<Solid>', {exact: true})).toBeVisible();
+			const solid = studio.getByText('<Solid>', {exact: true});
+			await expect(solid).toBeVisible();
 			await expect(studio.locator('svg[viewBox="0 0 24 16"]')).toBeVisible();
+			await solid.click();
+			await page.keyboard.press('Delete');
+			await expect(solid).toHaveCount(0);
+			await expect
+				.poll(() =>
+					page.evaluate(() => {
+						const browserWindow = window as typeof window & {
+							__browserStudioProject: {files: Record<string, string>};
+						};
+						return browserWindow.__browserStudioProject.files[
+							'/project/src/Composition.tsx'
+						];
+					}),
+				)
+				.not.toContain('<Solid');
 		})(),
 		pageError,
 	]);

--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -1,6 +1,7 @@
 import {
 	computeSequencePropsStatusFromContent,
 	computeSequencePropsSubscriptionFromContent,
+	deleteJsxNodes,
 	findProjectFile,
 	getCanUpdateDefaultPropsForProject,
 	getCompositionComponentInfo,
@@ -392,6 +393,71 @@ export const createBrowserStudioOperations = ({
 		return resolved;
 	};
 
+	const deleteJsxNode: BrowserStudioOperations['deleteJsxNode'] = async ({
+		nodes,
+	}) => {
+		try {
+			if (nodes.length === 0) {
+				throw new Error('No JSX nodes were specified for deletion');
+			}
+
+			const project = getProject();
+			const nodesByFile = new Map<
+				string,
+				(typeof nodes)[number]['nodePath'][]
+			>();
+			for (const node of nodes) {
+				const fileName = findProjectFile({
+					filePath: node.fileName,
+					project,
+				});
+				const fileNodes = nodesByFile.get(fileName) ?? [];
+				fileNodes.push(node.nodePath);
+				nodesByFile.set(fileName, fileNodes);
+			}
+
+			const updates = await Promise.all(
+				[...nodesByFile].map(async ([fileName, nodePaths]) => ({
+					fileName,
+					result: await deleteJsxNodes({
+						input: project.files[fileName],
+						nodePaths,
+						formatFile: formatCodemodFile,
+					}),
+				})),
+			);
+			const nextProject = {
+				...project,
+				files: {
+					...project.files,
+					...Object.fromEntries(
+						updates.map(({fileName, result}) => [fileName, result.output]),
+					),
+				},
+			};
+			const nodePathMutation = controller.applyMutation({
+				fileName: updates.map(({fileName}) => fileName).join(', '),
+				mutate: () => nextProject,
+				nodePathMutationFiles: updates.map(({fileName, result}) => ({
+					absolutePath: fileName,
+					remappings: result.nodePathRemappings,
+					restoredNodePaths: [],
+				})),
+			});
+			if (nodePathMutation === null) {
+				throw new Error('Could not delete JSX nodes');
+			}
+
+			return {success: true, nodePathMutation};
+		} catch (error) {
+			return {
+				success: false,
+				reason: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error && error.stack ? error.stack : '',
+			};
+		}
+	};
+
 	const insertJsxElement: BrowserStudioOperations['insertJsxElement'] = async (
 		request,
 	) => {
@@ -452,6 +518,7 @@ export const createBrowserStudioOperations = ({
 	};
 
 	return {
+		deleteJsxNode,
 		deleteStaticFile: controller.deleteStaticFile,
 		downloadProject: () =>
 			Promise.resolve(

--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -107,6 +107,38 @@ test('mutates virtual files, emits events, and preserves undo and redo history',
 	expect(project.files['/project/src/Composition.tsx']).toContain(
 		'width={1280}',
 	);
+	if (insertResult.insertedNodePath === null) {
+		throw new Error('Expected the inserted Solid to have a node path');
+	}
+
+	const deleteResult = await operations.deleteJsxNode({
+		nodes: [
+			{
+				fileName: '/project/src/Composition.tsx',
+				nodePath: insertResult.insertedNodePath.nodePath,
+			},
+		],
+	});
+	if (!deleteResult.success) {
+		throw new Error(deleteResult.reason);
+	}
+
+	expect(project.files['/project/src/Composition.tsx']).not.toContain('<Solid');
+	expect(deleteResult.nodePathMutation.files).toEqual([
+		{
+			absolutePath: '/project/src/Composition.tsx',
+			remappings: expect.arrayContaining([
+				{
+					oldNodePath: insertResult.insertedNodePath.nodePath,
+					newNodePath: null,
+				},
+			]),
+			restoredNodePaths: [],
+		},
+	]);
+	const undoDeleteResult = await undo();
+	expect(undoDeleteResult.success).toBe(true);
+	expect(project.files['/project/src/Composition.tsx']).toContain('<Solid');
 
 	const {writeStaticFile} = operations;
 	await writeStaticFile({

--- a/packages/studio-codemods/src/delete-jsx-node.ts
+++ b/packages/studio-codemods/src/delete-jsx-node.ts
@@ -1,0 +1,519 @@
+import type {
+	ArrayExpression,
+	ArrowFunctionExpression,
+	AssignmentExpression,
+	CallExpression,
+	ConditionalExpression,
+	ExportDefaultDeclaration,
+	Expression,
+	ExpressionStatement,
+	File,
+	JSXElement,
+	JSXExpressionContainer,
+	JSXFragment,
+	JSXIdentifier,
+	JSXMemberExpression,
+	JSXOpeningElement,
+	LogicalExpression,
+	NewExpression,
+	Node,
+	OptionalCallExpression,
+	ParenthesizedExpression,
+	ReturnStatement,
+	SequenceExpression,
+	TSAsExpression,
+	VariableDeclarator,
+} from '@babel/types';
+import * as recast from 'recast';
+import type {SequenceNodePath} from 'remotion';
+import {
+	captureJsxNodePaths,
+	getNodePathRemappings,
+} from './get-node-path-remappings';
+import {getAstNodePath} from './sequence-props/get-ast-node-path';
+import {parseAst, serializeAst} from './sequence-props/parse-ast';
+
+const {builders: b, namedTypes} = recast.types;
+
+/** Recast `builders.nullLiteral()` is typed against ast-types; normalize to Babel `Expression`. */
+const nullLiteralExpr = (): Expression =>
+	b.nullLiteral() as unknown as Expression;
+
+const jsxOpeningNameToString = (name: JSXOpeningElement['name']): string => {
+	if (name.type === 'JSXIdentifier') {
+		return name.name;
+	}
+
+	if (name.type === 'JSXNamespacedName') {
+		return `${name.namespace.name}:${name.name.name}`;
+	}
+
+	if (name.type === 'JSXMemberExpression') {
+		const memberToString = (
+			expr: JSXMemberExpression | JSXIdentifier,
+		): string => {
+			if (expr.type === 'JSXIdentifier') {
+				return expr.name;
+			}
+
+			return `${memberToString(expr.object)}.${expr.property.name}`;
+		};
+
+		return memberToString(name);
+	}
+
+	return 'Unknown';
+};
+
+/** e.g. `<Video>` or `<Remotion.Sequence>` for logs and undo copy. */
+export const getJsxElementTagLabel = (element: JSXElement): string => {
+	return `<${jsxOpeningNameToString(element.openingElement.name)}>`;
+};
+
+export const findJsxElementPathForDeletion = (
+	ast: File,
+	nodePath: SequenceNodePath,
+): recast.types.NodePath | null => {
+	const current = getAstNodePath(ast, nodePath);
+	if (!current) {
+		return null;
+	}
+
+	if (namedTypes.JSXOpeningElement.check(current.value)) {
+		const parent = current.parentPath;
+		if (parent && namedTypes.JSXElement.check(parent.value)) {
+			return parent;
+		}
+
+		return null;
+	}
+
+	if (namedTypes.JSXElement.check(current.value)) {
+		return current;
+	}
+
+	return null;
+};
+
+const replaceInLogicalExpression = (
+	parent: LogicalExpression,
+	node: JSXElement,
+): boolean => {
+	const nl = nullLiteralExpr();
+	if (parent.left === node) {
+		parent.left = nl;
+		return true;
+	}
+
+	if (parent.right === node) {
+		parent.right = nl;
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInConditionalExpression = (
+	parent: ConditionalExpression,
+	node: JSXElement,
+): boolean => {
+	const nl = nullLiteralExpr();
+	if (parent.consequent === node) {
+		parent.consequent = nl;
+		return true;
+	}
+
+	if (parent.alternate === node) {
+		parent.alternate = nl;
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInArrowFunctionExpression = (
+	parent: ArrowFunctionExpression,
+	node: JSXElement,
+): boolean => {
+	if (parent.body === node) {
+		parent.body = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInReturnStatement = (
+	parent: ReturnStatement,
+	node: JSXElement,
+): boolean => {
+	if (parent.argument === node) {
+		parent.argument = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInCallExpression = (
+	parent: CallExpression,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.arguments.indexOf(node);
+	if (idx !== -1) {
+		parent.arguments[idx] = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInOptionalCallExpression = (
+	parent: OptionalCallExpression,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.arguments.indexOf(node);
+	if (idx !== -1) {
+		parent.arguments[idx] = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInArrayExpression = (
+	parent: ArrayExpression,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.elements.indexOf(node);
+	if (idx !== -1) {
+		parent.elements[idx] = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInAssignmentExpression = (
+	parent: AssignmentExpression,
+	node: JSXElement,
+): boolean => {
+	if (parent.right === node) {
+		parent.right = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInVariableDeclarator = (
+	parent: VariableDeclarator,
+	node: JSXElement,
+): boolean => {
+	if (parent.init === node) {
+		parent.init = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInExportDefaultDeclaration = (
+	parent: ExportDefaultDeclaration,
+	node: JSXElement,
+): boolean => {
+	if (parent.declaration === node) {
+		parent.declaration = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInSequenceExpression = (
+	parent: SequenceExpression,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.expressions.indexOf(node);
+	if (idx !== -1) {
+		parent.expressions[idx] = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInNewExpression = (
+	parent: NewExpression,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.arguments.indexOf(node);
+	if (idx !== -1) {
+		parent.arguments[idx] = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInExpressionStatement = (
+	parent: ExpressionStatement,
+	node: JSXElement,
+): boolean => {
+	if (parent.expression === node) {
+		parent.expression = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInParenthesizedExpression = (
+	parent: ParenthesizedExpression,
+	node: JSXElement,
+): boolean => {
+	if (parent.expression === node) {
+		parent.expression = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInJSXExpressionContainer = (
+	parent: JSXExpressionContainer,
+	node: JSXElement,
+): boolean => {
+	if (parent.expression === node) {
+		parent.expression = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInTSAsExpression = (
+	parent: TSAsExpression,
+	node: JSXElement,
+): boolean => {
+	if (parent.expression === node) {
+		parent.expression = nullLiteralExpr();
+		return true;
+	}
+
+	return false;
+};
+
+const replaceInJSXParentChildren = (
+	parent: JSXElement | JSXFragment,
+	node: JSXElement,
+): boolean => {
+	const idx = parent.children.indexOf(node);
+	if (idx !== -1) {
+		parent.children.splice(idx, 1);
+		return true;
+	}
+
+	return false;
+};
+
+const replaceNodeWithNull = (parentNode: Node, node: JSXElement): boolean => {
+	if (namedTypes.LogicalExpression.check(parentNode)) {
+		return replaceInLogicalExpression(parentNode, node);
+	}
+
+	if (namedTypes.ConditionalExpression.check(parentNode)) {
+		return replaceInConditionalExpression(parentNode, node);
+	}
+
+	if (namedTypes.ArrowFunctionExpression.check(parentNode)) {
+		return replaceInArrowFunctionExpression(parentNode, node);
+	}
+
+	if (namedTypes.ReturnStatement.check(parentNode)) {
+		return replaceInReturnStatement(parentNode, node);
+	}
+
+	if (namedTypes.CallExpression.check(parentNode)) {
+		return replaceInCallExpression(parentNode, node);
+	}
+
+	if (parentNode.type === 'OptionalCallExpression') {
+		return replaceInOptionalCallExpression(parentNode, node);
+	}
+
+	if (namedTypes.ArrayExpression.check(parentNode)) {
+		return replaceInArrayExpression(parentNode, node);
+	}
+
+	if (namedTypes.AssignmentExpression.check(parentNode)) {
+		return replaceInAssignmentExpression(parentNode, node);
+	}
+
+	if (namedTypes.VariableDeclarator.check(parentNode)) {
+		return replaceInVariableDeclarator(parentNode, node);
+	}
+
+	if (namedTypes.ExportDefaultDeclaration.check(parentNode)) {
+		return replaceInExportDefaultDeclaration(parentNode, node);
+	}
+
+	if (namedTypes.SequenceExpression.check(parentNode)) {
+		return replaceInSequenceExpression(parentNode, node);
+	}
+
+	if (namedTypes.NewExpression.check(parentNode)) {
+		return replaceInNewExpression(parentNode, node);
+	}
+
+	if (namedTypes.ExpressionStatement.check(parentNode)) {
+		return replaceInExpressionStatement(parentNode, node);
+	}
+
+	if (namedTypes.ParenthesizedExpression.check(parentNode)) {
+		return replaceInParenthesizedExpression(parentNode, node);
+	}
+
+	if (namedTypes.JSXExpressionContainer.check(parentNode)) {
+		return replaceInJSXExpressionContainer(parentNode, node);
+	}
+
+	if (namedTypes.TSAsExpression.check(parentNode)) {
+		return replaceInTSAsExpression(parentNode, node);
+	}
+
+	if (namedTypes.JSXElement.check(parentNode)) {
+		return replaceInJSXParentChildren(parentNode, node);
+	}
+
+	if (namedTypes.JSXFragment.check(parentNode)) {
+		return replaceInJSXParentChildren(parentNode, node);
+	}
+
+	return false;
+};
+
+export const deleteJsxElementAtPath = (
+	jsxPath: recast.types.NodePath,
+): void => {
+	const {node, parentPath} = jsxPath;
+	if (!parentPath) {
+		throw new Error('Cannot delete JSX element with no parent');
+	}
+
+	const jsxNode = node as JSXElement;
+
+	if (replaceNodeWithNull(parentPath.node, jsxNode)) {
+		return;
+	}
+
+	// Recast can replace this node in arbitrary parent contexts.
+	jsxPath.replace(b.nullLiteral());
+};
+
+export const deleteJsxNodes = async ({
+	input,
+	nodePaths,
+	formatFile,
+	prettierConfigOverride,
+}: {
+	input: string;
+	nodePaths: SequenceNodePath[];
+	formatFile: (input: {
+		contents: string;
+		prettierConfigOverride: Record<string, unknown> | null;
+	}) => Promise<{output: string; formatted: boolean}>;
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	nodeLabels: string[];
+	logLines: number[];
+	nodePathRemappings: Array<{
+		oldNodePath: SequenceNodePath;
+		newNodePath: SequenceNodePath | null;
+	}>;
+}> => {
+	if (nodePaths.length === 0) {
+		throw new Error('No JSX nodes were specified for deletion');
+	}
+
+	const ast = parseAst(input);
+	const capturedNodePaths = captureJsxNodePaths(ast);
+	const pathsToDelete = nodePaths.map((nodePath) => {
+		const jsxPath = findJsxElementPathForDeletion(ast, nodePath);
+		if (!jsxPath) {
+			throw new Error(
+				'Could not find a JSX element at the specified location to delete',
+			);
+		}
+
+		const jsxElement = jsxPath.node as JSXElement;
+
+		return {
+			jsxPath,
+			nodeLabel: getJsxElementTagLabel(jsxElement),
+			logLine:
+				jsxElement.openingElement.loc?.start.line ??
+				jsxElement.loc?.start.line ??
+				1,
+		};
+	});
+
+	for (const {jsxPath} of pathsToDelete) {
+		deleteJsxElementAtPath(jsxPath);
+	}
+
+	const finalFile = serializeAst(ast);
+	const {output, formatted} = await formatFile({
+		contents: finalFile,
+		prettierConfigOverride: prettierConfigOverride ?? null,
+	});
+	const {nodePathRemappings} = getNodePathRemappings({
+		ast,
+		captured: capturedNodePaths,
+		output,
+	});
+
+	return {
+		output,
+		formatted,
+		nodeLabels: pathsToDelete.map(({nodeLabel}) => nodeLabel),
+		logLines: pathsToDelete.map(({logLine}) => logLine),
+		nodePathRemappings,
+	};
+};
+
+export const deleteJsxNode = async ({
+	input,
+	nodePath,
+	formatFile,
+	prettierConfigOverride,
+}: {
+	input: string;
+	nodePath: SequenceNodePath;
+	formatFile: (input: {
+		contents: string;
+		prettierConfigOverride: Record<string, unknown> | null;
+	}) => Promise<{output: string; formatted: boolean}>;
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	nodeLabel: string;
+	logLine: number;
+}> => {
+	const {output, formatted, nodeLabels, logLines} = await deleteJsxNodes({
+		input,
+		nodePaths: [nodePath],
+		formatFile,
+		prettierConfigOverride,
+	});
+
+	return {
+		output,
+		formatted,
+		nodeLabel: nodeLabels[0],
+		logLine: logLines[0],
+	};
+};

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -11,6 +11,13 @@ import type {SequenceNodePath} from 'remotion';
 import {getNodePathForRecastPath} from './sequence-props';
 import {parseAst} from './sequence-props/parse-ast';
 
+export {
+	deleteJsxElementAtPath,
+	deleteJsxNode,
+	deleteJsxNodes,
+	findJsxElementPathForDeletion,
+	getJsxElementTagLabel,
+} from './delete-jsx-node';
 export {findSearchPosition} from './find-search-position';
 export {
 	insertJsxElementIntoComposition,

--- a/packages/studio-server/src/codemods/delete-jsx-node.ts
+++ b/packages/studio-server/src/codemods/delete-jsx-node.ts
@@ -1,418 +1,20 @@
-import type {
-	ArrayExpression,
-	ArrowFunctionExpression,
-	AssignmentExpression,
-	CallExpression,
-	ConditionalExpression,
-	ExportDefaultDeclaration,
-	Expression,
-	ExpressionStatement,
-	File,
-	JSXElement,
-	JSXExpressionContainer,
-	JSXFragment,
-	JSXIdentifier,
-	JSXMemberExpression,
-	JSXOpeningElement,
-	LogicalExpression,
-	NewExpression,
-	Node,
-	OptionalCallExpression,
-	ParenthesizedExpression,
-	ReturnStatement,
-	SequenceExpression,
-	TSAsExpression,
-	VariableDeclarator,
-} from '@babel/types';
-import * as recast from 'recast';
-import type {SequenceNodePath} from 'remotion';
-import {getAstNodePath} from '../helpers/get-ast-node-path';
-import {formatFileContent} from './format-file-content';
 import {
-	captureJsxNodePaths,
-	getNodePathRemappings,
-} from './get-node-path-remappings';
-import {parseAst, serializeAst} from './parse-ast';
+	deleteJsxElementAtPath,
+	deleteJsxNode as deleteJsxNodeCodemod,
+	deleteJsxNodes as deleteJsxNodesCodemod,
+	findJsxElementPathForDeletion,
+	getJsxElementTagLabel,
+} from '@remotion/studio-codemods';
+import type {SequenceNodePath} from 'remotion';
+import {formatFileContent} from './format-file-content';
 
-const {builders: b, namedTypes} = recast.types;
-
-/** Recast `builders.nullLiteral()` is typed against ast-types; normalize to Babel `Expression`. */
-const nullLiteralExpr = (): Expression =>
-	b.nullLiteral() as unknown as Expression;
-
-const jsxOpeningNameToString = (name: JSXOpeningElement['name']): string => {
-	if (name.type === 'JSXIdentifier') {
-		return name.name;
-	}
-
-	if (name.type === 'JSXNamespacedName') {
-		return `${name.namespace.name}:${name.name.name}`;
-	}
-
-	if (name.type === 'JSXMemberExpression') {
-		const memberToString = (
-			expr: JSXMemberExpression | JSXIdentifier,
-		): string => {
-			if (expr.type === 'JSXIdentifier') {
-				return expr.name;
-			}
-
-			return `${memberToString(expr.object)}.${expr.property.name}`;
-		};
-
-		return memberToString(name);
-	}
-
-	return 'Unknown';
+export {
+	deleteJsxElementAtPath,
+	findJsxElementPathForDeletion,
+	getJsxElementTagLabel,
 };
 
-/** e.g. `<Video>` or `<Remotion.Sequence>` for logs and undo copy. */
-export const getJsxElementTagLabel = (element: JSXElement): string => {
-	return `<${jsxOpeningNameToString(element.openingElement.name)}>`;
-};
-
-export const findJsxElementPathForDeletion = (
-	ast: File,
-	nodePath: SequenceNodePath,
-): recast.types.NodePath | null => {
-	const current = getAstNodePath(ast, nodePath);
-	if (!current) {
-		return null;
-	}
-
-	if (namedTypes.JSXOpeningElement.check(current.value)) {
-		const parent = current.parentPath;
-		if (parent && namedTypes.JSXElement.check(parent.value)) {
-			return parent;
-		}
-
-		return null;
-	}
-
-	if (namedTypes.JSXElement.check(current.value)) {
-		return current;
-	}
-
-	return null;
-};
-
-const replaceInLogicalExpression = (
-	parent: LogicalExpression,
-	node: JSXElement,
-): boolean => {
-	const nl = nullLiteralExpr();
-	if (parent.left === node) {
-		parent.left = nl;
-		return true;
-	}
-
-	if (parent.right === node) {
-		parent.right = nl;
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInConditionalExpression = (
-	parent: ConditionalExpression,
-	node: JSXElement,
-): boolean => {
-	const nl = nullLiteralExpr();
-	if (parent.consequent === node) {
-		parent.consequent = nl;
-		return true;
-	}
-
-	if (parent.alternate === node) {
-		parent.alternate = nl;
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInArrowFunctionExpression = (
-	parent: ArrowFunctionExpression,
-	node: JSXElement,
-): boolean => {
-	if (parent.body === node) {
-		parent.body = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInReturnStatement = (
-	parent: ReturnStatement,
-	node: JSXElement,
-): boolean => {
-	if (parent.argument === node) {
-		parent.argument = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInCallExpression = (
-	parent: CallExpression,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.arguments.indexOf(node);
-	if (idx !== -1) {
-		parent.arguments[idx] = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInOptionalCallExpression = (
-	parent: OptionalCallExpression,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.arguments.indexOf(node);
-	if (idx !== -1) {
-		parent.arguments[idx] = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInArrayExpression = (
-	parent: ArrayExpression,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.elements.indexOf(node);
-	if (idx !== -1) {
-		parent.elements[idx] = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInAssignmentExpression = (
-	parent: AssignmentExpression,
-	node: JSXElement,
-): boolean => {
-	if (parent.right === node) {
-		parent.right = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInVariableDeclarator = (
-	parent: VariableDeclarator,
-	node: JSXElement,
-): boolean => {
-	if (parent.init === node) {
-		parent.init = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInExportDefaultDeclaration = (
-	parent: ExportDefaultDeclaration,
-	node: JSXElement,
-): boolean => {
-	if (parent.declaration === node) {
-		parent.declaration = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInSequenceExpression = (
-	parent: SequenceExpression,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.expressions.indexOf(node);
-	if (idx !== -1) {
-		parent.expressions[idx] = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInNewExpression = (
-	parent: NewExpression,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.arguments.indexOf(node);
-	if (idx !== -1) {
-		parent.arguments[idx] = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInExpressionStatement = (
-	parent: ExpressionStatement,
-	node: JSXElement,
-): boolean => {
-	if (parent.expression === node) {
-		parent.expression = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInParenthesizedExpression = (
-	parent: ParenthesizedExpression,
-	node: JSXElement,
-): boolean => {
-	if (parent.expression === node) {
-		parent.expression = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInJSXExpressionContainer = (
-	parent: JSXExpressionContainer,
-	node: JSXElement,
-): boolean => {
-	if (parent.expression === node) {
-		parent.expression = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInTSAsExpression = (
-	parent: TSAsExpression,
-	node: JSXElement,
-): boolean => {
-	if (parent.expression === node) {
-		parent.expression = nullLiteralExpr();
-		return true;
-	}
-
-	return false;
-};
-
-const replaceInJSXParentChildren = (
-	parent: JSXElement | JSXFragment,
-	node: JSXElement,
-): boolean => {
-	const idx = parent.children.indexOf(node);
-	if (idx !== -1) {
-		parent.children.splice(idx, 1);
-		return true;
-	}
-
-	return false;
-};
-
-const replaceNodeWithNull = (parentNode: Node, node: JSXElement): boolean => {
-	if (namedTypes.LogicalExpression.check(parentNode)) {
-		return replaceInLogicalExpression(parentNode, node);
-	}
-
-	if (namedTypes.ConditionalExpression.check(parentNode)) {
-		return replaceInConditionalExpression(parentNode, node);
-	}
-
-	if (namedTypes.ArrowFunctionExpression.check(parentNode)) {
-		return replaceInArrowFunctionExpression(parentNode, node);
-	}
-
-	if (namedTypes.ReturnStatement.check(parentNode)) {
-		return replaceInReturnStatement(parentNode, node);
-	}
-
-	if (namedTypes.CallExpression.check(parentNode)) {
-		return replaceInCallExpression(parentNode, node);
-	}
-
-	if (parentNode.type === 'OptionalCallExpression') {
-		return replaceInOptionalCallExpression(parentNode, node);
-	}
-
-	if (namedTypes.ArrayExpression.check(parentNode)) {
-		return replaceInArrayExpression(parentNode, node);
-	}
-
-	if (namedTypes.AssignmentExpression.check(parentNode)) {
-		return replaceInAssignmentExpression(parentNode, node);
-	}
-
-	if (namedTypes.VariableDeclarator.check(parentNode)) {
-		return replaceInVariableDeclarator(parentNode, node);
-	}
-
-	if (namedTypes.ExportDefaultDeclaration.check(parentNode)) {
-		return replaceInExportDefaultDeclaration(parentNode, node);
-	}
-
-	if (namedTypes.SequenceExpression.check(parentNode)) {
-		return replaceInSequenceExpression(parentNode, node);
-	}
-
-	if (namedTypes.NewExpression.check(parentNode)) {
-		return replaceInNewExpression(parentNode, node);
-	}
-
-	if (namedTypes.ExpressionStatement.check(parentNode)) {
-		return replaceInExpressionStatement(parentNode, node);
-	}
-
-	if (namedTypes.ParenthesizedExpression.check(parentNode)) {
-		return replaceInParenthesizedExpression(parentNode, node);
-	}
-
-	if (namedTypes.JSXExpressionContainer.check(parentNode)) {
-		return replaceInJSXExpressionContainer(parentNode, node);
-	}
-
-	if (namedTypes.TSAsExpression.check(parentNode)) {
-		return replaceInTSAsExpression(parentNode, node);
-	}
-
-	if (namedTypes.JSXElement.check(parentNode)) {
-		return replaceInJSXParentChildren(parentNode, node);
-	}
-
-	if (namedTypes.JSXFragment.check(parentNode)) {
-		return replaceInJSXParentChildren(parentNode, node);
-	}
-
-	return false;
-};
-
-export const deleteJsxElementAtPath = (
-	jsxPath: recast.types.NodePath,
-): void => {
-	const {node, parentPath} = jsxPath;
-	if (!parentPath) {
-		throw new Error('Cannot delete JSX element with no parent');
-	}
-
-	const jsxNode = node as JSXElement;
-
-	if (replaceNodeWithNull(parentPath.node, jsxNode)) {
-		return;
-	}
-
-	// Recast can replace this node in arbitrary parent contexts.
-	jsxPath.replace(b.nullLiteral());
-};
-
-export const deleteJsxNodes = async ({
+export const deleteJsxNodes = ({
 	input,
 	nodePaths,
 	prettierConfigOverride,
@@ -420,67 +22,19 @@ export const deleteJsxNodes = async ({
 	input: string;
 	nodePaths: SequenceNodePath[];
 	prettierConfigOverride?: Record<string, unknown> | null;
-}): Promise<{
-	output: string;
-	formatted: boolean;
-	nodeLabels: string[];
-	logLines: number[];
-	nodePathRemappings: Array<{
-		oldNodePath: SequenceNodePath;
-		newNodePath: SequenceNodePath | null;
-	}>;
-}> => {
-	if (nodePaths.length === 0) {
-		throw new Error('No JSX nodes were specified for deletion');
-	}
-
-	const ast = parseAst(input);
-	const capturedNodePaths = captureJsxNodePaths(ast);
-	const pathsToDelete = nodePaths.map((nodePath) => {
-		const jsxPath = findJsxElementPathForDeletion(ast, nodePath);
-		if (!jsxPath) {
-			throw new Error(
-				'Could not find a JSX element at the specified location to delete',
-			);
-		}
-
-		const jsxElement = jsxPath.node as JSXElement;
-
-		return {
-			jsxPath,
-			nodeLabel: getJsxElementTagLabel(jsxElement),
-			logLine:
-				jsxElement.openingElement.loc?.start.line ??
-				jsxElement.loc?.start.line ??
-				1,
-		};
-	});
-
-	for (const {jsxPath} of pathsToDelete) {
-		deleteJsxElementAtPath(jsxPath);
-	}
-
-	const finalFile = serializeAst(ast);
-	const {output, formatted} = await formatFileContent({
-		input: finalFile,
+}) =>
+	deleteJsxNodesCodemod({
+		input,
+		nodePaths,
+		formatFile: ({contents, prettierConfigOverride: override}) =>
+			formatFileContent({
+				input: contents,
+				prettierConfigOverride: override,
+			}),
 		prettierConfigOverride,
 	});
-	const {nodePathRemappings} = getNodePathRemappings({
-		ast,
-		captured: capturedNodePaths,
-		output,
-	});
 
-	return {
-		output,
-		formatted,
-		nodeLabels: pathsToDelete.map(({nodeLabel}) => nodeLabel),
-		logLines: pathsToDelete.map(({logLine}) => logLine),
-		nodePathRemappings,
-	};
-};
-
-export const deleteJsxNode = async ({
+export const deleteJsxNode = ({
 	input,
 	nodePath,
 	prettierConfigOverride,
@@ -488,22 +42,14 @@ export const deleteJsxNode = async ({
 	input: string;
 	nodePath: SequenceNodePath;
 	prettierConfigOverride?: Record<string, unknown> | null;
-}): Promise<{
-	output: string;
-	formatted: boolean;
-	nodeLabel: string;
-	logLine: number;
-}> => {
-	const {output, formatted, nodeLabels, logLines} = await deleteJsxNodes({
+}) =>
+	deleteJsxNodeCodemod({
 		input,
-		nodePaths: [nodePath],
+		nodePath,
+		formatFile: ({contents, prettierConfigOverride: override}) =>
+			formatFileContent({
+				input: contents,
+				prettierConfigOverride: override,
+			}),
 		prettierConfigOverride,
 	});
-
-	return {
-		output,
-		formatted,
-		nodeLabel: nodeLabels[0],
-		logLine: logLines[0],
-	};
-};

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -1,6 +1,8 @@
 import type {
 	CompositionComponentInfoRequest,
 	CompositionComponentInfoResponse,
+	DeleteJsxNodeRequest,
+	DeleteJsxNodeResponse,
 	DeleteStaticFileRequest,
 	DeleteStaticFileResponse,
 	FindInFileRequest,
@@ -32,6 +34,9 @@ export type WriteStaticFileRequest = {
 };
 
 export type BrowserStudioOperations = {
+	deleteJsxNode: (
+		request: DeleteJsxNodeRequest,
+	) => Promise<DeleteJsxNodeResponse>;
 	deleteStaticFile: (
 		request: DeleteStaticFileRequest,
 	) => Promise<DeleteStaticFileResponse>;

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -16,8 +16,8 @@ import {
 	useSetTimelineSequenceHover,
 } from '../state/timeline-sequence-hover';
 import {Transform3DModeStateContext} from '../state/transform-3d-mode';
-import {callApi} from './call-api';
 import {useConfirmationDialog} from './ConfirmationDialog';
+import {deleteJsxNode} from './delete-jsx-node-api';
 import {useSelectComposition} from './InitialCompositionLoader';
 import {showNotification} from './Notifications/NotificationCenter';
 import {getSelectedOutlineControlLayout} from './selected-outline-control-layout';
@@ -321,7 +321,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				}
 
 				try {
-					const result = await callApi('/api/delete-jsx-node', {
+					const result = await deleteJsxNode({
 						nodes: [
 							{
 								fileName: nodePath.absolutePath,

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -30,9 +30,9 @@ import {
 import {useMaxMediaDuration} from '../../helpers/use-max-media-duration';
 import {SetSelectedModalContext} from '../../state/modals';
 import {AudioWaveform} from '../AudioWaveform';
-import {callApi} from '../call-api';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
+import {deleteJsxNode} from '../delete-jsx-node-api';
 import {useSelectComposition} from '../InitialCompositionLoader';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
@@ -416,7 +416,7 @@ const TimelineSequenceInner: React.FC<{
 		}
 
 		try {
-			const result = await callApi('/api/delete-jsx-node', {
+			const result = await deleteJsxNode({
 				nodes: [
 					{
 						fileName: validatedLocation.source,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -38,6 +38,7 @@ import {callApi} from '../call-api';
 import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
+import {deleteJsxNode} from '../delete-jsx-node-api';
 import {
 	addEffectFromDragData,
 	getEffectDragData,
@@ -405,7 +406,7 @@ const TimelineSequenceItemInner: React.FC<{
 		}
 
 		try {
-			const result = await callApi('/api/delete-jsx-node', {
+			const result = await deleteJsxNode({
 				nodes: [
 					{
 						fileName: validatedLocation.source,

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -3,6 +3,7 @@ import {Internals} from 'remotion';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {callApi} from '../call-api';
 import type {ConfirmationDialogFunction} from '../ConfirmationDialog-types';
+import {deleteJsxNode} from '../delete-jsx-node-api';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {deleteSelectedKeyframes} from './delete-selected-keyframe';
 import {findTrackForNodePathInfo} from './find-track-for-node-path-info';
@@ -56,7 +57,7 @@ export const deleteSequencesFromSource = async (
 		return false;
 	}
 
-	return callApi('/api/delete-jsx-node', {
+	return deleteJsxNode({
 		nodes: nodePathInfos.map((nodePathInfo) => {
 			const nodePath = nodePathInfo.sequenceSubscriptionKey;
 

--- a/packages/studio/src/components/delete-jsx-node-api.ts
+++ b/packages/studio/src/components/delete-jsx-node-api.ts
@@ -1,0 +1,15 @@
+import type {
+	DeleteJsxNodeRequest,
+	DeleteJsxNodeResponse,
+} from '@remotion/studio-shared';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
+import {callApi} from './call-api';
+
+export const deleteJsxNode = (
+	request: DeleteJsxNodeRequest,
+): Promise<DeleteJsxNodeResponse> => {
+	const browserStudioOperations = getBrowserStudioOperations();
+	return browserStudioOperations
+		? browserStudioOperations.deleteJsxNode(request)
+		: callApi('/api/delete-jsx-node', request);
+};

--- a/packages/studio/src/test/make-browser-studio-operations.ts
+++ b/packages/studio/src/test/make-browser-studio-operations.ts
@@ -8,6 +8,7 @@ export const makeBrowserStudioOperations = (
 	overrides: Partial<BrowserStudioOperations>,
 ): BrowserStudioOperations => {
 	return {
+		deleteJsxNode: () => unusedOperation('deleteJsxNode'),
 		deleteStaticFile: () => unusedOperation('deleteStaticFile'),
 		downloadProject: () => unusedOperation('downloadProject'),
 		findInFile: () => unusedOperation('findInFile'),


### PR DESCRIPTION
## Summary

- implement JSX node deletion for Browser Studio projects
- route canvas and timeline deletion through the Browser Studio operations bridge
- preserve undo/redo history and sequence node-path remappings
- share the existing deletion codemod between desktop Studio and Browser Studio

## Test plan

- `bun test packages/browser-studio/src/test/browser-studio-project-operations.test.ts packages/studio-server/src/test/delete-jsx-node.test.ts`
- `bunx playwright test e2e/browser-studio.test.ts --grep "can add and delete items"`
- `bun run build`
- `bun run stylecheck`

Red/green verified by disconnecting the Browser Studio delete bridge and confirming the Playwright workflow retained the Solid, then restoring the bridge and confirming deletion persisted to project source.
