### PR TITLE
`@remotion/studio`: Fix phantom `<AbsoluteFill>` tracks in timeline

### DIFF
--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -1,5 +1,6 @@
 import {createRef} from 'react';
 import {getAbsoluteSrc} from './absolute-src.js';
+import {AbsoluteFillElement} from './AbsoluteFillElement.js';
 import {getAnimatedImageDurationInSeconds} from './animated-image/get-duration-in-seconds.js';
 import {AudioForPreview} from './audio/AudioForPreview.js';
 import type {ScheduleAudioNodeResult} from './audio/shared-audio-tags.js';
@@ -290,6 +291,7 @@ const compositionSelectorRef = createRef<{
 // Mark them as Internals so use don't assume this is public
 // API and are less likely to use it
 export const Internals = {
+	AbsoluteFillElement,
 	MaxMediaCacheSizeContext,
 	makeRenderResourceManager,
 	RenderResourceManagerContext,

--- a/packages/studio/src/components/AskAiModal.tsx
+++ b/packages/studio/src/components/AskAiModal.tsx
@@ -6,7 +6,7 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {ModalContainer} from './ModalContainer';
 import {ModalHeader} from './ModalHeader';
 
@@ -90,7 +90,9 @@ export const AskAiModal: React.FC = () => {
 	}
 
 	return (
-		<AbsoluteFill style={{display: state === 'visible' ? 'block' : 'none'}}>
+		<Internals.AbsoluteFillElement
+			style={{display: state === 'visible' ? 'block' : 'none'}}
+		>
 			<ModalContainer
 				noZIndex={state === 'hidden'}
 				onOutsideClick={onQuit}
@@ -105,6 +107,6 @@ export const AskAiModal: React.FC = () => {
 					allow="clipboard-read; clipboard-write"
 				/>
 			</ModalContainer>
-		</AbsoluteFill>
+		</Internals.AbsoluteFillElement>
 	);
 };

--- a/packages/studio/src/components/NoRegisterRoot.tsx
+++ b/packages/studio/src/components/NoRegisterRoot.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {WHITE} from '../helpers/colors';
 
 const label: React.CSSProperties = {
@@ -41,7 +41,7 @@ export const NoRegisterRoot: React.FC = () => {
 	}
 
 	return (
-		<AbsoluteFill style={container}>
+		<Internals.AbsoluteFillElement style={container}>
 			<div style={label}>Waiting for registerRoot() to get called.</div>
 			<div style={label}>
 				Learn more:{' '}
@@ -53,6 +53,6 @@ export const NoRegisterRoot: React.FC = () => {
 					remotion.dev/docs/register-root
 				</a>
 			</div>
-		</AbsoluteFill>
+		</Internals.AbsoluteFillElement>
 	);
 };

--- a/packages/studio/src/components/RefreshCompositionOverlay.tsx
+++ b/packages/studio/src/components/RefreshCompositionOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {SHADOW_BLACK} from '../helpers/colors';
 import {RunningCalculateMetadata} from './RunningCalculateMetadata';
 
@@ -16,10 +16,10 @@ const shadow: React.CSSProperties = {
 
 export const RefreshCompositionOverlay: React.FC = () => {
 	return (
-		<AbsoluteFill style={container}>
+		<Internals.AbsoluteFillElement style={container}>
 			<div style={shadow}>
 				<RunningCalculateMetadata />
 			</div>
-		</AbsoluteFill>
+		</Internals.AbsoluteFillElement>
 	);
 };

--- a/packages/studio/src/components/Timeline/LoopedIndicator.tsx
+++ b/packages/studio/src/components/Timeline/LoopedIndicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {
 	LIGHT_COLOR,
 	LOOPED_INDICATOR_DROP_SHADOW,
@@ -41,12 +41,12 @@ const centerContainer: React.CSSProperties = {
 export const LoopedIndicator: React.FC = () => {
 	return (
 		<div style={width}>
-			<AbsoluteFill style={centerContainer}>
+			<Internals.AbsoluteFillElement style={centerContainer}>
 				<div style={verticalLine} />
-			</AbsoluteFill>
-			<AbsoluteFill style={centerContainer}>
+			</Internals.AbsoluteFillElement>
+			<Internals.AbsoluteFillElement style={centerContainer}>
 				<Icon />
-			</AbsoluteFill>
+			</Internals.AbsoluteFillElement>
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/LoopedTimelineIndicators.tsx
+++ b/packages/studio/src/components/Timeline/LoopedTimelineIndicators.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {LoopedIndicator} from './LoopedIndicator';
 
 const row: React.CSSProperties = {
@@ -35,7 +35,7 @@ export const LoopedTimelineIndicator: React.FC<{
 		.map((_, index) => (firstVisibleBoundaryIndex + index) * loopWidth);
 
 	return (
-		<AbsoluteFill style={row}>
+		<Internals.AbsoluteFillElement style={row}>
 			{boundaries.map((boundary) => {
 				return (
 					<div
@@ -52,6 +52,6 @@ export const LoopedTimelineIndicator: React.FC<{
 					</div>
 				);
 			})}
-		</AbsoluteFill>
+		</Internals.AbsoluteFillElement>
 	);
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Overlay.tsx
@@ -4,7 +4,7 @@ import React, {
 	useImperativeHandle,
 	useState,
 } from 'react';
-import {AbsoluteFill} from 'remotion';
+import {Internals} from 'remotion';
 import {MENU_TOOLBAR_HEIGHT} from '../../components/menu-toolbar-height';
 import {SettingsProvider} from '../../components/SettingsContext';
 import {PreviewServerConnection} from '../../helpers/client-id';
@@ -72,7 +72,7 @@ export const Overlay: React.FC = () => {
 		<PreviewServerConnection>
 			<SettingsProvider>
 				<KeybindingContextProvider>
-					<AbsoluteFill
+					<Internals.AbsoluteFillElement
 						style={{
 							backgroundColor: BACKGROUND_COLOR,
 							overflow: 'auto',
@@ -94,7 +94,7 @@ export const Overlay: React.FC = () => {
 								/>
 							);
 						})}
-					</AbsoluteFill>
+					</Internals.AbsoluteFillElement>
 				</KeybindingContextProvider>
 			</SettingsProvider>
 		</PreviewServerConnection>

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -17,7 +17,6 @@ import type {
 	VideoConfigWithSerializedProps,
 } from 'remotion';
 import {
-	AbsoluteFill,
 	getInputProps,
 	getRemotionEnvironment,
 	continueRender as globalContinueRender,
@@ -79,7 +78,7 @@ const DelayedSpinner: React.FC = () => {
 	}
 
 	return (
-		<AbsoluteFill
+		<Internals.AbsoluteFillElement
 			style={{
 				justifyContent: 'center',
 				alignItems: 'center',
@@ -90,7 +89,7 @@ const DelayedSpinner: React.FC = () => {
 			}}
 		>
 			Loading Studio
-		</AbsoluteFill>
+		</Internals.AbsoluteFillElement>
 	);
 };
 


### PR DESCRIPTION
## Problem

Studio's own UI components (timeline loop indicators, error overlay, modals, loading spinner) used the public `<AbsoluteFill>` from `remotion`. Since `<AbsoluteFill>` now wraps itself in a `<Sequence>` whenever a video config is available — and `useUnsafeVideoConfig()` resolves the currently selected composition anywhere inside the Studio app — every such usage registered a phantom sequence.

This became visible as extra `<AbsoluteFill>` tracks in the timeline: opening a composition with looped media rendered the loop-boundary indicators, whose `AbsoluteFill`s registered as full-duration sequences and appeared as bogus timeline rows (which in turn rendered more indicators).

## Fix

- Export the plain, non-registering `AbsoluteFillElement` via `Internals`.
- Replace all `AbsoluteFill` usages in `@remotion/studio` UI code with `Internals.AbsoluteFillElement`:
  - `Timeline/LoopedTimelineIndicators.tsx` and `Timeline/LoopedIndicator.tsx` (the direct cause of the phantom tracks)
  - `renderEntry.tsx` (loading spinner)
  - `error-overlay/remotion-overlay/Overlay.tsx`
  - `AskAiModal.tsx`
  - `NoRegisterRoot.tsx`
  - `RefreshCompositionOverlay.tsx`

`AbsoluteFillElement` renders the same styled `<div>` without any sequence registration.
