### PR TITLE
`@remotion/browser-studio`: Support composition and folder codemods

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -7,10 +7,13 @@ import {
 	getCanUpdateDefaultPropsForProject,
 	getCompositionComponentInfo,
 	getCompositionFile,
+	getFolderFile,
+	getRootFileForProject,
 	insertJsxElementIntoProjectWithNodePathRemappings,
 	JsxElementIdentityMismatchError,
 	JsxElementNotFoundAtLocationError,
 	makeInMemoryInsertJsxElementCodemodEnvironment,
+	parseAndApplyCodemod,
 	resolveCompositionComponentWithFile,
 	simpleDiff,
 	splitJsxSequence as splitJsxSequenceCodemod,
@@ -23,8 +26,10 @@ import {
 	type ElementInstallExpectedFileState,
 	type EventSourceEvent,
 	type InsertElementResponse,
+	type RecastCodemod,
 	type SubscribeToSequencePropsRequest,
 	type SubscribeToSequencePropsResponse,
+	type SymbolicatedStackFrame,
 	type UnsubscribeFromSequencePropsRequest,
 } from '@remotion/studio-shared';
 import * as prettierPluginEstree from 'prettier/plugins/estree';
@@ -127,6 +132,89 @@ const relativeToRoot = (filePath: string, rootDir: string) => {
 		? filePath.slice(root.length + 1)
 		: filePath.replace(/^\//, '');
 };
+
+const getCodemodTargetCompositionId = (
+	codemod: RecastCodemod,
+): string | null => {
+	if (codemod.type === 'duplicate-composition') {
+		return codemod.idToDuplicate;
+	}
+
+	if (codemod.type === 'rename-composition') {
+		return codemod.idToRename;
+	}
+
+	if (codemod.type === 'update-composition-metadata') {
+		return codemod.idToUpdate;
+	}
+
+	if (codemod.type === 'delete-composition') {
+		return codemod.idToDelete;
+	}
+
+	if (codemod.type === 'move-composition-to-folder') {
+		return codemod.idToMove;
+	}
+
+	return null;
+};
+
+const resolveCodemodTargetFile = ({
+	codemod,
+	project,
+	symbolicatedStack,
+}: {
+	codemod: RecastCodemod;
+	project: VirtualProject;
+	symbolicatedStack: SymbolicatedStackFrame | null;
+}): string => {
+	if (symbolicatedStack?.originalFileName) {
+		return findProjectFile({
+			filePath: symbolicatedStack.originalFileName,
+			project,
+		});
+	}
+
+	const compositionId = getCodemodTargetCompositionId(codemod);
+	if (compositionId !== null) {
+		const compositionFile = getCompositionFile({compositionId, project});
+		if (compositionFile === null) {
+			throw new Error(`Could not find composition "${compositionId}"`);
+		}
+
+		return findProjectFile({filePath: compositionFile, project});
+	}
+
+	if (codemod.type === 'rename-folder' || codemod.type === 'delete-folder') {
+		const folderFile = getFolderFile({
+			folderName: codemod.folderName,
+			project,
+		});
+		if (folderFile === null) {
+			throw new Error(`Could not find folder "${codemod.folderName}"`);
+		}
+
+		return findProjectFile({filePath: folderFile, project});
+	}
+
+	const rootFile = getRootFileForProject({
+		entryPoint: project.entryPoint,
+		project,
+	});
+	if (rootFile === null) {
+		throw new Error('Could not find the root file of the project');
+	}
+
+	return findProjectFile({filePath: rootFile, project});
+};
+
+const makeNewCompositionComponentSource = (componentName: string) =>
+	`import React from 'react';
+
+export const ${componentName}: React.FC = () => {
+	return null;
+};
+`;
 
 const getElementInstallPlanForProject = async ({
 	compositionFile,
@@ -509,6 +597,77 @@ export const createBrowserStudioOperations = ({
 		}
 	};
 
+	const applyCodemod: BrowserStudioOperations['applyCodemod'] = async ({
+		codemod,
+		dryRun,
+		symbolicatedStack,
+	}) => {
+		try {
+			if (codemod.type === 'apply-visual-control') {
+				throw new Error(
+					'Applying visual controls is not supported in Browser Studio',
+				);
+			}
+
+			if (
+				codemod.type === 'new-composition' &&
+				codemod.canvasCapture !== null
+			) {
+				throw new Error(
+					'Creating canvas capture compositions is not supported in Browser Studio',
+				);
+			}
+
+			const project = getProject();
+			const absolutePath = resolveCodemodTargetFile({
+				codemod,
+				project,
+				symbolicatedStack,
+			});
+			const input = project.files[absolutePath];
+			const {newContents} = parseAndApplyCodemod({input, codeMod: codemod});
+			const {output} = await formatCodemodFile({contents: newContents});
+			const files: Record<string, string> = {
+				...project.files,
+				[absolutePath]: output,
+			};
+
+			if (codemod.type === 'new-composition') {
+				const componentFilePath = `${dirname(absolutePath)}/${codemod.componentName}.tsx`;
+				if (project.files[componentFilePath] !== undefined) {
+					throw new Error(
+						`Cannot create ${relativeToRoot(componentFilePath, project.rootDir)} because it already exists`,
+					);
+				}
+
+				const componentFile = await formatCodemodFile({
+					contents: makeNewCompositionComponentSource(codemod.componentName),
+				});
+				files[componentFilePath] = componentFile.output;
+			}
+
+			const diff = simpleDiff({
+				oldLines: input.split('\n'),
+				newLines: output.split('\n'),
+			});
+
+			if (!dryRun) {
+				controller.applyMutation({
+					fileName: absolutePath,
+					nodePathMutationFiles: null,
+					mutate: () => ({...project, files}),
+				});
+			}
+
+			return {success: true, diff};
+		} catch (error) {
+			return {
+				success: false,
+				reason: error instanceof Error ? error.message : String(error),
+			};
+		}
+	};
+
 	const duplicateComposition: BrowserStudioOperations['duplicateComposition'] =
 		async ({codemod, dryRun}) => {
 			try {
@@ -657,6 +816,7 @@ export const createBrowserStudioOperations = ({
 	};
 
 	return {
+		applyCodemod,
 		deleteJsxNode,
 		deleteStaticFile: controller.deleteStaticFile,
 		downloadProject: () =>

--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -772,3 +772,327 @@ registerRoot(Root);`,
 		'<Sequence from={15} durationInFrames={15} trimBefore={5} />',
 	);
 });
+
+const makeOperationsForProject = (project: VirtualProject) => {
+	let currentProject = project;
+	const operations = createBrowserStudioOperations({
+		dependencyVersions: {},
+		getStaticFiles: null,
+		getProject: () => currentProject,
+		onProjectChange: (nextProject) => {
+			currentProject = nextProject;
+		},
+		resolveDependencies: null,
+	});
+	return {operations, getProject: () => currentProject};
+};
+
+test('renames a composition by resolving the file from the composition id', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+
+	const result = await operations.applyCodemod({
+		codemod: {
+			type: 'rename-composition',
+			idToRename: 'MyComp',
+			newId: 'RenamedComp',
+		},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	expect(getProject().files['/project/src/Composition.tsx']).toContain(
+		'id="RenamedComp"',
+	);
+
+	const undoResult = await operations.undo();
+	expect(undoResult.success).toBe(true);
+	expect(getProject().files['/project/src/Composition.tsx']).toContain(
+		'id="MyComp"',
+	);
+});
+
+test('updates composition metadata in Browser Studio', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+
+	const result = await operations.applyCodemod({
+		codemod: {
+			type: 'update-composition-metadata',
+			idToUpdate: 'MyComp',
+			newDurationInFrames: 120,
+			newFps: 60,
+			newHeight: 1080,
+			newWidth: 1920,
+		},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	const composition = getProject().files['/project/src/Composition.tsx'];
+	expect(composition).toContain('durationInFrames={120}');
+	expect(composition).toContain('fps={60}');
+	expect(composition).toContain('width={1920}');
+	expect(composition).toContain('height={1080}');
+});
+
+test('deletes a composition and supports a dry run', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+	const initialContents = getProject().files['/project/src/Composition.tsx'];
+
+	const dryRunResult = await operations.applyCodemod({
+		codemod: {type: 'delete-composition', idToDelete: 'MyComp'},
+		dryRun: true,
+		symbolicatedStack: null,
+	});
+	if (!dryRunResult.success) {
+		throw new Error(dryRunResult.reason);
+	}
+
+	expect(dryRunResult.diff.deletions).toBeGreaterThan(0);
+	expect(getProject().files['/project/src/Composition.tsx']).toBe(
+		initialContents,
+	);
+
+	const result = await operations.applyCodemod({
+		codemod: {type: 'delete-composition', idToDelete: 'MyComp'},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	expect(getProject().files['/project/src/Composition.tsx']).not.toContain(
+		'<Composition',
+	);
+});
+
+test('creates a composition with a component file in the root file', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+
+	const codemod = {
+		type: 'new-composition' as const,
+		newId: 'FreshComp',
+		componentName: 'FreshComp',
+		componentImportPath: './FreshComp',
+		folderName: null,
+		parentName: null,
+		newHeight: 720,
+		newWidth: 1280,
+		newFps: 30,
+		newDurationInFrames: 90,
+		canvasCapture: null,
+	};
+	const result = await operations.applyCodemod({
+		codemod,
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	const rootFile = getProject().files['/project/src/Root.tsx'];
+	expect(rootFile).toContain('id="FreshComp"');
+	expect(rootFile).toContain("import {Composition} from 'remotion'");
+	expect(rootFile).toContain("import {FreshComp} from './FreshComp'");
+	expect(getProject().files['/project/src/FreshComp.tsx']).toContain(
+		'export const FreshComp: React.FC',
+	);
+
+	const conflict = await operations.applyCodemod({
+		codemod: {...codemod, newId: 'FreshComp2'},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	expect(conflict).toEqual({
+		success: false,
+		reason: 'Cannot create src/FreshComp.tsx because it already exists',
+	});
+
+	const undoResult = await operations.undo();
+	expect(undoResult.success).toBe(true);
+	expect(getProject().files['/project/src/FreshComp.tsx']).toBeUndefined();
+	expect(getProject().files['/project/src/Root.tsx']).not.toContain(
+		'id="FreshComp"',
+	);
+});
+
+test('creates, renames and deletes a folder in Browser Studio', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+
+	const createResult = await operations.applyCodemod({
+		codemod: {type: 'new-folder', folderName: 'my-folder', parentName: null},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!createResult.success) {
+		throw new Error(createResult.reason);
+	}
+
+	const rootFile = getProject().files['/project/src/Root.tsx'];
+	expect(rootFile).toContain('<Folder name="my-folder" />');
+	expect(rootFile).toContain("import {Folder} from 'remotion'");
+
+	const renameResult = await operations.applyCodemod({
+		codemod: {
+			type: 'rename-folder',
+			folderName: 'my-folder',
+			parentName: null,
+			newName: 'renamed-folder',
+		},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!renameResult.success) {
+		throw new Error(renameResult.reason);
+	}
+
+	expect(getProject().files['/project/src/Root.tsx']).toContain(
+		'<Folder name="renamed-folder" />',
+	);
+
+	const deleteResult = await operations.applyCodemod({
+		codemod: {
+			type: 'delete-folder',
+			folderName: 'renamed-folder',
+			parentName: null,
+		},
+		dryRun: false,
+		symbolicatedStack: null,
+	});
+	if (!deleteResult.success) {
+		throw new Error(deleteResult.reason);
+	}
+
+	expect(getProject().files['/project/src/Root.tsx']).not.toContain('<Folder');
+});
+
+test('moves a composition into a folder using a symbolicated stack', async () => {
+	const fileName = '/project/src/Root.tsx';
+	const {operations, getProject} = makeOperationsForProject({
+		rootDir: '/project',
+		entryPoint: '/project/src/index.ts',
+		files: {
+			'/project/src/index.ts': `import {registerRoot} from 'remotion';
+import {Root} from './Root';
+registerRoot(Root);
+`,
+			[fileName]: `import {Composition, Folder} from 'remotion';
+
+const MyComponent = () => null;
+
+export const Root = () => {
+	return (
+		<>
+			<Folder name="target-folder" />
+			<Composition id="MyComp" component={MyComponent} durationInFrames={60} fps={30} width={1280} height={720} />
+		</>
+	);
+};
+`,
+		},
+	});
+
+	const result = await operations.applyCodemod({
+		codemod: {
+			type: 'move-composition-to-folder',
+			idToMove: 'MyComp',
+			folderName: 'target-folder',
+			parentName: null,
+		},
+		dryRun: false,
+		symbolicatedStack: {
+			originalFileName: 'src/Root.tsx',
+			originalFunctionName: null,
+			originalLineNumber: 9,
+			originalColumnNumber: 4,
+			originalScriptCode: null,
+		},
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	const rootFile = getProject().files[fileName];
+	expect(rootFile).toContain('<Folder name="target-folder">');
+	expect(rootFile.indexOf('<Composition')).toBeGreaterThan(
+		rootFile.indexOf('<Folder'),
+	);
+});
+
+test('reports structured failures for unsupported codemods', async () => {
+	const {operations, getProject} = makeOperationsForProject(
+		createBlankTemplateProject(),
+	);
+	const initialFiles = {...getProject().files};
+
+	expect(
+		await operations.applyCodemod({
+			codemod: {type: 'apply-visual-control', changes: []},
+			dryRun: false,
+			symbolicatedStack: null,
+		}),
+	).toEqual({
+		success: false,
+		reason: 'Applying visual controls is not supported in Browser Studio',
+	});
+
+	expect(
+		await operations.applyCodemod({
+			codemod: {
+				type: 'new-composition',
+				newId: 'CanvasComp',
+				componentName: 'CanvasComp',
+				componentImportPath: './CanvasComp',
+				folderName: null,
+				parentName: null,
+				newHeight: 720,
+				newWidth: 1280,
+				newFps: 30,
+				newDurationInFrames: 90,
+				canvasCapture: {
+					videoFileName: 'video.mp4',
+					videoHeight: 720,
+					videoWidth: 1280,
+					keyframeFps: 30,
+					data: {version: 1, tracks: []} as never,
+				},
+			},
+			dryRun: false,
+			symbolicatedStack: null,
+		}),
+	).toEqual({
+		success: false,
+		reason:
+			'Creating canvas capture compositions is not supported in Browser Studio',
+	});
+
+	expect(
+		await operations.applyCodemod({
+			codemod: {type: 'delete-composition', idToDelete: 'MissingComp'},
+			dryRun: false,
+			symbolicatedStack: null,
+		}),
+	).toEqual({
+		success: false,
+		reason: 'Could not find composition "MissingComp"',
+	});
+
+	expect(getProject().files).toEqual(initialFiles);
+});

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -1366,6 +1366,126 @@ export const getCompositionFile = ({
 	return null;
 };
 
+export const getFolderFile = ({
+	folderName,
+	project,
+}: {
+	folderName: string;
+	project: CodemodProject;
+}) => {
+	for (const [filePath, source] of Object.entries(project.files)) {
+		if (typeof source !== 'string') {
+			continue;
+		}
+
+		try {
+			const ast = parseSource(source);
+			let found = false;
+			visit(ast, (node) => {
+				if (node.type !== 'JSXElement') {
+					return false;
+				}
+
+				const openingElement = getNode(node, 'openingElement');
+				if (
+					!openingElement ||
+					jsxName(getNode(openingElement, 'name')) !== 'Folder'
+				) {
+					return false;
+				}
+
+				if (
+					jsxAttributeString(getJsxAttribute(openingElement, 'name')) !==
+					folderName
+				) {
+					return false;
+				}
+
+				found = true;
+				return true;
+			});
+			if (found) {
+				return relativeToRoot(filePath, project.rootDir);
+			}
+		} catch {
+			// Ignore files that are not parseable source modules.
+		}
+	}
+
+	return null;
+};
+
+export const getRootFileForProject = ({
+	entryPoint,
+	project,
+}: {
+	entryPoint: string;
+	project: CodemodProject;
+}): string | null => {
+	let entryFile: string;
+	try {
+		entryFile = findProjectFile({filePath: entryPoint, project});
+	} catch {
+		return null;
+	}
+
+	try {
+		const ast = parseSource(project.files[entryFile]);
+		let rootComponentName: string | null = null;
+		visit(ast, (node) => {
+			if (node.type !== 'CallExpression') {
+				return false;
+			}
+
+			const callee = getNode(node, 'callee');
+			if (
+				callee?.type !== 'Identifier' ||
+				getString(callee, 'name') !== 'registerRoot'
+			) {
+				return false;
+			}
+
+			const [argument] = getNodes(node, 'arguments');
+			if (argument?.type === 'Identifier') {
+				rootComponentName = getString(argument, 'name');
+			}
+
+			return true;
+		});
+		if (rootComponentName === null) {
+			return null;
+		}
+
+		let importPath: string | null = null;
+		visit(ast, (node) => {
+			if (node.type !== 'ImportDeclaration') {
+				return false;
+			}
+
+			for (const specifier of getNodes(node, 'specifiers')) {
+				const local = getNode(specifier, 'local');
+				if (local && getString(local, 'name') === rootComponentName) {
+					importPath = getString(getNode(node, 'source'), 'value');
+					return true;
+				}
+			}
+
+			return false;
+		});
+		if (importPath === null) {
+			// The root component is defined in the entry file itself.
+			return relativeToRoot(entryFile, project.rootDir);
+		}
+
+		return relativeToRoot(
+			resolveImportFile({fromFile: entryFile, importPath, project}),
+			project.rootDir,
+		);
+	} catch {
+		return null;
+	}
+};
+
 const staticFileToken = 'remotion-file:';
 const dateToken = 'remotion-date:';
 

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -1,4 +1,6 @@
 import type {
+	ApplyCodemodRequest,
+	ApplyCodemodResponse,
 	CompositionComponentInfoRequest,
 	CompositionComponentInfoResponse,
 	DeleteJsxNodeRequest,
@@ -56,6 +58,7 @@ export type DuplicateCompositionResponse =
 	  };
 
 export type BrowserStudioOperations = {
+	applyCodemod: (request: ApplyCodemodRequest) => Promise<ApplyCodemodResponse>;
 	deleteJsxNode: (
 		request: DeleteJsxNodeRequest,
 	) => Promise<DeleteJsxNodeResponse>;

--- a/packages/studio/src/components/RenderQueue/actions.ts
+++ b/packages/studio/src/components/RenderQueue/actions.ts
@@ -21,6 +21,7 @@ import type {
 } from '@remotion/studio-shared';
 import type {_InternalTypes} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {callApi} from '../call-api';
 
 export const addStillRenderJob = ({
@@ -361,6 +362,11 @@ export const applyCodemod = ({
 		dryRun,
 		symbolicatedStack,
 	};
+	const browserStudioOperations = getBrowserStudioOperations();
+	if (browserStudioOperations !== null) {
+		return browserStudioOperations.applyCodemod(body);
+	}
+
 	return callApi('/api/apply-codemod', body, signal);
 };
 

--- a/packages/studio/src/test/make-browser-studio-operations.ts
+++ b/packages/studio/src/test/make-browser-studio-operations.ts
@@ -8,6 +8,7 @@ export const makeBrowserStudioOperations = (
 	overrides: Partial<BrowserStudioOperations>,
 ): BrowserStudioOperations => {
 	return {
+		applyCodemod: () => unusedOperation('applyCodemod'),
 		deleteJsxNode: () => unusedOperation('deleteJsxNode'),
 		deleteStaticFile: () => unusedOperation('deleteStaticFile'),
 		downloadProject: () => unusedOperation('downloadProject'),


### PR DESCRIPTION
Closes #10570.
Closes #10571.
Closes #10572.

Adds a typed `applyCodemod` Browser Studio operation so composition and folder codemods work on [remotion.dev/new](https://remotion.dev/new) without `@remotion/studio-server`:

- Creating, duplicating, renaming, deleting and moving compositions.
- Creating, renaming and deleting composition folders.
- Changing composition metadata (`durationInFrames`, `fps`, width, height).

## How it works

- `applyCodemod` is added to `BrowserStudioOperations` and implemented in `@remotion/browser-studio` using the shared `parseAndApplyCodemod` from `@remotion/studio-codemods` against the virtual project. The HTTP API is not mocked.
- The single `applyCodemod` client in `RenderQueue/actions.ts` now prefers the Browser Studio operation when available, so all call sites (new composition, rename, delete, move to folder, folders, metadata, `CodemodFooter` dry-run previews) work at once.
- Target file resolution mirrors the server: the symbolicated stack frame wins; otherwise the file is resolved from the composition id (`getCompositionFile`), the folder name (new `getFolderFile`), or the project root file (new `getRootFileForProject`, which follows `registerRoot()` imports).
- `new-composition` also creates the component file next to the target file and fails with a structured error if it already exists, matching the server.
- Mutations go through the project controller, so they trigger HMR and participate in undo/redo. Dry runs return a diff without mutating.
- Unsupported actions fail gracefully with a structured error: `apply-visual-control` and canvas-capture compositions.

## Tests

Browser Studio unit tests cover rename/metadata/delete (including dry run), new composition (component file creation, conflict error, undo), folder create/rename/delete, move-to-folder via a symbolicated stack, and structured failures for unsupported codemods.
