### PR TITLE
`@remotion/studio`: Virtualize wide timeline items

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -1,10 +1,8 @@
 import {
 	drawBars,
-	getLoopDisplayWidth,
 	loadWaveformPeaks,
 	makeAudioWaveformWorker,
-	shouldTileLoopDisplay,
-	sliceWaveformPeaks,
+	sliceVisibleWaveformPeaks,
 	type AudioWaveformWorkerOutgoingMessage,
 	type AudioWaveformWorkerRenderMessage,
 	type WaveformVolume,
@@ -70,60 +68,14 @@ const parseVolume = (volume: string | number): WaveformVolume => {
 	return volume.split(',').map((v) => Number(v));
 };
 
-const drawLoopedWaveform = ({
-	canvas,
-	peaks,
-	volume,
-	visualizationWidth,
-	loopWidth,
-}: {
-	canvas: HTMLCanvasElement;
-	peaks: Float32Array;
-	volume: WaveformVolume;
-	visualizationWidth: number;
-	loopWidth: number;
-}) => {
-	const h = canvas.height;
-	const w = Math.ceil(visualizationWidth);
-	const targetCanvas = document.createElement('canvas');
-	targetCanvas.width = Math.max(1, Math.ceil(loopWidth));
-	targetCanvas.height = h;
-
-	drawBars({
-		canvas: targetCanvas,
-		peaks,
-		color: WHITE_ALPHA_60,
-		volume,
-		width: targetCanvas.width,
-	});
-
-	canvas.width = w;
-	canvas.height = h;
-
-	const ctx = canvas.getContext('2d');
-	if (!ctx) {
-		throw new Error('Failed to get canvas context');
-	}
-
-	const pattern = ctx.createPattern(targetCanvas, 'repeat-x');
-	if (!pattern) {
-		return;
-	}
-
-	pattern.setTransform(
-		new DOMMatrix().scaleSelf(loopWidth / targetCanvas.width, 1),
-	);
-	ctx.clearRect(0, 0, w, h);
-	ctx.fillStyle = pattern;
-	ctx.fillRect(0, 0, w, h);
-};
-
 const AudioWaveformInner: React.FC<{
 	readonly src: string;
 	readonly height: number;
 	readonly visualizationWidth: number;
 	readonly startFrom: number;
 	readonly durationInFrames: number;
+	readonly displayOffsetInFrames: number;
+	readonly displayDurationInFrames: number;
 	readonly volume: string | number;
 	readonly doesVolumeChange: boolean;
 	readonly playbackRate: number;
@@ -133,6 +85,8 @@ const AudioWaveformInner: React.FC<{
 	height,
 	startFrom,
 	durationInFrames,
+	displayOffsetInFrames,
+	displayDurationInFrames,
 	visualizationWidth,
 	volume,
 	doesVolumeChange,
@@ -156,6 +110,51 @@ const AudioWaveformInner: React.FC<{
 	const shouldRenderVolumeOverlay =
 		doesVolumeChange && typeof volume === 'string';
 	const parsedVolume = useMemo(() => parseVolume(volume), [volume]);
+	const visibleVolume = useMemo((): WaveformVolume => {
+		if (!Array.isArray(parsedVolume)) {
+			return parsedVolume;
+		}
+
+		if (!loopDisplay || loopDisplay.numberOfTimes <= 1) {
+			const start = Math.max(0, Math.floor(displayOffsetInFrames));
+			const end = Math.min(
+				parsedVolume.length,
+				Math.ceil(displayOffsetInFrames + displayDurationInFrames),
+			);
+			return parsedVolume.slice(start, end);
+		}
+
+		const result: number[] = [];
+		let processed = 0;
+		while (processed < displayDurationInFrames) {
+			const absoluteOffset = displayOffsetInFrames + processed;
+			const loopOffset =
+				((absoluteOffset % loopDisplay.durationInFrames) +
+					loopDisplay.durationInFrames) %
+				loopDisplay.durationInFrames;
+			const segmentDuration = Math.min(
+				displayDurationInFrames - processed,
+				loopDisplay.durationInFrames - loopOffset,
+			);
+			result.push(
+				...parsedVolume.slice(
+					Math.max(0, Math.floor(loopOffset)),
+					Math.min(
+						parsedVolume.length,
+						Math.ceil(loopOffset + segmentDuration),
+					),
+				),
+			);
+			processed += segmentDuration;
+		}
+
+		return result;
+	}, [
+		displayDurationInFrames,
+		displayOffsetInFrames,
+		loopDisplay,
+		parsedVolume,
+	]);
 
 	useEffect(() => {
 		if (canUseWorkerPath) {
@@ -253,17 +252,20 @@ const AudioWaveformInner: React.FC<{
 			return null;
 		}
 
-		return sliceWaveformPeaks({
-			durationInFrames: shouldTileLoopDisplay(loopDisplay)
-				? loopDisplay.durationInFrames
-				: durationInFrames,
+		return sliceVisibleWaveformPeaks({
+			displayDurationInFrames,
+			displayOffsetInFrames,
+			durationInFrames,
 			fps: vidConf.fps,
+			loopDisplay,
 			peaks,
 			playbackRate,
 			startFrom,
 		});
 	}, [
 		canUseWorkerPath,
+		displayDurationInFrames,
+		displayOffsetInFrames,
 		durationInFrames,
 		loopDisplay,
 		peaks,
@@ -295,9 +297,11 @@ const AudioWaveformInner: React.FC<{
 				src,
 				width: w,
 				height: h,
-				volume: parsedVolume,
+				volume: visibleVolume,
 				startFrom,
 				durationInFrames,
+				displayOffsetInFrames,
+				displayDurationInFrames,
 				fps: vidConf.fps,
 				playbackRate,
 				loopDisplay,
@@ -309,38 +313,27 @@ const AudioWaveformInner: React.FC<{
 		canvasElement.width = w;
 		canvasElement.height = h;
 
-		if (shouldTileLoopDisplay(loopDisplay)) {
-			drawLoopedWaveform({
-				canvas: canvasElement,
-				peaks: portionPeaks ?? EMPTY_PEAKS,
-				volume: parsedVolume,
-				visualizationWidth,
-				loopWidth: getLoopDisplayWidth({
-					visualizationWidth,
-					loopDisplay,
-				}),
-			});
-		} else {
-			drawBars({
-				canvas: canvasElement,
-				peaks: portionPeaks ?? EMPTY_PEAKS,
-				color: WHITE_ALPHA_60,
-				volume: parsedVolume,
-				width: w,
-			});
-		}
+		drawBars({
+			canvas: canvasElement,
+			peaks: portionPeaks ?? EMPTY_PEAKS,
+			color: WHITE_ALPHA_60,
+			volume: visibleVolume,
+			width: w,
+		});
 	}, [
 		canUseWorkerPath,
+		displayDurationInFrames,
+		displayOffsetInFrames,
 		durationInFrames,
 		height,
 		loopDisplay,
 		playbackRate,
-		parsedVolume,
 		portionPeaks,
 		src,
 		startFrom,
 		vidConf.fps,
 		visualizationWidth,
+		visibleVolume,
 		waveformCanvasKey,
 	]);
 
@@ -364,17 +357,17 @@ const AudioWaveformInner: React.FC<{
 		volumeCanvasElement.height = h;
 
 		context.clearRect(0, 0, visualizationWidth, h);
-		if (!Array.isArray(parsedVolume)) {
+		if (!Array.isArray(visibleVolume)) {
 			return;
 		}
 
 		context.beginPath();
 		context.moveTo(0, h);
-		parsedVolume.forEach((v, index) => {
+		visibleVolume.forEach((v, index) => {
 			const x =
-				parsedVolume.length <= 1
+				visibleVolume.length <= 1
 					? 0
-					: (index / (parsedVolume.length - 1)) * visualizationWidth;
+					: (index / (visibleVolume.length - 1)) * visualizationWidth;
 			const y = (1 - v) * (h - TIMELINE_BORDER * 2) + 1;
 			if (index === 0) {
 				context.moveTo(x, y);
@@ -384,7 +377,7 @@ const AudioWaveformInner: React.FC<{
 		});
 		context.strokeStyle = WHITE_ALPHA_70;
 		context.stroke();
-	}, [height, parsedVolume, shouldRenderVolumeOverlay, visualizationWidth]);
+	}, [height, shouldRenderVolumeOverlay, visibleVolume, visualizationWidth]);
 
 	if (error) {
 		return null;

--- a/packages/studio/src/components/Timeline/LoopedTimelineIndicators.tsx
+++ b/packages/studio/src/components/Timeline/LoopedTimelineIndicators.tsx
@@ -1,30 +1,57 @@
 import React from 'react';
 import {AbsoluteFill} from 'remotion';
-import {Flex} from '../layout';
 import {LoopedIndicator} from './LoopedIndicator';
 
 const row: React.CSSProperties = {
-	flexDirection: 'row',
+	overflow: 'hidden',
 };
 
 export const LoopedTimelineIndicator: React.FC<{
 	readonly loops: number;
-}> = ({loops}) => {
-	const leftOver = loops % 1;
+	readonly fullWidth: number;
+	readonly visibleOffset: number;
+	readonly visibleWidth: number;
+}> = ({loops, fullWidth, visibleOffset, visibleWidth}) => {
+	if (loops <= 1 || fullWidth <= 0 || visibleWidth <= 0) {
+		return null;
+	}
+
+	const loopWidth = fullWidth / loops;
+	const lastBoundaryIndex = Math.ceil(loops) - 1;
+	const firstVisibleBoundaryIndex = Math.max(
+		1,
+		Math.floor(visibleOffset / loopWidth),
+	);
+	const lastVisibleBoundaryIndex = Math.min(
+		lastBoundaryIndex,
+		Math.ceil((visibleOffset + visibleWidth) / loopWidth),
+	);
+	const visibleBoundaryCount = Math.max(
+		0,
+		lastVisibleBoundaryIndex - firstVisibleBoundaryIndex + 1,
+	);
+	const boundaries = new Array(visibleBoundaryCount)
+		.fill(true)
+		.map((_, index) => (firstVisibleBoundaryIndex + index) * loopWidth);
+
 	return (
 		<AbsoluteFill style={row}>
-			{new Array(Math.floor(loops)).fill(true).map((_l, i) => {
+			{boundaries.map((boundary) => {
 				return (
-					<React.Fragment
-						// eslint-disable-next-line
-						key={i}
+					<div
+						key={boundary}
+						style={{
+							position: 'absolute',
+							display: 'flex',
+							left: boundary - visibleOffset,
+							top: 0,
+							bottom: 0,
+						}}
 					>
-						<Flex />
-						{i === loops - 1 ? null : <LoopedIndicator />}
-					</React.Fragment>
+						<LoopedIndicator />
+					</div>
 				);
 			})}
-			{leftOver > 0 ? <div style={{flex: leftOver}} /> : null}
 		</AbsoluteFill>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineImageInfo.tsx
@@ -17,7 +17,8 @@ const containerStyle: React.CSSProperties = {
 export const TimelineImageInfo: React.FC<{
 	readonly src: string;
 	readonly visualizationWidth: number;
-}> = ({src, visualizationWidth}) => {
+	readonly offsetInPixels: number;
+}> = ({src, visualizationWidth, offsetInPixels}) => {
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -45,6 +46,7 @@ export const TimelineImageInfo: React.FC<{
 			drawRepeatingImageThumbnail({
 				canvas,
 				image: img,
+				offsetInPixels: offsetInPixels * window.devicePixelRatio,
 			});
 		};
 
@@ -53,7 +55,7 @@ export const TimelineImageInfo: React.FC<{
 		return () => {
 			current.removeChild(canvas);
 		};
-	}, [src, visualizationWidth]);
+	}, [offsetInPixels, src, visualizationWidth]);
 
 	return <div ref={ref} style={containerStyle} />;
 };

--- a/packages/studio/src/components/Timeline/TimelineScrollable.tsx
+++ b/packages/studio/src/components/Timeline/TimelineScrollable.tsx
@@ -10,6 +10,7 @@ import {
 	TIMELINE_BACKGROUND,
 	useTimelineMarqueeSelection,
 } from './TimelineSelection';
+import {TimelineViewportProvider} from './TimelineViewport';
 
 const outer: React.CSSProperties = {
 	width: '100%',
@@ -49,7 +50,9 @@ export const TimelineScrollable: React.FC<{
 			className={HORIZONTAL_SCROLLBAR_CLASSNAME}
 			onPointerDownCapture={onPointerDownCapture}
 		>
-			<div style={containerStyle}>{children}</div>
+			<TimelineViewportProvider scrollable={scrollableRef}>
+				<div style={containerStyle}>{children}</div>
+			</TimelineViewportProvider>
 			<TimelineAssetDropIndicator />
 			{marqueeRect === null ? null : (
 				<div

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -26,6 +26,7 @@ import {isVideoWithLastFrameHold} from '../../helpers/is-video-with-last-frame-h
 import {
 	getTimelineLayerHeight,
 	TIMELINE_LAYER_HEIGHT_AUDIO,
+	TIMELINE_PADDING,
 } from '../../helpers/timeline-layout';
 import {useMaxMediaDuration} from '../../helpers/use-max-media-duration';
 import {SetSelectedModalContext} from '../../state/modals';
@@ -39,7 +40,7 @@ import {useSelectAsset} from '../use-select-asset';
 import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {getSequenceContextMenuItems} from './get-sequence-context-menu-items';
-import {getTimelineMediaVisualizationLayout} from './get-timeline-media-visualization-layout';
+import {getTimelineSequenceVisibleLayout} from './get-timeline-sequence-visible-layout';
 import {getCurrentFrame} from './imperative-state';
 import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {getTimelineAssetLinkInfo} from './timeline-asset-link';
@@ -62,6 +63,7 @@ import {
 	useTimelineSequenceFromDrag,
 } from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineVideoInfo} from './TimelineVideoInfo';
+import {TimelineViewportContext} from './TimelineViewport';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 import {useOpenSequenceInApps} from './use-open-sequence-in-apps';
 import {getSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
@@ -92,8 +94,8 @@ const TimelineSequenceFn: React.FC<{
 const TimelineSequenceCurrentFrame: React.FC<{
 	readonly s: TSequence;
 	readonly displayDurationInFrames: number;
-	readonly premountWidth: number | null;
-	readonly postmountWidth: number | null;
+	readonly premount: {readonly left: number; readonly width: number} | null;
+	readonly postmount: {readonly left: number; readonly width: number} | null;
 	readonly style: React.CSSProperties;
 	readonly children: React.ReactNode;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
@@ -107,8 +109,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 }> = ({
 	s,
 	displayDurationInFrames,
-	premountWidth,
-	postmountWidth,
+	premount,
+	postmount,
 	style,
 	children,
 	nodePathInfo,
@@ -183,10 +185,11 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onDoubleClick={onDoubleClick}
 		>
-			{premountWidth ? (
+			{premount ? (
 				<div
 					style={{
-						width: premountWidth,
+						left: premount.left,
+						width: premount.width,
 						height: '100%',
 						background: `repeating-linear-gradient(
 								-45deg,
@@ -200,10 +203,11 @@ const TimelineSequenceCurrentFrame: React.FC<{
 				/>
 			) : null}
 
-			{postmountWidth ? (
+			{postmount ? (
 				<div
 					style={{
-						width: postmountWidth,
+						left: postmount.left,
+						width: postmount.width,
 						height: '100%',
 						background: `repeating-linear-gradient(
 								-45deg,
@@ -213,7 +217,6 @@ const TimelineSequenceCurrentFrame: React.FC<{
 								${isPostmounting ? WHITE_ALPHA_50 : WHITE_ALPHA_20} 4px
 							)`,
 						position: 'absolute',
-						right: 0,
 					}}
 				/>
 			) : null}
@@ -227,7 +230,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			(isInRange || isPremounting || isPostmounting) ? (
 				<div
 					style={{
-						paddingLeft: 5 + (premountWidth ?? 0),
+						paddingLeft: 5 + (premount?.width ?? 0),
 						height: '100%',
 						display: 'flex',
 						alignItems: 'center',
@@ -263,6 +266,7 @@ const TimelineSequenceInner: React.FC<{
 	// if that is the case, it needs to be asynchronously determined
 
 	const video = Internals.useVideo();
+	const renderWindow = useContext(TimelineViewportContext);
 
 	const maxMediaDuration = useMaxMediaDuration(s, video?.fps ?? 30);
 	const effectiveMaxMediaDuration = s.loopDisplay ? null : maxMediaDuration;
@@ -557,40 +561,46 @@ const TimelineSequenceInner: React.FC<{
 		? s.loopDisplay.durationInFrames * s.loopDisplay.numberOfTimes
 		: s.duration;
 
-	const {marginLeft, width, naturalWidth, premountWidth, postmountWidth} =
-		useMemo(() => {
-			return getTimelineSequenceLayout({
-				durationInFrames: displayDurationInFrames,
-				startFrom: s.loopDisplay ? s.from + s.loopDisplay.startOffset : s.from,
-				startFromMedia:
-					s.type === 'sequence' || s.type === 'image' ? 0 : s.startMediaFrom,
-				maxMediaDuration: effectiveMaxMediaDuration,
-				video,
-				windowWidth,
-				premountDisplay: s.premountDisplay,
-				postmountDisplay: s.postmountDisplay,
-			});
-		}, [
-			displayDurationInFrames,
-			effectiveMaxMediaDuration,
-			s,
+	const {marginLeft, width, premountWidth, postmountWidth} = useMemo(() => {
+		return getTimelineSequenceLayout({
+			durationInFrames: displayDurationInFrames,
+			startFrom: s.loopDisplay ? s.from + s.loopDisplay.startOffset : s.from,
+			startFromMedia:
+				s.type === 'sequence' || s.type === 'image' ? 0 : s.startMediaFrom,
+			maxMediaDuration: effectiveMaxMediaDuration,
 			video,
 			windowWidth,
-		]);
-	const mediaVisualizationLayout = useMemo(() => {
-		return getTimelineMediaVisualizationLayout({
-			visualizationWidth: width,
+			premountDisplay: s.premountDisplay,
+			postmountDisplay: s.postmountDisplay,
+		});
+	}, [
+		displayDurationInFrames,
+		effectiveMaxMediaDuration,
+		s,
+		video,
+		windowWidth,
+	]);
+	const visibleLayout = useMemo(() => {
+		if (renderWindow === null) {
+			return null;
+		}
+
+		return getTimelineSequenceVisibleLayout({
+			marginLeft,
+			width,
 			premountWidth: premountWidth ?? 0,
 			postmountWidth: postmountWidth ?? 0,
+			renderWindowLeft: renderWindow.left - TIMELINE_PADDING,
+			renderWindowWidth: renderWindow.width,
 		});
-	}, [postmountWidth, premountWidth, width]);
+	}, [marginLeft, postmountWidth, premountWidth, renderWindow, width]);
 	const mediaVisualizationStyle = useMemo((): React.CSSProperties => {
 		return {
-			width: mediaVisualizationLayout.width,
-			marginLeft: mediaVisualizationLayout.marginLeft,
+			width: visibleLayout?.media?.width ?? 0,
+			marginLeft: visibleLayout?.media?.left ?? 0,
 			height: '100%',
 		};
-	}, [mediaVisualizationLayout]);
+	}, [visibleLayout]);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -603,15 +613,24 @@ const TimelineSequenceInner: React.FC<{
 							? TIMELINE_IMAGE_GRADIENT
 							: BLUE,
 			border: `${SEQUENCE_BORDER_WIDTH}px solid ${WHITE_ALPHA_20}`,
-			borderRadius: 2,
+			borderLeftColor: visibleLayout?.leftEdgeVisible
+				? WHITE_ALPHA_20
+				: TRANSPARENT,
+			borderRightColor: visibleLayout?.rightEdgeVisible
+				? WHITE_ALPHA_20
+				: TRANSPARENT,
+			borderTopLeftRadius: visibleLayout?.leftEdgeVisible ? 2 : 0,
+			borderBottomLeftRadius: visibleLayout?.leftEdgeVisible ? 2 : 0,
+			borderTopRightRadius: visibleLayout?.rightEdgeVisible ? 2 : 0,
+			borderBottomRightRadius: visibleLayout?.rightEdgeVisible ? 2 : 0,
 			position: 'absolute',
 			height: getTimelineLayerHeight(s.type),
-			marginLeft,
-			width,
+			marginLeft: visibleLayout?.marginLeft ?? 0,
+			width: visibleLayout?.width ?? 0,
 			color: WHITE,
 			overflow: 'hidden',
 		};
-	}, [marginLeft, s.type, width]);
+	}, [s.type, visibleLayout]);
 
 	const showRightEdgeDragHandle =
 		isTimelineSequenceDurationDraggable(s) &&
@@ -626,16 +645,25 @@ const TimelineSequenceInner: React.FC<{
 		durationCanUpdate &&
 		trimBeforeCanUpdate;
 
-	if (maxMediaDuration === null && !s.loopDisplay) {
+	if ((maxMediaDuration === null && !s.loopDisplay) || visibleLayout === null) {
 		return null;
 	}
+
+	const frameIncrement =
+		(windowWidth - TIMELINE_PADDING * 2) / video.durationInFrames;
+	const mediaDisplayOffsetInFrames = visibleLayout.media
+		? visibleLayout.media.offset / frameIncrement
+		: 0;
+	const mediaDisplayDurationInFrames = visibleLayout.media
+		? visibleLayout.media.width / frameIncrement
+		: 0;
 
 	const sequence = (
 		<TimelineSequenceCurrentFrame
 			s={s}
 			displayDurationInFrames={displayDurationInFrames}
-			premountWidth={premountWidth}
-			postmountWidth={postmountWidth}
+			premount={visibleLayout.premount}
+			postmount={visibleLayout.postmount}
 			style={style}
 			nodePathInfo={nodePathInfo}
 			sequenceFrameOffset={sequenceFrameOffset}
@@ -646,59 +674,72 @@ const TimelineSequenceInner: React.FC<{
 				canHandleSequenceDoubleClick ? onSequenceDoubleClick : undefined
 			}
 		>
-			{s.type === 'audio' ? (
+			{s.type === 'audio' && visibleLayout.media ? (
 				<div style={mediaVisualizationStyle}>
 					<AudioWaveform
 						src={s.src}
 						height={TIMELINE_LAYER_HEIGHT_AUDIO}
 						doesVolumeChange={s.doesVolumeChange}
-						visualizationWidth={mediaVisualizationLayout.width}
+						visualizationWidth={visibleLayout.media.width}
 						startFrom={s.startMediaFrom}
 						durationInFrames={s.duration}
+						displayOffsetInFrames={mediaDisplayOffsetInFrames}
+						displayDurationInFrames={mediaDisplayDurationInFrames}
 						volume={s.volume}
 						playbackRate={s.playbackRate}
 						loopDisplay={s.loopDisplay}
 					/>
 				</div>
 			) : null}
-			{s.type === 'video' ? (
+			{s.type === 'video' && visibleLayout.media ? (
 				<TimelineVideoInfo
 					src={s.src}
-					visualizationWidth={width}
-					naturalWidth={naturalWidth}
+					visualizationWidth={visibleLayout.media.width}
+					displayOffsetInFrames={mediaDisplayOffsetInFrames}
+					displayDurationInFrames={mediaDisplayDurationInFrames}
 					startMediaFrom={s.startMediaFrom}
 					mediaFrameAtSequenceZero={s.mediaFrameAtSequenceZero}
 					sequenceFrameOffset={sequenceFrameOffset}
-					durationInFrames={s.duration}
 					playbackRate={s.playbackRate}
 					volume={s.volume}
 					doesVolumeChange={s.doesVolumeChange}
-					premountWidth={premountWidth ?? 0}
-					postmountWidth={postmountWidth ?? 0}
+					marginLeft={visibleLayout.media.left}
 					loopDisplay={s.loopDisplay}
 					frozenMediaFrame={s.frozenMediaFrame}
 					extendLastFrame={extendVideoLastFrame}
 				/>
 			) : null}
-			{s.type === 'image' ? (
+			{s.type === 'image' && visibleLayout.media ? (
 				<div style={mediaVisualizationStyle}>
 					<TimelineImageInfo
 						src={s.src}
-						visualizationWidth={mediaVisualizationLayout.width}
+						visualizationWidth={visibleLayout.media.width}
+						offsetInPixels={visibleLayout.media.offset}
 					/>
 				</div>
 			) : null}
 			{s.loopDisplay === undefined ? null : (
-				<LoopedTimelineIndicator loops={s.loopDisplay.numberOfTimes} />
+				<LoopedTimelineIndicator
+					loops={s.loopDisplay.numberOfTimes}
+					fullWidth={width}
+					visibleOffset={visibleLayout.cropLeft}
+					visibleWidth={visibleLayout.width}
+				/>
 			)}
-			{showLeftEdgeDragHandle && nodePathInfo && validatedLocation ? (
+			{showLeftEdgeDragHandle &&
+			visibleLayout.leftEdgeVisible &&
+			nodePathInfo &&
+			validatedLocation ? (
 				<TimelineSequenceLeftEdgeDragHandle
 					nodePathInfo={nodePathInfo}
 					windowWidth={windowWidth}
 					timelineDurationInFrames={video.durationInFrames ?? 1}
 				/>
 			) : null}
-			{showRightEdgeDragHandle && nodePathInfo && validatedLocation ? (
+			{showRightEdgeDragHandle &&
+			visibleLayout.rightEdgeVisible &&
+			nodePathInfo &&
+			validatedLocation ? (
 				<TimelineSequenceRightEdgeDragHandle
 					nodePathInfo={nodePathInfo}
 					windowWidth={windowWidth}

--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -307,7 +307,7 @@ const TimelineVideoInfoSegment: React.FC<{
 			});
 			repeatTarget();
 			const unfilled = Array.from(filledSlots.keys()).filter(
-				(timestamp) => !filledSlots.get(timestamp),
+				(timestamp) => filledSlots.get(timestamp) === undefined,
 			);
 
 			// Don't extract frames if all slots are filled
@@ -336,10 +336,21 @@ const TimelineVideoInfoSegment: React.FC<{
 					aspectRatio: aspectRatio.current,
 					frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
 				});
+				fillWithCachedFrames({
+					ctx: targetCtx,
+					naturalWidth: targetWidth,
+					filledSlots,
+					src,
+					segmentDuration: toSeconds - fromSeconds,
+					fromSeconds,
+					devicePixelRatio: window.devicePixelRatio,
+					frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+				});
+				repeatTarget();
 
-				return Array.from(filledSlots.keys()).map(
-					(timestamp) => timestamp / WEBCODECS_TIMESCALE,
-				);
+				return Array.from(filledSlots.keys())
+					.filter((timestamp) => filledSlots.get(timestamp) === undefined)
+					.map((timestamp) => timestamp / WEBCODECS_TIMESCALE);
 			},
 			src,
 			onVideoSample: (sample) => {
@@ -496,6 +507,7 @@ const getVisibleSegments = ({
 	if (!loopDisplay || loopDisplay.numberOfTimes <= 1) {
 		return [
 			{
+				key: 'single',
 				displayOffsetInFrames,
 				durationInFrames: displayDurationInFrames,
 				sourceOffsetInFrames: displayOffsetInFrames,
@@ -504,6 +516,7 @@ const getVisibleSegments = ({
 	}
 
 	const segments: {
+		key: string;
 		displayOffsetInFrames: number;
 		durationInFrames: number;
 		sourceOffsetInFrames: number;
@@ -524,6 +537,7 @@ const getVisibleSegments = ({
 		}
 
 		segments.push({
+			key: `loop-${Math.floor(absoluteOffset / loopDisplay.durationInFrames)}`,
 			displayOffsetInFrames: absoluteOffset,
 			durationInFrames,
 			sourceOffsetInFrames,
@@ -573,13 +587,40 @@ const TimelineVideoInfoInner: React.FC<{
 		loopDisplay !== undefined &&
 		loopWidth !== null &&
 		loopWidth <= visualizationWidth;
-	const segments = shouldTileLoop
-		? []
-		: getVisibleSegments({
-				displayDurationInFrames,
-				displayOffsetInFrames,
-				loopDisplay,
-			});
+	const tiledLoop = useMemo(() => {
+		if (!shouldTileLoop || !loopDisplay || loopWidth === null) {
+			return null;
+		}
+
+		return {
+			displayDurationInFrames,
+			displayOffsetInFrames,
+			loopDisplay,
+			loopWidth,
+		};
+	}, [
+		displayDurationInFrames,
+		displayOffsetInFrames,
+		loopDisplay,
+		loopWidth,
+		shouldTileLoop,
+	]);
+	const segments = useMemo(() => {
+		if (shouldTileLoop) {
+			return [];
+		}
+
+		return getVisibleSegments({
+			displayDurationInFrames,
+			displayOffsetInFrames,
+			loopDisplay,
+		});
+	}, [
+		displayDurationInFrames,
+		displayOffsetInFrames,
+		loopDisplay,
+		shouldTileLoop,
+	]);
 	const getSegmentVolume = (
 		segmentDisplayOffsetInFrames: number,
 		segmentDurationInFrames: number,
@@ -602,21 +643,16 @@ const TimelineVideoInfoInner: React.FC<{
 
 	return (
 		<div style={{display: 'flex', marginLeft, height: '100%'}}>
-			{shouldTileLoop ? (
+			{tiledLoop ? (
 				<TimelineVideoInfoSegment
 					src={src}
 					visualizationWidth={visualizationWidth}
 					startMediaFrom={startMediaFrom}
 					mediaFrameAtSequenceZero={mediaFrameAtSequenceZero}
 					sequenceFrameOffset={sequenceFrameOffset}
-					durationInFrames={loopDisplay.durationInFrames}
+					durationInFrames={tiledLoop.loopDisplay.durationInFrames}
 					sourceOffsetInFrames={0}
-					tiledLoop={{
-						displayDurationInFrames,
-						displayOffsetInFrames,
-						loopDisplay,
-						loopWidth,
-					}}
+					tiledLoop={tiledLoop}
 					playbackRate={playbackRate}
 					volume={volume}
 					doesVolumeChange={doesVolumeChange}
@@ -626,7 +662,7 @@ const TimelineVideoInfoInner: React.FC<{
 			) : (
 				segments.map((segment) => (
 					<TimelineVideoInfoSegment
-						key={segment.displayOffsetInFrames}
+						key={segment.key}
 						src={src}
 						visualizationWidth={segment.durationInFrames * pixelsPerFrame}
 						startMediaFrom={startMediaFrom}

--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -8,11 +8,9 @@ import {
 	frameDatabase,
 	getAspectRatioFromCache,
 	getFrameDatabaseKeyPrefix,
-	getLoopDisplayWidth,
 	getTimestampFromFrameDatabaseKey,
 	makeFrameDatabaseKey,
 	resizeVideoFrame,
-	shouldTileLoopDisplay,
 	WEBCODECS_TIMESCALE,
 } from '@remotion/timeline-utils';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
@@ -25,7 +23,6 @@ import {
 } from '../../helpers/timeline-layout';
 import {AudioWaveform} from '../AudioWaveform';
 import {getTimelineMediaStartFrame} from './get-timeline-media-start-frame';
-import {getTimelineVideoInfoWidths} from './get-timeline-video-info-widths';
 import {getTimelineVideoFilmstripTimes} from './timeline-video-filmstrip-times';
 
 const outerStyle: React.CSSProperties = {
@@ -46,36 +43,37 @@ const filmstripContainerStyle: React.CSSProperties = {
 
 const MAX_FROZEN_FRAME_CACHE_DEVIATION = WEBCODECS_TIMESCALE * 0.05;
 
-const TimelineVideoInfoInner: React.FC<{
+const TimelineVideoInfoSegment: React.FC<{
 	readonly src: string;
 	readonly visualizationWidth: number;
-	readonly naturalWidth: number;
 	readonly startMediaFrom: number;
 	readonly mediaFrameAtSequenceZero: number | null;
 	readonly sequenceFrameOffset: number;
 	readonly durationInFrames: number;
+	readonly sourceOffsetInFrames: number;
+	readonly tiledLoop: {
+		readonly displayDurationInFrames: number;
+		readonly displayOffsetInFrames: number;
+		readonly loopDisplay: LoopDisplay;
+		readonly loopWidth: number;
+	} | null;
 	readonly playbackRate: number;
 	readonly volume: string | number;
 	readonly doesVolumeChange: boolean;
-	readonly premountWidth: number;
-	readonly postmountWidth: number;
-	readonly loopDisplay: LoopDisplay | undefined;
 	readonly frozenMediaFrame: number | null;
 	readonly extendLastFrame: boolean;
 }> = ({
 	src,
 	visualizationWidth,
-	naturalWidth,
 	startMediaFrom,
 	mediaFrameAtSequenceZero,
 	sequenceFrameOffset,
 	durationInFrames,
+	sourceOffsetInFrames,
+	tiledLoop,
 	playbackRate,
 	volume,
 	doesVolumeChange,
-	premountWidth,
-	postmountWidth,
-	loopDisplay,
 	frozenMediaFrame,
 	extendLastFrame,
 }) => {
@@ -83,20 +81,14 @@ const TimelineVideoInfoInner: React.FC<{
 	const ref = useRef<HTMLDivElement>(null);
 	const [error, setError] = useState<Error | null>(null);
 	const aspectRatio = useRef<number | null>(getAspectRatioFromCache(src));
-	const mediaStartFrame = getTimelineMediaStartFrame({
-		startMediaFrom,
-		mediaFrameAtSequenceZero,
-		sequenceFrameOffset,
-		playbackRate,
-	});
-	const {mediaVisualizationWidth, mediaNaturalWidth} = useMemo(() => {
-		return getTimelineVideoInfoWidths({
-			visualizationWidth,
-			naturalWidth,
-			premountWidth,
-			postmountWidth,
-		});
-	}, [naturalWidth, postmountWidth, premountWidth, visualizationWidth]);
+	const mediaStartFrame =
+		getTimelineMediaStartFrame({
+			startMediaFrom,
+			mediaFrameAtSequenceZero,
+			sequenceFrameOffset,
+			playbackRate,
+		}) +
+		sourceOffsetInFrames * playbackRate;
 
 	// for rendering frames
 	useEffect(() => {
@@ -112,7 +104,7 @@ const TimelineVideoInfoInner: React.FC<{
 		const controller = new AbortController();
 
 		const canvas = document.createElement('canvas');
-		canvas.width = mediaVisualizationWidth;
+		canvas.width = visualizationWidth;
 		canvas.height = TIMELINE_LAYER_FILMSTRIP_HEIGHT;
 		const ctx = canvas.getContext('2d');
 		if (!ctx) {
@@ -172,7 +164,7 @@ const TimelineVideoInfoInner: React.FC<{
 			durationInFrames,
 			playbackRate,
 			fps,
-			loopDisplay,
+			loopDisplay: undefined,
 			frozenMediaFrame,
 		});
 
@@ -248,26 +240,24 @@ const TimelineVideoInfoInner: React.FC<{
 			};
 		}
 
-		const loopWidth = getLoopDisplayWidth({
-			visualizationWidth: mediaNaturalWidth,
-			loopDisplay,
-		});
-		const shouldRepeatVideo = shouldTileLoopDisplay(loopDisplay);
-		const targetCanvas = shouldRepeatVideo
-			? document.createElement('canvas')
-			: canvas;
-		targetCanvas.width = shouldRepeatVideo
-			? Math.max(1, Math.ceil(loopWidth))
+		const targetCanvas = tiledLoop ? document.createElement('canvas') : canvas;
+		targetCanvas.width = tiledLoop
+			? Math.max(1, Math.ceil(tiledLoop.loopWidth))
 			: canvas.width;
 		targetCanvas.height = canvas.height;
-		const targetCtx = shouldRepeatVideo ? targetCanvas.getContext('2d') : ctx;
+		const targetCtx = tiledLoop ? targetCanvas.getContext('2d') : ctx;
 		if (!targetCtx) {
 			current.removeChild(canvas);
 			return;
 		}
 
+		// desired-timestamp -> filled-timestamp
+		const filledSlots = new Map<number, number | undefined>();
+
+		const {fromSeconds, toSeconds} = times;
+		const targetWidth = tiledLoop ? targetCanvas.width : visualizationWidth;
 		const repeatTarget = () => {
-			if (!shouldRepeatVideo) {
+			if (!tiledLoop) {
 				return;
 			}
 
@@ -276,21 +266,24 @@ const TimelineVideoInfoInner: React.FC<{
 				return;
 			}
 
+			const phase =
+				(tiledLoop.displayOffsetInFrames %
+					tiledLoop.loopDisplay.durationInFrames) *
+				(tiledLoop.loopWidth / tiledLoop.loopDisplay.durationInFrames);
 			pattern.setTransform(
-				new DOMMatrix().scaleSelf(loopWidth / targetCanvas.width, 1),
+				new DOMMatrix([
+					tiledLoop.loopWidth / targetCanvas.width,
+					0,
+					0,
+					1,
+					-phase,
+					0,
+				]),
 			);
 			ctx.clearRect(0, 0, canvas.width, canvas.height);
 			ctx.fillStyle = pattern;
 			ctx.fillRect(0, 0, canvas.width, canvas.height);
 		};
-
-		// desired-timestamp -> filled-timestamp
-		const filledSlots = new Map<number, number | undefined>();
-
-		const {fromSeconds, toSeconds} = times;
-		const targetWidth = shouldRepeatVideo
-			? targetCanvas.width
-			: mediaNaturalWidth;
 
 		if (aspectRatio.current !== null) {
 			ensureSlots({
@@ -313,7 +306,6 @@ const TimelineVideoInfoInner: React.FC<{
 				frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
 			});
 			repeatTarget();
-
 			const unfilled = Array.from(filledSlots.keys()).filter(
 				(timestamp) => !filledSlots.get(timestamp),
 			);
@@ -438,34 +430,38 @@ const TimelineVideoInfoInner: React.FC<{
 		extendLastFrame,
 		fps,
 		frozenMediaFrame,
-		loopDisplay,
-		mediaNaturalWidth,
-		mediaVisualizationWidth,
 		mediaStartFrame,
 		playbackRate,
 		src,
+		tiledLoop,
+		visualizationWidth,
 	]);
 
-	const audioWidth = mediaVisualizationWidth;
+	const audioWidth = visualizationWidth;
 
 	const filmstripStyle: React.CSSProperties = useMemo(() => {
 		return {
 			...filmstripContainerStyle,
-			width: mediaVisualizationWidth,
-			marginLeft: premountWidth,
+			width: visualizationWidth,
 		};
-	}, [mediaVisualizationWidth, premountWidth]);
+	}, [visualizationWidth]);
 
 	const audioStyle: React.CSSProperties = useMemo(() => {
 		return {
 			width: audioWidth,
 			position: 'relative',
-			marginLeft: premountWidth,
 		};
-	}, [audioWidth, premountWidth]);
+	}, [audioWidth]);
+	const segmentStyle: React.CSSProperties = useMemo(() => {
+		return {
+			...outerStyle,
+			width: visualizationWidth,
+			flexShrink: 0,
+		};
+	}, [visualizationWidth]);
 
 	return (
-		<div style={outerStyle}>
+		<div style={segmentStyle}>
 			<div ref={ref} style={filmstripStyle} />
 			<div style={audioStyle}>
 				<AudioWaveform
@@ -474,12 +470,182 @@ const TimelineVideoInfoInner: React.FC<{
 					visualizationWidth={audioWidth}
 					startFrom={mediaStartFrame}
 					durationInFrames={durationInFrames}
+					displayOffsetInFrames={tiledLoop?.displayOffsetInFrames ?? 0}
+					displayDurationInFrames={
+						tiledLoop?.displayDurationInFrames ?? durationInFrames
+					}
 					volume={volume}
 					doesVolumeChange={doesVolumeChange}
 					playbackRate={playbackRate}
-					loopDisplay={loopDisplay}
+					loopDisplay={tiledLoop?.loopDisplay}
 				/>
 			</div>
+		</div>
+	);
+};
+
+const getVisibleSegments = ({
+	displayDurationInFrames,
+	displayOffsetInFrames,
+	loopDisplay,
+}: {
+	readonly displayDurationInFrames: number;
+	readonly displayOffsetInFrames: number;
+	readonly loopDisplay: LoopDisplay | undefined;
+}) => {
+	if (!loopDisplay || loopDisplay.numberOfTimes <= 1) {
+		return [
+			{
+				displayOffsetInFrames,
+				durationInFrames: displayDurationInFrames,
+				sourceOffsetInFrames: displayOffsetInFrames,
+			},
+		];
+	}
+
+	const segments: {
+		displayOffsetInFrames: number;
+		durationInFrames: number;
+		sourceOffsetInFrames: number;
+	}[] = [];
+	let processed = 0;
+	while (processed < displayDurationInFrames) {
+		const absoluteOffset = displayOffsetInFrames + processed;
+		const sourceOffsetInFrames =
+			((absoluteOffset % loopDisplay.durationInFrames) +
+				loopDisplay.durationInFrames) %
+			loopDisplay.durationInFrames;
+		const durationInFrames = Math.min(
+			displayDurationInFrames - processed,
+			loopDisplay.durationInFrames - sourceOffsetInFrames,
+		);
+		if (durationInFrames <= 0) {
+			break;
+		}
+
+		segments.push({
+			displayOffsetInFrames: absoluteOffset,
+			durationInFrames,
+			sourceOffsetInFrames,
+		});
+		processed += durationInFrames;
+	}
+
+	return segments;
+};
+
+const TimelineVideoInfoInner: React.FC<{
+	readonly src: string;
+	readonly visualizationWidth: number;
+	readonly displayOffsetInFrames: number;
+	readonly displayDurationInFrames: number;
+	readonly startMediaFrom: number;
+	readonly mediaFrameAtSequenceZero: number | null;
+	readonly sequenceFrameOffset: number;
+	readonly playbackRate: number;
+	readonly volume: string | number;
+	readonly doesVolumeChange: boolean;
+	readonly marginLeft: number;
+	readonly loopDisplay: LoopDisplay | undefined;
+	readonly frozenMediaFrame: number | null;
+	readonly extendLastFrame: boolean;
+}> = ({
+	src,
+	visualizationWidth,
+	displayOffsetInFrames,
+	displayDurationInFrames,
+	startMediaFrom,
+	mediaFrameAtSequenceZero,
+	sequenceFrameOffset,
+	playbackRate,
+	volume,
+	doesVolumeChange,
+	marginLeft,
+	loopDisplay,
+	frozenMediaFrame,
+	extendLastFrame,
+}) => {
+	const pixelsPerFrame = visualizationWidth / displayDurationInFrames;
+	const loopWidth = loopDisplay
+		? loopDisplay.durationInFrames * pixelsPerFrame
+		: null;
+	const shouldTileLoop =
+		loopDisplay !== undefined &&
+		loopWidth !== null &&
+		loopWidth <= visualizationWidth;
+	const segments = shouldTileLoop
+		? []
+		: getVisibleSegments({
+				displayDurationInFrames,
+				displayOffsetInFrames,
+				loopDisplay,
+			});
+	const getSegmentVolume = (
+		segmentDisplayOffsetInFrames: number,
+		segmentDurationInFrames: number,
+	) => {
+		if (typeof volume === 'number') {
+			return volume;
+		}
+
+		const values = volume.split(',');
+		return values
+			.slice(
+				Math.max(0, Math.floor(segmentDisplayOffsetInFrames)),
+				Math.min(
+					values.length,
+					Math.ceil(segmentDisplayOffsetInFrames + segmentDurationInFrames),
+				),
+			)
+			.join(',');
+	};
+
+	return (
+		<div style={{display: 'flex', marginLeft, height: '100%'}}>
+			{shouldTileLoop ? (
+				<TimelineVideoInfoSegment
+					src={src}
+					visualizationWidth={visualizationWidth}
+					startMediaFrom={startMediaFrom}
+					mediaFrameAtSequenceZero={mediaFrameAtSequenceZero}
+					sequenceFrameOffset={sequenceFrameOffset}
+					durationInFrames={loopDisplay.durationInFrames}
+					sourceOffsetInFrames={0}
+					tiledLoop={{
+						displayDurationInFrames,
+						displayOffsetInFrames,
+						loopDisplay,
+						loopWidth,
+					}}
+					playbackRate={playbackRate}
+					volume={volume}
+					doesVolumeChange={doesVolumeChange}
+					frozenMediaFrame={frozenMediaFrame}
+					extendLastFrame={extendLastFrame}
+				/>
+			) : (
+				segments.map((segment) => (
+					<TimelineVideoInfoSegment
+						key={segment.displayOffsetInFrames}
+						src={src}
+						visualizationWidth={segment.durationInFrames * pixelsPerFrame}
+						startMediaFrom={startMediaFrom}
+						mediaFrameAtSequenceZero={mediaFrameAtSequenceZero}
+						sequenceFrameOffset={sequenceFrameOffset}
+						durationInFrames={segment.durationInFrames}
+						sourceOffsetInFrames={segment.sourceOffsetInFrames}
+						tiledLoop={null}
+						playbackRate={playbackRate}
+						volume={getSegmentVolume(
+							segment.sourceOffsetInFrames,
+							segment.durationInFrames,
+						)}
+						doesVolumeChange={doesVolumeChange}
+						frozenMediaFrame={frozenMediaFrame}
+						extendLastFrame={extendLastFrame}
+					/>
+				))
+			)}
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineViewport.tsx
+++ b/packages/studio/src/components/Timeline/TimelineViewport.tsx
@@ -1,0 +1,83 @@
+import React, {
+	createContext,
+	useCallback,
+	useLayoutEffect,
+	useState,
+} from 'react';
+
+type TimelineRenderWindow = {
+	readonly left: number;
+	readonly width: number;
+};
+
+export const TimelineViewportContext =
+	createContext<TimelineRenderWindow | null>(null);
+
+const getRenderWindow = (scrollable: HTMLDivElement): TimelineRenderWindow => {
+	const viewportWidth = scrollable.clientWidth;
+	if (viewportWidth === 0) {
+		return {left: 0, width: 0};
+	}
+
+	const currentSection = Math.floor(scrollable.scrollLeft / viewportWidth);
+	const left = Math.max(0, (currentSection - 1) * viewportWidth);
+
+	return {
+		left,
+		width: viewportWidth * 3,
+	};
+};
+
+export const TimelineViewportProvider: React.FC<{
+	readonly children: React.ReactNode;
+	readonly scrollable: React.RefObject<HTMLDivElement | null>;
+}> = ({children, scrollable}) => {
+	const [renderWindow, setRenderWindow] = useState<TimelineRenderWindow>({
+		left: 0,
+		width: window.innerWidth * 3,
+	});
+
+	const update = useCallback(() => {
+		const element = scrollable.current;
+		if (!element) {
+			return;
+		}
+
+		const next = getRenderWindow(element);
+		setRenderWindow((previous) => {
+			if (previous.left === next.left && previous.width === next.width) {
+				return previous;
+			}
+
+			return next;
+		});
+	}, [scrollable]);
+
+	useLayoutEffect(() => {
+		let element: HTMLDivElement | null = null;
+		let resizeObserver: ResizeObserver | null = null;
+		const animationFrame = requestAnimationFrame(() => {
+			element = scrollable.current;
+			if (!element) {
+				return;
+			}
+
+			resizeObserver = new ResizeObserver(update);
+			resizeObserver.observe(element);
+			update();
+			element.addEventListener('scroll', update);
+		});
+
+		return () => {
+			cancelAnimationFrame(animationFrame);
+			resizeObserver?.disconnect();
+			element?.removeEventListener('scroll', update);
+		};
+	}, [scrollable, update]);
+
+	return (
+		<TimelineViewportContext.Provider value={renderWindow}>
+			{children}
+		</TimelineViewportContext.Provider>
+	);
+};

--- a/packages/studio/src/components/Timeline/get-timeline-sequence-visible-layout.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-sequence-visible-layout.ts
@@ -1,0 +1,101 @@
+type TimelineSequenceVisibleLayout = {
+	readonly marginLeft: number;
+	readonly width: number;
+	readonly cropLeft: number;
+	readonly leftEdgeVisible: boolean;
+	readonly rightEdgeVisible: boolean;
+	readonly premount: {readonly left: number; readonly width: number} | null;
+	readonly postmount: {readonly left: number; readonly width: number} | null;
+	readonly media: {
+		readonly left: number;
+		readonly width: number;
+		readonly offset: number;
+		readonly fullWidth: number;
+	} | null;
+};
+
+const getVisibleSection = ({
+	sectionStart,
+	sectionEnd,
+	cropStart,
+	cropEnd,
+}: {
+	readonly sectionStart: number;
+	readonly sectionEnd: number;
+	readonly cropStart: number;
+	readonly cropEnd: number;
+}) => {
+	const start = Math.max(sectionStart, cropStart);
+	const end = Math.min(sectionEnd, cropEnd);
+	if (end <= start) {
+		return null;
+	}
+
+	return {
+		left: start - cropStart,
+		width: end - start,
+	};
+};
+
+export const getTimelineSequenceVisibleLayout = ({
+	marginLeft,
+	width,
+	premountWidth,
+	postmountWidth,
+	renderWindowLeft,
+	renderWindowWidth,
+}: {
+	readonly marginLeft: number;
+	readonly width: number;
+	readonly premountWidth: number;
+	readonly postmountWidth: number;
+	readonly renderWindowLeft: number;
+	readonly renderWindowWidth: number;
+}): TimelineSequenceVisibleLayout | null => {
+	const itemStart = marginLeft;
+	const itemEnd = marginLeft + width;
+	const renderWindowEnd = renderWindowLeft + renderWindowWidth;
+	const visibleStart = Math.max(itemStart, renderWindowLeft);
+	const visibleEnd = Math.min(itemEnd, renderWindowEnd);
+	if (visibleEnd <= visibleStart) {
+		return null;
+	}
+
+	const cropStart = visibleStart - itemStart;
+	const cropEnd = visibleEnd - itemStart;
+	const mediaStart = premountWidth;
+	const mediaEnd = Math.max(mediaStart, width - postmountWidth);
+	const media = getVisibleSection({
+		sectionStart: mediaStart,
+		sectionEnd: mediaEnd,
+		cropStart,
+		cropEnd,
+	});
+
+	return {
+		marginLeft: visibleStart,
+		width: visibleEnd - visibleStart,
+		cropLeft: cropStart,
+		leftEdgeVisible: visibleStart === itemStart,
+		rightEdgeVisible: visibleEnd === itemEnd,
+		premount: getVisibleSection({
+			sectionStart: 0,
+			sectionEnd: premountWidth,
+			cropStart,
+			cropEnd,
+		}),
+		postmount: getVisibleSection({
+			sectionStart: Math.max(0, width - postmountWidth),
+			sectionEnd: width,
+			cropStart,
+			cropEnd,
+		}),
+		media: media
+			? {
+					...media,
+					offset: Math.max(0, cropStart - mediaStart),
+					fullWidth: Math.max(0, mediaEnd - mediaStart),
+				}
+			: null,
+	};
+};

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -8,7 +8,7 @@ import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-s
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
 
 export const TIMELINE_MIN_ZOOM = 1;
-export const TIMELINE_MAX_ZOOM = 100;
+export const TIMELINE_MAX_ZOOM = 5;
 
 export type TimelineSetZoomOptions = {
 	anchorFrame: number | null;

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -8,7 +8,7 @@ import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-s
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
 
 export const TIMELINE_MIN_ZOOM = 1;
-export const TIMELINE_MAX_ZOOM = 5;
+export const TIMELINE_MAX_ZOOM = 100;
 
 export type TimelineSetZoomOptions = {
 	anchorFrame: number | null;

--- a/packages/studio/src/test/timeline-sequence-visible-layout.test.ts
+++ b/packages/studio/src/test/timeline-sequence-visible-layout.test.ts
@@ -1,0 +1,89 @@
+import {expect, test} from 'bun:test';
+import {getTimelineSequenceVisibleLayout} from '../components/Timeline/get-timeline-sequence-visible-layout';
+
+test('clips a very wide sequence to the render window', () => {
+	const layout = getTimelineSequenceVisibleLayout({
+		marginLeft: 100,
+		width: 10_000,
+		premountWidth: 50,
+		postmountWidth: 75,
+		renderWindowLeft: 1_000,
+		renderWindowWidth: 600,
+	});
+
+	expect(layout).toEqual({
+		marginLeft: 1_000,
+		width: 600,
+		cropLeft: 900,
+		leftEdgeVisible: false,
+		rightEdgeVisible: false,
+		premount: null,
+		postmount: null,
+		media: {
+			left: 0,
+			width: 600,
+			offset: 850,
+			fullWidth: 9_875,
+		},
+	});
+});
+
+test('preserves the real item edges and mount regions when visible', () => {
+	const layout = getTimelineSequenceVisibleLayout({
+		marginLeft: 100,
+		width: 500,
+		premountWidth: 50,
+		postmountWidth: 75,
+		renderWindowLeft: 0,
+		renderWindowWidth: 1_000,
+	});
+
+	expect(layout).toEqual({
+		marginLeft: 100,
+		width: 500,
+		cropLeft: 0,
+		leftEdgeVisible: true,
+		rightEdgeVisible: true,
+		premount: {left: 0, width: 50},
+		postmount: {left: 425, width: 75},
+		media: {
+			left: 50,
+			width: 375,
+			offset: 0,
+			fullWidth: 375,
+		},
+	});
+});
+
+test('preserves a real edge when floating-point subtraction changes the width', () => {
+	const marginLeft = 3.256666666666667;
+	const width = 5.513333333333334;
+
+	// Recomputing the width from the endpoints loses a fraction here.
+	expect(marginLeft + width - marginLeft).not.toBe(width);
+
+	const layout = getTimelineSequenceVisibleLayout({
+		marginLeft,
+		width,
+		premountWidth: 0,
+		postmountWidth: 0,
+		renderWindowLeft: 0,
+		renderWindowWidth: 100,
+	});
+
+	expect(layout?.leftEdgeVisible).toBe(true);
+	expect(layout?.rightEdgeVisible).toBe(true);
+});
+
+test('does not render a sequence outside the render window', () => {
+	expect(
+		getTimelineSequenceVisibleLayout({
+			marginLeft: 2_000,
+			width: 500,
+			premountWidth: 0,
+			postmountWidth: 0,
+			renderWindowLeft: 0,
+			renderWindowWidth: 1_000,
+		}),
+	).toBeNull();
+});

--- a/packages/timeline-utils/src/audio-waveform-worker.ts
+++ b/packages/timeline-utils/src/audio-waveform-worker.ts
@@ -7,8 +7,7 @@ import type {
 } from './audio-waveform/audio-waveform-worker-types';
 import {drawBars} from './audio-waveform/draw-peaks';
 import {loadWaveformPeaks} from './audio-waveform/load-waveform-peaks';
-import {sliceWaveformPeaks} from './audio-waveform/slice-waveform-peaks';
-import {getLoopDisplayWidth, shouldTileLoopDisplay} from './loop-display';
+import {sliceVisibleWaveformPeaks} from './audio-waveform/slice-visible-waveform-peaks';
 
 declare const self: DedicatedWorkerGlobalScope;
 
@@ -36,59 +35,24 @@ const drawPartialWaveform = (
 		return;
 	}
 
-	const portionPeaks = sliceWaveformPeaks({
-		durationInFrames: shouldTileLoopDisplay(message.loopDisplay)
-			? message.loopDisplay.durationInFrames
-			: message.durationInFrames,
+	const portionPeaks = sliceVisibleWaveformPeaks({
+		displayDurationInFrames: message.displayDurationInFrames,
+		displayOffsetInFrames: message.displayOffsetInFrames,
+		durationInFrames: message.durationInFrames,
 		fps: message.fps,
+		loopDisplay: message.loopDisplay,
 		peaks,
 		playbackRate: message.playbackRate,
 		startFrom: message.startFrom,
 	});
 
-	if (!shouldTileLoopDisplay(message.loopDisplay)) {
-		drawBars({
-			canvas,
-			peaks: portionPeaks,
-			color: 'rgba(255, 255, 255, 0.6)',
-			volume: message.volume,
-			width: message.width,
-		});
-		return;
-	}
-
-	const loopWidth = getLoopDisplayWidth({
-		visualizationWidth: message.width,
-		loopDisplay: message.loopDisplay,
-	});
-	const targetCanvas = new OffscreenCanvas(
-		Math.max(1, Math.ceil(loopWidth)),
-		message.height,
-	);
 	drawBars({
-		canvas: targetCanvas,
+		canvas,
 		peaks: portionPeaks,
 		color: 'rgba(255, 255, 255, 0.6)',
 		volume: message.volume,
-		width: targetCanvas.width,
+		width: message.width,
 	});
-
-	const ctx = canvas.getContext('2d');
-	if (!ctx) {
-		throw new Error('Failed to get canvas context');
-	}
-
-	const pattern = ctx.createPattern(targetCanvas, 'repeat-x');
-	if (!pattern) {
-		return;
-	}
-
-	pattern.setTransform(
-		new DOMMatrix().scaleSelf(loopWidth / targetCanvas.width, 1),
-	);
-	ctx.clearRect(0, 0, message.width, message.height);
-	ctx.fillStyle = pattern;
-	ctx.fillRect(0, 0, message.width, message.height);
 };
 
 const renderWaveform = async (message: AudioWaveformWorkerRenderMessage) => {

--- a/packages/timeline-utils/src/audio-waveform/audio-waveform-worker-types.ts
+++ b/packages/timeline-utils/src/audio-waveform/audio-waveform-worker-types.ts
@@ -15,6 +15,8 @@ export type AudioWaveformWorkerRenderMessage = {
 	readonly volume: WaveformVolume;
 	readonly startFrom: number;
 	readonly durationInFrames: number;
+	readonly displayOffsetInFrames: number;
+	readonly displayDurationInFrames: number;
 	readonly fps: number;
 	readonly playbackRate: number;
 	readonly loopDisplay: TimelineLoopDisplay | undefined;

--- a/packages/timeline-utils/src/audio-waveform/slice-visible-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/slice-visible-waveform-peaks.ts
@@ -1,0 +1,78 @@
+import type {TimelineLoopDisplay} from '../loop-display';
+import {shouldTileLoopDisplay} from '../loop-display';
+import {sliceWaveformPeaks} from './slice-waveform-peaks';
+
+export const sliceVisibleWaveformPeaks = ({
+	displayDurationInFrames,
+	displayOffsetInFrames,
+	durationInFrames,
+	fps,
+	loopDisplay,
+	peaks,
+	playbackRate,
+	startFrom,
+}: {
+	readonly displayDurationInFrames: number;
+	readonly displayOffsetInFrames: number;
+	readonly durationInFrames: number;
+	readonly fps: number;
+	readonly loopDisplay: TimelineLoopDisplay | undefined;
+	readonly peaks: Float32Array;
+	readonly playbackRate: number;
+	readonly startFrom: number;
+}) => {
+	if (!shouldTileLoopDisplay(loopDisplay)) {
+		return sliceWaveformPeaks({
+			durationInFrames: Math.min(
+				displayDurationInFrames,
+				Math.max(0, durationInFrames - displayOffsetInFrames),
+			),
+			fps,
+			peaks,
+			playbackRate,
+			startFrom: startFrom + displayOffsetInFrames * playbackRate,
+		});
+	}
+
+	const parts: Float32Array[] = [];
+	let processed = 0;
+	let totalLength = 0;
+	while (processed < displayDurationInFrames) {
+		const absoluteOffset = displayOffsetInFrames + processed;
+		const loopOffset =
+			((absoluteOffset % loopDisplay.durationInFrames) +
+				loopDisplay.durationInFrames) %
+			loopDisplay.durationInFrames;
+		const segmentDuration = Math.min(
+			displayDurationInFrames - processed,
+			loopDisplay.durationInFrames - loopOffset,
+		);
+		if (segmentDuration <= 0) {
+			break;
+		}
+
+		const part = sliceWaveformPeaks({
+			durationInFrames: segmentDuration,
+			fps,
+			peaks,
+			playbackRate,
+			startFrom: startFrom + loopOffset * playbackRate,
+		});
+		parts.push(part);
+		totalLength += part.length;
+		processed += segmentDuration;
+	}
+
+	if (parts.length === 1) {
+		return parts[0];
+	}
+
+	const result = new Float32Array(totalLength);
+	let writeOffset = 0;
+	for (const part of parts) {
+		result.set(part, writeOffset);
+		writeOffset += part.length;
+	}
+
+	return result;
+};

--- a/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
+++ b/packages/timeline-utils/src/image-thumbnail/draw-repeating-image-thumbnail.ts
@@ -23,9 +23,11 @@ const createOffscreenCanvas = (width: number, height: number) => {
 export const drawRepeatingImageThumbnail = ({
 	canvas,
 	image,
+	offsetInPixels = 0,
 }: {
 	readonly canvas: HTMLCanvasElement | OffscreenCanvas;
 	readonly image: ImageWithNaturalDimensions;
+	readonly offsetInPixels?: number;
 }) => {
 	const ctx = canvas.getContext('2d');
 
@@ -64,6 +66,7 @@ export const drawRepeatingImageThumbnail = ({
 		return;
 	}
 
+	pattern.setTransform(new DOMMatrix().translate(-offsetInPixels, 0));
 	ctx.fillStyle = pattern;
 	ctx.fillRect(0, 0, width, height);
 };

--- a/packages/timeline-utils/src/index.ts
+++ b/packages/timeline-utils/src/index.ts
@@ -8,6 +8,7 @@ export {drawBars, type WaveformVolume} from './audio-waveform/draw-peaks';
 export {loadWaveformPeaks} from './audio-waveform/load-waveform-peaks';
 export {makeAudioWaveformWorker} from './audio-waveform/make-audio-waveform-worker';
 export {sliceWaveformPeaks} from './audio-waveform/slice-waveform-peaks';
+export {sliceVisibleWaveformPeaks} from './audio-waveform/slice-visible-waveform-peaks';
 export {
 	createWaveformPeakProcessor,
 	emitWaveformProgress,

--- a/packages/timeline-utils/src/test/slice-visible-waveform-peaks.test.ts
+++ b/packages/timeline-utils/src/test/slice-visible-waveform-peaks.test.ts
@@ -1,0 +1,43 @@
+import {expect, test} from 'bun:test';
+import {sliceVisibleWaveformPeaks} from '../audio-waveform/slice-visible-waveform-peaks';
+
+test('slices only the visible part of a waveform', () => {
+	const peaks = Float32Array.from({length: 300}, (_, index) => index);
+	const visible = sliceVisibleWaveformPeaks({
+		displayDurationInFrames: 10,
+		displayOffsetInFrames: 10,
+		durationInFrames: 30,
+		fps: 10,
+		loopDisplay: undefined,
+		peaks,
+		playbackRate: 1,
+		startFrom: 0,
+	});
+
+	expect(Array.from(visible)).toEqual(
+		Array.from({length: 100}, (_, index) => index + 100),
+	);
+});
+
+test('joins waveform portions across a loop boundary', () => {
+	const peaks = Float32Array.from({length: 100}, (_, index) => index);
+	const visible = sliceVisibleWaveformPeaks({
+		displayDurationInFrames: 5,
+		displayOffsetInFrames: 8,
+		durationInFrames: 10,
+		fps: 10,
+		loopDisplay: {
+			durationInFrames: 10,
+			numberOfTimes: 3,
+			startOffset: 0,
+		},
+		peaks,
+		playbackRate: 1,
+		startFrom: 0,
+	});
+
+	expect(Array.from(visible)).toEqual([
+		...Array.from({length: 20}, (_, index) => index + 80),
+		...Array.from({length: 30}, (_, index) => index),
+	]);
+});


### PR DESCRIPTION
## Summary

- bound wide timeline sequence elements to a viewport-sized render window while preserving their logical timeline positions and trim handles
- render only visible video filmstrip, image thumbnail, audio waveform, loop, premount, and postmount portions
- keep trim edges and loop indicators stable under high-zoom floating-point geometry
- preserve timeline media caches while scrolling between virtual render windows
- track increasing the current 5× zoom limit separately in #10566

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/timeline-video-info.test.ts packages/studio/src/test/timeline-sequence-visible-layout.test.ts packages/timeline-utils/src/test/slice-visible-waveform-peaks.test.ts`
- `bunx turbo run make lint --filter='@remotion/studio'`
- manually verified trimming and loop indicators at 1× and 5× zoom in Remotion Studio
- verified through browser network events that scrolling across virtual windows and back does not refetch cached media or recreate the audio worker
