### PR TITLE
Elements: use a consistent responsive 16:9 Player for Element gallery previews

### DIFF
--- a/packages/docs/elements-template/index.mdx
+++ b/packages/docs/elements-template/index.mdx
@@ -24,7 +24,7 @@ export const elementDefinition = {
     posterUrl: '/elements/category-element-title-preview.png',
     videoUrl: '/elements/category-element-title-preview.mp4',
   },
-  previewPadding: 0,
+  safeArea: 0,
   slug: 'category/element-title',
   installationMode: 'wrapped',
   width: 1920,

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -107,8 +107,6 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 						component={PreviewComponent}
 						durationInFrames={durationInFrames}
 						fps={fps}
-						height={previewHeight}
-						width={previewWidth}
 					/>
 					{children ? (
 						<div className={styles.sourceArea}>

--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -5,18 +5,15 @@ type ElementPreviewProps = {
 	readonly component: ComponentType<Record<string, never>>;
 	readonly durationInFrames: number;
 	readonly fps: number;
-	readonly width: number;
-	readonly height: number;
 };
 
-const maxPreviewHeight = 560;
+const previewWidth = 1920;
+const previewHeight = 1080;
 
 export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	component,
 	durationInFrames,
 	fps,
-	width,
-	height,
 }) => {
 	const [checkerboard, setCheckerboard] = useState(true);
 	const transparencyLabel = checkerboard
@@ -32,8 +29,7 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 		>
 			<div
 				style={{
-					aspectRatio: `${width} / ${height}`,
-					maxHeight: maxPreviewHeight,
+					aspectRatio: `${previewWidth} / ${previewHeight}`,
 					width: '100%',
 				}}
 			>
@@ -43,8 +39,8 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 					component={component}
 					durationInFrames={durationInFrames}
 					fps={fps}
-					compositionWidth={width}
-					compositionHeight={height}
+					compositionWidth={previewWidth}
+					compositionHeight={previewHeight}
 					controls
 					initiallyMuted
 					loop

--- a/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
+++ b/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AbsoluteFill, Sequence} from 'remotion';
+import {AbsoluteFill, Sequence, useVideoConfig} from 'remotion';
 import type {ElementDefinition} from './element-definitions';
 import {getElementDefinition} from './element-utils';
 
@@ -11,12 +11,12 @@ export const getElementPreviewDimensions = (definition: ElementDefinition) => {
 
 	return {
 		height:
-			hasElementDimensions && definition.previewPadding > 0
-				? definition.elementHeight! + definition.previewPadding * 2
+			hasElementDimensions && definition.safeArea > 0
+				? definition.elementHeight! + definition.safeArea * 2
 				: definition.height,
 		width:
-			hasElementDimensions && definition.previewPadding > 0
-				? definition.elementWidth! + definition.previewPadding * 2
+			hasElementDimensions && definition.safeArea > 0
+				? definition.elementWidth! + definition.safeArea * 2
 				: definition.width,
 	};
 };
@@ -28,42 +28,42 @@ export const ElementPreviewComposition: React.FC<{
 		component: Component,
 		elementHeight,
 		elementWidth,
-		previewPadding,
+		safeArea,
 	} = definition;
+	const {height, width} = useVideoConfig();
 	const hasElementDimensions = elementWidth !== null && elementHeight !== null;
 
 	if (!hasElementDimensions) {
 		return <Component />;
 	}
 
