### PR TITLE
`@remotion/studio-server`: Log codemod duration at trace level

### DIFF
--- a/packages/studio-server/src/preview-server/routes/add-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect.ts
@@ -16,7 +16,10 @@ import {
 } from '../undo-stack';
 import {attrName} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const addEffectHandler: ApiHandler<
 	AddEffectRequest,
@@ -86,7 +89,7 @@ export const addEffectHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Added ${attrName(effectLabel)} to ${nodeLabel}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Added ${attrName(effectLabel)} to ${nodeLabel}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -23,7 +23,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {checkIfTypeScriptFile} from './can-update-default-props';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const formatNewCompositionFile = (
 	codemod: Extract<ApplyCodemodRequest['codemod'], {type: 'new-composition'}>,
@@ -338,7 +341,7 @@ export const applyCodemodHandler: ApiHandler<
 				}
 
 				const logMessage = getCodemodLogMessage(codemod);
-				const editMessage = `${RenderInternals.chalk.blueBright(
+				const editMessage = `${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(
 					formatLogFileLocation({
 						remotionRoot,
 						absolutePath: filePath,

--- a/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
@@ -20,7 +20,10 @@ import {
 } from '../undo-stack';
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const getVisualControlChangeLine = (file: File, changeId: string): number => {
 	let line = 1;
@@ -146,7 +149,7 @@ export const applyVisualControlHandler: ApiHandler<
 		});
 		RenderInternals.Log.info(
 			{indent: false, logLevel},
-			`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Applied visual control changes`,
+			`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Applied visual control changes`,
 		);
 		if (!formatted) {
 			warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -16,7 +16,10 @@ import {
 } from '../undo-stack';
 import {strikeThroughOrRemovedPrefix} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const getDeletedEffectDescription = (effectLabels: string[]): string => {
 	if (effectLabels.length === 1) {
@@ -121,7 +124,7 @@ export const deleteEffectHandler: ApiHandler<
 				});
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					`${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${strikeThroughOrRemovedPrefix(deletedEffectDescription)}`,
+					`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${strikeThroughOrRemovedPrefix(deletedEffectDescription)}`,
 				);
 				if (!update.formatted) {
 					warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -16,7 +16,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const getDeletedNodeDescription = (nodeLabels: string[]): string => {
 	if (nodeLabels.length === 1) {
@@ -119,7 +122,7 @@ export const deleteJsxNodeHandler: ApiHandler<
 				});
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Deleted ${deletedNodeDescription}`,
+					`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Deleted ${deletedNodeDescription}`,
 				);
 				if (!update.formatted) {
 					warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/duplicate-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-effect.ts
@@ -16,7 +16,10 @@ import {
 } from '../undo-stack';
 import {attrName} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const getDuplicatedEffectDescription = (effectLabels: string[]): string => {
 	if (effectLabels.length === 1) {
@@ -113,7 +116,7 @@ export const duplicateEffectHandler: ApiHandler<
 				});
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Duplicated ${attrName(duplicatedEffectDescription)}`,
+					`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Duplicated ${attrName(duplicatedEffectDescription)}`,
 				);
 				if (!update.formatted) {
 					warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -16,7 +16,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const duplicateJsxNodeHandler: ApiHandler<
 	DuplicateJsxNodeRequest,
@@ -76,7 +79,7 @@ export const duplicateJsxNodeHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Duplicated ${nodeLabel}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Duplicated ${nodeLabel}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -20,7 +20,10 @@ import {
 	validateElementInstallPosition,
 } from './element-install-plan';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const hasExpectedFileState = ({
 	expected,
@@ -268,11 +271,11 @@ export const insertElementHandler: ApiHandler<
 					: 'Created Element source';
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(elementLocationLabel)} ${elementFileAction}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(elementLocationLabel)} ${elementFileAction}`,
 			);
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(compositionLocationLabel)} Added <${plan.componentName}>`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(compositionLocationLabel)} Added <${plan.componentName}>`,
 			);
 			if (!inserted.formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -19,7 +19,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const validateDimension = (name: string, value: number) => {
 	if (!Number.isFinite(value) || value < 1) {
@@ -301,7 +304,7 @@ export const insertJsxElementHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Added ${elementLabel}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Added ${elementLabel}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/log-updates/log-effect-update.ts
+++ b/packages/studio-server/src/preview-server/routes/log-updates/log-effect-update.ts
@@ -1,5 +1,6 @@
 import {RenderInternals} from '@remotion/renderer';
 import type {LogLevel} from '@remotion/renderer';
+import {getCodemodTimingPrefix} from '../source-file-write-queue';
 import {formatEffectPropChange} from './format-effect-prop-change';
 import type {PropDelta} from './formatting';
 import {normalizeQuotes, warnAboutPrettierOnce} from './log-update';
@@ -42,7 +43,7 @@ export const logEffectUpdate = ({
 	});
 	RenderInternals.Log.info(
 		{indent: false, logLevel},
-		`${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${propChange}`,
+		`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${propChange}`,
 	);
 	if (!formatted) {
 		warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/log-updates/log-update.ts
+++ b/packages/studio-server/src/preview-server/routes/log-updates/log-update.ts
@@ -1,5 +1,6 @@
 import {RenderInternals} from '@remotion/renderer';
 import type {LogLevel} from '@remotion/renderer';
+import {getCodemodTimingPrefix} from '../source-file-write-queue';
 import {formatPropChange} from './format-prop-change';
 import type {PropDelta} from './formatting';
 
@@ -66,7 +67,7 @@ export const logUpdate = ({
 	});
 	RenderInternals.Log.info(
 		{indent: false, logLevel},
-		`${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${propChange}`,
+		`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} ${propChange}`,
 	);
 	if (!formatted) {
 		warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/paste-effects.ts
+++ b/packages/studio-server/src/preview-server/routes/paste-effects.ts
@@ -16,7 +16,10 @@ import {
 } from '../undo-stack';
 import {attrName} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 const getPastedEffectDescription = (effectLabels: string[]): string => {
 	if (effectLabels.length === 1) {
@@ -100,7 +103,7 @@ export const pasteEffectsHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Pasted ${attrName(effectDescription)}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Pasted ${attrName(effectDescription)}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/reorder-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/reorder-effect.ts
@@ -16,7 +16,10 @@ import {
 } from '../undo-stack';
 import {attrName} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const reorderEffectHandler: ApiHandler<
 	ReorderEffectRequest,
@@ -77,7 +80,7 @@ export const reorderEffectHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Reordered ${attrName(effectLabel)}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Reordered ${attrName(effectLabel)}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
@@ -17,7 +17,10 @@ import {
 } from '../undo-stack';
 import {attrName} from './log-updates/formatting';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const reorderSequenceHandler: ApiHandler<
 	ReorderSequenceRequest,
@@ -86,7 +89,7 @@ export const reorderSequenceHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Reordered ${attrName(sequenceLabel)}`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Reordered ${attrName(sequenceLabel)}`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/preview-server/routes/source-file-write-queue.ts
+++ b/packages/studio-server/src/preview-server/routes/source-file-write-queue.ts
@@ -1,10 +1,22 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+import type {LogLevel} from '@remotion/renderer';
+
 let chain: Promise<unknown> = Promise.resolve();
+const codemodStartTime = new AsyncLocalStorage<number>();
+
+export const getCodemodTimingPrefix = (logLevel: LogLevel) => {
+	const startTime = codemodStartTime.getStore();
+	return logLevel === 'trace' && startTime !== undefined
+		? `[${Date.now() - startTime}ms] `
+		: '';
+};
 
 export const withSourceFileWriteQueue = <T>(
 	fn: () => Promise<T>,
 ): Promise<T> => {
-	const run = () => fn();
+	const run = () => codemodStartTime.run(Date.now(), fn);
 	const next = chain.then(run, run);
+
 	chain = next.then(
 		() => undefined,
 		() => undefined,

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -16,7 +16,10 @@ import {
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const splitJsxSequenceHandler: ApiHandler<
 	SplitJsxSequenceRequest,
@@ -85,7 +88,7 @@ export const splitJsxSequenceHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(
 					`${locationLabel}`,
 				)} Split ${nodeLabel}`,
 			);

--- a/packages/studio-server/src/preview-server/routes/update-default-props.ts
+++ b/packages/studio-server/src/preview-server/routes/update-default-props.ts
@@ -20,7 +20,10 @@ import {
 import {suppressBundlerUpdateForFile} from '../watch-ignore-next-change';
 import {checkIfTypeScriptFile} from './can-update-default-props';
 import {warnAboutPrettierOnce} from './log-updates/log-update';
-import {withSourceFileWriteQueue} from './source-file-write-queue';
+import {
+	getCodemodTimingPrefix,
+	withSourceFileWriteQueue,
+} from './source-file-write-queue';
 
 export const updateDefaultPropsHandler: ApiHandler<
 	UpdateDefaultPropsRequest,
@@ -87,7 +90,7 @@ export const updateDefaultPropsHandler: ApiHandler<
 			});
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
-				`${RenderInternals.chalk.blueBright(`${locationLabel}`)} Updated default props for "${compositionId}"`,
+				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Updated default props for "${compositionId}"`,
 			);
 			if (!formatted) {
 				warnAboutPrettierOnce(logLevel);

--- a/packages/studio-server/src/test/apply-codemod.test.ts
+++ b/packages/studio-server/src/test/apply-codemod.test.ts
@@ -386,6 +386,7 @@ const runCompositionCodemodUndoRedoTest = async ({
 			const logOutput = consoleSpy?.mock.calls.flat().join(' ');
 			expect(logOutput).toContain('Root.tsx:9');
 			expect(logOutput).toContain(expectedLogMessage);
+			expect(logOutput).not.toMatch(/\[\d+ms\]/);
 		}
 
 		const undoResponse = await undoHandler(

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'bun:test';
+import {expect, spyOn, test} from 'bun:test';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
@@ -104,6 +104,7 @@ export const Comp = () => {
 		effectKeys: [],
 		videoConfigValues: null,
 	};
+	const consoleSpy = spyOn(console, 'log').mockImplementation(() => undefined);
 
 	try {
 		writeFileSync(filePath, input);
@@ -142,7 +143,7 @@ export const Comp = () => {
 			remotionRoot: dir,
 			request: {} as never,
 			response: {} as never,
-			logLevel: 'error',
+			logLevel: 'trace',
 			methods: {
 				addJob: () => undefined,
 				cancelJob: () => undefined,
@@ -166,6 +167,10 @@ export const Comp = () => {
 		expect(output).toContain(
 			"rotate: interpolate(frame, [0, 30], ['0deg', '90deg'])",
 		);
+		const completionLog = consoleSpy.mock.calls
+			.map((call) => call.join(' '))
+			.find((line) => line.includes('Comp.tsx:4'));
+		expect(completionLog).toMatch(/^\[\d+ms\] Comp\.tsx:4/);
 		expect(getUndoStack()).toHaveLength(1);
 		expect(popUndo()).toEqual({success: true, nodePathMutation: null});
 		expect(readFileSync(filePath, 'utf-8')).toBe(input);
@@ -173,6 +178,7 @@ export const Comp = () => {
 		clearUndoStackForTests();
 		cleanupLiveEvents();
 		cleanupFileWatcher();
+		consoleSpy.mockRestore();
 		rmSync(dir, {force: true, recursive: true});
 	}
 });

--- a/packages/studio-server/src/test/save-sequence-props.test.ts
+++ b/packages/studio-server/src/test/save-sequence-props.test.ts
@@ -170,7 +170,8 @@ export const Comp = () => {
 		const completionLog = consoleSpy.mock.calls
 			.map((call) => call.join(' '))
 			.find((line) => line.includes('Comp.tsx:4'));
-		expect(completionLog).toMatch(/^\[\d+ms\] Comp\.tsx:4/);
+		expect(completionLog).toMatch(/^\[\d+ms\] /);
+		expect(completionLog).toContain('Comp.tsx:4');
 		expect(getUndoStack()).toHaveLength(1);
 		expect(popUndo()).toEqual({success: true, nodePathMutation: null});
 		expect(readFileSync(filePath, 'utf-8')).toBe(input);


### PR DESCRIPTION
## Summary

- measure Studio source-edit codemods inside the serialized write queue
- prefix completion logs with elapsed milliseconds when `logLevel` is `trace`
- keep completion logs unchanged at other log levels

## Testing

- `bun test packages/studio-server/src/test/source-file-write-queue.test.ts packages/studio-server/src/test/save-sequence-props.test.ts packages/studio-server/src/test/apply-codemod.test.ts`
- `bun run build`
- `bun run stylecheck`
