### PR TITLE
`@remotion/studio`: Scale timeline max zoom with composition duration

### DIFF
--- a/packages/core/src/use-media-in-timeline.ts
+++ b/packages/core/src/use-media-in-timeline.ts
@@ -69,6 +69,14 @@ export const useBasicMediaInTimeline = ({
 			return volume;
 		}
 
+		if (typeof volume !== 'function') {
+			return evaluateVolume({
+				frame: 0,
+				volume,
+				mediaVolume,
+			});
+		}
+
 		return new Array(Math.floor(Math.max(0, duration + mediaStartsAt)))
 			.fill(true)
 			.map((_, i) => {

--- a/packages/example/src/HourLongTimelineTestbed.tsx
+++ b/packages/example/src/HourLongTimelineTestbed.tsx
@@ -1,0 +1,85 @@
+import {Audio, Video} from '@remotion/media';
+import React from 'react';
+import {AbsoluteFill, Sequence} from 'remotion';
+
+export const HOUR_LONG_TIMELINE_FPS = 30;
+export const HOUR_LONG_TIMELINE_DURATION_IN_FRAMES =
+	60 * 60 * HOUR_LONG_TIMELINE_FPS;
+
+const minutesToFrames = (minutes: number) => {
+	return minutes * 60 * HOUR_LONG_TIMELINE_FPS;
+};
+
+const OVERLAY_CLIPS: Array<{
+	readonly name: string;
+	readonly from: number;
+	readonly durationInFrames: number;
+	readonly src: string;
+}> = [
+	{
+		name: 'Start',
+		from: 0,
+		durationInFrames: 10 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video-10s.mp4',
+	},
+	{
+		name: 'Five minutes',
+		from: minutesToFrames(5),
+		durationInFrames: 10 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video.mp4',
+	},
+	{
+		name: 'Fifteen minutes',
+		from: minutesToFrames(15),
+		durationInFrames: 30 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video-30s.mp4',
+	},
+	{
+		name: 'Halfway',
+		from: minutesToFrames(30),
+		durationInFrames: 60 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video-1m.mp4',
+	},
+	{
+		name: 'Forty-five minutes',
+		from: minutesToFrames(45),
+		durationInFrames: 10 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video-10s.mp4',
+	},
+	{
+		name: 'Near the end',
+		from: HOUR_LONG_TIMELINE_DURATION_IN_FRAMES - 20 * HOUR_LONG_TIMELINE_FPS,
+		durationInFrames: 10 * HOUR_LONG_TIMELINE_FPS,
+		src: 'https://remotion.media/video.mp4',
+	},
+];
+
+export const HourLongTimelineTestbed: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#111'}}>
+			<Video
+				name="Looped minute"
+				src="https://remotion.media/video-1m.mp4"
+				loop
+			/>
+			{OVERLAY_CLIPS.map((clip) => (
+				<Sequence
+					key={clip.name}
+					from={clip.from}
+					durationInFrames={clip.durationInFrames}
+					name={clip.name}
+				>
+					<Video src={clip.src} />
+				</Sequence>
+			))}
+			<Audio name="Music" src="https://remotion.media/music.mp3" loop />
+			<Sequence
+				from={minutesToFrames(10)}
+				durationInFrames={minutesToFrames(5)}
+				name="Dialogue"
+			>
+				<Audio src="https://remotion.media/dialogue.wav" />
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -63,6 +63,11 @@ import {
 	HlsMediaVideoTrimmed,
 } from './Hls/HlsMediaVideo';
 import {
+	HOUR_LONG_TIMELINE_DURATION_IN_FRAMES,
+	HOUR_LONG_TIMELINE_FPS,
+	HourLongTimelineTestbed,
+} from './HourLongTimelineTestbed';
+import {
 	BookFlipTransitionDoc,
 	BookFlipTransitionDocThumb,
 	CrossZoomTransitionDoc,
@@ -2837,6 +2842,14 @@ export const Index: React.FC = () => {
 				/>
 			</Folder>
 			<Folder name="video-editing">
+				<Composition
+					id="hour-long-timeline"
+					component={HourLongTimelineTestbed}
+					width={1920}
+					height={1080}
+					fps={HOUR_LONG_TIMELINE_FPS}
+					durationInFrames={HOUR_LONG_TIMELINE_DURATION_IN_FRAMES}
+				/>
 				<Composition
 					id="video-editing-cascading"
 					component={Issue8974TransitionSeriesTimeline}

--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -1,5 +1,6 @@
 import {
 	drawBars,
+	getVisibleWaveformVolume,
 	loadWaveformPeaks,
 	makeAudioWaveformWorker,
 	sliceVisibleWaveformPeaks,
@@ -111,44 +112,12 @@ const AudioWaveformInner: React.FC<{
 		doesVolumeChange && typeof volume === 'string';
 	const parsedVolume = useMemo(() => parseVolume(volume), [volume]);
 	const visibleVolume = useMemo((): WaveformVolume => {
-		if (!Array.isArray(parsedVolume)) {
-			return parsedVolume;
-		}
-
-		if (!loopDisplay || loopDisplay.numberOfTimes <= 1) {
-			const start = Math.max(0, Math.floor(displayOffsetInFrames));
-			const end = Math.min(
-				parsedVolume.length,
-				Math.ceil(displayOffsetInFrames + displayDurationInFrames),
-			);
-			return parsedVolume.slice(start, end);
-		}
-
-		const result: number[] = [];
-		let processed = 0;
-		while (processed < displayDurationInFrames) {
-			const absoluteOffset = displayOffsetInFrames + processed;
-			const loopOffset =
-				((absoluteOffset % loopDisplay.durationInFrames) +
-					loopDisplay.durationInFrames) %
-				loopDisplay.durationInFrames;
-			const segmentDuration = Math.min(
-				displayDurationInFrames - processed,
-				loopDisplay.durationInFrames - loopOffset,
-			);
-			result.push(
-				...parsedVolume.slice(
-					Math.max(0, Math.floor(loopOffset)),
-					Math.min(
-						parsedVolume.length,
-						Math.ceil(loopOffset + segmentDuration),
-					),
-				),
-			);
-			processed += segmentDuration;
-		}
-
-		return result;
+		return getVisibleWaveformVolume({
+			displayDurationInFrames,
+			displayOffsetInFrames,
+			loopDisplay,
+			volume: parsedVolume,
+		});
 	}, [
 		displayDurationInFrames,
 		displayOffsetInFrames,

--- a/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
@@ -7,11 +7,11 @@ import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {viewportClientXToScrollContentX} from './timeline-scroll-logic';
 
 /**
- * Maps wheel deltaY to zoom delta. Must be large enough that typical ctrl+wheel
- * pinch steps change `TimelineZoomCtx` zoom by at least one 0.1 step after
- * `Math.round(z * 10) / 10` in `timeline-zoom.tsx` (0.005 was too small).
+ * Maps wheel deltaY to a multiplicative zoom change. Must be large enough that
+ * typical ctrl+wheel pinch steps change `TimelineZoomCtx` zoom by at least one
+ * 0.1 step after rounding in `clampTimelineZoom` (0.005 was too small at 1x).
  */
-const ZOOM_WHEEL_DELTA = 0.06;
+const ZOOM_WHEEL_SENSITIVITY = 0.06;
 
 type WebKitGestureEvent = UIEvent & {
 	scale: number;
@@ -82,7 +82,7 @@ export const TimelinePinchZoom: FC = () => {
 
 			setZoom(
 				canvasContent.compositionId,
-				(z) => z - scaledDeltaY * ZOOM_WHEEL_DELTA,
+				(z) => z * Math.exp(-scaledDeltaY * ZOOM_WHEEL_SENSITIVITY),
 				{anchorFrame: null, anchorContentX},
 			);
 		},

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -1,16 +1,21 @@
 import React, {useCallback, useContext} from 'react';
 import {Internals} from 'remotion';
 import {BLACK} from '../../helpers/colors';
+import {
+	getTimelineMaxZoom,
+	sliderValueToTimelineZoom,
+	TIMELINE_MIN_ZOOM,
+	TIMELINE_ZOOM_SLIDER_PROPS,
+	timelineZoomToSliderValue,
+} from '../../helpers/get-timeline-max-zoom';
 import {useIsStill} from '../../helpers/is-current-selected-still';
 import {CanvasZoomIcon, CanvasZoomOutIcon} from '../../icons/canvas-zoom';
-import {
-	TIMELINE_MAX_ZOOM,
-	TIMELINE_MIN_ZOOM,
-	TimelineZoomCtx,
-} from '../../state/timeline-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {ControlButton} from '../ControlButton';
 import {Spacing} from '../layout';
+
+const TIMELINE_ZOOM_BUTTON_FACTOR = 1.2;
 
 const container: React.CSSProperties = {
 	color: BLACK,
@@ -25,7 +30,8 @@ const buttonStyle: React.CSSProperties = {
 
 const TimelineZoomSlider: React.FC<{
 	readonly maxWidth?: number;
-}> = ({maxWidth}) => {
+	readonly maxZoom: number;
+}> = ({maxWidth, maxZoom}) => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom, zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const {tabIndex} = useZIndex();
@@ -37,12 +43,20 @@ const TimelineZoomSlider: React.FC<{
 				return;
 			}
 
-			setZoom(canvasContent.compositionId, () => Number(e.target.value), {
-				anchorFrame: null,
-				anchorContentX: null,
-			});
+			setZoom(
+				canvasContent.compositionId,
+				() =>
+					sliderValueToTimelineZoom({
+						sliderValue: Number(e.target.value),
+						maxZoom,
+					}),
+				{
+					anchorFrame: null,
+					anchorContentX: null,
+				},
+			);
 		},
-		[canvasContent, setZoom],
+		[canvasContent, maxZoom, setZoom],
 	);
 
 	if (
@@ -61,10 +75,10 @@ const TimelineZoomSlider: React.FC<{
 			title={`Timeline zoom (${zoom}x)`}
 			alt={`Timeline zoom (${zoom}x)`}
 			type="range"
-			min={TIMELINE_MIN_ZOOM}
-			step={0.1}
-			value={zoom}
-			max={TIMELINE_MAX_ZOOM}
+			min={TIMELINE_ZOOM_SLIDER_PROPS.min}
+			max={TIMELINE_ZOOM_SLIDER_PROPS.max}
+			step={TIMELINE_ZOOM_SLIDER_PROPS.step}
+			value={timelineZoomToSliderValue({zoom, maxZoom})}
 			onChange={onChange}
 			className="__remotion-timeline-slider"
 			tabIndex={tabIndex}
@@ -77,6 +91,8 @@ const TimelineZoomControlsInner: React.FC<{
 }> = ({sliderMaxWidth}) => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom} = useContext(TimelineZoomCtx);
+	const videoConfig = Internals.useUnsafeVideoConfig();
+	const maxZoom = getTimelineMaxZoom(videoConfig?.durationInFrames ?? 1);
 
 	const onMinusClicked = useCallback(() => {
 		if (canvasContent === null || canvasContent.type !== 'composition') {
@@ -85,7 +101,7 @@ const TimelineZoomControlsInner: React.FC<{
 
 		setZoom(
 			canvasContent.compositionId,
-			(z) => Math.max(TIMELINE_MIN_ZOOM, z - 0.2),
+			(z) => z / TIMELINE_ZOOM_BUTTON_FACTOR,
 			{anchorFrame: null, anchorContentX: null},
 		);
 	}, [canvasContent, setZoom]);
@@ -97,7 +113,7 @@ const TimelineZoomControlsInner: React.FC<{
 
 		setZoom(
 			canvasContent.compositionId,
-			(z) => Math.min(TIMELINE_MAX_ZOOM, z + 0.2),
+			(z) => z * TIMELINE_ZOOM_BUTTON_FACTOR,
 			{anchorFrame: null, anchorContentX: null},
 		);
 	}, [canvasContent, setZoom]);
@@ -124,7 +140,7 @@ const TimelineZoomControlsInner: React.FC<{
 				{(color) => <CanvasZoomOutIcon color={color} />}
 			</ControlButton>
 			<Spacing x={0.5} />
-			<TimelineZoomSlider maxWidth={sliderMaxWidth} />
+			<TimelineZoomSlider maxWidth={sliderMaxWidth} maxZoom={maxZoom} />
 			<Spacing x={0.5} />
 			<ControlButton
 				onClick={onPlusClicked}

--- a/packages/studio/src/helpers/get-timeline-max-zoom.ts
+++ b/packages/studio/src/helpers/get-timeline-max-zoom.ts
@@ -1,0 +1,69 @@
+export const TIMELINE_MIN_ZOOM = 1;
+export const TIMELINE_MAX_ZOOM_FLOOR = 5;
+
+/**
+ * How many frames fill the timeline viewport at max zoom.
+ * 30 frames matches the previous 5x cap on a 150-frame composition
+ * (5 seconds at 30fps) and keeps a single frame wide enough to trim.
+ */
+export const TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM = 30;
+
+const TIMELINE_ZOOM_SLIDER_MAX = 1000;
+
+export const getTimelineMaxZoom = (durationInFrames: number): number => {
+	const frameLevelZoom = durationInFrames / TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM;
+	return Math.max(TIMELINE_MAX_ZOOM_FLOOR, Math.ceil(frameLevelZoom * 10) / 10);
+};
+
+export const clampTimelineZoom = ({
+	zoom,
+	durationInFrames,
+}: {
+	zoom: number;
+	durationInFrames: number;
+}): number => {
+	const clamped = Math.min(
+		getTimelineMaxZoom(durationInFrames),
+		Math.max(TIMELINE_MIN_ZOOM, zoom),
+	);
+	return Math.round(clamped * 10) / 10;
+};
+
+export const timelineZoomToSliderValue = ({
+	zoom,
+	maxZoom,
+}: {
+	zoom: number;
+	maxZoom: number;
+}): number => {
+	if (maxZoom <= TIMELINE_MIN_ZOOM) {
+		return 0;
+	}
+
+	const clampedZoom = Math.min(maxZoom, Math.max(TIMELINE_MIN_ZOOM, zoom));
+	const t =
+		Math.log(clampedZoom / TIMELINE_MIN_ZOOM) /
+		Math.log(maxZoom / TIMELINE_MIN_ZOOM);
+	return Math.round(t * TIMELINE_ZOOM_SLIDER_MAX);
+};
+
+export const sliderValueToTimelineZoom = ({
+	sliderValue,
+	maxZoom,
+}: {
+	sliderValue: number;
+	maxZoom: number;
+}): number => {
+	if (maxZoom <= TIMELINE_MIN_ZOOM) {
+		return TIMELINE_MIN_ZOOM;
+	}
+
+	const t = sliderValue / TIMELINE_ZOOM_SLIDER_MAX;
+	return TIMELINE_MIN_ZOOM * (maxZoom / TIMELINE_MIN_ZOOM) ** t;
+};
+
+export const TIMELINE_ZOOM_SLIDER_PROPS = {
+	min: 0,
+	max: TIMELINE_ZOOM_SLIDER_MAX,
+	step: 1,
+} as const;

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -6,9 +6,15 @@ import {
 } from '../components/Timeline/imperative-state';
 import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-scroll-logic';
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
+import {
+	clampTimelineZoom,
+	TIMELINE_MIN_ZOOM,
+} from '../helpers/get-timeline-max-zoom';
 
-export const TIMELINE_MIN_ZOOM = 1;
-export const TIMELINE_MAX_ZOOM = 5;
+export {
+	getTimelineMaxZoom,
+	TIMELINE_MIN_ZOOM,
+} from '../helpers/get-timeline-max-zoom';
 
 export type TimelineSetZoomOptions = {
 	anchorFrame: number | null;
@@ -52,14 +58,10 @@ export const TimelineZoomContext: React.FC<{
 
 			flushSync(() => {
 				setZoomState((prevZoomMap) => {
-					const newZoomWithFloatingPointErrors = Math.min(
-						TIMELINE_MAX_ZOOM,
-						Math.max(
-							TIMELINE_MIN_ZOOM,
-							callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
-						),
-					);
-					const newZoom = Math.round(newZoomWithFloatingPointErrors * 10) / 10;
+					const newZoom = clampTimelineZoom({
+						zoom: callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
+						durationInFrames: getCurrentDuration(),
+					});
 
 					return {...prevZoomMap, [compositionId]: newZoom};
 				});

--- a/packages/studio/src/test/get-timeline-max-zoom.test.ts
+++ b/packages/studio/src/test/get-timeline-max-zoom.test.ts
@@ -1,0 +1,70 @@
+import {expect, test} from 'bun:test';
+import {
+	clampTimelineZoom,
+	getTimelineMaxZoom,
+	sliderValueToTimelineZoom,
+	TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM,
+	TIMELINE_MAX_ZOOM_FLOOR,
+	TIMELINE_MIN_ZOOM,
+	TIMELINE_ZOOM_SLIDER_PROPS,
+	timelineZoomToSliderValue,
+} from '../helpers/get-timeline-max-zoom';
+
+test('keeps the previous max zoom for short compositions', () => {
+	expect(getTimelineMaxZoom(1)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
+	expect(getTimelineMaxZoom(30)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
+	expect(getTimelineMaxZoom(150)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
+});
+
+test('raises max zoom so longer compositions can still show individual frames', () => {
+	expect(getTimelineMaxZoom(151)).toBe(5.1);
+	expect(getTimelineMaxZoom(300)).toBe(10);
+	expect(getTimelineMaxZoom(60 * 60 * 30)).toBe(3600);
+	expect(getTimelineMaxZoom(2 * 60 * 60 * 30)).toBe(7200);
+});
+
+test('max zoom shows a fixed number of frames in the viewport', () => {
+	const oneHourInFrames = 60 * 60 * 30;
+	const maxZoom = getTimelineMaxZoom(oneHourInFrames);
+
+	expect(oneHourInFrames / maxZoom).toBe(TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM);
+});
+
+test('clamps and rounds timeline zoom', () => {
+	expect(clampTimelineZoom({zoom: 0.2, durationInFrames: 150})).toBe(
+		TIMELINE_MIN_ZOOM,
+	);
+	expect(clampTimelineZoom({zoom: 3.16, durationInFrames: 150})).toBe(3.2);
+	expect(clampTimelineZoom({zoom: 9999, durationInFrames: 150})).toBe(
+		TIMELINE_MAX_ZOOM_FLOOR,
+	);
+	expect(clampTimelineZoom({zoom: 9999, durationInFrames: 60 * 60 * 30})).toBe(
+		3600,
+	);
+});
+
+test('timeline zoom slider maps min and max', () => {
+	const maxZoom = getTimelineMaxZoom(60 * 60 * 30);
+
+	expect(timelineZoomToSliderValue({zoom: TIMELINE_MIN_ZOOM, maxZoom})).toBe(0);
+	expect(timelineZoomToSliderValue({zoom: maxZoom, maxZoom})).toBe(
+		TIMELINE_ZOOM_SLIDER_PROPS.max,
+	);
+	expect(sliderValueToTimelineZoom({sliderValue: 0, maxZoom})).toBe(
+		TIMELINE_MIN_ZOOM,
+	);
+	expect(
+		sliderValueToTimelineZoom({
+			sliderValue: TIMELINE_ZOOM_SLIDER_PROPS.max,
+			maxZoom,
+		}),
+	).toBe(maxZoom);
+});
+
+test('timeline zoom slider increases with zoom', () => {
+	const maxZoom = getTimelineMaxZoom(60 * 60 * 30);
+
+	expect(timelineZoomToSliderValue({zoom: 100, maxZoom})).toBeGreaterThan(
+		timelineZoomToSliderValue({zoom: 5, maxZoom}),
+	);
+});

--- a/packages/timeline-utils/src/audio-waveform/get-visible-waveform-volume.ts
+++ b/packages/timeline-utils/src/audio-waveform/get-visible-waveform-volume.ts
@@ -1,0 +1,69 @@
+import {shouldTileLoopDisplay, type TimelineLoopDisplay} from '../loop-display';
+import type {WaveformVolume} from './draw-peaks';
+
+export const getVisibleWaveformVolume = ({
+	displayDurationInFrames,
+	displayOffsetInFrames,
+	loopDisplay,
+	volume,
+}: {
+	readonly displayDurationInFrames: number;
+	readonly displayOffsetInFrames: number;
+	readonly loopDisplay: TimelineLoopDisplay | undefined;
+	readonly volume: WaveformVolume;
+}): WaveformVolume => {
+	if (!Array.isArray(volume)) {
+		return volume;
+	}
+
+	if (
+		!Number.isFinite(displayDurationInFrames) ||
+		displayDurationInFrames <= 0
+	) {
+		return [];
+	}
+
+	if (
+		!shouldTileLoopDisplay(loopDisplay) ||
+		loopDisplay.durationInFrames <= 0
+	) {
+		const start = Math.max(0, Math.floor(displayOffsetInFrames));
+		const end = Math.min(
+			volume.length,
+			Math.ceil(displayOffsetInFrames + displayDurationInFrames),
+		);
+		return volume.slice(start, end);
+	}
+
+	const result: number[] = [];
+	let processed = 0;
+	while (processed < displayDurationInFrames) {
+		const absoluteOffset = displayOffsetInFrames + processed;
+		const loopOffset =
+			((absoluteOffset % loopDisplay.durationInFrames) +
+				loopDisplay.durationInFrames) %
+			loopDisplay.durationInFrames;
+		const segmentDuration = Math.min(
+			displayDurationInFrames - processed,
+			loopDisplay.durationInFrames - loopOffset,
+		);
+		if (segmentDuration <= 0) {
+			break;
+		}
+
+		const start = Math.max(0, Math.floor(loopOffset));
+		const end = Math.min(
+			volume.length,
+			Math.ceil(loopOffset + segmentDuration),
+		);
+		// Do not `push(...slice)`: Chrome throws RangeError: Invalid array length
+		// once a loop segment is longer than ~65k frames.
+		for (let index = start; index < end; index++) {
+			result.push(volume[index]);
+		}
+
+		processed += segmentDuration;
+	}
+
+	return result;
+};

--- a/packages/timeline-utils/src/index.ts
+++ b/packages/timeline-utils/src/index.ts
@@ -8,6 +8,7 @@ export {drawBars, type WaveformVolume} from './audio-waveform/draw-peaks';
 export {loadWaveformPeaks} from './audio-waveform/load-waveform-peaks';
 export {makeAudioWaveformWorker} from './audio-waveform/make-audio-waveform-worker';
 export {sliceWaveformPeaks} from './audio-waveform/slice-waveform-peaks';
+export {getVisibleWaveformVolume} from './audio-waveform/get-visible-waveform-volume';
 export {sliceVisibleWaveformPeaks} from './audio-waveform/slice-visible-waveform-peaks';
 export {
 	createWaveformPeakProcessor,

--- a/packages/timeline-utils/src/test/get-visible-waveform-volume.test.ts
+++ b/packages/timeline-utils/src/test/get-visible-waveform-volume.test.ts
@@ -1,0 +1,82 @@
+import {expect, test} from 'bun:test';
+import {getVisibleWaveformVolume} from '../audio-waveform/get-visible-waveform-volume';
+
+test('passes a constant volume through', () => {
+	expect(
+		getVisibleWaveformVolume({
+			displayDurationInFrames: 108_000,
+			displayOffsetInFrames: 0,
+			loopDisplay: {
+				durationInFrames: 1_800,
+				numberOfTimes: 60,
+				startOffset: 0,
+			},
+			volume: 1,
+		}),
+	).toBe(1);
+});
+
+test('slices a non-looped volume curve', () => {
+	expect(
+		getVisibleWaveformVolume({
+			displayDurationInFrames: 3,
+			displayOffsetInFrames: 2,
+			loopDisplay: undefined,
+			volume: [0.1, 0.2, 0.3, 0.4, 0.5],
+		}),
+	).toEqual([0.3, 0.4, 0.5]);
+});
+
+test('tiles a looped volume curve across a loop boundary', () => {
+	expect(
+		getVisibleWaveformVolume({
+			displayDurationInFrames: 4,
+			displayOffsetInFrames: 3,
+			loopDisplay: {
+				durationInFrames: 5,
+				numberOfTimes: 3,
+				startOffset: 0,
+			},
+			volume: [1, 2, 3, 4, 5],
+		}),
+	).toEqual([4, 5, 1, 2]);
+});
+
+test('tiles a long looped volume curve', () => {
+	const loopDurationInFrames = 80_000;
+	const volume = Array.from({length: loopDurationInFrames}, (_, index) =>
+		index % 2 === 0 ? 1 : 0.5,
+	);
+
+	const visible = getVisibleWaveformVolume({
+		displayDurationInFrames: loopDurationInFrames,
+		displayOffsetInFrames: 0,
+		loopDisplay: {
+			durationInFrames: loopDurationInFrames,
+			numberOfTimes: 2,
+			startOffset: 0,
+		},
+		volume,
+	});
+
+	expect(Array.isArray(visible)).toBe(true);
+	expect((visible as number[]).length).toBe(loopDurationInFrames);
+	expect((visible as number[])[0]).toBe(1);
+	expect((visible as number[])[1]).toBe(0.5);
+	expect((visible as number[])[loopDurationInFrames - 1]).toBe(0.5);
+});
+
+test('stops tiling if a loop segment would not advance', () => {
+	expect(
+		getVisibleWaveformVolume({
+			displayDurationInFrames: 100,
+			displayOffsetInFrames: 0,
+			loopDisplay: {
+				durationInFrames: 0,
+				numberOfTimes: 10,
+				startOffset: 0,
+			},
+			volume: [1, 2, 3],
+		}),
+	).toEqual([1, 2, 3]);
+});


### PR DESCRIPTION
## Summary
- Scale Studio timeline max zoom with composition duration so long videos can still be edited at frame level (about 30 frames across the viewport at max zoom).
- Use a logarithmic zoom slider and multiplicative pinch/button steps so high zoom remains usable.
- Avoid expanding constant volume into a per-frame array, and copy looped waveform samples without spreading huge arrays, so long looped clips no longer crash AudioWaveform.
- Add the `hour-long-timeline` example composition for exercising this in Studio.

## Test plan
- [ ] Open `hour-long-timeline` in Studio (`packages/example`)
- [ ] Zoom all the way in and confirm individual frames are still reachable on the 1-hour timeline
- [ ] Use the slider, +/- buttons, and pinch/ctrl+wheel and confirm zoom stays smooth across the full range
- [ ] Confirm waveforms for the looped audio/video tracks render without crashing
- [ ] Open a short composition and confirm the previous 5x max zoom behavior is unchanged
