### PR TITLE
`@remotion/web-renderer`: Preserve HtmlInCanvas WebGL output in software composition

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -182,8 +182,7 @@ declare global {
 
 export type HtmlInCanvasOnPaintParams = {
 	/**
-	 * The `OffscreenCanvas` from {@link HTMLCanvasElement.transferControlToOffscreen}
-	 * on the layout `<canvas>` (same logical canvas as the forwarded ref).
+	 * The `OffscreenCanvas` used to paint the layout `<canvas>`.
 	 */
 	readonly canvas: OffscreenCanvas;
 	readonly element: HTMLDivElement;
@@ -436,6 +435,8 @@ const HtmlInCanvasContent = forwardRef<
 		const canRetryMissingPaintRecord = !isRendering || isClientSideRendering;
 		const usesDirectLayoutCanvas =
 			onPaint === undefined && onInit === undefined;
+		const usesDetachedClientSidePaintTarget =
+			isRendering && isClientSideRendering && !usesDirectLayoutCanvas;
 
 		if (!isHtmlInCanvasSupported()) {
 			cancelRender(new Error(HTML_IN_CANVAS_UNSUPPORTED_MESSAGE));
@@ -443,6 +444,7 @@ const HtmlInCanvasContent = forwardRef<
 
 		const canvas2dRef = useRef<HTMLCanvasElement | null>(null);
 		const paintTargetRef = useRef<HtmlInCanvasPaintTarget | null>(null);
+		const clientSidePaintTargetRef = useRef<OffscreenCanvas | null>(null);
 		const divRef = useRef<HTMLDivElement | null>(null);
 		const canvasSizeKey = `${width}x${height}@${resolvedPixelDensity}-${usesDirectLayoutCanvas ? 'direct' : 'offscreen'}`;
 
@@ -619,6 +621,20 @@ const HtmlInCanvasContent = forwardRef<
 						width: canvasWidth,
 						height: canvasHeight,
 					});
+
+					if (usesDetachedClientSidePaintTarget) {
+						const placeholderContext = placeholderCanvas.getContext('2d');
+						if (!placeholderContext) {
+							throw new Error(
+								'HtmlInCanvas: Failed to acquire a 2D context for client-side rendering',
+							);
+						}
+
+						// The DOM compositor reads the HTML canvas. Publish the finished
+						// detached paint target before marking the frame as ready.
+						placeholderContext.reset();
+						placeholderContext.drawImage(paintTarget, 0, 0);
+					}
 				} finally {
 					elImage.close();
 				}
@@ -641,11 +657,12 @@ const HtmlInCanvasContent = forwardRef<
 			delayRender,
 			resolvedPixelDensity,
 			canRetryMissingPaintRecord,
+			usesDetachedClientSidePaintTarget,
 		]);
 
 		// Default paint handlers draw synchronously on the layout canvas itself so
 		// Chromium can include their final pixels during its deepest-first nested
