### PR TITLE
`@remotion/studio`: Auto-scroll timeline when dragging playhead or marquee to the edge

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -10,23 +10,27 @@ import React, {
 import {Internals, useVideoConfig} from 'remotion';
 import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
 import {startCapturedPointerSession} from '../../helpers/pointer-session';
-import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import {setCurrentFrame} from './imperative-state';
 import {
 	scrollableRef,
 	sliderAreaRef,
 	timelineVerticalScroll,
 } from './timeline-refs';
+import type {
+	TimelineEdgeAutoScroller,
+	TimelineEdgeScrollDirections,
+} from './timeline-scroll-logic';
 import {
-	canScrollTimelineIntoDirection,
 	getFrameFromX,
 	getFrameWhileScrollingLeft,
 	getFrameWhileScrollingRight,
 	getScrollPositionForCursorOnLeftEdge,
 	getScrollPositionForCursorOnRightEdge,
 	scrollToTimelineXOffset,
+	startTimelineEdgeAutoScroll,
 } from './timeline-scroll-logic';
 import {TIMELINE_SCRUBBER_ATTR} from './TimelineSelection';
 import {redrawTimelineSliderFast} from './TimelineSlider';
@@ -121,14 +125,7 @@ const TimelineDragHandlerInner: React.FC = () => {
 	});
 	const {isPlaying, play, pause, seek} = PlayerInternals.usePlayerMethods();
 
-	const scroller = useRef<Timer | null>(null);
-
-	const stopInterval = () => {
-		if (scroller.current) {
-			clearInterval(scroller.current);
-			scroller.current = null;
-		}
-	};
+	const autoScroller = useRef<TimelineEdgeAutoScroller | null>(null);
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
@@ -140,7 +137,6 @@ const TimelineDragHandlerInner: React.FC = () => {
 				return;
 			}
 
-			stopInterval();
 			if (!videoConfig) {
 				return;
 			}
@@ -170,6 +166,46 @@ const TimelineDragHandlerInner: React.FC = () => {
 		[isHighestContext, videoConfig, left, width, seek, isPlaying, pause],
 	);
 
