### PR TITLE
`@remotion/studio`: Gracefully reject visual control saves and Figma pastes in Browser Studio

### DIFF
--- a/packages/studio/src/components/VisualControls/VisualControlHandle.tsx
+++ b/packages/studio/src/components/VisualControls/VisualControlHandle.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useContext, useEffect, useState} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
 import {FastRefreshContext} from '../../fast-refresh-context';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {getVisualControlEditedValue} from '../../visual-controls/get-current-edited-value';
 import {
 	SetVisualControlsContext,
@@ -48,6 +49,17 @@ export const VisualControlHandle: React.FC<{
 	const saveToFile = useCallback(
 		(updater: (old: unknown) => unknown) => {
 			if (disableSave) {
+				return;
+			}
+
+			// Saving visual control changes goes through
+			// /api/apply-visual-control-change, which Browser Studio does not
+			// support.
+			if (getBrowserStudioOperations()) {
+				showNotification(
+					'Saving visual control changes is not supported in Browser Studio',
+					4000,
+				);
 				return;
 			}
 

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -937,6 +937,16 @@ export const importFigmaClipboard = async ({
 	dropPosition: InsertElementDropPosition | null;
 	html: string;
 }) => {
+	// Figma clipboard conversion requires the SVGR-based pipeline in
+	// @remotion/studio-server, which Browser Studio does not support.
+	if (getBrowserStudioOperations()) {
+		showNotification(
+			'Importing Figma clipboard data is not supported in Browser Studio',
+			4000,
+		);
+		return;
+	}
+
 	try {
 		const converted = await callApi('/api/convert-figma-clipboard-to-svg', {
 			html,


### PR DESCRIPTION
Part of #9807.

Applying `<VisualControl>` changes and pasting Figma clipboard data are won't-fix in Browser Studio (see the "Won't fix" section of #9807). Previously, both actions fired requests to `/api/apply-visual-control-change` and `/api/convert-figma-clipboard-to-svg`, which do not exist in Browser Studio, surfacing confusing network-level error messages.

Now, both paths short-circuit when Browser Studio operations are present and show a clear notification instead:

- Saving a visual control change shows "Saving visual control changes is not supported in Browser Studio".
- Pasting Figma clipboard data shows "Importing Figma clipboard data is not supported in Browser Studio".

Importing SVG markup inline is also won't-fix, but already fails gracefully via the `svgMarkupToJsx` stub in `@remotion/browser-studio`, so no change was needed there.
