### PR TITLE
`remotion`: Avoid duplicate delay-render initialization

### DIFF
--- a/packages/core/src/delay-render-constants.ts
+++ b/packages/core/src/delay-render-constants.ts
@@ -1,0 +1,5 @@
+export const DELAY_RENDER_CALLSTACK_TOKEN = 'The delayRender was called:';
+export const DELAY_RENDER_RETRIES_LEFT = 'Retries left: ';
+export const DELAY_RENDER_RETRY_TOKEN =
+	'- Rendering the frame will be retried.';
+export const DELAY_RENDER_CLEAR_TOKEN = 'handle was cleared after';

--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -2,11 +2,24 @@ import {
 	cancelRenderInternal,
 	getErrorStackWithMessage,
 } from './cancel-render.js';
+import {
+	DELAY_RENDER_CALLSTACK_TOKEN,
+	DELAY_RENDER_CLEAR_TOKEN,
+	DELAY_RENDER_RETRIES_LEFT,
+	DELAY_RENDER_RETRY_TOKEN,
+} from './delay-render-constants.js';
 import {getRemotionEnvironment} from './get-remotion-environment.js';
 import type {LogLevel} from './log.js';
 import {Log} from './log.js';
 import type {RemotionEnvironment} from './remotion-environment-context.js';
 import {truthy} from './truthy.js';
+
+export {
+	DELAY_RENDER_CALLSTACK_TOKEN,
+	DELAY_RENDER_CLEAR_TOKEN,
+	DELAY_RENDER_RETRIES_LEFT,
+	DELAY_RENDER_RETRY_TOKEN,
+} from './delay-render-constants.js';
 
 export type DelayRenderScope = {
 	remotion_renderReady: boolean;
@@ -31,12 +44,6 @@ if (typeof window !== 'undefined') {
 
 	window.remotion_delayRenderHandles = [];
 }
-
-export const DELAY_RENDER_CALLSTACK_TOKEN = 'The delayRender was called:';
-export const DELAY_RENDER_RETRIES_LEFT = 'Retries left: ';
-export const DELAY_RENDER_RETRY_TOKEN =
-	'- Rendering the frame will be retried.';
-export const DELAY_RENDER_CLEAR_TOKEN = 'handle was cleared after';
 
 const defaultTimeout = 30000;
 

--- a/packages/core/src/no-react.ts
+++ b/packages/core/src/no-react.ts
@@ -25,7 +25,7 @@ import {
 	DELAY_RENDER_CLEAR_TOKEN,
 	DELAY_RENDER_RETRIES_LEFT,
 	DELAY_RENDER_RETRY_TOKEN,
-} from './delay-render';
+} from './delay-render-constants';
 import {findPropsToDelete} from './find-props-to-delete';
 import {
 	deserializeJSONWithSpecialTypes,

--- a/packages/it-tests/src/bundle/bundle-studio.test.ts
+++ b/packages/it-tests/src/bundle/bundle-studio.test.ts
@@ -36,6 +36,10 @@ test(
 		if (contents.includes('PreviewToolbar') || contents.includes('TopPanel')) {
 			throw new Error('Studio was bundled');
 		}
+		// remotion/no-react must not pull in another stateful delay-render module.
+		expect(
+			contents.match(/window\.remotion_delayRenderHandles = \[\]/g),
+		).toHaveLength(1);
 
 		const indexHtmlContent = readFileSync(
 			path.join(folder, 'index.html'),
@@ -72,6 +76,24 @@ test(
 			return document.querySelectorAll('.css-reset').length;
 		});
 		expect(result.toString()).toBeGreaterThan(1);
+
+		const fontLoaded = await tab.evaluateHandle(() => {
+			let loaded = false;
+			document.fonts.forEach((font) => {
+				if (font.family === 'Bangers' && font.status === 'loaded') {
+					loaded = true;
+				}
+			});
+			return loaded;
+		});
+		expect(String(fontLoaded.toString())).toBe('true');
+
+		const orphanedFontTimeouts = await tab.evaluateHandle(() => {
+			return Object.values(window.remotion_delayRenderTimeouts).filter(
+				(timeout) => timeout.label?.startsWith('Loading font Bangers'),
+			).length;
+		});
+		expect(Number(orphanedFontTimeouts.toString())).toBe(0);
 
 		await (await browser).close({silent: false});
 		await close();


### PR DESCRIPTION
## Summary

- move delay-render diagnostic tokens into a side-effect-free module
- prevent `remotion/no-react` from evaluating the stateful delay-render initializer a second time
- cover the emitted bundle and local-font timeout lifecycle in the browser integration test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test` in `packages/core`
- `bun test src/bundle/bundle-studio.test.ts --run --timeout 30000` in `packages/it-tests`
