### PR TITLE
Elements: Track requests sent to Studio

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -73,17 +73,17 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 			return;
 		}
 
-		if (window.location.origin === 'https://www.remotion.dev') {
-			navigator.sendBeacon(
-				`https://www.remotion.pro/api/track/element-install-request?slug=${encodeURIComponent(definition.slug)}`,
-			);
-		}
-
 		const {target} = result;
 		setInstallStatus({
 			type: 'success',
 			message: `Sent to ${target.projectName ?? 'Remotion Studio'} / ${target.compositionId}. Confirm the installation in Studio.`,
 		});
+
+		if (window.location.origin === 'https://www.remotion.dev') {
+			navigator.sendBeacon(
+				`https://www.remotion.pro/api/track/element-install-request?slug=${encodeURIComponent(definition.slug)}`,
+			);
+		}
 	}, [definition.slug, elementPayload]);
 
 	const PreviewComponent = useMemo(() => {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -73,12 +73,18 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 			return;
 		}
 
+		if (window.location.origin === 'https://www.remotion.dev') {
+			navigator.sendBeacon(
+				`https://www.remotion.pro/api/track/element-install-request?slug=${encodeURIComponent(definition.slug)}`,
+			);
+		}
+
 		const {target} = result;
 		setInstallStatus({
 			type: 'success',
 			message: `Sent to ${target.projectName ?? 'Remotion Studio'} / ${target.compositionId}. Confirm the installation in Studio.`,
 		});
-	}, [elementPayload]);
+	}, [definition.slug, elementPayload]);
 
 	const PreviewComponent = useMemo(() => {
 		return () => <ElementPreviewComposition definition={definition} />;


### PR DESCRIPTION
## Summary

- Send a small event after `remotion.dev` sends an Element request to Studio.
- Send only the Element slug.
- Keep the current installation request and user interface unchanged.

The API and database change is in https://github.com/remotion-dev/pro/pull/823.

## Data collection

The browser sends the Element slug to `remotion.pro`. It sends the event only after Studio accepts the installation request.

The application stores only these values:

- a generated row ID;
- the event time;
- the Element slug.

The application does not store an IP address, a cookie, a user ID, project data, source code, dependency data, or account data.

The hosting service can process standard request data, such as an IP address. The application does not copy this data to the event table.

The event shows that the request reached Studio. It does not show that the user confirmed the installation. We do not use an external analytics service.

@MehmetAdemi Please review this section and tell us if we must change the privacy policy.

## Tests

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter=docs`
