### PR TITLE
remotion.dev/convert: Handle probe cleanup

### DIFF
--- a/packages/convert/app/components/use-probe.ts
+++ b/packages/convert/app/components/use-probe.ts
@@ -21,9 +21,9 @@ export const useProbe = ({src}: {src: Source}) => {
 	const [audioCodec, setAudioCodec] = useState<
 		InputAudioTrack['codec'] | null | undefined
 	>(undefined);
-	const [frameRate, setFrameRate] = useState<
-		VideoFrameRate | null | undefined
-	>(undefined);
+	const [frameRate, setFrameRate] = useState<VideoFrameRate | null | undefined>(
+		undefined,
+	);
 	const [isHdr, setHdr] = useState<boolean | undefined>(undefined);
 	const [durationInSeconds, setDurationInSeconds] = useState<
 		number | null | undefined
@@ -56,81 +56,95 @@ export const useProbe = ({src}: {src: Source}) => {
 	}, [src]);
 
 	const getStart = useCallback(() => {
+		let isDisposed = false;
+
 		const run = async () => {
-			input.getFormat().then((format) => setContainer(format));
-			input.source.getSize().then((s) => setSize(s));
-			getVideoFrameRate(input).then(setFrameRate);
-			getDurationOrCompute(input).then((duration) =>
-				setDurationInSeconds(duration),
-			);
-			input.getMetadataTags().then((tags) => setMetadata(tags));
+			await Promise.all([
+				input.getFormat().then((format) => setContainer(format)),
+				input.source.getSize().then((s) => setSize(s)),
+				getVideoFrameRate(input).then(setFrameRate),
+				getDurationOrCompute(input).then((duration) =>
+					setDurationInSeconds(duration),
+				),
+				input.getMetadataTags().then((tags) => setMetadata(tags)),
+				(async () => {
+					const trx = await input.getTracks();
+					for (const track of trx) {
+						if (await track.isLive()) {
+							throw new Error(
+								'Live streams are not currently supported by Remotion. Sorry!',
+							);
+						}
 
-			const trx = await input.getTracks();
-			for (const track of trx) {
-				if (await track.isLive()) {
-					throw new Error(
-						'Live streams are not currently supported by Remotion. Sorry!',
-					);
-				}
+						if (await track.isRelativeToUnixEpoch()) {
+							throw new Error(
+								'Streams with UNIX timestamps are not currently supported by Remotion. Sorry!',
+							);
+						}
+					}
 
-				if (await track.isRelativeToUnixEpoch()) {
-					throw new Error(
-						'Streams with UNIX timestamps are not currently supported by Remotion. Sorry!',
-					);
-				}
-			}
+					let hasAudioTrack = false;
+					let hasVideoTrack = false;
+					for (const track of trx) {
+						if (track.isVideoTrack()) {
+							hasVideoTrack = true;
+							const codec = await track.getCodec();
+							setVideoCodec(codec);
+							const [displayWidth, displayHeight, trackRotation, hdr] =
+								await Promise.all([
+									track.getDisplayWidth(),
+									track.getDisplayHeight(),
+									track.getRotation(),
+									track.hasHighDynamicRange(),
+								]);
+							setDimensions({
+								width: displayWidth,
+								height: displayHeight,
+							});
+							setRotation(trackRotation);
+							setHdr(hdr);
+						} else if (track.isAudioTrack()) {
+							hasAudioTrack = true;
+							const [codec, sr] = await Promise.all([
+								track.getCodec(),
+								track.getSampleRate(),
+							]);
+							setAudioCodec(codec);
+							setSampleRate(sr);
+						}
+					}
 
-			let hasAudioTrack = false;
-			let hasVideoTrack = false;
-			for (const track of trx) {
-				if (track.isVideoTrack()) {
-					hasVideoTrack = true;
-					const codec = await track.getCodec();
-					setVideoCodec(codec);
-					const [displayWidth, displayHeight, trackRotation] =
-						await Promise.all([
-							track.getDisplayWidth(),
-							track.getDisplayHeight(),
-							track.getRotation(),
-						]);
-					setDimensions({
-						width: displayWidth,
-						height: displayHeight,
-					});
-					setRotation(trackRotation);
-					track.hasHighDynamicRange().then((hdr) => setHdr(hdr));
-				} else if (track.isAudioTrack()) {
-					hasAudioTrack = true;
-					const codec = await track.getCodec();
-					setAudioCodec(codec);
-					track.getSampleRate().then((sr) => setSampleRate(sr));
-				}
-			}
+					setTracks(trx);
 
-			setTracks(trx);
+					if (!hasAudioTrack) {
+						setAudioCodec(null);
+						setSampleRate(null);
+					}
 
-			if (!hasAudioTrack) {
-				setAudioCodec(null);
-				setSampleRate(null);
-			}
-
-			if (!hasVideoTrack) {
-				setVideoCodec(null);
-				setFrameRate(null);
-				setDimensions(null);
-				setHdr(false);
-			}
+					if (!hasVideoTrack) {
+						setVideoCodec(null);
+						setFrameRate(null);
+						setDimensions(null);
+						setHdr(false);
+					}
+				})(),
+			]);
 		};
 
 		run()
 			.then(() => {
-				setDone(true);
+				if (!isDisposed) {
+					setDone(true);
+				}
 			})
 			.catch((e) => {
-				setError(e);
+				if (!isDisposed) {
+					setError(e);
+				}
 			});
 
 		return () => {
+			isDisposed = true;
 			input.dispose();
 		};
 	}, [input]);

--- a/packages/convert/test/frame-rate.test.tsx
+++ b/packages/convert/test/frame-rate.test.tsx
@@ -45,3 +45,15 @@ test('probes constant and variable frame rates for the player and metadata', asy
 	render(<FrameRateProbe file={constantFile} />);
 	expect(await screen.findByText('30.00 FPS')).toBeTruthy();
 });
+
+test('can unmount while probing a file', async () => {
+	const variableFile = await loadFixture(
+		'../example-videos/videos/variable-fps.webm',
+	);
+	const pendingProbe = render(<FrameRateProbe file={variableFile} />);
+	pendingProbe.unmount();
+
+	const constantFile = await loadFixture('../example/public/framer.webm');
+	render(<FrameRateProbe file={constantFile} />);
+	expect(await screen.findByText('30.00 FPS')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

- keep every asynchronous Mediabunny probe operation in the lifecycle-owned promise chain
- ignore terminal probe state updates after the input has been disposed
- cover immediate unmounting during a real file probe and verify a subsequent probe still completes

## Test plan

- `bun test test` in `packages/convert`
- `bun run build`
- `bun run stylecheck`

Red/green verified against the `InputDisposedError` failure from the Windows CI job.
