### PR TITLE
`@remotion/studio-server`: Avoid rebuilding an already-running Studio

### DIFF
--- a/packages/it-tests/src/bundle/studio.test.ts
+++ b/packages/it-tests/src/bundle/studio.test.ts
@@ -1,5 +1,8 @@
 import {expect, test} from 'bun:test';
-import {execSync} from 'child_process';
+import {execSync, spawn} from 'child_process';
+import {mkdtempSync, rmSync, writeFileSync} from 'fs';
+import {createServer} from 'http';
+import {tmpdir} from 'os';
 import path from 'path';
 
 test('Should be able to start the studio without zod installed', () => {
@@ -21,3 +24,99 @@ test('Should be able to start the studio', () => {
 	expect(res.length).toBeLessThan(200);
 	expect(res).toContain('Yes, the server started.');
 });
+
+test(
+	'Should not build if the studio is already running',
+	async () => {
+		const exampleDirectory = path.join(process.cwd(), '..', 'example');
+		const temporaryDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-studio-already-running-'),
+		);
+		const configFile = path.join(temporaryDirectory, 'remotion.config.js');
+		writeFileSync(
+			configFile,
+			`const {Config} = require('@remotion/cli/config');
+Config.overrideWebpackConfig((config) => {
+	console.log('Bundler override ran');
+	return config;
+});
+`,
+		);
+		const existingStudio = createServer((request, response) => {
+			if (request.url === '/__remotion_config') {
+				response.writeHead(200, {'Content-Type': 'application/json'});
+				response.end(
+					JSON.stringify({
+						isRemotion: true,
+						cwd: exampleDirectory,
+						version: null,
+					}),
+				);
+				return;
+			}
+
+			response.writeHead(404);
+			response.end();
+		});
+
+		await new Promise<void>((resolve) => {
+			existingStudio.listen(0, resolve);
+		});
+
+		try {
+			const address = existingStudio.address();
+			if (!address || typeof address === 'string') {
+				throw new Error('Could not determine the existing Studio port');
+			}
+
+			const studioProcess = spawn(
+				'bunx',
+				[
+					'remotion',
+					'studio',
+					'--port',
+					String(address.port),
+					'--no-open',
+					'--config',
+					configFile,
+				],
+				{
+					cwd: exampleDirectory,
+					env: {...process.env, BROWSER: 'none'},
+					stdio: 'pipe',
+				},
+			);
+
+			let output = '';
+			studioProcess.stdout.on('data', (data: Buffer) => {
+				output += data.toString();
+			});
+			studioProcess.stderr.on('data', (data: Buffer) => {
+				output += data.toString();
+			});
+
+			const exitCode = await new Promise<number | null>((resolve, reject) => {
+				studioProcess.on('error', reject);
+				studioProcess.on('close', resolve);
+			});
+
+			expect(exitCode).toBe(0);
+			expect(output).toContain(`Already running on port ${address.port}.`);
+			expect(output).not.toContain('Bundler override ran');
+			expect(output).not.toContain('Built in');
+		} finally {
+			await new Promise<void>((resolve, reject) => {
+				existingStudio.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+
+					resolve();
+				});
+			});
+			rmSync(temporaryDirectory, {recursive: true});
+		}
+	},
+	{timeout: 20_000},
+);

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -98,125 +98,81 @@ export const startServer = async (options: {
 				return detection.type === 'match' ? 'stop' : 'continue';
 			};
 
-	const watchIgnorePlugin = new WatchIgnoreNextChangePlugin((...args) => {
-		RenderInternals.Log.trace(
-			{indent: false, logLevel: options.logLevel},
-			...args,
-		);
+	let portSelection = await RenderInternals.getDesiredPort({
+		desiredPort,
+		from: 3000,
+		to: 3100,
+		hostsToTry: portConfig.hostsToTry,
+		onPortUnavailable,
 	});
 
-	const configArgs = {
-		entry: options.entry,
-		userDefinedComponent: options.userDefinedComponent,
-		outDir: null,
-		environment: 'development' as const,
-		bundlerOverride: options.bundlerOverride,
-		rspackOverride: options.rspackOverride,
-		webpackOverride: options?.webpackOverride,
-		remotionRoot: options.remotionRoot,
-		poll: options.poll,
-		extraPlugins: [watchIgnorePlugin],
-	};
-
-	let compiler: webpack.Compiler;
-	if (options.rspack) {
-		const [, rspackConf] = await BundlerInternals.rspackConfig(configArgs);
-		compiler = BundlerInternals.createRspackCompiler(
-			rspackConf,
-		) as unknown as webpack.Compiler;
-	} else {
-		const [, webpackConf] = await BundlerInternals.webpackConfig(configArgs);
-		compiler = webpack(webpackConf);
+	if (portSelection.didUsePort) {
+		portSelection.unlockPort();
+		return {
+			type: 'already-running' as const,
+			port: portSelection.port,
+		};
 	}
 
-	setWatchIgnoreNextChangePlugin(watchIgnorePlugin);
+	const handleRequestBeforeReady: http.RequestListener = (
+		_request,
+		response,
+	) => {
+		response.writeHead(503);
+		response.end('Studio is starting...');
+	};
 
-	const wdmMiddleware = wdm(compiler, options.logLevel);
-	const liveEventsServer = makeLiveEventsRouter(options.logLevel, () => {
-		const undoStack = getUndoStack();
-		const redoStack = getRedoStack();
-		return {
-			undoFile:
-				undoStack.length > 0 ? undoStack[undoStack.length - 1].filePath : null,
-			redoFile:
-				redoStack.length > 0 ? redoStack[redoStack.length - 1].filePath : null,
-		};
-	});
-	setupWebpackHmr(compiler, options.logLevel, liveEventsServer);
-	compiler.hooks.done.tap('remotion-node-path-cache', () => {
-		clearNodePathCache();
-	});
-
-	const server = http.createServer((request, response) => {
-		if (options.enableCrossSiteIsolation) {
-			response.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-			response.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
-		}
-
-		new Promise<void>((resolve) => {
-			wdmMiddleware(request as IncomingMessage, response, () => {
-				resolve();
-			});
-		})
-			.then(() => {
-				return handleRoutes({
-					staticHash: options.staticHash,
-					staticHashPrefix: options.staticHashPrefix,
-					outputHash: options.outputHash,
-					outputHashPrefix: options.outputHashPrefix,
-					request: request as IncomingMessage,
-					response,
-					liveEventsServer,
-					getCurrentInputProps: options.getCurrentInputProps,
-					getEnvVariables: options.getEnvVariables,
-					remotionRoot: options.remotionRoot,
-					entryPoint: options.userDefinedComponent,
-					publicDir: options.publicDir,
-					logLevel: options.logLevel,
-					getRenderQueue: options.getRenderQueue,
-					getRenderDefaults: options.getRenderDefaults,
-					getNumberOfAudioTags: options.getNumberOfAudioTags,
-					queueMethods: options.queueMethods,
-					gitSource: options.gitSource,
-					binariesDirectory: options.binariesDirectory,
-					getAudioLatencyHint: options.getAudioLatencyHint,
-					getExperimentalKeepAudioContextAlive:
-						options.getExperimentalKeepAudioContextAlive,
-					getPreviewSampleRate: options.getPreviewSampleRate,
-					enableCrossSiteIsolation: options.enableCrossSiteIsolation,
-					getStudioRuntimeConfig: options.getStudioRuntimeConfig,
-					getDefaultCodingAgent: options.getDefaultCodingAgent,
-					getDefaultEditor: options.getDefaultEditor,
-					configFile: options.configFile,
-				});
-			})
-			.catch((err) => {
-				RenderInternals.Log.error(
-					{indent: false, logLevel: options.logLevel},
-					`Error while calling ${request.url}`,
-					err,
-				);
-				if (!response.headersSent) {
-					response.setHeader('content-type', 'application/json');
-					response.writeHead(500);
-				}
-
-				if (!response.writableEnded) {
-					response.end(
-						JSON.stringify({
-							err: (err as Error).message,
-						}),
-					);
-				}
-			});
-	});
-
+	const server = http.createServer(handleRequestBeforeReady);
 	const maxTries = 5;
+	let selectedPort: number | null = null;
 
 	for (let i = 0; i < maxTries; i++) {
 		try {
-			const {port, unlockPort, didUsePort} =
-				await RenderInternals.getDesiredPort({
+			const {port, unlockPort} = portSelection;
+
+			selectedPort = await new Promise<number>((resolve, reject) => {
+				RenderInternals.Log.verbose(
+					{indent: false, logLevel: options.logLevel},
+					`Binding server to host ${portConfig.host}, port ${port}`,
+				);
+				const onListening = () => {
+					server.off('error', onError);
+					unlockPort();
+					resolve(port);
+				};
+
+				const onError = (error: Error) => {
+					server.off('listening', onListening);
+					reject(error);
+				};
+
+				server.once('listening', onListening);
+				server.once('error', onError);
+				server.listen({
+					port,
+					host: portConfig.host,
+				});
+			});
+			break;
+		} catch (err) {
+			if (!(err instanceof Error)) {
+				portSelection.unlockPort();
+				throw err;
+			}
+
+			const codedError = err as Error & {code: string; port: number};
+
+			if (codedError.code === 'EADDRINUSE') {
+				portSelection.unlockPort();
+				RenderInternals.Log.error(
+					{indent: false, logLevel: options.logLevel},
+					`Port ${codedError.port} is already in use. Trying another port...`,
+				);
+				if (i === maxTries - 1) {
+					break;
+				}
+
+				portSelection = await RenderInternals.getDesiredPort({
 					desiredPort,
 					from: 3000,
 					to: 3100,
@@ -224,77 +180,176 @@ export const startServer = async (options: {
 					onPortUnavailable,
 				});
 
-			if (didUsePort) {
-				unlockPort();
-				await Promise.all([
-					new Promise<void>((resolve) => {
-						server.close(() => resolve());
-					}),
-					new Promise<void>((resolve) => {
-						compiler.close(() => resolve());
-					}),
-				]);
-				return {
-					type: 'already-running' as const,
-					port,
-				};
-			}
-
-			const selectedPort = await new Promise<number>((resolve, reject) => {
-				RenderInternals.Log.verbose(
-					{indent: false, logLevel: options.logLevel},
-					`Binding server to host ${portConfig.host}, port ${port}`,
-				);
-				server.listen({
-					port,
-					host: portConfig.host,
-				});
-				server.on('listening', () => {
-					resolve(port);
-					return unlockPort();
-				});
-				server.on('error', (err) => {
-					reject(err);
-				});
-			});
-
-			return {
-				type: 'started' as const,
-				port: selectedPort as number,
-				liveEventsServer,
-				close: async () => {
-					server.closeAllConnections();
-					await Promise.all([
-						new Promise<void>((resolve) => {
-							server.close(() => {
-								resolve();
-							});
-						}),
-						new Promise<void>((resolve) => {
-							compiler.close(() => {
-								resolve();
-							});
-						}),
-					]);
-				},
-			};
-		} catch (err) {
-			if (!(err instanceof Error)) {
-				throw err;
-			}
-
-			const codedError = err as Error & {code: string; port: number};
-
-			if (codedError.code === 'EADDRINUSE') {
-				RenderInternals.Log.error(
-					{indent: false, logLevel: options.logLevel},
-					`Port ${codedError.port} is already in use. Trying another port...`,
-				);
+				if (portSelection.didUsePort) {
+					portSelection.unlockPort();
+					return {
+						type: 'already-running' as const,
+						port: portSelection.port,
+					};
+				}
 			} else {
+				portSelection.unlockPort();
 				throw err;
 			}
 		}
 	}
 
-	throw new Error(`Tried ${maxTries} times to find a free port. Giving up.`);
+	if (selectedPort === null) {
+		throw new Error(`Tried ${maxTries} times to find a free port. Giving up.`);
+	}
+
+	let compiler: webpack.Compiler | null = null;
+	try {
+		const watchIgnorePlugin = new WatchIgnoreNextChangePlugin((...args) => {
+			RenderInternals.Log.trace(
+				{indent: false, logLevel: options.logLevel},
+				...args,
+			);
+		});
+
+		const configArgs = {
+			entry: options.entry,
+			userDefinedComponent: options.userDefinedComponent,
+			outDir: null,
+			environment: 'development' as const,
+			bundlerOverride: options.bundlerOverride,
+			rspackOverride: options.rspackOverride,
+			webpackOverride: options?.webpackOverride,
+			remotionRoot: options.remotionRoot,
+			poll: options.poll,
+			extraPlugins: [watchIgnorePlugin],
+		};
+
+		if (options.rspack) {
+			const [, rspackConf] = await BundlerInternals.rspackConfig(configArgs);
+			compiler = BundlerInternals.createRspackCompiler(
+				rspackConf,
+			) as unknown as webpack.Compiler;
+		} else {
+			const [, webpackConf] = await BundlerInternals.webpackConfig(configArgs);
+			compiler = webpack(webpackConf);
+		}
+
+		setWatchIgnoreNextChangePlugin(watchIgnorePlugin);
+
+		const wdmMiddleware = wdm(compiler, options.logLevel);
+		const liveEventsServer = makeLiveEventsRouter(options.logLevel, () => {
+			const undoStack = getUndoStack();
+			const redoStack = getRedoStack();
+			return {
+				undoFile:
+					undoStack.length > 0
+						? undoStack[undoStack.length - 1].filePath
+						: null,
+				redoFile:
+					redoStack.length > 0
+						? redoStack[redoStack.length - 1].filePath
+						: null,
+			};
+		});
+		setupWebpackHmr(compiler, options.logLevel, liveEventsServer);
+		compiler.hooks.done.tap('remotion-node-path-cache', () => {
+			clearNodePathCache();
+		});
+
+		server.off('request', handleRequestBeforeReady);
+		server.on('request', (request, response) => {
+			if (options.enableCrossSiteIsolation) {
+				response.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+				response.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+			}
+
+			new Promise<void>((resolve) => {
+				wdmMiddleware(request as IncomingMessage, response, () => {
+					resolve();
+				});
+			})
+				.then(() => {
+					return handleRoutes({
+						staticHash: options.staticHash,
+						staticHashPrefix: options.staticHashPrefix,
+						outputHash: options.outputHash,
+						outputHashPrefix: options.outputHashPrefix,
+						request: request as IncomingMessage,
+						response,
+						liveEventsServer,
+						getCurrentInputProps: options.getCurrentInputProps,
+						getEnvVariables: options.getEnvVariables,
+						remotionRoot: options.remotionRoot,
+						entryPoint: options.userDefinedComponent,
+						publicDir: options.publicDir,
+						logLevel: options.logLevel,
+						getRenderQueue: options.getRenderQueue,
+						getRenderDefaults: options.getRenderDefaults,
+						getNumberOfAudioTags: options.getNumberOfAudioTags,
+						queueMethods: options.queueMethods,
+						gitSource: options.gitSource,
+						binariesDirectory: options.binariesDirectory,
+						getAudioLatencyHint: options.getAudioLatencyHint,
+						getExperimentalKeepAudioContextAlive:
+							options.getExperimentalKeepAudioContextAlive,
+						getPreviewSampleRate: options.getPreviewSampleRate,
+						enableCrossSiteIsolation: options.enableCrossSiteIsolation,
+						getStudioRuntimeConfig: options.getStudioRuntimeConfig,
+						getDefaultCodingAgent: options.getDefaultCodingAgent,
+						getDefaultEditor: options.getDefaultEditor,
+						configFile: options.configFile,
+					});
+				})
+				.catch((err) => {
+					RenderInternals.Log.error(
+						{indent: false, logLevel: options.logLevel},
+						`Error while calling ${request.url}`,
+						err,
+					);
+					if (!response.headersSent) {
+						response.setHeader('content-type', 'application/json');
+						response.writeHead(500);
+					}
+
+					if (!response.writableEnded) {
+						response.end(
+							JSON.stringify({
+								err: (err as Error).message,
+							}),
+						);
+					}
+				});
+		});
+
+		const initializedCompiler = compiler;
+		return {
+			type: 'started' as const,
+			port: selectedPort,
+			liveEventsServer,
+			close: async () => {
+				server.closeAllConnections();
+				await Promise.all([
+					new Promise<void>((resolve) => {
+						server.close(() => {
+							resolve();
+						});
+					}),
+					new Promise<void>((resolve) => {
+						initializedCompiler.close(() => {
+							resolve();
+						});
+					}),
+				]);
+			},
+		};
+	} catch (error) {
+		server.closeAllConnections();
+		await Promise.all([
+			new Promise<void>((resolve) => {
+				server.close(() => resolve());
+			}),
+			compiler
+				? new Promise<void>((resolve) => {
+						compiler?.close(() => resolve());
+					})
+				: Promise.resolve(),
+		]);
+		throw error;
+	}
 };


### PR DESCRIPTION
## Summary

- detect an already-running Studio before initializing Webpack or Rspack
- bind the selected port before starting the compiler watcher
- add CLI integration coverage that verifies the bundler is not initialized and no `Built in` message is emitted

## Test plan

- `bun test src/bundle/studio.test.ts --timeout 30000` in `packages/it-tests`
- `bun run build`
- `bun run stylecheck`