-	if (previewPadding > 0) {
-		return (
-			<AbsoluteFill
-				style={{
-					alignItems: 'center',
-					justifyContent: 'center',
-				}}
-				showInTimeline={false}
-			>
-				<Sequence height={elementHeight} layout="none" width={elementWidth}>
-					<div
-						style={{
-							height: elementHeight,
-							position: 'relative',
-							width: elementWidth,
-						}}
-					>
-						<Component />
-					</div>
-				</Sequence>
-			</AbsoluteFill>
-		);
-	}
+	const scale = Math.min(
+		1,
+		(width - safeArea * 2) / elementWidth,
+		(height - safeArea * 2) / elementHeight,
+	);
 
 	return (
-		<Sequence height={elementHeight} width={elementWidth}>
-			<Component />
-		</Sequence>
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				justifyContent: 'center',
+			}}
+			showInTimeline={false}
+		>
+			<Sequence height={elementHeight} layout="none" width={elementWidth}>
+				<div
+					style={{
+						height: elementHeight,
+						position: 'relative',
+						scale,
+						width: elementWidth,
+					}}
+				>
+					<Component />
+				</div>
+			</Sequence>
+		</AbsoluteFill>
 	);
 };
 

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -60,7 +60,7 @@ export type ElementDefinition = {
 	readonly height: number;
 	readonly posterFrame: number;
 	readonly preview: ElementPreviewMetadata;
-	readonly previewPadding: number;
+	readonly safeArea: number;
 	readonly slug: string;
 	readonly installationMode: ElementInstallationMode;
 	readonly width: number;
@@ -85,7 +85,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/backgrounds-liquid-contours-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -108,7 +108,7 @@ const elementImplementations = {
 			posterUrl: 'https://remotion.media/elements/maps-map-flyover-preview.png',
 			videoUrl: 'https://remotion.media/elements/maps-map-flyover-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -133,7 +133,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/maps-watercolor-map-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -154,7 +154,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/backgrounds-notebook-paper-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -176,7 +176,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/backgrounds-paper-texture-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -197,7 +197,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -218,7 +218,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/overlays-location-lower-third-preview.mp4',
 		},
-		previewPadding: 300,
+		safeArea: 300,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -240,7 +240,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/overlays-name-lower-third-preview.mp4',
 		},
-		previewPadding: 300,
+		safeArea: 300,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -261,7 +261,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/youtube-youtube-comment-highlight-preview.mp4',
 		},
-		previewPadding: 200,
+		safeArea: 200,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -283,7 +283,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/overlays-social-endcard-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -309,7 +309,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/youtube-youtube-subscribe-nudge-preview.mp4',
 		},
-		previewPadding: 240,
+		safeArea: 240,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -330,7 +330,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/data-horizontal-bar-chart-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -349,7 +349,7 @@ const elementImplementations = {
 			posterUrl: 'https://remotion.media/elements/data-line-chart-preview.png',
 			videoUrl: 'https://remotion.media/elements/data-line-chart-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -369,7 +369,7 @@ const elementImplementations = {
 			posterUrl: 'https://remotion.media/elements/data-pie-chart-preview.png',
 			videoUrl: 'https://remotion.media/elements/data-pie-chart-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -396,7 +396,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/data-number-counter-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -418,7 +418,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/data-vertical-bar-chart-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -443,7 +443,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/commerce-product-discount-callout-preview.mp4',
 		},
-		previewPadding: 90,
+		safeArea: 90,
 		installationMode: 'wrapped',
 		width: 1080,
 	},
@@ -465,7 +465,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/commerce-product-offer-preview.mp4',
 		},
-		previewPadding: 90,
+		safeArea: 90,
 		installationMode: 'wrapped',
 		width: 1080,
 	},
@@ -490,7 +490,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/text-circle-marker-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -513,7 +513,7 @@ const elementImplementations = {
 			posterUrl: 'https://remotion.media/elements/text-crossed-off-preview.png',
 			videoUrl: 'https://remotion.media/elements/text-crossed-off-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -535,7 +535,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/text-spinning-text-wheel-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -557,7 +557,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/text-news-article-highlight-preview.mp4',
 		},
-		previewPadding: 0,
+		safeArea: 0,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -582,7 +582,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/text-strike-through-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -605,7 +605,7 @@ const elementImplementations = {
 			posterUrl: 'https://remotion.media/elements/text-text-marker-preview.png',
 			videoUrl: 'https://remotion.media/elements/text-text-marker-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -631,7 +631,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/captions-moving-pill-captions-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -656,7 +656,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/captions-popping-word-captions-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -681,7 +681,7 @@ const elementImplementations = {
 			videoUrl:
 				'https://remotion.media/elements/captions-word-highlight-captions-preview.mp4',
 		},
-		previewPadding: 120,
+		safeArea: 120,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},


### PR DESCRIPTION
## Summary

- use a consistent responsive 16:9 Player for Element gallery previews
- center fixed-size Elements and scale them down when needed while preserving a safe area
- rename preview padding metadata to `safeArea`
- keep generated preview asset and Open Graph dimensions element-specific

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- verified Watercolor Map, Pie Chart, and Product Offer previews at a wide viewport with Playwriter
