### PR TITLE
`@remotion/captions`: Add silence-based caption page breaks

### DIFF
--- a/packages/captions/src/create-tiktok-style-captions.ts
+++ b/packages/captions/src/create-tiktok-style-captions.ts
@@ -16,7 +16,11 @@ export type TikTokPage = {
 export type CreateTikTokStyleCaptionsInput = {
 	captions: Caption[];
 	combineTokensWithinMilliseconds: number;
+	breakOnPunctuation?: boolean;
+	silenceGapMs?: number;
 };
+
+const SENTENCE_ENDING_PUNCTUATION = /[.!?…]["'”’)\]]*$/;
 
 export type CreateTikTokStyleCaptionsOutput = {
 	pages: TikTokPage[];
@@ -25,6 +29,8 @@ export type CreateTikTokStyleCaptionsOutput = {
 export const createTikTokStyleCaptions = ({
 	captions,
 	combineTokensWithinMilliseconds,
+	breakOnPunctuation,
+	silenceGapMs,
 }: CreateTikTokStyleCaptionsInput): CreateTikTokStyleCaptionsOutput => {
 	const tikTokStyleCaptions: TikTokPage[] = [];
 	let currentText = '';
@@ -48,10 +54,22 @@ export const createTikTokStyleCaptions = ({
 
 	captions.forEach((item, index) => {
 		const {text} = item;
+		const exceedsDuration =
+			currentTo - currentFrom > combineTokensWithinMilliseconds;
+		// A pause between the previous word and this one
+		const exceedsSilenceGap =
+			silenceGapMs !== undefined &&
+			currentText !== '' &&
+			item.startMs - currentTo >= silenceGapMs;
+		// Fixed slice keeps the check O(1) however long the page grows
+		const endsSentence =
+			breakOnPunctuation === true &&
+			SENTENCE_ENDING_PUNCTUATION.test(currentText.slice(-24).trimEnd());
+
 		// If text starts with a space, push the currentText (if it exists) and start a new one
 		if (
 			text.startsWith(' ') &&
-			currentTo - currentFrom > combineTokensWithinMilliseconds
+			(exceedsDuration || exceedsSilenceGap || endsSentence)
 		) {
 			if (currentText !== '') {
 				add();

--- a/packages/captions/src/create-tiktok-style-captions.ts
+++ b/packages/captions/src/create-tiktok-style-captions.ts
@@ -17,7 +17,7 @@ export type CreateTikTokStyleCaptionsInput = {
 	captions: Caption[];
 	combineTokensWithinMilliseconds: number;
 	breakOnPunctuation?: boolean;
-	silenceGapMs?: number;
+	breakOnSilenceAfterMilliseconds?: number;
 };
 
 const SENTENCE_ENDING_PUNCTUATION = /[.!?…]["'”’)\]]*$/;
@@ -30,7 +30,7 @@ export const createTikTokStyleCaptions = ({
 	captions,
 	combineTokensWithinMilliseconds,
 	breakOnPunctuation,
-	silenceGapMs,
+	breakOnSilenceAfterMilliseconds,
 }: CreateTikTokStyleCaptionsInput): CreateTikTokStyleCaptionsOutput => {
 	const tikTokStyleCaptions: TikTokPage[] = [];
 	let currentText = '';
@@ -56,11 +56,11 @@ export const createTikTokStyleCaptions = ({
 		const {text} = item;
 		const exceedsDuration =
 			currentTo - currentFrom > combineTokensWithinMilliseconds;
-		// A pause between the previous word and this one
-		const exceedsSilenceGap =
-			silenceGapMs !== undefined &&
+		// A pause between the previous caption and this one
+		const shouldBreakOnSilence =
+			breakOnSilenceAfterMilliseconds !== undefined &&
 			currentText !== '' &&
-			item.startMs - currentTo >= silenceGapMs;
+			item.startMs - currentTo >= breakOnSilenceAfterMilliseconds;
 		// Fixed slice keeps the check O(1) however long the page grows
 		const endsSentence =
 			breakOnPunctuation === true &&
@@ -69,7 +69,7 @@ export const createTikTokStyleCaptions = ({
 		// If text starts with a space, push the currentText (if it exists) and start a new one
 		if (
 			text.startsWith(' ') &&
-			(exceedsDuration || exceedsSilenceGap || endsSentence)
+			(exceedsDuration || shouldBreakOnSilence || endsSentence)
 		) {
 			if (currentText !== '') {
 				add();

--- a/packages/captions/src/create-tiktok-style-captions.ts
+++ b/packages/captions/src/create-tiktok-style-captions.ts
@@ -16,11 +16,8 @@ export type TikTokPage = {
 export type CreateTikTokStyleCaptionsInput = {
 	captions: Caption[];
 	combineTokensWithinMilliseconds: number;
-	breakOnPunctuation?: boolean;
 	breakOnSilenceAfterMilliseconds?: number;
 };
-
-const SENTENCE_ENDING_PUNCTUATION = /[.!?…]["'”’)\]]*$/;
 
 export type CreateTikTokStyleCaptionsOutput = {
 	pages: TikTokPage[];
@@ -29,7 +26,6 @@ export type CreateTikTokStyleCaptionsOutput = {
 export const createTikTokStyleCaptions = ({
 	captions,
 	combineTokensWithinMilliseconds,
-	breakOnPunctuation,
 	breakOnSilenceAfterMilliseconds,
 }: CreateTikTokStyleCaptionsInput): CreateTikTokStyleCaptionsOutput => {
 	const tikTokStyleCaptions: TikTokPage[] = [];
@@ -61,16 +57,9 @@ export const createTikTokStyleCaptions = ({
 			breakOnSilenceAfterMilliseconds !== undefined &&
 			currentText !== '' &&
 			item.startMs - currentTo >= breakOnSilenceAfterMilliseconds;
-		// Fixed slice keeps the check O(1) however long the page grows
-		const endsSentence =
-			breakOnPunctuation === true &&
-			SENTENCE_ENDING_PUNCTUATION.test(currentText.slice(-24).trimEnd());
 
 		// If text starts with a space, push the currentText (if it exists) and start a new one
-		if (
-			text.startsWith(' ') &&
-			(exceedsDuration || shouldBreakOnSilence || endsSentence)
-		) {
+		if (text.startsWith(' ') && (exceedsDuration || shouldBreakOnSilence)) {
 			if (currentText !== '') {
 				add();
 			}

--- a/packages/captions/src/test/tiktok.test.ts
+++ b/packages/captions/src/test/tiktok.test.ts
@@ -351,3 +351,35 @@ test('Should never break inside a word, even across a silence or after punctuati
 		},
 	]);
 });
+
+test('Should break at every word boundary when silenceGapMs is 0', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: 'one',
+				startMs: 0,
+				endMs: 200,
+				timestampMs: 100,
+				confidence: null,
+			},
+			{
+				text: ' two',
+				startMs: 200,
+				endMs: 400,
+				timestampMs: 300,
+				confidence: null,
+			},
+			{
+				text: ' three',
+				startMs: 400,
+				endMs: 600,
+				timestampMs: 500,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 10000,
+		silenceGapMs: 0,
+	});
+
+	expect(pages.map((p) => p.text)).toEqual(['one', 'two', 'three']);
+});

--- a/packages/captions/src/test/tiktok.test.ts
+++ b/packages/captions/src/test/tiktok.test.ts
@@ -211,7 +211,7 @@ test('Should break on punctuation inside closing quotes', () => {
 	expect(pages.map((p) => p.text)).toEqual(['"done."', 'next']);
 });
 
-test('Should start a new page after a silence of at least silenceGapMs', () => {
+test('Should start a new page after the configured silence duration', () => {
 	const {pages} = createTikTokStyleCaptions({
 		captions: [
 			{
@@ -237,7 +237,7 @@ test('Should start a new page after a silence of at least silenceGapMs', () => {
 			},
 		],
 		combineTokensWithinMilliseconds: 10000,
-		silenceGapMs: 1000,
+		breakOnSilenceAfterMilliseconds: 1000,
 	});
 
 	expect(pages).toEqual([
@@ -259,7 +259,7 @@ test('Should start a new page after a silence of at least silenceGapMs', () => {
 	]);
 });
 
-test('Should not break when the silence is shorter than silenceGapMs', () => {
+test('Should not break when the silence is shorter than the configured duration', () => {
 	const {pages} = createTikTokStyleCaptions({
 		captions: [
 			{
@@ -278,7 +278,7 @@ test('Should not break when the silence is shorter than silenceGapMs', () => {
 			},
 		],
 		combineTokensWithinMilliseconds: 10000,
-		silenceGapMs: 1000,
+		breakOnSilenceAfterMilliseconds: 1000,
 	});
 
 	expect(pages.map((p) => p.text)).toEqual(['hello there']);
@@ -336,7 +336,7 @@ test('Should never break inside a word, even across a silence or after punctuati
 		],
 		combineTokensWithinMilliseconds: 100,
 		breakOnPunctuation: true,
-		silenceGapMs: 500,
+		breakOnSilenceAfterMilliseconds: 500,
 	});
 
 	expect(pages).toEqual([
@@ -352,7 +352,7 @@ test('Should never break inside a word, even across a silence or after punctuati
 	]);
 });
 
-test('Should break at every word boundary when silenceGapMs is 0', () => {
+test('Should break at every word boundary when the silence duration is 0', () => {
 	const {pages} = createTikTokStyleCaptions({
 		captions: [
 			{
@@ -378,7 +378,7 @@ test('Should break at every word boundary when silenceGapMs is 0', () => {
 			},
 		],
 		combineTokensWithinMilliseconds: 10000,
-		silenceGapMs: 0,
+		breakOnSilenceAfterMilliseconds: 0,
 	});
 
 	expect(pages.map((p) => p.text)).toEqual(['one', 'two', 'three']);

--- a/packages/captions/src/test/tiktok.test.ts
+++ b/packages/captions/src/test/tiktok.test.ts
@@ -120,97 +120,6 @@ test('Should finalize the duration when captions end in whitespace', () => {
 	]);
 });
 
-test('Should break after sentence-ending punctuation when breakOnPunctuation is set', () => {
-	const {pages} = createTikTokStyleCaptions({
-		captions: [
-			{
-				text: 'the',
-				startMs: 0,
-				endMs: 200,
-				timestampMs: 100,
-				confidence: null,
-			},
-			{
-				text: ' blank',
-				startMs: 200,
-				endMs: 500,
-				timestampMs: 350,
-				confidence: null,
-			},
-			{
-				text: ' page.',
-				startMs: 500,
-				endMs: 900,
-				timestampMs: 700,
-				confidence: null,
-			},
-			{
-				text: ' This',
-				startMs: 1000,
-				endMs: 1200,
-				timestampMs: 1100,
-				confidence: null,
-			},
-			{
-				text: ' continues',
-				startMs: 1200,
-				endMs: 1600,
-				timestampMs: 1400,
-				confidence: null,
-			},
-		],
-		combineTokensWithinMilliseconds: 5000,
-		breakOnPunctuation: true,
-	});
-
-	expect(pages).toEqual([
-		{
-			text: 'the blank page.',
-			startMs: 0,
-			durationMs: 1000,
-			tokens: [
-				{text: 'the', fromMs: 0, toMs: 200},
-				{text: ' blank', fromMs: 200, toMs: 500},
-				{text: ' page.', fromMs: 500, toMs: 900},
-			],
-		},
-		{
-			text: 'This continues',
-			startMs: 1000,
-			durationMs: 600,
-			tokens: [
-				{text: 'This', fromMs: 1000, toMs: 1200},
-				{text: ' continues', fromMs: 1200, toMs: 1600},
-			],
-		},
-	]);
-});
-
-test('Should break on punctuation inside closing quotes', () => {
-	const {pages} = createTikTokStyleCaptions({
-		captions: [
-			{
-				text: '"done."',
-				startMs: 0,
-				endMs: 300,
-				timestampMs: 150,
-				confidence: null,
-			},
-			{
-				text: ' next',
-				startMs: 300,
-				endMs: 500,
-				timestampMs: 400,
-				confidence: null,
-			},
-		],
-		combineTokensWithinMilliseconds: 5000,
-		breakOnPunctuation: true,
-	});
-
-	expect(pages.map((p) => p.text)).toEqual(['"done."', 'next']);
-});
-
 test('Should start a new page after the configured silence duration', () => {
 	const {pages} = createTikTokStyleCaptions({
 		captions: [
@@ -284,38 +193,7 @@ test('Should not break when the silence is shorter than the configured duration'
 	expect(pages.map((p) => p.text)).toEqual(['hello there']);
 });
 
-test('Should produce identical output when the new options are omitted or disabled', () => {
-	const input: Caption[] = [
-		{
-			text: 'one.',
-			startMs: 0,
-			endMs: 300,
-			timestampMs: 150,
-			confidence: null,
-		},
-		{
-			text: ' two',
-			startMs: 1000,
-			endMs: 1300,
-			timestampMs: 1150,
-			confidence: null,
-		},
-	];
-
-	const omitted = createTikTokStyleCaptions({
-		captions: input,
-		combineTokensWithinMilliseconds: 500,
-	});
-	const disabled = createTikTokStyleCaptions({
-		captions: input,
-		combineTokensWithinMilliseconds: 500,
-		breakOnPunctuation: false,
-	});
-
-	expect(disabled).toEqual(omitted);
-});
-
-test('Should never break inside a word, even across a silence or after punctuation', () => {
+test('Should never break inside a word, even across a silence', () => {
 	const {pages} = createTikTokStyleCaptions({
 		captions: [
 			{
@@ -335,7 +213,6 @@ test('Should never break inside a word, even across a silence or after punctuati
 			},
 		],
 		combineTokensWithinMilliseconds: 100,
-		breakOnPunctuation: true,
 		breakOnSilenceAfterMilliseconds: 500,
 	});
 

--- a/packages/captions/src/test/tiktok.test.ts
+++ b/packages/captions/src/test/tiktok.test.ts
@@ -119,3 +119,235 @@ test('Should finalize the duration when captions end in whitespace', () => {
 		},
 	]);
 });
+
+test('Should break after sentence-ending punctuation when breakOnPunctuation is set', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: 'the',
+				startMs: 0,
+				endMs: 200,
+				timestampMs: 100,
+				confidence: null,
+			},
+			{
+				text: ' blank',
+				startMs: 200,
+				endMs: 500,
+				timestampMs: 350,
+				confidence: null,
+			},
+			{
+				text: ' page.',
+				startMs: 500,
+				endMs: 900,
+				timestampMs: 700,
+				confidence: null,
+			},
+			{
+				text: ' This',
+				startMs: 1000,
+				endMs: 1200,
+				timestampMs: 1100,
+				confidence: null,
+			},
+			{
+				text: ' continues',
+				startMs: 1200,
+				endMs: 1600,
+				timestampMs: 1400,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 5000,
+		breakOnPunctuation: true,
+	});
+
+	expect(pages).toEqual([
+		{
+			text: 'the blank page.',
+			startMs: 0,
+			durationMs: 1000,
+			tokens: [
+				{text: 'the', fromMs: 0, toMs: 200},
+				{text: ' blank', fromMs: 200, toMs: 500},
+				{text: ' page.', fromMs: 500, toMs: 900},
+			],
+		},
+		{
+			text: 'This continues',
+			startMs: 1000,
+			durationMs: 600,
+			tokens: [
+				{text: 'This', fromMs: 1000, toMs: 1200},
+				{text: ' continues', fromMs: 1200, toMs: 1600},
+			],
+		},
+	]);
+});
+
+test('Should break on punctuation inside closing quotes', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: '"done."',
+				startMs: 0,
+				endMs: 300,
+				timestampMs: 150,
+				confidence: null,
+			},
+			{
+				text: ' next',
+				startMs: 300,
+				endMs: 500,
+				timestampMs: 400,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 5000,
+		breakOnPunctuation: true,
+	});
+
+	expect(pages.map((p) => p.text)).toEqual(['"done."', 'next']);
+});
+
+test('Should start a new page after a silence of at least silenceGapMs', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: 'hello',
+				startMs: 0,
+				endMs: 200,
+				timestampMs: 100,
+				confidence: null,
+			},
+			{
+				text: ' there',
+				startMs: 200,
+				endMs: 400,
+				timestampMs: 300,
+				confidence: null,
+			},
+			{
+				text: ' again',
+				startMs: 5000,
+				endMs: 5200,
+				timestampMs: 5100,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 10000,
+		silenceGapMs: 1000,
+	});
+
+	expect(pages).toEqual([
+		{
+			text: 'hello there',
+			startMs: 0,
+			durationMs: 5000,
+			tokens: [
+				{text: 'hello', fromMs: 0, toMs: 200},
+				{text: ' there', fromMs: 200, toMs: 400},
+			],
+		},
+		{
+			text: 'again',
+			startMs: 5000,
+			durationMs: 200,
+			tokens: [{text: 'again', fromMs: 5000, toMs: 5200}],
+		},
+	]);
+});
+
+test('Should not break when the silence is shorter than silenceGapMs', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: 'hello',
+				startMs: 0,
+				endMs: 200,
+				timestampMs: 100,
+				confidence: null,
+			},
+			{
+				text: ' there',
+				startMs: 900,
+				endMs: 1100,
+				timestampMs: 1000,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 10000,
+		silenceGapMs: 1000,
+	});
+
+	expect(pages.map((p) => p.text)).toEqual(['hello there']);
+});
+
+test('Should produce identical output when the new options are omitted or disabled', () => {
+	const input: Caption[] = [
+		{
+			text: 'one.',
+			startMs: 0,
+			endMs: 300,
+			timestampMs: 150,
+			confidence: null,
+		},
+		{
+			text: ' two',
+			startMs: 1000,
+			endMs: 1300,
+			timestampMs: 1150,
+			confidence: null,
+		},
+	];
+
+	const omitted = createTikTokStyleCaptions({
+		captions: input,
+		combineTokensWithinMilliseconds: 500,
+	});
+	const disabled = createTikTokStyleCaptions({
+		captions: input,
+		combineTokensWithinMilliseconds: 500,
+		breakOnPunctuation: false,
+	});
+
+	expect(disabled).toEqual(omitted);
+});
+
+test('Should never break inside a word, even across a silence or after punctuation', () => {
+	const {pages} = createTikTokStyleCaptions({
+		captions: [
+			{
+				text: 'Dr.',
+				startMs: 0,
+				endMs: 200,
+				timestampMs: 100,
+				confidence: null,
+			},
+			// No leading space means continuation, so never a page break
+			{
+				text: 'Strange',
+				startMs: 5000,
+				endMs: 5300,
+				timestampMs: 5150,
+				confidence: null,
+			},
+		],
+		combineTokensWithinMilliseconds: 100,
+		breakOnPunctuation: true,
+		silenceGapMs: 500,
+	});
+
+	expect(pages).toEqual([
+		{
+			text: 'Dr.Strange',
+			startMs: 0,
+			durationMs: 5300,
+			tokens: [
+				{text: 'Dr.', fromMs: 0, toMs: 200},
+				{text: 'Strange', fromMs: 5000, toMs: 5300},
+			],
+		},
+	]);
+});

--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -104,16 +104,6 @@ An array of [`Caption`](/docs/captions/caption) objects.
 
 Controls how long captions are combined into a page. Once the current page's duration exceeds this value, the next caption that starts with a space begins a new page.
 
-### `breakOnPunctuation?`<AvailableFrom v="4.0.514" />
-
-_boolean_
-
-If set to `true`, a caption ending in sentence-ending punctuation (`.`, `!`, `?`, `…`, optionally followed by closing quotes or brackets) finishes the current page, even if `combineTokensWithinMilliseconds` has not been exceeded yet. Default is `false`.
-
-This prevents pages like `"the blank page. This"` which span across a sentence boundary.
-
-Abbreviations are not detected: `"Dr."` also triggers a break. The rule is a plain punctuation match to stay predictable.
-
 ### `breakOnSilenceAfterMilliseconds?`<AvailableFrom v="4.0.514" />
 
 _number_
@@ -126,7 +116,7 @@ As with all page breaks, the previous page's `durationMs` extends until the next
 
 A value of `0` starts a new page at every word boundary, resulting in word-by-word pages.
 
-Both options only add earlier page breaks: `combineTokensWithinMilliseconds` remains the upper bound, and pages can only get shorter, never longer.
+This option only adds earlier page breaks: `combineTokensWithinMilliseconds` remains the upper bound, and pages can only get shorter, never longer.
 
 ## Return value
 

--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -114,11 +114,13 @@ This prevents pages like `"the blank page. This"` which span across a sentence b
 
 Abbreviations are not detected: `"Dr."` also triggers a break. The rule is a plain punctuation match to stay predictable.
 
-### `silenceGapMs?`<AvailableFrom v="4.0.514" />
+### `breakOnSilenceAfterMilliseconds?`<AvailableFrom v="4.0.514" />
 
 _number_
 
-If set, a silence of at least this many milliseconds between the end of one caption and the start of the next begins a new page, even if `combineTokensWithinMilliseconds` has not been exceeded yet.
+If set, a gap of at least this many milliseconds between the end of one caption and the start of the next begins a new page, even if `combineTokensWithinMilliseconds` has not been exceeded yet. By default, gaps do not cause an early page break.
+
+This compares caption timestamps and does not analyze the audio track.
 
 As with all page breaks, the previous page's `durationMs` extends until the next page starts, so the caption stays on screen through the pause.
 

--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -104,6 +104,26 @@ An array of [`Caption`](/docs/captions/caption) objects.
 
 Controls how long captions are combined into a page. Once the current page's duration exceeds this value, the next caption that starts with a space begins a new page.
 
+### `breakOnPunctuation?`<AvailableFrom v="4.0.513" />
+
+_boolean_
+
+If set to `true`, a caption ending in sentence-ending punctuation (`.`, `!`, `?`, `…`, optionally followed by closing quotes or brackets) finishes the current page, even if `combineTokensWithinMilliseconds` has not been exceeded yet. Default is `false`.
+
+This prevents pages like `"the blank page. This"` which span across a sentence boundary.
+
+Abbreviations are not detected: `"Dr."` also triggers a break. The rule is a plain punctuation match to stay predictable.
+
+### `silenceGapMs?`<AvailableFrom v="4.0.513" />
+
+_number_
+
+If set, a silence of at least this many milliseconds between the end of one caption and the start of the next begins a new page, even if `combineTokensWithinMilliseconds` has not been exceeded yet.
+
+As with all page breaks, the previous page's `durationMs` extends until the next page starts, so the caption stays on screen through the pause.
+
+Both options only add earlier page breaks: `combineTokensWithinMilliseconds` remains the upper bound, and pages can only get shorter, never longer.
+
 ## Return value
 
 An object with the following properties:

--- a/packages/docs/docs/captions/create-tiktok-style-captions.mdx
+++ b/packages/docs/docs/captions/create-tiktok-style-captions.mdx
@@ -104,7 +104,7 @@ An array of [`Caption`](/docs/captions/caption) objects.
 
 Controls how long captions are combined into a page. Once the current page's duration exceeds this value, the next caption that starts with a space begins a new page.
 
-### `breakOnPunctuation?`<AvailableFrom v="4.0.513" />
+### `breakOnPunctuation?`<AvailableFrom v="4.0.514" />
 
 _boolean_
 
@@ -114,13 +114,15 @@ This prevents pages like `"the blank page. This"` which span across a sentence b
 
 Abbreviations are not detected: `"Dr."` also triggers a break. The rule is a plain punctuation match to stay predictable.
 
-### `silenceGapMs?`<AvailableFrom v="4.0.513" />
+### `silenceGapMs?`<AvailableFrom v="4.0.514" />
 
 _number_
 
 If set, a silence of at least this many milliseconds between the end of one caption and the start of the next begins a new page, even if `combineTokensWithinMilliseconds` has not been exceeded yet.
 
 As with all page breaks, the previous page's `durationMs` extends until the next page starts, so the caption stays on screen through the pause.
+
+A value of `0` starts a new page at every word boundary, resulting in word-by-word pages.
 
 Both options only add earlier page breaks: `combineTokensWithinMilliseconds` remains the upper bound, and pages can only get shorter, never longer.
 

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
 import {expect, test, type Page} from '@playwright/test';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
+import fs from 'fs';
+import path from 'path';
 import {
 	STUDIO_URL,
 	effectKeyframeE2eFile,
@@ -368,20 +368,12 @@ test.describe('visual mode', () => {
 		).toBeVisible();
 
 		const canvasItem = page.getByText('Performance overview', {exact: true});
-		const canvasItemBox = await canvasItem.boundingBox();
-		if (canvasItemBox === null) {
-			throw new Error('Canvas item has no bounding box');
-		}
-
-		const canvasItemCenter = {
-			x: canvasItemBox.x + canvasItemBox.width / 2,
-			y: canvasItemBox.y + canvasItemBox.height / 2,
-		};
-		await page.mouse.move(canvasItemCenter.x, canvasItemCenter.y);
-		await page.waitForTimeout(100);
-		await page.mouse.click(canvasItemCenter.x, canvasItemCenter.y, {
-			button: 'right',
-		});
+		await canvasItem.hover();
+		const canvasItemOutline = page.locator(
+			'polygon[data-remotion-prevent-selection-clear="true"][stroke-opacity="1"]',
+		);
+		await expect(canvasItemOutline).toHaveCount(1);
+		await canvasItemOutline.click({button: 'right'});
 
 		const duplicateButton = page.getByRole('button', {
 			name: 'Duplicate',


### PR DESCRIPTION
## Summary



- add opt-in `breakOnPunctuation` to finish a page after sentence-ending punctuation (plain match, no abbreviation heuristics)

- add opt-in `silenceGapMs` to start a new page after a silence between captions

- both default off, existing output is byte-identical (covered by an equivalence test)

- punctuation check runs on a fixed tail slice, O(1) per caption

- docs for both options (AvailableFrom markers set to 4.0.513, can bump if needed)



## Testing



- `bun run test` in `packages/captions` (11 pass)

- `bun run make`

- `bun run lint` (no new warnings)



Closes #10542