### PR TITLE
`@remotion/studio-server`: Reload public directory config changes

### DIFF
--- a/packages/cli/src/render-queue/queue.ts
+++ b/packages/cli/src/render-queue/queue.ts
@@ -15,17 +15,11 @@ import {processStill} from './process-still';
 import {processVideoJob} from './process-video';
 import type {StudioRenderJobFixedConfig} from './studio-render-job-fixed-config';
 
-type RenderJobWithCleanupAndFixedConfig = RenderJobWithCleanup & {
-	fixedConfig: StudioRenderJobFixedConfig;
-};
-
-let jobQueue: RenderJobWithCleanupAndFixedConfig[] = [];
+let jobQueue: RenderJobWithCleanup[] = [];
 
 const updateJob = (
 	id: string,
-	updater: (
-		job: RenderJobWithCleanupAndFixedConfig,
-	) => RenderJobWithCleanupAndFixedConfig,
+	updater: (job: RenderJobWithCleanup) => RenderJobWithCleanup,
 ) => {
 	jobQueue = jobQueue.map((j) => {
 		if (id === j.id) {
@@ -39,7 +33,7 @@ const updateJob = (
 
 export const getRenderQueue = (): RenderJob[] => {
 	return jobQueue.map((j) => {
-		const {cleanup, fixedConfig, ...rest} = j;
+		const {cleanup, ...rest} = j;
 		return rest;
 	});
 };
@@ -111,8 +105,8 @@ export const addJob = ({
 	logLevel: LogLevel;
 	fixedConfig: StudioRenderJobFixedConfig;
 }) => {
-	jobQueue.push({...job, fixedConfig});
-	processJobIfPossible({entryPoint, remotionRoot, logLevel});
+	jobQueue.push(job);
+	processJobIfPossible({entryPoint, remotionRoot, logLevel, fixedConfig});
 
 	notifyClientsOfJobUpdate();
 };
@@ -148,10 +142,12 @@ const processJobIfPossible = async ({
 	remotionRoot,
 	entryPoint,
 	logLevel,
+	fixedConfig,
 }: {
 	remotionRoot: string;
 	entryPoint: string;
 	logLevel: LogLevel;
+	fixedConfig: StudioRenderJobFixedConfig;
 }) => {
 	const runningJob = jobQueue.find((q) => {
 		return q.status === 'running';
@@ -228,7 +224,7 @@ const processJobIfPossible = async ({
 				jobCleanups.push({label, job: cleanup});
 			},
 			logLevel,
-			fixedConfig: nextJob.fixedConfig,
+			fixedConfig,
 		});
 		Log.info(
 			{indent: false, logLevel},
@@ -302,5 +298,5 @@ const processJobIfPossible = async ({
 		);
 	}
 
-	processJobIfPossible({remotionRoot, entryPoint, logLevel});
+	processJobIfPossible({remotionRoot, entryPoint, logLevel, fixedConfig});
 };

--- a/packages/cli/src/render-queue/queue.ts
+++ b/packages/cli/src/render-queue/queue.ts
@@ -15,11 +15,17 @@ import {processStill} from './process-still';
 import {processVideoJob} from './process-video';
 import type {StudioRenderJobFixedConfig} from './studio-render-job-fixed-config';
 
-let jobQueue: RenderJobWithCleanup[] = [];
+type RenderJobWithCleanupAndFixedConfig = RenderJobWithCleanup & {
+	fixedConfig: StudioRenderJobFixedConfig;
+};
+
+let jobQueue: RenderJobWithCleanupAndFixedConfig[] = [];
 
 const updateJob = (
 	id: string,
-	updater: (job: RenderJobWithCleanup) => RenderJobWithCleanup,
+	updater: (
+		job: RenderJobWithCleanupAndFixedConfig,
+	) => RenderJobWithCleanupAndFixedConfig,
 ) => {
 	jobQueue = jobQueue.map((j) => {
 		if (id === j.id) {
@@ -33,7 +39,7 @@ const updateJob = (
 
 export const getRenderQueue = (): RenderJob[] => {
 	return jobQueue.map((j) => {
-		const {cleanup, ...rest} = j;
+		const {cleanup, fixedConfig, ...rest} = j;
 		return rest;
 	});
 };
@@ -105,8 +111,8 @@ export const addJob = ({
 	logLevel: LogLevel;
 	fixedConfig: StudioRenderJobFixedConfig;
 }) => {
-	jobQueue.push(job);
-	processJobIfPossible({entryPoint, remotionRoot, logLevel, fixedConfig});
+	jobQueue.push({...job, fixedConfig});
+	processJobIfPossible({entryPoint, remotionRoot, logLevel});
 
 	notifyClientsOfJobUpdate();
 };
@@ -142,12 +148,10 @@ const processJobIfPossible = async ({
 	remotionRoot,
 	entryPoint,
 	logLevel,
-	fixedConfig,
 }: {
 	remotionRoot: string;
 	entryPoint: string;
 	logLevel: LogLevel;
-	fixedConfig: StudioRenderJobFixedConfig;
 }) => {
 	const runningJob = jobQueue.find((q) => {
 		return q.status === 'running';
@@ -224,7 +228,7 @@ const processJobIfPossible = async ({
 				jobCleanups.push({label, job: cleanup});
 			},
 			logLevel,
-			fixedConfig,
+			fixedConfig: nextJob.fixedConfig,
 		});
 		Log.info(
 			{indent: false, logLevel},
@@ -298,5 +302,5 @@ const processJobIfPossible = async ({
 		);
 	}
 
-	processJobIfPossible({remotionRoot, entryPoint, logLevel, fixedConfig});
+	processJobIfPossible({remotionRoot, entryPoint, logLevel});
 };

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -132,9 +132,16 @@ export const studioCommand = async (
 		commandLine: parsedCli,
 	}).value;
 
-	const relativePublicDir = publicDirOption.getValue({
+	let activeRelativePublicDir = publicDirOption.getValue({
 		commandLine: parsedCli,
 	}).value;
+	const activateRelativePublicDir = () => {
+		activeRelativePublicDir = publicDirOption.getValue({
+			commandLine: parsedCli,
+		}).value;
+		return activeRelativePublicDir;
+	};
+
 	const rendererPort = ConfigInternals.getRendererPortFromConfigFile();
 
 	const enableCrossSiteIsolation = enableCrossSiteIsolationOption.getValue({
@@ -305,7 +312,7 @@ export const studioCommand = async (
 		getEnvVariables: () => envVariables,
 		desiredPort,
 		remotionRoot,
-		relativePublicDir,
+		getRelativePublicDir: activateRelativePublicDir,
 		bundlerOverride,
 		rspackOverride,
 		webpackOverride,
@@ -319,7 +326,7 @@ export const studioCommand = async (
 					...options,
 					fixedConfig: {
 						bundlerOverride,
-						publicDir: relativePublicDir,
+						publicDir: activeRelativePublicDir,
 						rendererPort,
 						rspackOverride,
 						rspack: useRspack,

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -132,14 +132,13 @@ export const studioCommand = async (
 		commandLine: parsedCli,
 	}).value;
 
-	let activeRelativePublicDir = publicDirOption.getValue({
+	const relativePublicDir = publicDirOption.getValue({
 		commandLine: parsedCli,
 	}).value;
-	const activateRelativePublicDir = () => {
-		activeRelativePublicDir = publicDirOption.getValue({
+	const getRelativePublicDir = () => {
+		return publicDirOption.getValue({
 			commandLine: parsedCli,
 		}).value;
-		return activeRelativePublicDir;
 	};
 
 	const rendererPort = ConfigInternals.getRendererPortFromConfigFile();
@@ -312,7 +311,7 @@ export const studioCommand = async (
 		getEnvVariables: () => envVariables,
 		desiredPort,
 		remotionRoot,
-		getRelativePublicDir: activateRelativePublicDir,
+		getRelativePublicDir,
 		bundlerOverride,
 		rspackOverride,
 		webpackOverride,
@@ -326,7 +325,7 @@ export const studioCommand = async (
 					...options,
 					fixedConfig: {
 						bundlerOverride,
-						publicDir: activeRelativePublicDir,
+						publicDir: relativePublicDir,
 						rendererPort,
 						rspackOverride,
 						rspack: useRspack,

--- a/packages/cli/src/test/config-file-change.test.ts
+++ b/packages/cli/src/test/config-file-change.test.ts
@@ -45,6 +45,12 @@ test('classifies runtime config changes', () => {
 test('classifies changes that require a page reload', () => {
 	expect(
 		classify(
+			prepare('import_config.Config.setPublicDir("public");'),
+			prepare('import_config.Config.setPublicDir("assets");'),
+		),
+	).toBe('reload');
+	expect(
+		classify(
 			prepare('import_config.Config.setAudioLatencyHint("playback");'),
 			prepare('import_config.Config.setAudioLatencyHint("interactive");'),
 		),

--- a/packages/cli/src/test/config-reset.test.ts
+++ b/packages/cli/src/test/config-reset.test.ts
@@ -49,6 +49,7 @@ test('reset config options restores defaults before reloading config', async () 
 	Config.setKeyboardShortcutsEnabled(false);
 	Config.setLogLevel('verbose');
 	Config.setNumberOfSharedAudioTags(2);
+	Config.setPublicDir('assets');
 	Config.setRspack(true);
 	Config.setExperimentalKeepAudioContextAlive(true);
 	Config.overrideBundlerConfig((config, {bundler}) => ({
@@ -106,6 +107,9 @@ test('reset config options restores defaults before reloading config', async () 
 	expect(
 		BrowserSafeApis.options.numberOfSharedAudioTagsOption.getConfigValue(),
 	).toBe(2);
+	expect(
+		BrowserSafeApis.options.publicDirOption.getValue({commandLine: {}}).value,
+	).toBe('assets');
 	expect(BrowserSafeApis.options.rspackOption.getConfigValue()).toBe(true);
 	expect(StudioServerInternals.getConfiguredMaxTimelineTracks()).toBe(123);
 	expect(
@@ -179,6 +183,9 @@ test('reset config options restores defaults before reloading config', async () 
 	expect(
 		BrowserSafeApis.options.numberOfSharedAudioTagsOption.getConfigValue(),
 	).toBeNull();
+	expect(
+		BrowserSafeApis.options.publicDirOption.getValue({commandLine: {}}).value,
+	).toBeNull();
 	expect(BrowserSafeApis.options.rspackOption.getConfigValue()).toBeNull();
 	expect(StudioServerInternals.getConfiguredMaxTimelineTracks()).toBeNull();
 	expect(
@@ -223,6 +230,7 @@ test('CLI app flags take precedence over the configured defaults', () => {
 		arguments: ['--goto', '%TARGET_PATH%:%LINE_NUMBER%:%COLUMN_NUMBER%'],
 	});
 	Config.setExperimentalKeepAudioContextAlive(false);
+	Config.setPublicDir('assets');
 
 	expect(
 		BrowserSafeApis.options.experimentalKeepAudioContextAliveOption.getValue({
@@ -239,6 +247,11 @@ test('CLI app flags take precedence over the configured defaults', () => {
 			commandLine: {editor: 'zed'},
 		}),
 	).toEqual({source: 'cli', value: 'zed'});
+	expect(
+		BrowserSafeApis.options.publicDirOption.getValue({
+			commandLine: {'public-dir': 'cli-assets'},
+		}),
+	).toEqual({source: 'cli', value: 'cli-assets'});
 	expect(() => Config.setDefaultCodingAgent('invalid' as 'codex')).toThrow(
 		'Config.setDefaultCodingAgent() must be one of',
 	);

--- a/packages/studio-server/src/preview-server/public-folder.ts
+++ b/packages/studio-server/src/preview-server/public-folder.ts
@@ -1,4 +1,4 @@
-import {existsSync, watch} from 'node:fs';
+import {existsSync, watch, type FSWatcher} from 'node:fs';
 import path from 'node:path';
 import {BundlerInternals} from '@remotion/bundler';
 import type {StaticFile} from 'remotion';
@@ -16,8 +16,58 @@ export const initPublicFolderWatch = ({
 	onUpdate: () => void;
 	staticHash: string;
 }) => {
+	let watchedPublicDir: string | null = publicDir;
+	let watcher: FSWatcher | null = null;
+
+	const watchPublicFolder = (dir: string): FSWatcher => {
+		if (!existsSync(dir)) {
+			const parentDir = path.dirname(dir);
+			const parentWatcher = watch(parentDir, {}, () => {
+				if (watchedPublicDir !== dir || !existsSync(dir)) {
+					return;
+				}
+
+				parentWatcher.close();
+				watcher = watchPublicFolder(dir);
+				fetchFolder({publicDir: dir, staticHash});
+				onUpdate();
+			});
+			return parentWatcher;
+		}
+
+		// Known bug: If whole public folder is deleted, this will not be called on macOS.
+		// This is not severe, so a wontfix for now.
+		return watch(dir, {recursive: envSupportsFsRecursive()}, () => {
+			if (watchedPublicDir !== dir) {
+				return;
+			}
+
+			fetchFolder({publicDir: dir, staticHash});
+			onUpdate();
+		});
+	};
+
 	fetchFolder({publicDir, staticHash});
-	watchPublicFolder({publicDir, onUpdate, staticHash});
+	watcher = watchPublicFolder(publicDir);
+
+	return {
+		updatePublicFolderWatch: (newPublicDir: string) => {
+			if (newPublicDir === watchedPublicDir) {
+				return;
+			}
+
+			watcher?.close();
+			watchedPublicDir = newPublicDir;
+			fetchFolder({publicDir: newPublicDir, staticHash});
+			watcher = watchPublicFolder(newPublicDir);
+			onUpdate();
+		},
+		close: () => {
+			watcher?.close();
+			watcher = null;
+			watchedPublicDir = null;
+		},
+	};
 };
 
 export const fetchFolder = ({
@@ -37,41 +87,6 @@ export const fetchFolder = ({
 			...f,
 			name: f.name.split(path.sep).join('/'),
 		};
-	});
-};
-
-const watchPublicFolder = ({
-	publicDir,
-	onUpdate,
-	staticHash,
-}: {
-	publicDir: string;
-	onUpdate: () => void;
-	staticHash: string;
-}) => {
-	if (!existsSync(publicDir)) {
-		const parentDir = path.dirname(publicDir);
-		const onDirChange = () => {
-			if (existsSync(publicDir)) {
-				watchPublicFolder({
-					publicDir,
-					onUpdate,
-					staticHash,
-				});
-				onUpdate();
-				watcher.close();
-			}
-		};
-
-		const watcher = watch(parentDir, {}, onDirChange);
-		return;
-	}
-
-	// Known bug: If whole public folder is deleted, this will not be called on macOS.
-	// This is not severe, so a wontfix for now.
-	watch(publicDir, {recursive: envSupportsFsRecursive()}, () => {
-		fetchFolder({publicDir, staticHash});
-		onUpdate();
 	});
 };
 

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -55,7 +55,8 @@ export const startServer = async (options: {
 	getEnvVariables: () => Record<string, string>;
 	port: number | null;
 	remotionRoot: string;
-	publicDir: string;
+	getPublicDir: () => string;
+	updatePublicDir: () => void;
 	poll: number | null;
 	staticHash: string;
 	staticHashPrefix: string;
@@ -171,7 +172,8 @@ export const startServer = async (options: {
 					getEnvVariables: options.getEnvVariables,
 					remotionRoot: options.remotionRoot,
 					entryPoint: options.userDefinedComponent,
-					publicDir: options.publicDir,
+					getPublicDir: options.getPublicDir,
+					updatePublicDir: options.updatePublicDir,
 					logLevel: options.logLevel,
 					getRenderQueue: options.getRenderQueue,
 					getRenderDefaults: options.getRenderDefaults,

--- a/packages/studio-server/src/routes.ts
+++ b/packages/studio-server/src/routes.ts
@@ -375,7 +375,8 @@ export const handleRoutes = ({
 	getEnvVariables,
 	remotionRoot,
 	entryPoint,
-	publicDir,
+	getPublicDir,
+	updatePublicDir,
 	logLevel,
 	getRenderQueue,
 	getRenderDefaults,
@@ -403,7 +404,8 @@ export const handleRoutes = ({
 	getEnvVariables: () => Record<string, string>;
 	remotionRoot: string;
 	entryPoint: string;
-	publicDir: string;
+	getPublicDir: () => string;
+	updatePublicDir: () => void;
 	logLevel: LogLevel;
 	getRenderQueue: () => RenderJob[];
 	getRenderDefaults: () => RenderDefaults;
@@ -421,6 +423,7 @@ export const handleRoutes = ({
 	configFile: string | null;
 }): Promise<void> => {
 	const url = new URL(request.url as string, 'http://localhost');
+	const publicDir = getPublicDir();
 
 	if (url.pathname === '/api/file-source') {
 		return handleFileSource({
@@ -580,6 +583,11 @@ export const handleRoutes = ({
 		return output404(response);
 	}
 
+	const acceptsHtml = (request.headers.accept ?? '').includes('text/html');
+	if (request.method === 'GET' && acceptsHtml) {
+		updatePublicDir();
+	}
+
 	return handleFallback({
 		remotionRoot,
 		hash: staticHash,
@@ -587,7 +595,7 @@ export const handleRoutes = ({
 		request,
 		getCurrentInputProps,
 		getEnvVariables,
-		publicDir,
+		publicDir: getPublicDir(),
 		getRenderQueue,
 		getRenderDefaults,
 		getNumberOfAudioTags,

--- a/packages/studio-server/src/start-studio.ts
+++ b/packages/studio-server/src/start-studio.ts
@@ -46,7 +46,7 @@ export const startStudio = async ({
 	getEnvVariables,
 	desiredPort,
 	remotionRoot,
-	relativePublicDir,
+	getRelativePublicDir,
 	bundlerOverride,
 	rspackOverride,
 	webpackOverride,
@@ -79,7 +79,7 @@ export const startStudio = async ({
 	getEnvVariables: () => Record<string, string>;
 	desiredPort: number | null;
 	remotionRoot: string;
-	relativePublicDir: string | null;
+	getRelativePublicDir: () => string | null;
 	bundlerOverride: BundlerOverrideFn;
 	rspackOverride: RspackOverrideFn;
 	webpackOverride: WebpackOverrideFn;
@@ -117,8 +117,8 @@ export const startStudio = async ({
 	getFileWatcherRegistry();
 
 	watchRootFile(remotionRoot, previewEntry);
-	const publicDir = getAbsolutePublicDir({
-		relativePublicDir,
+	let publicDir = getAbsolutePublicDir({
+		relativePublicDir: getRelativePublicDir(),
 		remotionRoot,
 	});
 	const hash = crypto.randomBytes(6).toString('hex');
@@ -129,7 +129,7 @@ export const startStudio = async ({
 	const staticHashPrefix = '/static-';
 	const staticHash = `${staticHashPrefix}${hash}`;
 
-	initPublicFolderWatch({
+	const publicFolderWatch = initPublicFolderWatch({
 		publicDir,
 		remotionRoot,
 		onUpdate: () => {
@@ -149,6 +149,18 @@ export const startStudio = async ({
 		},
 		staticHash,
 	});
+	const updatePublicDir = () => {
+		const newPublicDir = getAbsolutePublicDir({
+			relativePublicDir: getRelativePublicDir(),
+			remotionRoot,
+		});
+		if (newPublicDir === publicDir) {
+			return;
+		}
+
+		publicDir = newPublicDir;
+		publicFolderWatch.updatePublicFolderWatch(newPublicDir);
+	};
 
 	const result = await startServer({
 		entry: path.resolve(previewEntry),
@@ -157,7 +169,8 @@ export const startStudio = async ({
 		getEnvVariables,
 		port: desiredPort,
 		remotionRoot,
-		publicDir,
+		getPublicDir: () => publicDir,
+		updatePublicDir,
 		bundlerOverride,
 		rspackOverride,
 		webpackOverride,
@@ -187,6 +200,7 @@ export const startStudio = async ({
 	});
 
 	if (result.type === 'already-running') {
+		publicFolderWatch.close();
 		RenderInternals.Log.info(
 			{indent: false, logLevel},
 			`Already running on port ${result.port}.`,
@@ -246,6 +260,7 @@ export const startStudio = async ({
 		await noOpUntilRestart();
 	} finally {
 		openBrowserShortcut.cleanup();
+		publicFolderWatch.close();
 	}
 
 	RenderInternals.Log.info(

--- a/packages/studio-server/src/test/file-source-route.test.ts
+++ b/packages/studio-server/src/test/file-source-route.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'bun:test';
-import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import type {IncomingMessage, ServerResponse} from 'node:http';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
@@ -82,6 +82,7 @@ test('serves file source from an origin-less GET request', async () => {
 			getRenderQueue: () => [],
 			getNumberOfAudioTags: () => 0,
 			getPreviewSampleRate: () => null,
+			getPublicDir: () => remotionRoot,
 			getStudioRuntimeConfig: () => ({
 				askAIEnabled: false,
 				bufferStateDelayInMilliseconds: null,
@@ -98,7 +99,6 @@ test('serves file source from an origin-less GET request', async () => {
 			logLevel: 'info',
 			outputHash: '/outputs',
 			outputHashPrefix: '/outputs',
-			publicDir: remotionRoot,
 			queueMethods: {
 				addJob: () => undefined,
 				cancelJob: () => undefined,
@@ -112,10 +112,86 @@ test('serves file source from an origin-less GET request', async () => {
 			response,
 			staticHash: '/static',
 			staticHashPrefix: '/static',
+			updatePublicDir: () => undefined,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.body).toBe('export const value = 1;');
+	} finally {
+		await rm(remotionRoot, {force: true, recursive: true});
+	}
+});
+
+test('activates the latest public directory when the Studio page reloads', async () => {
+	const remotionRoot = await mkdtemp(path.join(tmpdir(), 'remotion-source-'));
+	const firstPublicDir = path.join(remotionRoot, 'first');
+	const secondPublicDir = path.join(remotionRoot, 'second');
+	await mkdir(firstPublicDir);
+	await mkdir(secondPublicDir);
+	await writeFile(path.join(remotionRoot, 'package.json'), '{}');
+	await writeFile(path.join(firstPublicDir, 'first.txt'), 'first');
+	await writeFile(path.join(secondPublicDir, 'second.txt'), 'second');
+
+	let publicDir = firstPublicDir;
+	let updates = 0;
+	const request = Readable.from([]) as IncomingMessage;
+	request.method = 'GET';
+	request.url = '/';
+	request.headers = {accept: 'text/html', host: 'localhost:3000'};
+
+	try {
+		const response = makeResponse();
+		await handleRoutes({
+			binariesDirectory: null,
+			configFile: null,
+			enableCrossSiteIsolation: false,
+			entryPoint: '',
+			getAudioLatencyHint: () => null,
+			getExperimentalKeepAudioContextAlive: () => false,
+			getCurrentInputProps: () => ({}),
+			getDefaultCodingAgent: () => null,
+			getDefaultEditor: () => null,
+			getEnvVariables: () => ({}),
+			getRenderDefaults: () => ({}) as RenderDefaults,
+			getRenderQueue: () => [],
+			getNumberOfAudioTags: () => 0,
+			getPreviewSampleRate: () => null,
+			getPublicDir: () => publicDir,
+			getStudioRuntimeConfig: () => ({
+				askAIEnabled: false,
+				bufferStateDelayInMilliseconds: null,
+				defaultCodingAgent: null,
+				defaultEditor: null,
+				interactivityEnabled: true,
+				keyboardShortcutsEnabled: true,
+				maxTimelineTracks: null,
+				publicLicenseKey: null,
+				configFileStudioSettings: null,
+			}),
+			gitSource: null,
+			liveEventsServer: noopLiveEventsServer,
+			logLevel: 'info',
+			outputHash: '/outputs',
+			outputHashPrefix: '/outputs',
+			queueMethods: {
+				addJob: () => undefined,
+				cancelJob: () => undefined,
+				removeJob: () => undefined,
+			},
+			remotionRoot,
+			request,
+			response,
+			staticHash: '/static',
+			staticHashPrefix: '/static',
+			updatePublicDir: () => {
+				updates++;
+				publicDir = secondPublicDir;
+			},
+		});
+
+		expect(updates).toBe(1);
+		expect(response.body).toContain('second.txt');
+		expect(response.body).not.toContain('first.txt');
 	} finally {
 		await rm(remotionRoot, {force: true, recursive: true});
 	}

--- a/packages/studio-server/src/test/public-folder.test.ts
+++ b/packages/studio-server/src/test/public-folder.test.ts
@@ -1,0 +1,38 @@
+import {expect, test} from 'bun:test';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {getFiles, initPublicFolderWatch} from '../preview-server/public-folder';
+
+test('switches the public folder and refreshes the file list', () => {
+	const temporaryDirectory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-public-folder-'),
+	);
+	const firstPublicDir = path.join(temporaryDirectory, 'first');
+	const secondPublicDir = path.join(temporaryDirectory, 'second');
+	mkdirSync(firstPublicDir);
+	mkdirSync(secondPublicDir);
+	writeFileSync(path.join(firstPublicDir, 'first.txt'), 'first');
+	writeFileSync(path.join(secondPublicDir, 'second.txt'), 'second');
+
+	let updates = 0;
+	const publicFolderWatch = initPublicFolderWatch({
+		publicDir: firstPublicDir,
+		remotionRoot: temporaryDirectory,
+		staticHash: '/static-test',
+		onUpdate: () => {
+			updates++;
+		},
+	});
+
+	try {
+		expect(getFiles().map((file) => file.name)).toEqual(['first.txt']);
+
+		publicFolderWatch.updatePublicFolderWatch(secondPublicDir);
+		expect(getFiles().map((file) => file.name)).toEqual(['second.txt']);
+		expect(updates).toBe(1);
+	} finally {
+		publicFolderWatch.close();
+		rmSync(temporaryDirectory, {recursive: true});
+	}
+});

--- a/packages/studio-shared/src/config-method-lifecycles.ts
+++ b/packages/studio-shared/src/config-method-lifecycles.ts
@@ -77,7 +77,7 @@ export const configMethodLifecycles = {
 	setPreferLosslessAudio: 'runtime',
 	setPreviewSampleRate: 'reload',
 	setProResProfile: 'runtime',
-	setPublicDir: 'restart',
+	setPublicDir: 'reload',
 	setPublicLicenseKey: 'runtime',
 	setPublicPath: 'runtime',
 	setQuality: 'runtime',


### PR DESCRIPTION
## Summary

- classify `Config.setPublicDir()` changes as requiring a page reload
- activate the latest public directory when Studio HTML is reloaded
- replace the public-folder watcher when the selected directory changes

## Testing

- `bun run build`
- `bun run stylecheck`
- focused config lifecycle, config reset, public-folder watcher, and route tests

Closes #9015
