### PR TITLE
Elements: Redesign Name Lower Third

### DIFF
--- a/packages/docs/elements/overlays/name-lower-third/name-lower-third.tsx
+++ b/packages/docs/elements/overlays/name-lower-third/name-lower-third.tsx
@@ -67,7 +67,7 @@ export const NameLowerThird: React.FC = () => {
 				style={{
 					display: 'flex',
 					alignItems: 'center',
-					width: 534,
+					width: 514,
 					height: 66,
 					boxSizing: 'border-box',
 					padding: '0 24px',

--- a/packages/docs/elements/overlays/name-lower-third/name-lower-third.tsx
+++ b/packages/docs/elements/overlays/name-lower-third/name-lower-third.tsx
@@ -1,12 +1,6 @@
 import {loadFont} from '@remotion/google-fonts/Inter';
 import React from 'react';
-import {
-	Interactive,
-	interpolate,
-	spring,
-	useCurrentFrame,
-	useVideoConfig,
-} from 'remotion';
+import {Easing, Interactive, interpolate, useCurrentFrame} from 'remotion';
 
 loadFont('normal', {
 	subsets: ['latin'],
@@ -15,36 +9,14 @@ loadFont('normal', {
 
 export const NameLowerThird: React.FC = () => {
 	const frame = useCurrentFrame();
-	const {fps} = useVideoConfig();
-	const accentOpacity = interpolate(frame, [0, 8, 110, 119], [0, 1, 1, 0], {
-		extrapolateLeft: 'clamp',
-		extrapolateRight: 'clamp',
-	});
-	const panelProgress =
-		frame < 60
-			? spring({
-					frame: Math.max(0, frame - 8),
-					fps,
-					durationInFrames: 18,
-					config: {
-						damping: 16,
-						mass: 0.8,
-						stiffness: 180,
-					},
-				})
-			: interpolate(frame, [102, 110], [1, 0], {
-					extrapolateLeft: 'clamp',
-					extrapolateRight: 'clamp',
-				});
-	const visiblePanelProgress = Math.min(1, Math.max(0, panelProgress));
 
 	return (
 		<Interactive.Div
 			name="Container"
 			style={{
 				display: 'flex',
-				alignItems: 'stretch',
-				gap: 0,
+				flexDirection: 'column',
+				alignItems: 'flex-start',
 				width: 534,
 				height: 132,
 				boxSizing: 'border-box',
@@ -52,71 +24,64 @@ export const NameLowerThird: React.FC = () => {
 			}}
 		>
 			<Interactive.Div
-				name="Accent block"
-				style={{
-					width: 64,
-					height: 132,
-					boxSizing: 'border-box',
-					backgroundColor: '#2563eb',
-					opacity: accentOpacity,
-				}}
-			/>
-
-			<Interactive.Div
-				name="Text panel"
+				cropRight={interpolate(frame, [0, 20, 96, 116], [1, 0, 0, 1], {
+					easing: [
+						Easing.bezier(0.65, 0, 0.35, 1),
+						Easing.linear,
+						Easing.bezier(0.65, 0, 0.35, 1),
+					],
+					extrapolateLeft: 'clamp',
+					extrapolateRight: 'clamp',
+				})}
+				name="Name bar"
 				style={{
 					display: 'flex',
-					flexDirection: 'column',
-					justifyContent: 'center',
-					gap: 8,
-					width: 470,
-					height: 132,
-					minWidth: 0,
+					alignItems: 'center',
+					width: 410,
+					height: 66,
 					boxSizing: 'border-box',
-					padding: '16px 22px',
+					padding: '0 24px',
 					overflow: 'hidden',
-					backgroundColor: 'rgba(250, 250, 249, 0.97)',
-					borderWidth: 1,
-					borderStyle: 'solid',
-					borderColor: 'rgba(24, 24, 27, 0.1)',
-					clipPath: `inset(0 ${(1 - visiblePanelProgress) * 100}% 0 0)`,
+					backgroundColor: '#2563eb',
+					color: '#ffffff',
+					fontSize: 34,
+					fontWeight: 700,
+					letterSpacing: 1.2,
+					lineHeight: 1,
+					whiteSpace: 'nowrap',
 				}}
 			>
-				<Interactive.Div
-					name="Name"
-					style={{
-						width: '100%',
-						minWidth: 0,
-						overflow: 'hidden',
-						color: '#18181b',
-						fontSize: 46,
-						fontWeight: 700,
-						letterSpacing: -1,
-						lineHeight: 1.1,
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-						translate: `${-24 * (1 - panelProgress)}px 0px`,
-					}}
-				>
-					Alex Morgan
-				</Interactive.Div>
-				<Interactive.Div
-					name="Title"
-					style={{
-						width: '100%',
-						minWidth: 0,
-						overflow: 'hidden',
-						color: '#52525b',
-						fontSize: 27,
-						fontWeight: 500,
-						lineHeight: 1.15,
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-						translate: `${-24 * (1 - panelProgress)}px 0px`,
-					}}
-				>
-					Creative Developer
-				</Interactive.Div>
+				ALEX MORGAN
+			</Interactive.Div>
+			<Interactive.Div
+				cropRight={interpolate(frame, [4, 24, 92, 112], [1, 0, 0, 1], {
+					easing: [
+						Easing.bezier(0.65, 0, 0.35, 1),
+						Easing.linear,
+						Easing.bezier(0.65, 0, 0.35, 1),
+					],
+					extrapolateLeft: 'clamp',
+					extrapolateRight: 'clamp',
+				})}
+				name="Title bar"
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					width: 534,
+					height: 66,
+					boxSizing: 'border-box',
+					padding: '0 24px',
+					overflow: 'hidden',
+					backgroundColor: '#18181b',
+					color: '#ffffff',
+					fontSize: 34,
+					fontWeight: 500,
+					letterSpacing: 1.2,
+					lineHeight: 1,
+					whiteSpace: 'nowrap',
+				}}
+			>
+				CREATIVE DEVELOPER
 			</Interactive.Div>
 		</Interactive.Div>
 	);


### PR DESCRIPTION
## Summary

- redesign the Name Lower Third as two stacked, broadcast-style color bars
- use matching uppercase typography for the speaker name and role
- add smooth staggered crop reveals and a reverse-staggered exit animation

## Verification

- `bun run build`
- `bun run stylecheck`
- rendered preview frames during the entrance, hold, and exit animations

## Preview

- [Name Lower Third](https://remotion-git-lower-third-improvement-remotion.vercel.app/elements/overlays/name-lower-third)