-		// paint traversal. Custom handlers retain the transferred OffscreenCanvas API.
+		// paint traversal. Custom handlers retain an OffscreenCanvas paint target.
 		useLayoutEffect(() => {
 			const placeholder = canvas2dRef.current;
 			if (!placeholder) {
@@ -654,9 +671,23 @@ const HtmlInCanvasContent = forwardRef<
 
 			placeholder.layoutSubtree = true;
 
-			const paintTarget = usesDirectLayoutCanvas
-				? placeholder
-				: getTransferredOffscreenCanvas(placeholder);
+			let paintTarget: HtmlInCanvasPaintTarget;
+			if (usesDirectLayoutCanvas) {
+				paintTarget = placeholder;
+			} else if (usesDetachedClientSidePaintTarget) {
+				// A transferred placeholder reads as transparent to drawImage().
+				// Keep it readable when the client-side DOM compositor is the consumer.
+				if (!clientSidePaintTargetRef.current) {
+					clientSidePaintTargetRef.current = new OffscreenCanvas(
+						canvasWidth,
+						canvasHeight,
+					);
+				}
+
+				paintTarget = clientSidePaintTargetRef.current;
+			} else {
+				paintTarget = getTransferredOffscreenCanvas(placeholder);
+			}
 
 			paintTargetRef.current = paintTarget;
 			resizePaintTarget({
@@ -684,6 +715,7 @@ const HtmlInCanvasContent = forwardRef<
 			canvasWidth,
 			canvasHeight,
 			usesDirectLayoutCanvas,
+			usesDetachedClientSidePaintTarget,
 		]);
 
 		const onPaintChangedRef = useRef(false);

--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -122,7 +122,7 @@ The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: '
 [`<ThreeCanvas>`](/docs/three-canvas) from [`@remotion/three`](/docs/three) is <a style={{color: 'green'}}>supported</a>.  
 [`<SkiaCanvas>`](/docs/skia/skia-canvas) from [`@remotion/skia`](/docs/skia) is <a style={{color: 'green'}}>supported</a>.  
 [`<AnimatedImage>`](/docs/animatedimage) is <a style={{color: 'green'}}>supported</a> when rendering in Chrome.  
-[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
+[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. From <AvailableFrom v="4.0.514" inline />, custom paint output is also preserved when the built-in DOM composer is used. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
 [`<OffthreadVideo>`](/docs/offthreadvideo) is <a style={{color: 'red'}}>not supported</a>.  
  → Use [`<Video>`](/docs/media/video) instead.  
 [`<Html5Video>`](/docs/html5-video) is <a style={{color: 'red'}}>not supported</a>.  

--- a/packages/docs/docs/client-side-rendering/limitations.mdx
+++ b/packages/docs/docs/client-side-rendering/limitations.mdx
@@ -122,7 +122,7 @@ The [`<Audio>`](/docs/media/audio) from `@remotion/media` is <a style={{color: '
 [`<ThreeCanvas>`](/docs/three-canvas) from [`@remotion/three`](/docs/three) is <a style={{color: 'green'}}>supported</a>.  
 [`<SkiaCanvas>`](/docs/skia/skia-canvas) from [`@remotion/skia`](/docs/skia) is <a style={{color: 'green'}}>supported</a>.  
 [`<AnimatedImage>`](/docs/animatedimage) is <a style={{color: 'green'}}>supported</a> when rendering in Chrome.  
-[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. From <AvailableFrom v="4.0.514" inline />, custom paint output is also preserved when the built-in DOM composer is used. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
+[`<HtmlInCanvas>`](/docs/remotion/html-in-canvas) is <a style={{color: 'green'}}>supported</a> when the component itself is supported, including its [`onPaint`](/docs/remotion/html-in-canvas#onpaint) and [`onInit`](/docs/remotion/html-in-canvas#oninit) callbacks. Automatic [HTML-in-canvas capture](/docs/client-side-rendering/html-in-canvas) requires Chrome or Chromium `152.0.7944.0` or later; older browsers use the built-in DOM composer.<br />
 [`<OffthreadVideo>`](/docs/offthreadvideo) is <a style={{color: 'red'}}>not supported</a>.  
  → Use [`<Video>`](/docs/media/video) instead.  
 [`<Html5Video>`](/docs/html5-video) is <a style={{color: 'red'}}>not supported</a>.  

--- a/packages/web-renderer/src/drawing/process-node.ts
+++ b/packages/web-renderer/src/drawing/process-node.ts
@@ -270,5 +270,12 @@ export const processNode = async ({
 		scale,
 	});
 
+	// layoutSubtree children participate in layout and accessibility, but the
+	// browser only displays the pixels that their canvas paint handler produced.
+	if (element instanceof HTMLCanvasElement && element.layoutSubtree === true) {
+		cleanupAfterChildren?.();
+		return {type: 'skip-children'};
+	}
+
 	return {type: 'continue', cleanupAfterChildren};
 };

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -51,6 +51,7 @@ import {multiLevelTransformOrigins} from './fixtures/multi-level-transform-origi
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
 import {nestedTranslateScale} from './fixtures/nested-translate-scale';
 import {objectFit} from './fixtures/object-fit';
+import {onPaintHtmlInCanvas} from './fixtures/on-paint-html-in-canvas';
 import {opacityInherited} from './fixtures/opacity-inherited';
 import {opacityNested} from './fixtures/opacity-nested';
 import {opacityReset} from './fixtures/opacity-reset';
@@ -134,6 +135,7 @@ export const Root: React.FC = () => {
 			<Composition {...objectFit} />
 			<Composition {...nestedTranslateScale} />
 			<Composition {...nestedHtmlInCanvas} />
+			<Composition {...onPaintHtmlInCanvas} />
 			<Composition {...scaledTranslatedSvg} />
 			<Composition {...svgExplicitDimensions} />
 			<Composition {...svgDataUri} />

--- a/packages/web-renderer/src/test/fixtures/on-paint-html-in-canvas.tsx
+++ b/packages/web-renderer/src/test/fixtures/on-paint-html-in-canvas.tsx
@@ -1,0 +1,34 @@
+import {AbsoluteFill, HtmlInCanvas} from 'remotion';
+
+const Component: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#0000ff'}}>
+			<HtmlInCanvas
+				width={100}
+				height={100}
+				onPaint={({canvas}) => {
+					const gl = canvas.getContext('webgl2');
+					if (!gl) {
+						throw new Error('Expected a WebGL2 context');
+					}
+
+					gl.clearColor(0, 1, 0, 1);
+					gl.clear(gl.COLOR_BUFFER_BIT);
+				}}
+			>
+				{/* The callback paints green. Seeing this red child means that the DOM
+				composer ignored the painted canvas and rendered its layout subtree. */}
+				<AbsoluteFill style={{backgroundColor: '#ff0000'}} />
+			</HtmlInCanvas>
+		</AbsoluteFill>
+	);
+};
+
+export const onPaintHtmlInCanvas = {
+	component: Component,
+	id: 'on-paint-html-in-canvas',
+	width: 100,
+	height: 100,
+	fps: 30,
+	durationInFrames: 5,
+} as const;

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -10,13 +10,20 @@ import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
+import {onPaintHtmlInCanvas} from './fixtures/on-paint-html-in-canvas';
 import {testImage} from './utils';
 
 setForceDisableHtmlInCanvasForTesting(false);
 
+const chromeMajorVersion = Number(
+	navigator.userAgent.match(/\b(?:HeadlessChrome|Chrome)\/(\d+)/)?.[1],
+);
+const canRenderNestedHtmlInCanvas =
+	!Number.isFinite(chromeMajorVersion) || chromeMajorVersion >= 152;
+
 test('captures three nested HTML-in-canvas effect layers natively', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -51,7 +58,7 @@ test('captures three nested HTML-in-canvas effect layers natively', async () => 
 
 test('captures three nested HTML-in-canvas effect layers across video frames', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -65,7 +72,7 @@ test('captures three nested HTML-in-canvas effect layers across video frames', a
 
 test('retries a transient missing nested paint record during a client-side render', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -198,7 +205,7 @@ test('keeps the DOM composer scaffold paintable', () => {
 });
 
 test('uses the DOM composer when native HTML-in-canvas does not support nesting', async () => {
-	if (!supportsNativeHtmlInCanvas()) {
+	if (!supportsNativeHtmlInCanvas() || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -230,5 +237,52 @@ test('uses the DOM composer when native HTML-in-canvas does not support nesting'
 	} finally {
 		setForceDisableHtmlInCanvasForTesting(false);
 		warn.mockRestore();
+	}
+});
+
+test('includes custom onPaint output when composing in software', async () => {
+	if (!supportsNativeHtmlInCanvas()) {
+		if (/\b(?:HeadlessChrome|Chrome)\//.test(navigator.userAgent)) {
+			throw new Error(
+				'Expected CanvasDrawElement to be enabled for Chromium web renderer tests',
+			);
+		}
+
+		return;
+	}
+
+	setForceDisableHtmlInCanvasForTesting(true);
+
+	try {
+		const result = await renderStillOnWeb({
+			composition: onPaintHtmlInCanvas,
+			frame: 0,
+			inputProps: {},
+			licenseKey: 'free-license',
+		});
+
+		const blob = await result.blob({format: 'png'});
+		const bitmap = await createImageBitmap(blob);
+		const probe = new OffscreenCanvas(bitmap.width, bitmap.height);
+		const ctx = probe.getContext('2d');
+		if (!ctx) {
+			throw new Error('Expected a 2d context');
+		}
+
+		ctx.drawImage(bitmap, 0, 0);
+		bitmap.close();
+		const {data} = ctx.getImageData(
+			Math.floor(bitmap.width / 2),
+			Math.floor(bitmap.height / 2),
+			1,
+			1,
+		);
+
+		expect(data[0]).toBeLessThan(64);
+		expect(data[1]).toBeGreaterThan(192);
+		expect(data[2]).toBeLessThan(64);
+		expect(data[3]).toBe(255);
+	} finally {
+		setForceDisableHtmlInCanvasForTesting(false);
 	}
 });

--- a/packages/web-renderer/vitest.config.ts
+++ b/packages/web-renderer/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
 					browser: 'chromium',
 					provider: playwright({
 						launchOptions: {
+							args: ['--enable-blink-features=CanvasDrawElement'],
 							channel: 'chrome',
 						},
 						actionTimeout: 5_000,


### PR DESCRIPTION
## Summary

- add a browser-level WebGL repro for the missing custom `<HtmlInCanvas onPaint>` output reported in #10512
- keep the client-side rendering placeholder readable by painting custom callbacks on a detached `OffscreenCanvas`, then publishing the finished bitmap to the layout canvas before the frame becomes ready
- make the DOM compositor treat `layoutSubtree` children as layout-only and enable `CanvasDrawElement` in Chromium browser tests so the regression cannot silently return early

## Architecture

The DOM canvas remains the canonical readable output surface. Preview and server rendering keep the transferred `OffscreenCanvas` path, while client-side rendering uses a detached paint target because transferred placeholders read back as transparent.

This avoids adding a private readback property to `HTMLCanvasElement` or teaching `@remotion/web-renderer` about a component-specific side channel.

## Verification

- Red/green verified: the final WebGL pixel regression fails when the detached-surface publication is disconnected and passes when restored
- `bunx vitest src/test/html-in-canvas.test.tsx --run`
- `bun run testwebrenderer` — 693 passed, 27 skipped
- `bun run build`
- `bun run stylecheck`
