### PR TITLE
`@remotion/cli`: Fix upgrade on Windows

### DIFF
--- a/packages/cli/src/test/upgrade-windows.test.ts
+++ b/packages/cli/src/test/upgrade-windows.test.ts
@@ -1,0 +1,73 @@
+import {expect, test} from 'bun:test';
+import {spawnSync} from 'node:child_process';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+
+test.skipIf(process.platform !== 'win32')(
+	'upgrade runs the npm command shim on Windows',
+	() => {
+		const temporaryDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-upgrade-windows-'),
+		);
+		const npmInvocation = path.join(temporaryDirectory, 'npm-invocation.txt');
+
+		try {
+			writeFileSync(
+				path.join(temporaryDirectory, 'package.json'),
+				JSON.stringify({dependencies: {remotion: '4.0.512'}}),
+			);
+			writeFileSync(path.join(temporaryDirectory, 'package-lock.json'), '{}');
+			writeFileSync(
+				path.join(temporaryDirectory, 'npm.cmd'),
+				[
+					'@echo off',
+					'if "%1"=="view" (',
+					'  echo {}',
+					'  exit /b 0',
+					')',
+					`echo %* > "${npmInvocation}"`,
+					'exit /b 0',
+				].join('\r\n'),
+			);
+			const runner = path.join(temporaryDirectory, 'run-upgrade.cjs');
+			writeFileSync(
+				runner,
+				`const {upgradeCommand} = require(${JSON.stringify(
+					path.join(__dirname, '..', '..', 'dist', 'upgrade.js'),
+				)});
+
+(async () => {
+	await upgradeCommand(${JSON.stringify({
+		remotionRoot: temporaryDirectory,
+		version: '4.0.513',
+		skipSkills: true,
+		logLevel: 'error',
+		args: [],
+	})});
+})().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});
+`,
+			);
+
+			const result = spawnSync('node', [runner], {
+				cwd: temporaryDirectory,
+				env: {
+					...process.env,
+					PATH: `${temporaryDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+				},
+				encoding: 'utf-8',
+			});
+
+			expect(result.status, result.stderr).toBe(0);
+
+			expect(readFileSync(npmInvocation, 'utf-8').trim()).toBe(
+				'i --save-exact --no-fund --no-audit remotion@4.0.513',
+			);
+		} finally {
+			rmSync(temporaryDirectory, {recursive: true, force: true});
+		}
+	},
+);

--- a/packages/cli/src/upgrade.ts
+++ b/packages/cli/src/upgrade.ts
@@ -283,17 +283,23 @@ const runPackageManagerCommand = async ({
 		stdio: RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')
 			? 'inherit'
 			: 'ignore',
+		...StudioServerInternals.getPackageManagerSpawnOptions(),
 	});
 
-	await new Promise<void>((resolve) => {
+	await new Promise<void>((resolve, reject) => {
+		task.on('error', (err) => {
+			reject(err);
+		});
 		task.on('close', (code) => {
 			if (code === 0) {
 				resolve();
 			} else if (RenderInternals.isEqualOrBelowLogLevel(logLevel, 'info')) {
-				throw new Error('Failed to upgrade Remotion, see logs above');
+				reject(new Error('Failed to upgrade Remotion, see logs above'));
 			} else {
-				throw new Error(
-					'Failed to upgrade Remotion, run with --log=info info to see logs',
+				reject(
+					new Error(
+						'Failed to upgrade Remotion, run with --log=info info to see logs',
+					),
 				);
 			}
 		});


### PR DESCRIPTION
## Summary

- Run the detected package manager through the existing Windows shell options during `remotion upgrade`
- Reject child-process spawn and exit failures instead of throwing from event handlers
- Add a Windows integration test that runs the built upgrade command under Node with an `npm.cmd` shim

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run formatting lint make test --filter=@remotion/cli`