+	const onEdgeScrollTick = useCallback(
+		(directions: TimelineEdgeScrollDirections) => {
+			if (!videoConfig || directions.x === null) {
+				return;
+			}
+
+			const nextFrame =
+				directions.x === 'left'
+					? getFrameWhileScrollingLeft({
+							durationInFrames: videoConfig.durationInFrames,
+							width,
+						})
+					: getFrameWhileScrollingRight({
+							durationInFrames: videoConfig.durationInFrames,
+							width,
+						});
+
+			const scrollPos =
+				directions.x === 'left'
+					? getScrollPositionForCursorOnLeftEdge({
+							nextFrame,
+							durationInFrames: videoConfig.durationInFrames,
+						})
+					: getScrollPositionForCursorOnRightEdge({
+							nextFrame,
+							durationInFrames: videoConfig.durationInFrames,
+						});
+
+			// Update the imperative frame and apply the scroll before drawing, so
+			// every redraw (including the scroll event listener in TimelineSlider)
+			// sees a consistent (frame, scrollLeft) pair. Otherwise the playhead
+			// flickers between stale combinations while React commits the seek.
+			setCurrentFrame(nextFrame);
+			scrollToTimelineXOffset(scrollPos);
+			redrawTimelineSliderFast.current?.draw(nextFrame);
+			seek(nextFrame);
+		},
+		[videoConfig, width, seek],
+	);
+
 	const onPointerMoveScrubbing = useCallback(
 		(e: PointerEvent) => {
 			if (!videoConfig) {
@@ -180,13 +216,15 @@ const TimelineDragHandlerInner: React.FC = () => {
 				return;
 			}
 
-			const isRightOfArea =
-				e.clientX >=
-				(scrollableRef.current?.clientWidth as number) +
-					left -
-					TIMELINE_PADDING;
+			const directions = autoScroller.current?.update(e) ?? {
+				x: null,
+				y: null,
+			};
 
-			const isLeftOfArea = e.clientX <= left;
+			// While edge auto-scrolling is active, the tick owns seeking
+			if (directions.x !== null) {
+				return;
+			}
 
 			const frame = getFrameFromX({
 				clientX: getClientXWithScroll(e.clientX) - left,
@@ -195,81 +233,14 @@ const TimelineDragHandlerInner: React.FC = () => {
 				extrapolate: 'clamp',
 			});
 
-			if (isLeftOfArea && canScrollTimelineIntoDirection().canScrollLeft) {
-				if (scroller.current) {
-					return;
-				}
-
-				const scrollEvery = () => {
-					if (!canScrollTimelineIntoDirection().canScrollLeft) {
-						stopInterval();
-						return;
-					}
-
-					const nextFrame = getFrameWhileScrollingLeft({
-						durationInFrames: videoConfig.durationInFrames,
-						width,
-					});
-
-					const scrollPos = getScrollPositionForCursorOnLeftEdge({
-						nextFrame,
-						durationInFrames: videoConfig.durationInFrames,
-					});
-
-					redrawTimelineSliderFast.current?.draw(nextFrame);
-					seek(nextFrame);
-					scrollToTimelineXOffset(scrollPos);
-				};
-
-				scrollEvery();
-				scroller.current = setInterval(() => {
-					scrollEvery();
-				}, 100);
-			} else if (
-				isRightOfArea &&
-				canScrollTimelineIntoDirection().canScrollRight
-			) {
-				if (scroller.current) {
-					return;
-				}
-
-				const scrollEvery = () => {
-					if (!canScrollTimelineIntoDirection().canScrollRight) {
-						stopInterval();
-						return;
-					}
-
-					const nextFrame = getFrameWhileScrollingRight({
-						durationInFrames: videoConfig.durationInFrames,
-						width,
-					});
-
-					const scrollPos = getScrollPositionForCursorOnRightEdge({
-						nextFrame,
-						durationInFrames: videoConfig.durationInFrames,
-					});
-
-					redrawTimelineSliderFast.current?.draw(nextFrame);
-					seek(nextFrame);
-					scrollToTimelineXOffset(scrollPos);
-				};
-
-				scrollEvery();
-
-				scroller.current = setInterval(() => {
-					scrollEvery();
-				}, 100);
-			} else {
-				stopInterval();
-				seek(frame);
-			}
+			seek(frame);
 		},
 		[videoConfig, dragging.dragging, left, width, seek],
 	);
 
 	const onPointerUpScrubbing = useCallback(
 		(e: PointerEvent) => {
-			stopInterval();
+			autoScroller.current?.stop();
 			document.body.style.userSelect = '';
 			document.body.style.webkitUserSelect = '';
 
@@ -310,7 +281,7 @@ const TimelineDragHandlerInner: React.FC = () => {
 	);
 
 	const onPointerCancelScrubbing = useCallback(() => {
-		stopInterval();
+		autoScroller.current?.stop();
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
 		if (!dragging.dragging) {
@@ -328,7 +299,13 @@ const TimelineDragHandlerInner: React.FC = () => {
 			return;
 		}
 
-		return startCapturedPointerSession({
+		const scroller = startTimelineEdgeAutoScroll({
+			includeVertical: false,
+			onTick: onEdgeScrollTick,
+		});
+		autoScroller.current = scroller;
+
+		const endSession = startCapturedPointerSession({
 			event: dragging,
 			captureTarget: dragging.target,
 			onMove: onPointerMoveScrubbing,
@@ -343,8 +320,18 @@ const TimelineDragHandlerInner: React.FC = () => {
 				}
 			},
 		});
+
+		return () => {
+			scroller.stop();
+			if (autoScroller.current === scroller) {
+				autoScroller.current = null;
+			}
+
+			endSession();
+		};
 	}, [
 		dragging,
+		onEdgeScrollTick,
 		onPointerCancelScrubbing,
 		onPointerMoveScrubbing,
 		onPointerUpScrubbing,

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -62,6 +62,12 @@ import {
 	getSelectedTimelineExpandedRowKeys,
 	isTimelineExpandedNodeSelected,
 } from './timeline-expanded-filter';
+import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
+import {
+	EDGE_SCROLL_VERTICAL_INCREMENT,
+	SCROLL_INCREMENT,
+	startTimelineEdgeAutoScroll,
+} from './timeline-scroll-logic';
 import {TimelineClipboardKeybindings} from './TimelineClipboardKeybindings';
 import {TimelineDeleteKeybindings} from './TimelineDeleteKeybindings';
 
@@ -1529,15 +1535,19 @@ export const useTimelineMarqueeSelection = () => {
 
 			const {currentTarget: target} = event;
 
+			const scrollable = scrollableRef.current;
+			const verticalScroll = timelineVerticalScroll.current;
+			const initialScrollLeft = scrollable?.scrollLeft ?? 0;
+			const initialScrollTop = verticalScroll?.scrollTop ?? 0;
+
 			const initialBounds = target.getBoundingClientRect();
-			const marqueeBounds: TimelineMarqueeRect = {
-				bottom: initialBounds.bottom,
-				left: initialBounds.left,
-				right: initialBounds.right,
-				top: initialBounds.top,
-			};
 			const start = getClampedTimelineMarqueePoint({
-				bounds: marqueeBounds,
+				bounds: {
+					bottom: initialBounds.bottom,
+					left: initialBounds.left,
+					right: initialBounds.right,
+					top: initialBounds.top,
+				},
 				x: event.clientX,
 				y: event.clientY,
 			});
@@ -1550,25 +1560,57 @@ export const useTimelineMarqueeSelection = () => {
 
 			let hasDragged = false;
 			let lockedSelectionKind: TimelineMarqueeSelectionKind | null = null;
+			let lastClientX = event.clientX;
+			let lastClientY = event.clientY;
 			const extendSelection = event.metaKey || event.ctrlKey;
 			const selectionBeforeMarquee = selectedItems;
 
-			const cleanup = () => {
-				document.body.style.userSelect = previousUserSelect;
-				document.body.style.webkitUserSelect = previousWebkitUserSelect;
-				setMarqueeRect(null);
-			};
-
 			const updateSelection = (clientX: number, clientY: number) => {
+				lastClientX = clientX;
+				lastClientY = clientY;
+
+				// The container moves when the timeline scrolls vertically, so read
+				// the bounds live. Restrict them to the visible viewport of the
+				// vertical scroller so the fixed-positioned marquee cannot paint
+				// outside the visible timeline area.
+				const liveBounds = target.getBoundingClientRect();
+				const verticalRect = verticalScroll?.getBoundingClientRect() ?? null;
+				const bounds: TimelineMarqueeRect = {
+					bottom:
+						verticalRect === null
+							? liveBounds.bottom
+							: Math.min(liveBounds.bottom, verticalRect.bottom),
+					left: liveBounds.left,
+					right: liveBounds.right,
+					top:
+						verticalRect === null
+							? liveBounds.top
+							: Math.max(liveBounds.top, verticalRect.top),
+				};
+
+				// The anchor is fixed to timeline content, not to the screen:
+				// compensate for any scrolling that happened since pointerdown so the
+				// marquee keeps covering the originally spanned content while
+				// edge auto-scrolling. It is deliberately not clamped to the bounds -
+				// it may sit outside the viewport, and the selection should still
+				// include everything between it and the pointer.
+				const scrollDeltaX = (scrollable?.scrollLeft ?? 0) - initialScrollLeft;
+				const scrollDeltaY =
+					(verticalScroll?.scrollTop ?? 0) - initialScrollTop;
+				const anchorX = startX - scrollDeltaX;
+				const anchorY = startY - scrollDeltaY;
+
 				const current = getClampedTimelineMarqueePoint({
-					bounds: marqueeBounds,
+					bounds,
 					x: clientX,
 					y: clientY,
 				});
 				if (
 					!hasDragged &&
-					Math.max(Math.abs(current.x - startX), Math.abs(current.y - startY)) <
-						3
+					Math.max(
+						Math.abs(current.x - anchorX),
+						Math.abs(current.y - anchorY),
+					) < 3
 				) {
 					return;
 				}
@@ -1577,12 +1619,17 @@ export const useTimelineMarqueeSelection = () => {
 				const rect = getNormalizedTimelineMarqueeRect({
 					currentX: current.x,
 					currentY: current.y,
-					startX,
-					startY,
+					startX: anchorX,
+					startY: anchorY,
 				});
 				const nextSelection = getMarqueeSelection(rect, lockedSelectionKind);
 				lockedSelectionKind = nextSelection.lockedSelectionKind;
-				setMarqueeRect(rect);
+				setMarqueeRect({
+					bottom: Math.min(rect.bottom, bounds.bottom),
+					left: Math.max(rect.left, bounds.left),
+					right: Math.min(rect.right, bounds.right),
+					top: Math.max(rect.top, bounds.top),
+				});
 				selectItems(
 					extendSelection
 						? extendTimelineMarqueeSelection({
@@ -1593,8 +1640,39 @@ export const useTimelineMarqueeSelection = () => {
 				);
 			};
 
+			const autoScroll = startTimelineEdgeAutoScroll({
+				includeVertical: true,
+				onTick: (directions) => {
+					if (scrollable && directions.x !== null) {
+						scrollable.scrollLeft +=
+							directions.x === 'left' ? -SCROLL_INCREMENT : SCROLL_INCREMENT;
+					}
+
+					if (verticalScroll && directions.y !== null) {
+						verticalScroll.scrollTop +=
+							directions.y === 'up'
+								? -EDGE_SCROLL_VERTICAL_INCREMENT
+								: EDGE_SCROLL_VERTICAL_INCREMENT;
+					}
+
+					updateSelection(lastClientX, lastClientY);
+				},
+			});
+
+			const cleanup = () => {
+				autoScroll.stop();
+				document.body.style.userSelect = previousUserSelect;
+				document.body.style.webkitUserSelect = previousWebkitUserSelect;
+				setMarqueeRect(null);
+			};
+
 			const onPointerMove = (moveEvent: PointerEvent) => {
 				updateSelection(moveEvent.clientX, moveEvent.clientY);
+				// Only auto-scroll for an actual marquee drag, not a plain click
+				// near an edge
+				if (hasDragged) {
+					autoScroll.update(moveEvent);
+				}
 			};
 
 			startCapturedPointerSession({

--- a/packages/studio/src/components/Timeline/TimelineSlider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSlider.tsx
@@ -9,7 +9,7 @@ import {Internals, useVideoConfig} from 'remotion';
 import {TIMELINE_PLAYHEAD_COLOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
-import {getCurrentDuration} from './imperative-state';
+import {getCurrentDuration, getCurrentFrame} from './imperative-state';
 import {scrollableRef, sliderAreaRef} from './timeline-refs';
 import {TimelineSliderHandle} from './TimelineSliderHandle';
 import {TimelineWidthContext} from './TimelineWidthProvider';
@@ -106,19 +106,24 @@ const TimelineSliderInner: React.FC = () => {
 			return;
 		}
 
-		const draw = () => {
+		const draw = (frame: number) => {
 			el.style.transform = getTimelineSliderTransform({
 				durationInFrames: videoConfig.durationInFrames,
-				frame: timelinePosition,
+				frame,
 				scrollLeft: scrollable.scrollLeft,
 				width: measuredWidth,
 			});
 		};
 
-		draw();
-		scrollable.addEventListener('scroll', draw);
+		draw(timelinePosition);
+
+		// Read the frame imperatively on scroll: during edge auto-scrolling, the
+		// scroll event can fire before React has committed the seek, and drawing
+		// with the stale `timelinePosition` closure makes the playhead flicker.
+		const onScroll = () => draw(getCurrentFrame());
+		scrollable.addEventListener('scroll', onScroll);
 		return () => {
-			scrollable.removeEventListener('scroll', draw);
+			scrollable.removeEventListener('scroll', onScroll);
 		};
 	}, [
 		timelinePosition,

--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -1,6 +1,7 @@
 import {interpolate} from 'remotion';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
-import {scrollableRef} from './timeline-refs';
+import {setCurrentFrame} from './imperative-state';
+import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {redrawTimelineSliderFast} from './TimelineSlider';
 
 export const canScrollTimelineIntoDirection = () => {
@@ -12,7 +13,175 @@ export const canScrollTimelineIntoDirection = () => {
 	return {canScrollRight, canScrollLeft};
 };
 
-const SCROLL_INCREMENT = 200;
+export const SCROLL_INCREMENT = 200;
+
+export const EDGE_SCROLL_VERTICAL_INCREMENT = 60;
+
+const EDGE_SCROLL_INTERVAL_MS = 100;
+
+// Once edge-scrolling has started, the pointer must move this many pixels
+// back inside the timeline to stop it. Prevents pixel jitter around the edge
+// threshold from rapidly cancelling and restarting the auto-scroll.
+const EDGE_SCROLL_EXIT_HYSTERESIS = 8;
+
+// The vertical edge zones extend this many pixels into the viewport, so the
+// auto-scroll already engages when dragging close to (not exactly onto) the
+// top or bottom edge.
+const EDGE_SCROLL_VERTICAL_INSET = 8;
+
+export type TimelineEdgeScrollDirections = {
+	x: 'left' | 'right' | null;
+	y: 'up' | 'down' | null;
+};
+
+export type TimelineEdgeAutoScroller = {
+	update: (e: {
+		clientX: number;
+		clientY: number;
+	}) => TimelineEdgeScrollDirections;
+	stop: () => void;
+};
+
+const canScrollTimelineVerticallyIntoDirection = () => {
+	const {current} = timelineVerticalScroll;
+	if (!current) {
+		return {canScrollUp: false, canScrollDown: false};
+	}
+
+	const {scrollTop, scrollHeight, clientHeight} = current;
+	return {
+		canScrollUp: scrollTop > 0,
+		canScrollDown: scrollHeight - scrollTop - clientHeight > 0,
+	};
+};
+
+const getEdgeScrollDirections = ({
+	clientX,
+	clientY,
+	includeVertical,
+	active,
+}: {
+	clientX: number;
+	clientY: number;
+	includeVertical: boolean;
+	active: TimelineEdgeScrollDirections;
+}): TimelineEdgeScrollDirections => {
+	let x: TimelineEdgeScrollDirections['x'] = null;
+	const scrollable = scrollableRef.current;
+	if (scrollable) {
+		const rect = scrollable.getBoundingClientRect();
+		const leftThreshold =
+			rect.left + (active.x === 'left' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
+		const rightThreshold =
+			rect.left +
+			scrollable.clientWidth -
+			TIMELINE_PADDING -
+			(active.x === 'right' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
+		const {canScrollLeft, canScrollRight} = canScrollTimelineIntoDirection();
+		if (clientX <= leftThreshold && canScrollLeft) {
+			x = 'left';
+		} else if (clientX >= rightThreshold && canScrollRight) {
+			x = 'right';
+		}
+	}
+
+	let y: TimelineEdgeScrollDirections['y'] = null;
+	const vertical = timelineVerticalScroll.current;
+	if (includeVertical && vertical) {
+		const rect = vertical.getBoundingClientRect();
+		const topThreshold =
+			rect.top +
+			EDGE_SCROLL_VERTICAL_INSET +
+			(active.y === 'up' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
+		const bottomThreshold =
+			rect.bottom -
+			EDGE_SCROLL_VERTICAL_INSET -
+			(active.y === 'down' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
+		const {canScrollUp, canScrollDown} =
+			canScrollTimelineVerticallyIntoDirection();
+		if (clientY <= topThreshold && canScrollUp) {
+			y = 'up';
+		} else if (clientY >= bottomThreshold && canScrollDown) {
+			y = 'down';
+		}
+	}
+
+	return {x, y};
+};
+
+/**
+ * Shared edge auto-scroll loop for drag gestures on the timeline (playhead
+ * scrubbing, marquee selection). Detects when the pointer is in an edge zone
+ * and repeatedly invokes `onTick` while it stays there. The consumer performs
+ * the actual scrolling (and any dependent updates) inside `onTick`, so it can
+ * read a settled scroll position afterwards.
+ */
+export const startTimelineEdgeAutoScroll = ({
+	includeVertical,
+	onTick,
+}: {
+	includeVertical: boolean;
+	onTick: (directions: TimelineEdgeScrollDirections) => void;
+}): TimelineEdgeAutoScroller => {
+	let active: TimelineEdgeScrollDirections = {x: null, y: null};
+	let lastPointer: {clientX: number; clientY: number} | null = null;
+	let interval: ReturnType<typeof setInterval> | null = null;
+
+	const stopInterval = () => {
+		if (interval !== null) {
+			clearInterval(interval);
+			interval = null;
+		}
+	};
+
+	const tick = () => {
+		if (lastPointer === null) {
+			return;
+		}
+
+		active = getEdgeScrollDirections({
+			clientX: lastPointer.clientX,
+			clientY: lastPointer.clientY,
+			includeVertical,
+			active,
+		});
+		if (active.x === null && active.y === null) {
+			stopInterval();
+			return;
+		}
+
+		onTick(active);
+	};
+
+	const update = (e: {clientX: number; clientY: number}) => {
+		lastPointer = {clientX: e.clientX, clientY: e.clientY};
+		active = getEdgeScrollDirections({
+			clientX: e.clientX,
+			clientY: e.clientY,
+			includeVertical,
+			active,
+		});
+
+		if (active.x !== null || active.y !== null) {
+			if (interval === null) {
+				onTick(active);
+				interval = setInterval(tick, EDGE_SCROLL_INTERVAL_MS);
+			}
+		} else {
+			stopInterval();
+		}
+
+		return active;
+	};
+
+	const stop = () => {
+		stopInterval();
+		lastPointer = null;
+		active = {x: null, y: null};
+	};
+
+	return {update, stop};
+};
 
 const calculateFrameWhileScrollingRight = ({
 	durationInFrames,
@@ -104,6 +273,9 @@ export const ensureFrameIsInViewport = ({
 	durationInFrames: number;
 	frame: number;
 }) => {
+	// Sync the imperative frame first: scrolling below triggers the scroll
+	// listener in TimelineSlider, which reads the frame imperatively.
+	setCurrentFrame(frame);
 	redrawTimelineSliderFast.current?.draw(frame);
 	const width = scrollableRef.current?.scrollWidth ?? 0;
 	const scrollLeft = scrollableRef.current?.scrollLeft ?? 0;


### PR DESCRIPTION
## Summary

Unifies edge auto-scrolling for timeline drag gestures and fixes the playhead flickering while scrubbing at the edges.

- **Shared edge auto-scroll helper** (`startTimelineEdgeAutoScroll` in `timeline-scroll-logic.ts`): owns edge-zone detection and the scroll tick loop for both the playhead scrubber and the marquee selection, so both gestures scroll with the same cadence. Includes exit hysteresis so pixel jitter at the edge threshold no longer cancels and restarts the auto-scroll.
- **Playhead flicker fix**: the playhead position is `frameX(frame) - scrollLeft`, but during edge scrolling it was redrawn three times per tick with mixed stale pairs: an imperative draw with the new frame but the old scroll position, a scroll-event redraw using the stale `timelinePosition` closure (before React committed the `seek()`), and finally the correct pair after the React commit. Now the imperative frame is synced and the scroll is applied before drawing, and the scroll listener in `TimelineSlider` reads the frame imperatively, so every redraw sees a consistent (frame, scrollLeft) pair.
- **Marquee edge scrolling**: dragging a marquee selection to the left/right edge now scrolls the timeline horizontally, and to the top/bottom edge scrolls the track list vertically. The marquee anchor is fixed to timeline content (scroll-compensated), so the selection keeps covering everything swept over while the view scrolls, including items that moved off-screen. The rendered rectangle is clamped to the visible viewport, and each scroll tick re-runs the selection even while the pointer is stationary.

## Test plan

- [x] Playhead drag to the right edge auto-scrolls; measured the playhead's on-screen position at 60fps during a 2200px auto-scroll — it stays within a 5px band (previously it flickered between stale positions)
- [x] Marquee drag to the right edge auto-scrolls horizontally and selects tracks that were scrolled past
- [x] Marquee drag to the bottom edge auto-scrolls the vertical track list to its limit
- [x] `bunx turbo run make lint test --filter='@remotion/studio'`
- [x] `bun run build` and `bun run stylecheck`
