### PR TITLE
Docs: Fix Studio Protocol examples and formatting

### DIFF
--- a/.agents/skills/writing-docs/SKILL.md
+++ b/.agents/skills/writing-docs/SKILL.md
@@ -42,6 +42,7 @@ crumb: '@remotion/my-package'
 
 - **Keep it brief**: Developers don't like to read. Extra words cause information loss.
 - **Link to terminology**: Use [terminology](/docs/terminology) page for Remotion-specific terms.
+- **Do not bold terms**: Write terms as plain text, code spans, or links as appropriate. Do not use bold formatting to introduce a term.
 - **Avoid emotions**: Remove filler like "Great! Let's move on..." - it adds no information.
 - **Separate into paragraphs**: Break up long sections.
 - **Address as "you"**: Not "we".
@@ -95,11 +96,11 @@ console.log('Hello');
 
 ### Steps
 
-Formatting around `<Step>` is delicate. Keep one step per line, add a space after `</Step>`, and preserve an explicit line break (`<br/>` or `<br />`) when the steps are written as a compact inline list. Do not write `<Step>1</Step>Add...` without a space.
+Keep one `<Step>` per line and add a space after `</Step>`. Use an explicit line break (`<br/>` or `<br />`) when consecutive steps should appear on separate lines. Do not add Markdown bullet markers solely to wrap steps in a `<ul>`.
 
 ```md
-- <Step>1</Step> First step
-- <Step>2</Step> Second step
+<Step>1</Step> First step<br />
+<Step>2</Step> Second step
 ```
 
 ### Experimental badge

--- a/packages/docs/docs/studio-protocol/create-element-payload.mdx
+++ b/packages/docs/docs/studio-protocol/create-element-payload.mdx
@@ -10,9 +10,14 @@ Creates a validated, versioned Element payload for [`setStudioDragData()`](/docs
 
 ## Example
 
-```ts title="element-payload.ts"
+```ts twoslash title="element-payload.ts"
 import {createElementPayload} from '@remotion/studio-protocol';
-import elementSourceCode from './MyElement.tsx?raw'; // Import the source code as text
+
+const elementSourceCode = `
+export const MyElement = () => {
+  return <div>Hello world</div>;
+};
+`;
 
 const payload = createElementPayload({
   displayName: 'My Element',
@@ -41,9 +46,7 @@ A lowercase Element identifier. Its final path segment is used to create the `.e
 
 ### sourceCode
 
-The complete Element source code. It must contain exactly one exported named component.
-
-With Vite, use the [`?raw` import suffix](https://vite.dev/guide/assets#importing-asset-as-string) to import the component file as a string. Other build tools may provide an equivalent raw-text import.
+A string containing the complete Element source code. It must contain exactly one exported named component.
 
 ### dependencies
 

--- a/packages/docs/docs/studio-protocol/index.mdx
+++ b/packages/docs/docs/studio-protocol/index.mdx
@@ -14,12 +14,12 @@ A versioned protocol for providing content to Remotion Studio.
 
 ### Installing Remotion Elements
 
-A **Remotion Element** is a reusable React component distributed as source code, together with the metadata and dependencies needed to add it to a composition. Because its source code becomes part of the project, it can be edited and remixed by the user.
+A Remotion Element is a reusable React component distributed as source code, together with the metadata and dependencies needed to add it to a composition. Because its source code becomes part of the project, it can be edited and remixed by the user.
 
 Websites can provide Remotion Elements by drag-and-drop or request their installation into the active composition.
 
-- <Step>1</Step> Create an Element payload with [`createElementPayload()`](/docs/studio-protocol/create-element-payload).
-- <Step>2</Step> Provide the payload to Studio: put it on a drag event with [`setStudioDragData()`](/docs/studio-protocol/set-studio-drag-data), or request installation into the active composition with [`installInStudio()`](/docs/studio-protocol/install-in-studio).
+<Step>1</Step> Create an Element payload with [`createElementPayload()`](/docs/studio-protocol/create-element-payload).<br />
+<Step>2</Step> Provide the payload to Studio: put it on a drag event with [`setStudioDragData()`](/docs/studio-protocol/set-studio-drag-data), or request installation into the active composition with [`installInStudio()`](/docs/studio-protocol/install-in-studio).
 
 Offer both delivery methods when possible. They use the same Element payload but suit different workflows.
 

--- a/packages/docs/docs/studio-protocol/install-in-studio.mdx
+++ b/packages/docs/docs/studio-protocol/install-in-studio.mdx
@@ -10,12 +10,17 @@ Discovers a recently focused Remotion Studio and sends it an Element payload.
 
 ## Example
 
-```ts title="install-element.ts"
+```ts twoslash title="install-element.ts"
 import {
   createElementPayload,
   installInStudio,
 } from '@remotion/studio-protocol';
-import elementSourceCode from './MyElement.tsx?raw'; // Import the source code as text
+
+const elementSourceCode = `
+export const MyElement = () => {
+  return <div>Hello world</div>;
+};
+`;
 
 const payload = createElementPayload({
   displayName: 'My Element',

--- a/packages/docs/docs/studio-protocol/security.mdx
+++ b/packages/docs/docs/studio-protocol/security.mdx
@@ -1,6 +1,7 @@
 ---
 image: /generated/articles-docs-studio-protocol-security.png
 title: 'Studio Protocol security'
+sidebar_label: 'Security'
 crumb: '@remotion/studio-protocol'
 ---
 

--- a/packages/docs/docs/studio-protocol/set-studio-drag-data.mdx
+++ b/packages/docs/docs/studio-protocol/set-studio-drag-data.mdx
@@ -10,12 +10,17 @@ Writes an Element payload and its preview metadata to a browser `DataTransfer` o
 
 ## Example
 
-```tsx title="DraggableElement.tsx"
+```tsx twoslash title="DraggableElement.tsx"
 import {
   createElementPayload,
   setStudioDragData,
 } from '@remotion/studio-protocol';
-import elementSourceCode from './MyElement.tsx?raw'; // Import the source code as text
+
+const elementSourceCode = `
+export const MyElement = () => {
+  return <div>Hello world</div>;
+};
+`;
 
 const payload = createElementPayload({
   displayName: 'My Element',


### PR DESCRIPTION
## Summary

- type-check Studio Protocol examples with Twoslash and inline Element source strings
- clarify the `sourceCode` input and simplify the Security sidebar label
- align step and terminology formatting with the documentation writing guidelines

## Verification

- `cd packages/docs && TWOSLASH_WORKER_COUNT=1 bun run prewarm-twoslash`
- `bun run build`
- `bun run stylecheck`


## Preview

- [Studio Protocol](https://remotion-git-studio-protocol-doc-fixes-remotion.vercel.app/docs/studio-protocol/index)
- [`createElementPayload()`](https://remotion-git-studio-protocol-doc-fixes-remotion.vercel.app/docs/studio-protocol/create-element-payload)
- [`setStudioDragData()`](https://remotion-git-studio-protocol-doc-fixes-remotion.vercel.app/docs/studio-protocol/set-studio-drag-data)
- [`installInStudio()`](https://remotion-git-studio-protocol-doc-fixes-remotion.vercel.app/docs/studio-protocol/install-in-studio)
- [Security](https://remotion-git-studio-protocol-doc-fixes-remotion.vercel.app/docs/studio-protocol/security)
