### PR TITLE
`@remotion/web-renderer`: Preserve HtmlInCanvas paint pipeline output

### DIFF
--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -29,6 +29,10 @@ import {
 	transformSchema,
 	type InteractivitySchema,
 } from './interactivity-schema.js';
+import {
+	CanvasFrameOutputContext,
+	publishCanvasFrame,
+} from './published-canvas-frame.js';
 import type {AbsoluteFillLayout} from './Sequence.js';
 import {Sequence} from './Sequence.js';
 import {useCropStyle} from './use-crop-style.js';
@@ -416,6 +420,7 @@ const HtmlInCanvasContent = forwardRef<
 		ref,
 	) => {
 		const ancestor = useContext(HtmlInCanvasAncestorContext);
+		const shouldPublishCanvasFrame = useContext(CanvasFrameOutputContext);
 		assertHtmlInCanvasDimensions(width, height);
 		const chromeMajorVersion = getChromeMajorVersion();
 		if (
@@ -619,6 +624,16 @@ const HtmlInCanvasContent = forwardRef<
 						width: canvasWidth,
 						height: canvasHeight,
 					});
+
+					if (shouldPublishCanvasFrame) {
+						// Painting and effects form one pipeline. Materialize its final frame
+						// while GPU drawing buffers are still readable so the DOM composer
+						// consumes the same output regardless of which paint stage produced it.
+						publishCanvasFrame({
+							canvas: placeholderCanvas,
+							source: paintTarget,
+						});
+					}
 				} finally {
 					elImage.close();
 				}
@@ -641,6 +656,7 @@ const HtmlInCanvasContent = forwardRef<
 			delayRender,
 			resolvedPixelDensity,
 			canRetryMissingPaintRecord,
+			shouldPublishCanvasFrame,
 		]);
 
 		// Default paint handlers draw synchronously on the layout canvas itself so

--- a/packages/core/src/HtmlInCanvas.tsx
+++ b/packages/core/src/HtmlInCanvas.tsx
@@ -29,10 +29,7 @@ import {
 	transformSchema,
 	type InteractivitySchema,
 } from './interactivity-schema.js';
-import {
-	CanvasFrameOutputContext,
-	publishCanvasFrame,
-} from './published-canvas-frame.js';
+import {publishCanvasFrame} from './published-canvas-frame.js';
 import type {AbsoluteFillLayout} from './Sequence.js';
 import {Sequence} from './Sequence.js';
 import {useCropStyle} from './use-crop-style.js';
@@ -420,7 +417,6 @@ const HtmlInCanvasContent = forwardRef<
 		ref,
 	) => {
 		const ancestor = useContext(HtmlInCanvasAncestorContext);
-		const shouldPublishCanvasFrame = useContext(CanvasFrameOutputContext);
 		assertHtmlInCanvasDimensions(width, height);
 		const chromeMajorVersion = getChromeMajorVersion();
 		if (
@@ -625,15 +621,13 @@ const HtmlInCanvasContent = forwardRef<
 						height: canvasHeight,
 					});
 
-					if (shouldPublishCanvasFrame) {
-						// Painting and effects form one pipeline. Materialize its final frame
-						// while GPU drawing buffers are still readable so the DOM composer
-						// consumes the same output regardless of which paint stage produced it.
-						publishCanvasFrame({
-							canvas: placeholderCanvas,
-							source: paintTarget,
-						});
-					}
+					// Painting and effects form one pipeline. Materialize its final frame
+					// while GPU drawing buffers are still readable so every consumer sees
+					// the same output regardless of which paint stage produced it.
+					publishCanvasFrame({
+						canvas: placeholderCanvas,
+						source: paintTarget,
+					});
 				} finally {
 					elImage.close();
 				}
@@ -656,7 +650,6 @@ const HtmlInCanvasContent = forwardRef<
 			delayRender,
 			resolvedPixelDensity,
 			canRetryMissingPaintRecord,
-			shouldPublishCanvasFrame,
 		]);
 
 		// Default paint handlers draw synchronously on the layout canvas itself so

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -127,6 +127,10 @@ import {portalNode, setPortalNodeCurrentScale} from './portal-node.js';
 import {PrefetchProvider} from './prefetch-state.js';
 import {usePreload} from './prefetch.js';
 import {PremountContext} from './PremountContext.js';
