### PR TITLE
`@remotion/lambda`: Return errors from buffered invocations

### DIFF
--- a/packages/lambda/src/functions/index.ts
+++ b/packages/lambda/src/functions/index.ts
@@ -5,7 +5,12 @@ import type {
 	ResponseStream,
 	ServerlessPayload,
 } from '@remotion/serverless';
-import {innerHandler, streamWriter} from '@remotion/serverless';
+import {
+	innerHandler,
+	innerRoutine,
+	ServerlessRoutines,
+	streamWriter,
+} from '@remotion/serverless';
 import {serverAwsImplementation} from './aws-server-implementation';
 import {streamifyResponse} from './helpers/streamify-response';
 
@@ -16,7 +21,14 @@ export const routine = (
 ): Promise<void> => {
 	const responseWriter = streamWriter(responseStream);
 
-	return innerHandler({
+	const handle =
+		params.type === ServerlessRoutines.info ||
+		params.type === ServerlessRoutines.start ||
+		params.type === ServerlessRoutines.compositions
+			? innerRoutine
+			: innerHandler;
+
+	return handle({
 		params,
 		responseWriter,
 		context,

--- a/packages/lambda/src/test/unit/routine.test.ts
+++ b/packages/lambda/src/test/unit/routine.test.ts
@@ -1,0 +1,48 @@
+import {expect, test} from 'bun:test';
+import {
+	ResponseStream,
+	ServerlessRoutines,
+	VERSION,
+} from '@remotion/serverless';
+import {routine} from '../../functions';
+
+test('buffered routines serialize exceptions and end the response', async () => {
+	for (const type of [
+		ServerlessRoutines.info,
+		ServerlessRoutines.start,
+		ServerlessRoutines.compositions,
+	]) {
+		const responseStream = new ResponseStream();
+
+		await routine(
+			{
+				type,
+				version: VERSION,
+				logLevel: 'error',
+			} as never,
+			responseStream,
+			{
+				awsRequestId: 'request-id',
+				invokedFunctionArn: '',
+				getRemainingTimeInMillis: () => 120_000,
+			},
+		);
+
+		expect(responseStream.writableEnded).toBe(true);
+		const response = JSON.parse(
+			new TextDecoder().decode(responseStream.getBufferedData()),
+		) as {
+			type: string;
+			message: string;
+			stack: string;
+		};
+		expect(response).toMatchObject({
+			type: 'error',
+			message:
+				'Lambda function unexpectedly does not have context.invokedFunctionArn',
+		});
+		expect(response.stack).toContain(
+			'Error: Lambda function unexpectedly does not have context.invokedFunctionArn',
+		);
+	}
+});

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -6,15 +6,18 @@ export {
 export {compositionsHandler} from './handlers/compositions';
 export {launchHandler} from './handlers/launch';
 export {progressHandler} from './handlers/progress';
-export {RequestContext, rendererHandler} from './handlers/renderer';
+export {type RequestContext, rendererHandler} from './handlers/renderer';
 export {startHandler} from './handlers/start';
 export {stillHandler} from './handlers/still';
 export {infoHandler} from './info';
-export {innerHandler} from './inner-routine';
+export {innerHandler, innerRoutine} from './inner-routine';
 export {invokeWebhook} from './invoke-webhook';
 export {setCurrentRequestId, stopLeakDetection} from './leak-detection';
 export * from './provider-implementation';
 export {ResponseStream} from './streaming/response-stream';
-export {ResponseStreamWriter, streamWriter} from './streaming/stream-writer';
+export {
+	type ResponseStreamWriter,
+	streamWriter,
+} from './streaming/stream-writer';
 
 export {validateComposition} from './validate-composition';

--- a/packages/serverless/src/inner-routine.ts
+++ b/packages/serverless/src/inner-routine.ts
@@ -191,11 +191,15 @@ export const innerHandler = async <Provider extends CloudProvider>({
 		} catch (err) {
 			// eslint-disable-next-line no-console
 			console.log({err});
+			const response: OrError<0> = {
+				type: 'error',
+				message: (err as Error).message,
+				stack: (err as Error).stack as string,
+			};
 			await responseWriter.write(
-				new TextEncoder().encode(
-					JSON.stringify({type: 'error', message: (err as Error).stack}),
-				),
+				new TextEncoder().encode(JSON.stringify(response)),
 			);
+			await responseWriter.end();
 			return;
 		}
 	}

--- a/packages/serverless/src/test/inner-routine.test.ts
+++ b/packages/serverless/src/test/inner-routine.test.ts
@@ -4,7 +4,7 @@ import type {
 	ProviderSpecifics,
 } from '@remotion/serverless-client';
 import {VERSION} from '@remotion/serverless-client';
-import {innerHandler} from '../inner-routine';
+import {innerHandler, innerRoutine} from '../inner-routine';
 import type {InsideFunctionSpecifics} from '../provider-implementation';
 
 type MockProvider = CloudProvider<
@@ -73,4 +73,57 @@ test('buffered still errors are written to the response', async () => {
 	expect(response.stack).toContain(
 		'Error: downloadBehavior must be null or an object',
 	);
+});
+
+test('buffered render start exceptions are written to the response', async () => {
+	const chunks: Uint8Array[] = [];
+	let ended = false;
+
+	await innerRoutine<MockProvider>({
+		params: {
+			type: 'start',
+			version: VERSION,
+			logLevel: 'error',
+			deleteAfter: null,
+		} as never,
+		responseWriter: {
+			write: (message) => {
+				chunks.push(message);
+				return Promise.resolve();
+			},
+			end: () => {
+				ended = true;
+				return Promise.resolve();
+			},
+		},
+		context: {
+			awsRequestId: 'request-id',
+			invokedFunctionArn:
+				'arn:aws:lambda:mock-region:123456789012:function:test',
+			getRemainingTimeInMillis: () => 120_000,
+		},
+		providerSpecifics: {
+			printLoggingHelper: false,
+			randomHash: () => 'random-hash',
+		} as unknown as ProviderSpecifics<MockProvider>,
+		insideFunctionSpecifics: {
+			deleteTmpDir: () => Promise.resolve(),
+			generateRandomId: () => {
+				throw new Error('Could not generate a render ID');
+			},
+		} as unknown as InsideFunctionSpecifics<MockProvider>,
+	});
+
+	expect(ended).toBe(true);
+	expect(chunks).toHaveLength(1);
+	const response = JSON.parse(new TextDecoder().decode(chunks[0])) as {
+		type: string;
+		message: string;
+		stack: string;
+	};
+	expect(response).toMatchObject({
+		type: 'error',
+		message: 'Could not generate a render ID',
+	});
+	expect(response.stack).toContain('Error: Could not generate a render ID');
 });


### PR DESCRIPTION
## Summary

- serialize errors from buffered Lambda info, render start, and compositions routines
- close the response stream after render start failures
- add regression coverage at the Lambda routine and serverless response boundaries

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test lint formatting make --filter=@remotion/serverless --filter=@remotion/lambda`

Closes #10554
