### PR TITLE
`@remotion/studio`: Fix computed value text size

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -36,6 +36,9 @@ const unsupportedLabel: React.CSSProperties = {
 
 const computedValue: React.CSSProperties = {
 	color: WHITE_ALPHA_40,
+	fontFamily: 'Arial, Helvetica, sans-serif',
+	fontSize: 12,
+	lineHeight: '18px',
 	pointerEvents: 'none',
 };
 


### PR DESCRIPTION
## Summary

- explicitly size computed Studio values using the compact inspector typography
- prevent the global CSS reset from rendering computed source URLs and other runtime values at 16px

## Testing

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
- manually verified the computed source URL and other computed values render at 12px with an 18px line height

Closes #10562