+import {
+	CanvasFrameOutputContext,
+	getPublishedCanvasFrame,
+} from './published-canvas-frame.js';
 import {getRoot, waitForRoot} from './register-root.js';
 import type {RemotionEnvironment} from './remotion-environment-context.js';
 import {RemotionEnvironmentContext} from './remotion-environment-context.js';
@@ -356,6 +360,8 @@ export const Internals = {
 	isCompositionIdValid,
 	isFolderNameValid,
 	getPreviewDomElement,
+	CanvasFrameOutputContext,
+	getPublishedCanvasFrame,
 	compositionsRef,
 	portalNode,
 	setPortalNodeCurrentScale,

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -127,10 +127,7 @@ import {portalNode, setPortalNodeCurrentScale} from './portal-node.js';
 import {PrefetchProvider} from './prefetch-state.js';
 import {usePreload} from './prefetch.js';
 import {PremountContext} from './PremountContext.js';
-import {
-	CanvasFrameOutputContext,
-	getPublishedCanvasFrame,
-} from './published-canvas-frame.js';
+import {getPublishedCanvasFrame} from './published-canvas-frame.js';
 import {getRoot, waitForRoot} from './register-root.js';
 import type {RemotionEnvironment} from './remotion-environment-context.js';
 import {RemotionEnvironmentContext} from './remotion-environment-context.js';
@@ -360,7 +357,6 @@ export const Internals = {
 	isCompositionIdValid,
 	isFolderNameValid,
 	getPreviewDomElement,
-	CanvasFrameOutputContext,
 	getPublishedCanvasFrame,
 	compositionsRef,
 	portalNode,

--- a/packages/core/src/published-canvas-frame.ts
+++ b/packages/core/src/published-canvas-frame.ts
@@ -1,8 +1,4 @@
-import {createContext} from 'react';
-
 type CanvasFrameSource = HTMLCanvasElement | OffscreenCanvas;
-
-export const CanvasFrameOutputContext = createContext(false);
 
 const publishedCanvasFrames = new WeakMap<HTMLCanvasElement, OffscreenCanvas>();
 
@@ -13,6 +9,10 @@ export const publishCanvasFrame = ({
 	readonly canvas: HTMLCanvasElement;
 	readonly source: CanvasFrameSource;
 }): void => {
+	if (typeof OffscreenCanvas === 'undefined') {
+		return;
+	}
+
 	let publishedFrame = publishedCanvasFrames.get(canvas);
 	if (
 		!publishedFrame ||

--- a/packages/core/src/published-canvas-frame.ts
+++ b/packages/core/src/published-canvas-frame.ts
@@ -1,0 +1,41 @@
+import {createContext} from 'react';
+
+type CanvasFrameSource = HTMLCanvasElement | OffscreenCanvas;
+
+export const CanvasFrameOutputContext = createContext(false);
+
+const publishedCanvasFrames = new WeakMap<HTMLCanvasElement, OffscreenCanvas>();
+
+export const publishCanvasFrame = ({
+	canvas,
+	source,
+}: {
+	readonly canvas: HTMLCanvasElement;
+	readonly source: CanvasFrameSource;
+}): void => {
+	let publishedFrame = publishedCanvasFrames.get(canvas);
+	if (
+		!publishedFrame ||
+		publishedFrame.width !== source.width ||
+		publishedFrame.height !== source.height
+	) {
+		publishedFrame = new OffscreenCanvas(source.width, source.height);
+		publishedCanvasFrames.set(canvas, publishedFrame);
+	}
+
+	const context = publishedFrame.getContext('2d');
+	if (!context) {
+		throw new Error(
+			'Could not create a 2D context for a published canvas frame',
+		);
+	}
+
+	context.reset();
+	context.drawImage(source, 0, 0);
+};
+
+export const getPublishedCanvasFrame = (
+	canvas: HTMLCanvasElement,
+): OffscreenCanvas | null => {
+	return publishedCanvasFrames.get(canvas) ?? null;
+};

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -324,9 +324,13 @@ export function createScaffold<Props extends Record<string, unknown>>({
 											timeUpdater={timeUpdater}
 										>
 											<Internals.CanUseRemotionHooks.Provider value>
-												{/**
-												 * @ts-expect-error	*/}
-												<Component {...resolvedProps} />
+												<Internals.CanvasFrameOutputContext.Provider
+													value={!useHtmlInCanvas}
+												>
+													{/**
+													 * @ts-expect-error	*/}
+													<Component {...resolvedProps} />
+												</Internals.CanvasFrameOutputContext.Provider>
 											</Internals.CanUseRemotionHooks.Provider>
 										</UpdateTime>
 									</Internals.RenderAssetManagerProvider>

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -324,13 +324,9 @@ export function createScaffold<Props extends Record<string, unknown>>({
 											timeUpdater={timeUpdater}
 										>
 											<Internals.CanUseRemotionHooks.Provider value>
-												<Internals.CanvasFrameOutputContext.Provider
-													value={!useHtmlInCanvas}
-												>
-													{/**
-													 * @ts-expect-error	*/}
-													<Component {...resolvedProps} />
-												</Internals.CanvasFrameOutputContext.Provider>
+												{/**
+												 * @ts-expect-error	*/}
+												<Component {...resolvedProps} />
 											</Internals.CanUseRemotionHooks.Provider>
 										</UpdateTime>
 									</Internals.RenderAssetManagerProvider>

--- a/packages/web-renderer/src/drawing/draw-dom-element.ts
+++ b/packages/web-renderer/src/drawing/draw-dom-element.ts
@@ -1,3 +1,4 @@
+import {Internals} from 'remotion';
 import {calculateObjectFit, parseObjectFit} from './calculate-object-fit';
 import type {DrawFn} from './drawn-fn';
 import {fitSvgIntoItsContainer} from './fit-svg-into-its-dimensions';
@@ -68,7 +69,7 @@ const drawReplacedElement = ({
 	computedStyle,
 	contextToDraw,
 }: {
-	drawable: HTMLImageElement | HTMLCanvasElement;
+	drawable: HTMLImageElement | HTMLCanvasElement | OffscreenCanvas;
 	dimensions: DOMRect;
 	computedStyle: CSSStyleDeclaration;
 	contextToDraw: OffscreenCanvasRenderingContext2D;
@@ -183,7 +184,10 @@ export const drawDomElement = (node: HTMLElement | SVGElement) => {
 		if (node instanceof HTMLImageElement || node instanceof HTMLCanvasElement) {
 			try {
 				drawReplacedElement({
-					drawable: node,
+					drawable:
+						node instanceof HTMLCanvasElement
+							? (Internals.getPublishedCanvasFrame(node) ?? node)
+							: node,
 					dimensions,
 					computedStyle,
 					contextToDraw,

--- a/packages/web-renderer/src/drawing/process-node.ts
+++ b/packages/web-renderer/src/drawing/process-node.ts
@@ -270,5 +270,12 @@ export const processNode = async ({
 		scale,
 	});
 
+	// layoutSubtree children provide layout and accessibility input to the
+	// canvas paint pipeline. They are not independently visible output.
+	if (element instanceof HTMLCanvasElement && element.layoutSubtree === true) {
+		cleanupAfterChildren?.();
+		return {type: 'skip-children'};
+	}
+
 	return {type: 'continue', cleanupAfterChildren};
 };

--- a/packages/web-renderer/src/test/Root.tsx
+++ b/packages/web-renderer/src/test/Root.tsx
@@ -51,6 +51,10 @@ import {multiLevelTransformOrigins} from './fixtures/multi-level-transform-origi
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
 import {nestedTranslateScale} from './fixtures/nested-translate-scale';
 import {objectFit} from './fixtures/object-fit';
+import {
+	elementImageOnPaintHtmlInCanvas,
+	webGlOnPaintHtmlInCanvas,
+} from './fixtures/on-paint-html-in-canvas';
 import {opacityInherited} from './fixtures/opacity-inherited';
 import {opacityNested} from './fixtures/opacity-nested';
 import {opacityReset} from './fixtures/opacity-reset';
@@ -134,6 +138,8 @@ export const Root: React.FC = () => {
 			<Composition {...objectFit} />
 			<Composition {...nestedTranslateScale} />
 			<Composition {...nestedHtmlInCanvas} />
+			<Composition {...elementImageOnPaintHtmlInCanvas} />
+			<Composition {...webGlOnPaintHtmlInCanvas} />
 			<Composition {...scaledTranslatedSvg} />
 			<Composition {...svgExplicitDimensions} />
 			<Composition {...svgDataUri} />

--- a/packages/web-renderer/src/test/fixtures/on-paint-html-in-canvas.tsx
+++ b/packages/web-renderer/src/test/fixtures/on-paint-html-in-canvas.tsx
@@ -1,0 +1,84 @@
+import React, {useCallback, useRef} from 'react';
+import {
+	AbsoluteFill,
+	HtmlInCanvas,
+	type HtmlInCanvasOnInit,
+	type HtmlInCanvasOnPaint,
+} from 'remotion';
+
+const ElementImageComponent: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#0000ff'}}>
+			<HtmlInCanvas
+				width={100}
+				height={100}
+				onPaint={({canvas, elementImage}) => {
+					const ctx = canvas.getContext('2d');
+					if (!ctx) {
+						throw new Error('Expected a 2D context');
+					}
+
+					ctx.reset();
+					ctx.drawElementImage(elementImage, 0, 0);
+					ctx.globalCompositeOperation = 'source-in';
+					ctx.fillStyle = '#00ff00';
+					ctx.fillRect(0, 0, canvas.width, canvas.height);
+				}}
+			>
+				<AbsoluteFill style={{backgroundColor: '#ff0000'}} />
+			</HtmlInCanvas>
+		</AbsoluteFill>
+	);
+};
+
+const WebGlComponent: React.FC = () => {
+	const glRef = useRef<WebGL2RenderingContext | null>(null);
+
+	const onInit: HtmlInCanvasOnInit = useCallback(({canvas}) => {
+		const gl = canvas.getContext('webgl2');
+		if (!gl) {
+			throw new Error('Expected a WebGL2 context');
+		}
+
+		glRef.current = gl;
+		return () => {
+			glRef.current = null;
+		};
+	}, []);
+
+	const onPaint: HtmlInCanvasOnPaint = useCallback(() => {
+		const gl = glRef.current;
+		if (!gl) {
+			throw new Error('Expected WebGL to be initialized');
+		}
+
+		gl.clearColor(0, 1, 1, 1);
+		gl.clear(gl.COLOR_BUFFER_BIT);
+	}, []);
+
+	return (
+		<AbsoluteFill style={{backgroundColor: '#0000ff'}}>
+			<HtmlInCanvas width={100} height={100} onInit={onInit} onPaint={onPaint}>
+				<AbsoluteFill style={{backgroundColor: '#ff0000'}} />
+			</HtmlInCanvas>
+		</AbsoluteFill>
+	);
+};
+
+export const elementImageOnPaintHtmlInCanvas = {
+	component: ElementImageComponent,
+	id: 'element-image-on-paint-html-in-canvas',
+	width: 100,
+	height: 100,
+	fps: 30,
+	durationInFrames: 5,
+} as const;
+
+export const webGlOnPaintHtmlInCanvas = {
+	component: WebGlComponent,
+	id: 'webgl-on-paint-html-in-canvas',
+	width: 100,
+	height: 100,
+	fps: 30,
+	durationInFrames: 5,
+} as const;

--- a/packages/web-renderer/src/test/html-in-canvas.test.tsx
+++ b/packages/web-renderer/src/test/html-in-canvas.test.tsx
@@ -10,13 +10,23 @@ import {renderMediaOnWeb} from '../render-media-on-web';
 import {renderStillOnWeb} from '../render-still-on-web';
 import '../symbol-dispose';
 import {nestedHtmlInCanvas} from './fixtures/nested-html-in-canvas';
+import {
+	elementImageOnPaintHtmlInCanvas,
+	webGlOnPaintHtmlInCanvas,
+} from './fixtures/on-paint-html-in-canvas';
 import {testImage} from './utils';
 
 setForceDisableHtmlInCanvasForTesting(false);
 
+const chromeMajorVersion = Number(
+	navigator.userAgent.match(/\b(?:HeadlessChrome|Chrome)\/(\d+)/)?.[1],
+);
+const canRenderNestedHtmlInCanvas =
+	!Number.isFinite(chromeMajorVersion) || chromeMajorVersion >= 152;
+
 test('captures three nested HTML-in-canvas effect layers natively', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -51,7 +61,7 @@ test('captures three nested HTML-in-canvas effect layers natively', async () => 
 
 test('captures three nested HTML-in-canvas effect layers across video frames', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -65,7 +75,7 @@ test('captures three nested HTML-in-canvas effect layers across video frames', a
 
 test('retries a transient missing nested paint record during a client-side render', async () => {
 	const supportsNesting = await supportsNestedHtmlInCanvas();
-	if (!supportsNesting) {
+	if (!supportsNesting || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -198,7 +208,7 @@ test('keeps the DOM composer scaffold paintable', () => {
 });
 
 test('uses the DOM composer when native HTML-in-canvas does not support nesting', async () => {
-	if (!supportsNativeHtmlInCanvas()) {
+	if (!supportsNativeHtmlInCanvas() || !canRenderNestedHtmlInCanvas) {
 		return;
 	}
 
@@ -230,5 +240,65 @@ test('uses the DOM composer when native HTML-in-canvas does not support nesting'
 	} finally {
 		setForceDisableHtmlInCanvasForTesting(false);
 		warn.mockRestore();
+	}
+});
+
+test('publishes custom paint output during software composition', async () => {
+	if (!supportsNativeHtmlInCanvas()) {
+		if (/\b(?:HeadlessChrome|Chrome)\//.test(navigator.userAgent)) {
+			throw new Error(
+				'Expected CanvasDrawElement to be enabled for Chromium web renderer tests',
+			);
+		}
+
+		return;
+	}
+
+	setForceDisableHtmlInCanvasForTesting(true);
+
+	try {
+		const elementImageResult = await renderStillOnWeb({
+			composition: elementImageOnPaintHtmlInCanvas,
+			frame: 0,
+			inputProps: {},
+			licenseKey: 'free-license',
+		});
+		const elementImageBlob = await elementImageResult.blob({format: 'png'});
+		const elementImageBitmap = await createImageBitmap(elementImageBlob);
+		const elementImageProbe = new OffscreenCanvas(100, 100);
+		const elementImageCtx = elementImageProbe.getContext('2d');
+		if (!elementImageCtx) {
+			throw new Error('Expected a 2D context');
+		}
+
+		elementImageCtx.drawImage(elementImageBitmap, 0, 0);
+		elementImageBitmap.close();
+		const elementImagePixel = elementImageCtx.getImageData(50, 50, 1, 1).data;
+
+		// The custom paint stage consumes the red ElementImage and masks it green.
+		expect([...elementImagePixel]).toEqual([0, 255, 0, 255]);
+
+		const webGlResult = await renderStillOnWeb({
+			composition: webGlOnPaintHtmlInCanvas,
+			frame: 0,
+			inputProps: {},
+			licenseKey: 'free-license',
+		});
+		const webGlBlob = await webGlResult.blob({format: 'png'});
+		const webGlBitmap = await createImageBitmap(webGlBlob);
+		const webGlProbe = new OffscreenCanvas(100, 100);
+		const webGlCtx = webGlProbe.getContext('2d');
+		if (!webGlCtx) {
+			throw new Error('Expected a 2D context');
+		}
+
+		webGlCtx.drawImage(webGlBitmap, 0, 0);
+		webGlBitmap.close();
+		const webGlPixel = webGlCtx.getImageData(50, 50, 1, 1).data;
+
+		// The custom WebGL paint stage replaces the red layout child with cyan.
+		expect([...webGlPixel]).toEqual([0, 255, 255, 255]);
+	} finally {
+		setForceDisableHtmlInCanvasForTesting(false);
 	}
 });

--- a/packages/web-renderer/vitest.config.ts
+++ b/packages/web-renderer/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
 					browser: 'chromium',
 					provider: playwright({
 						launchOptions: {
+							args: ['--enable-blink-features=CanvasDrawElement'],
 							channel: 'chrome',
 						},
 						actionTimeout: 5_000,


### PR DESCRIPTION
## Summary

- model `<HtmlInCanvas>` rendering as one capture → paint → effects → publish pipeline, independent of whether the paint stage is built-in or supplied through `onPaint`
- publish every completed `<HtmlInCanvas>` frame into a readable surface while GPU drawing buffers are still valid
- have the DOM compositor consume the published frame and treat `layoutSubtree` children as paint inputs instead of drawing them again
- cover both an `ElementImage`-consuming custom painter and a WebGL painter initialized through `onInit`

The custom painter still uses the transferred `OffscreenCanvas` tied to the layout canvas, preserving the same-logical-canvas requirement from #7458. Publication is a property of the paint pipeline itself; the web renderer no longer opts into it or controls it.

Supersedes #10512 and #10555.

## Verification

- Red/green verified: on `main`, software composition returned the raw red layout child instead of the custom green output; the final test passes with the publication stage connected
- `bun test src/test/html-in-canvas.test.tsx` in `packages/core` — 17 passed
- `bunx vitest src/test/html-in-canvas.test.tsx --run` in `packages/web-renderer` — 21 passed across Chromium, Firefox, and WebKit
- `bun run testwebrenderer` — 691 passed, 27 skipped; two unrelated screenshot-stability timeouts passed immediately when rerun in isolation (6/6 browser cases)
- `bun run build`
- `bun run stylecheck`
