### PR TITLE
`@remotion/browser-studio`: Reorder sequences in the timeline

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -15,6 +15,7 @@ import {
 	JsxElementNotFoundAtLocationError,
 	makeInMemoryInsertJsxElementCodemodEnvironment,
 	parseAndApplyCodemod,
+	reorderSequence as reorderSequenceCodemod,
 	resolveCompositionComponentWithFile,
 	simpleDiff,
 	splitJsxSequence as splitJsxSequenceCodemod,
@@ -690,6 +691,53 @@ export const createBrowserStudioOperations = ({
 		}
 	};
 
+	const reorderSequence: BrowserStudioOperations['reorderSequence'] = async ({
+		fileName,
+		sourceNodePath,
+		targetNodePath,
+		position,
+	}) => {
+		try {
+			const project = getProject();
+			const absolutePath = findProjectFile({
+				filePath: fileName,
+				project,
+			});
+			const result = await reorderSequenceCodemod({
+				input: project.files[absolutePath],
+				sourceNodePath: sourceNodePath.nodePath,
+				targetNodePath: targetNodePath.nodePath,
+				position,
+				formatFile: formatCodemodFile,
+			});
+			const nodePathMutation = controller.applyMutation({
+				fileName: absolutePath,
+				mutate: () => ({
+					...project,
+					files: {...project.files, [absolutePath]: result.output},
+				}),
+				nodePathMutationFiles: [
+					{
+						absolutePath,
+						remappings: result.nodePathRemappings,
+						restoredNodePaths: [],
+					},
+				],
+			});
+			if (nodePathMutation === null) {
+				throw new Error('Could not reorder sequence');
+			}
+
+			return {success: true, nodePathMutation};
+		} catch (error) {
+			return {
+				success: false,
+				reason: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error && error.stack ? error.stack : '',
+			};
+		}
+	};
+
 	const duplicateComposition: BrowserStudioOperations['duplicateComposition'] =
 		async ({codemod, dryRun}) => {
 			try {
@@ -1056,6 +1104,7 @@ export const createBrowserStudioOperations = ({
 		},
 		redo: controller.redo,
 		renameStaticFile: controller.renameStaticFile,
+		reorderSequence,
 		saveSequenceProps: (request) => {
 			try {
 				let response: Awaited<

--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -1036,6 +1036,110 @@ export const Root = () => {
 	);
 });
 
+test('reorders JSX sequences as an undoable project mutation', async () => {
+	const fileName = '/project/src/Composition.tsx';
+	const initialContents = `import {Composition, Sequence} from 'remotion';
+
+export const Component = () => {
+	return (
+		<>
+			<Sequence name="first" from={0} durationInFrames={20} />
+			<Sequence name="second" from={20} durationInFrames={20} />
+		</>
+	);
+};
+
+export const Root = () => <Composition id="MyComp" component={Component} durationInFrames={60} fps={30} width={1280} height={720} />;
+`;
+	const {operations, getProject} = makeOperationsForProject({
+		rootDir: '/project',
+		entryPoint: '/project/src/index.tsx',
+		files: {
+			'/project/src/index.tsx': `import {registerRoot} from 'remotion';
+import {Root} from './Composition';
+registerRoot(Root);`,
+			[fileName]: initialContents,
+		},
+	});
+	const events: EventSourceEvent[] = [];
+	operations.subscribeToEvent((event) => events.push(event));
+
+	const subscribeAtLine = async (line: number) => {
+		const subscription = await operations.subscribeToSequenceProps({
+			fileName: 'src/Composition.tsx',
+			line,
+			column: 3,
+			nodePath: null,
+			componentIdentity: 'dev.remotion.remotion.Sequence',
+			keys: ['from', 'durationInFrames'],
+			assetKeys: [],
+			effects: [],
+			clientId: 'browser-studio',
+			videoConfigValues: {
+				durationInFrames: 60,
+				fps: 30,
+				height: 720,
+				width: 1280,
+			},
+		});
+		if (!subscription.success) {
+			throw new Error('Expected sequence props subscription to succeed');
+		}
+
+		return subscription.nodePath;
+	};
+
+	const firstNodePath = await subscribeAtLine(6);
+	const secondNodePath = await subscribeAtLine(7);
+
+	const identicalFailure = await operations.reorderSequence({
+		fileName: 'src/Composition.tsx',
+		sourceNodePath: firstNodePath,
+		targetNodePath: firstNodePath,
+		position: 'after',
+		clientId: 'browser-studio',
+	});
+	expect(identicalFailure).toMatchObject({
+		success: false,
+		reason: 'Cannot reorder sequence: source and target are identical',
+		stack: expect.any(String),
+	});
+	expect(getProject().files[fileName]).toBe(initialContents);
+
+	const result = await operations.reorderSequence({
+		fileName: 'src/Composition.tsx',
+		sourceNodePath: firstNodePath,
+		targetNodePath: secondNodePath,
+		position: 'after',
+		clientId: 'browser-studio',
+	});
+	if (!result.success) {
+		throw new Error(result.reason);
+	}
+
+	const reordered = getProject().files[fileName];
+	expect(reordered.indexOf('name="second"')).toBeLessThan(
+		reordered.indexOf('name="first"'),
+	);
+	expect(result.nodePathMutation.files).toEqual([
+		{
+			absolutePath: fileName,
+			remappings: expect.any(Array),
+			restoredNodePaths: [],
+		},
+	]);
+	expect(
+		events.findLast((event) => event.type === 'sequence-node-paths-remapped'),
+	).toEqual({
+		type: 'sequence-node-paths-remapped',
+		mutation: result.nodePathMutation,
+	});
+
+	const undoResult = await operations.undo();
+	expect(undoResult.success).toBe(true);
+	expect(getProject().files[fileName]).toBe(initialContents);
+});
+
 test('updates default props in the virtual project', async () => {
 	const fileName = '/project/src/Root.tsx';
 	const {operations, getProject} = makeOperationsForProject({

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -27,6 +27,7 @@ export {
 	type ApplyCodeModReturnType,
 	type Change,
 } from './recast-mods';
+export {reorderSequence} from './reorder-sequence';
 export {
 	insertJsxElementIntoComposition,
 	insertJsxElementIntoProjectWithNodePathRemappings,

--- a/packages/studio-codemods/src/reorder-sequence.ts
+++ b/packages/studio-codemods/src/reorder-sequence.ts
@@ -1,0 +1,142 @@
+import type {JSXElement, JSXFragment} from '@babel/types';
+import type {
+	ReorderSequencePosition,
+	SequenceNodePathRemapping,
+} from '@remotion/studio-shared';
+import * as recast from 'recast';
+import type {SequenceNodePath} from 'remotion';
+import {
+	findJsxElementPathForDeletion,
+	getJsxElementTagLabel,
+} from './delete-jsx-node';
+import {
+	captureJsxNodePaths,
+	getNodePathRemappings,
+} from './get-node-path-remappings';
+import {parseAst, serializeAst} from './sequence-props/parse-ast';
+
+const {namedTypes} = recast.types;
+
+const getJsxChildrenParent = (
+	path: recast.types.NodePath,
+): JSXElement | JSXFragment | null => {
+	const parent = path.parentPath?.node;
+	if (!parent) {
+		return null;
+	}
+
+	if (namedTypes.JSXElement.check(parent)) {
+		return parent as JSXElement;
+	}
+
+	if (namedTypes.JSXFragment.check(parent)) {
+		return parent as JSXFragment;
+	}
+
+	return null;
+};
+
+export const reorderSequence = async ({
+	input,
+	sourceNodePath,
+	targetNodePath,
+	position,
+	formatFile,
+	prettierConfigOverride,
+}: {
+	input: string;
+	sourceNodePath: SequenceNodePath;
+	targetNodePath: SequenceNodePath;
+	position: ReorderSequencePosition;
+	formatFile: (input: {
+		contents: string;
+		prettierConfigOverride: Record<string, unknown> | null;
+	}) => Promise<{output: string; formatted: boolean}>;
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	sequenceLabel: string;
+	logLine: number;
+	nodePathRemappings: SequenceNodePathRemapping[];
+}> => {
+	const ast = parseAst(input);
+	const capturedNodePaths = captureJsxNodePaths(ast);
+	const sourcePath = findJsxElementPathForDeletion(ast, sourceNodePath);
+	if (!sourcePath) {
+		throw new Error(
+			'Could not find a JSX element at the source location to reorder sequence',
+		);
+	}
+
+	const targetPath = findJsxElementPathForDeletion(ast, targetNodePath);
+	if (!targetPath) {
+		throw new Error(
+			'Could not find a JSX element at the target location to reorder sequence',
+		);
+	}
+
+	const sourceParent = getJsxChildrenParent(sourcePath);
+	const targetParent = getJsxChildrenParent(targetPath);
+	if (!sourceParent || !targetParent || sourceParent !== targetParent) {
+		throw new Error(
+			'Cannot reorder sequence: source and target are not JSX siblings',
+		);
+	}
+
+	const sourceElement = sourcePath.node as JSXElement;
+	const targetElement = targetPath.node as JSXElement;
+	if (sourceElement === targetElement) {
+		throw new Error('Cannot reorder sequence: source and target are identical');
+	}
+
+	const {children} = sourceParent;
+	const sourceIndex = children.indexOf(sourceElement);
+	const targetIndex = children.indexOf(targetElement);
+	if (sourceIndex === -1 || targetIndex === -1) {
+		throw new Error('Cannot reorder sequence: JSX sibling was not found');
+	}
+
+	const sequenceLabel = getJsxElementTagLabel(sourceElement);
+	const logLine =
+		sourceElement.openingElement.loc?.start.line ??
+		sourceElement.loc?.start.line ??
+		1;
+
+	const [moved] = children.splice(sourceIndex, 1);
+	if (!moved) {
+		throw new Error('Cannot reorder sequence: source sequence was not found');
+	}
+
+	const targetIndexAfterRemoval = children.indexOf(targetElement);
+	if (targetIndexAfterRemoval === -1) {
+		throw new Error('Cannot reorder sequence: target sequence was not found');
+	}
+
+	children.splice(
+		position === 'before'
+			? targetIndexAfterRemoval
+			: targetIndexAfterRemoval + 1,
+		0,
+		moved,
+	);
+
+	const finalFile = serializeAst(ast);
+	const {output, formatted} = await formatFile({
+		contents: finalFile,
+		prettierConfigOverride: prettierConfigOverride ?? null,
+	});
+	const {nodePathRemappings} = getNodePathRemappings({
+		ast,
+		captured: capturedNodePaths,
+		output,
+	});
+
+	return {
+		output,
+		formatted,
+		sequenceLabel,
+		logLine,
+		nodePathRemappings,
+	};
+};

--- a/packages/studio-server/src/codemods/reorder-sequence.ts
+++ b/packages/studio-server/src/codemods/reorder-sequence.ts
@@ -1,43 +1,9 @@
-import type {JSXElement, JSXFragment} from '@babel/types';
-import type {
-	ReorderSequencePosition,
-	SequenceNodePathRemapping,
-} from '@remotion/studio-shared';
-import * as recast from 'recast';
+import {reorderSequence as reorderSequenceCodemod} from '@remotion/studio-codemods';
+import type {ReorderSequencePosition} from '@remotion/studio-shared';
 import type {SequenceNodePath} from 'remotion';
-import {
-	findJsxElementPathForDeletion,
-	getJsxElementTagLabel,
-} from './delete-jsx-node';
 import {formatFileContent} from './format-file-content';
-import {
-	captureJsxNodePaths,
-	getNodePathRemappings,
-} from './get-node-path-remappings';
-import {parseAst, serializeAst} from './parse-ast';
 
-const {namedTypes} = recast.types;
-
-const getJsxChildrenParent = (
-	path: recast.types.NodePath,
-): JSXElement | JSXFragment | null => {
-	const parent = path.parentPath?.node;
-	if (!parent) {
-		return null;
-	}
-
-	if (namedTypes.JSXElement.check(parent)) {
-		return parent as JSXElement;
-	}
-
-	if (namedTypes.JSXFragment.check(parent)) {
-		return parent as JSXFragment;
-	}
-
-	return null;
-};
-
-export const reorderSequence = async ({
+export const reorderSequence = ({
 	input,
 	sourceNodePath,
 	targetNodePath,
@@ -49,90 +15,16 @@ export const reorderSequence = async ({
 	targetNodePath: SequenceNodePath;
 	position: ReorderSequencePosition;
 	prettierConfigOverride?: Record<string, unknown> | null;
-}): Promise<{
-	output: string;
-	formatted: boolean;
-	sequenceLabel: string;
-	logLine: number;
-	nodePathRemappings: SequenceNodePathRemapping[];
-}> => {
-	const ast = parseAst(input);
-	const capturedNodePaths = captureJsxNodePaths(ast);
-	const sourcePath = findJsxElementPathForDeletion(ast, sourceNodePath);
-	if (!sourcePath) {
-		throw new Error(
-			'Could not find a JSX element at the source location to reorder sequence',
-		);
-	}
-
-	const targetPath = findJsxElementPathForDeletion(ast, targetNodePath);
-	if (!targetPath) {
-		throw new Error(
-			'Could not find a JSX element at the target location to reorder sequence',
-		);
-	}
-
-	const sourceParent = getJsxChildrenParent(sourcePath);
-	const targetParent = getJsxChildrenParent(targetPath);
-	if (!sourceParent || !targetParent || sourceParent !== targetParent) {
-		throw new Error(
-			'Cannot reorder sequence: source and target are not JSX siblings',
-		);
-	}
-
-	const sourceElement = sourcePath.node as JSXElement;
-	const targetElement = targetPath.node as JSXElement;
-	if (sourceElement === targetElement) {
-		throw new Error('Cannot reorder sequence: source and target are identical');
-	}
-
-	const {children} = sourceParent;
-	const sourceIndex = children.indexOf(sourceElement);
-	const targetIndex = children.indexOf(targetElement);
-	if (sourceIndex === -1 || targetIndex === -1) {
-		throw new Error('Cannot reorder sequence: JSX sibling was not found');
-	}
-
-	const sequenceLabel = getJsxElementTagLabel(sourceElement);
-	const logLine =
-		sourceElement.openingElement.loc?.start.line ??
-		sourceElement.loc?.start.line ??
-		1;
-
-	const [moved] = children.splice(sourceIndex, 1);
-	if (!moved) {
-		throw new Error('Cannot reorder sequence: source sequence was not found');
-	}
-
-	const targetIndexAfterRemoval = children.indexOf(targetElement);
-	if (targetIndexAfterRemoval === -1) {
-		throw new Error('Cannot reorder sequence: target sequence was not found');
-	}
-
-	children.splice(
-		position === 'before'
-			? targetIndexAfterRemoval
-			: targetIndexAfterRemoval + 1,
-		0,
-		moved,
-	);
-
-	const finalFile = serializeAst(ast);
-	const {output, formatted} = await formatFileContent({
-		input: finalFile,
+}) =>
+	reorderSequenceCodemod({
+		input,
+		sourceNodePath,
+		targetNodePath,
+		position,
+		formatFile: ({contents, prettierConfigOverride: override}) =>
+			formatFileContent({
+				input: contents,
+				prettierConfigOverride: override,
+			}),
 		prettierConfigOverride,
 	});
-	const {nodePathRemappings} = getNodePathRemappings({
-		ast,
-		captured: capturedNodePaths,
-		output,
-	});
-
-	return {
-		output,
-		formatted,
-		sequenceLabel,
-		logLine,
-		nodePathRemappings,
-	};
-};

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -18,6 +18,8 @@ import type {
 	RedoResponse,
 	RenameStaticFileRequest,
 	RenameStaticFileResponse,
+	ReorderSequenceRequest,
+	ReorderSequenceResponse,
 	SaveSequencePropsRequest,
 	SaveSequencePropsResponse,
 	SimpleDiff,
@@ -96,6 +98,9 @@ export type BrowserStudioOperations = {
 	renameStaticFile: (
 		request: RenameStaticFileRequest,
 	) => Promise<RenameStaticFileResponse>;
+	reorderSequence: (
+		request: ReorderSequenceRequest,
+	) => Promise<ReorderSequenceResponse>;
 	saveSequenceProps: (
 		request: SaveSequencePropsRequest,
 	) => Promise<SaveSequencePropsResponse>;

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -34,7 +34,6 @@ import {
 import {SetSelectedModalContext} from '../../state/modals';
 import {useTimelineSequenceHover} from '../../state/timeline-sequence-hover';
 import {Transform3DModeStateContext} from '../../state/transform-3d-mode';
-import {callApi} from '../call-api';
 import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
@@ -52,6 +51,7 @@ import {
 import {useSelectComposition} from '../InitialCompositionLoader';
 import {Spacing} from '../layout';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {reorderSequence} from '../reorder-sequence-api';
 import {
 	canEditSelectedOutlineCrop,
 	cropFieldKeys,
@@ -625,7 +625,7 @@ const TimelineSequenceItemInner: React.FC<{
 			currentSequenceDrag = null;
 
 			try {
-				const result = await callApi('/api/reorder-sequence', {
+				const result = await reorderSequence({
 					fileName: validatedLocation.source,
 					sourceNodePath: dropTarget.dragData.nodePath,
 					targetNodePath: nodePath,

--- a/packages/studio/src/components/reorder-sequence-api.ts
+++ b/packages/studio/src/components/reorder-sequence-api.ts
@@ -1,0 +1,15 @@
+import type {
+	ReorderSequenceRequest,
+	ReorderSequenceResponse,
+} from '@remotion/studio-shared';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
+import {callApi} from './call-api';
+
+export const reorderSequence = (
+	request: ReorderSequenceRequest,
+): Promise<ReorderSequenceResponse> => {
+	const browserStudioOperations = getBrowserStudioOperations();
+	return browserStudioOperations
+		? browserStudioOperations.reorderSequence(request)
+		: callApi('/api/reorder-sequence', request);
+};

--- a/packages/studio/src/test/make-browser-studio-operations.ts
+++ b/packages/studio/src/test/make-browser-studio-operations.ts
@@ -24,6 +24,7 @@ export const makeBrowserStudioOperations = (
 		prepareElementInstall: () => unusedOperation('prepareElementInstall'),
 		redo: () => unusedOperation('redo'),
 		renameStaticFile: () => unusedOperation('renameStaticFile'),
+		reorderSequence: () => unusedOperation('reorderSequence'),
 		saveSequenceProps: () => unusedOperation('saveSequenceProps'),
 		splitJsxSequence: () => unusedOperation('splitJsxSequence'),
 		splitVideoFromAudio: () => unusedOperation('splitVideoFromAudio'),


### PR DESCRIPTION
Closes #10574.

Supports reordering sequences by dragging in the timeline in Browser Studio on [remotion.dev/new](https://remotion.dev/new). This previously went through `/api/reorder-sequence`, which requires `@remotion/studio-server`.

## How it works

- The `reorderSequence` codemod moves from `@remotion/studio-server` to `@remotion/studio-codemods` with an injectable `formatFile`, following the `splitJsxSequence` pattern. The server keeps a thin wrapper that injects Node Prettier.
- A typed `reorderSequence` Browser Studio operation applies the codemod to the virtual project and broadcasts node-path remappings, so Visual Mode selections stay attached.
- The timeline drop handler goes through a new `reorder-sequence-api.ts` fork that prefers the Browser Studio operation and falls back to the HTTP API on desktop.
- The mutation goes through the project controller, so it triggers HMR and participates in undo/redo.

## Tests

Browser Studio unit tests cover a successful reorder (content order, node-path mutation event, undo restoring the original source) and the structured failure when source and target are identical. Existing server-side `reorder-sequence` codemod tests keep passing against the moved implementation.
