### PR TITLE
`remotion`: Hide checkerboard while resolving Suspense

### DIFF
--- a/packages/core/src/loading-indicator.tsx
+++ b/packages/core/src/loading-indicator.tsx
@@ -18,6 +18,14 @@ const container: React.CSSProperties = {
 	backgroundColor: '#1f2428',
 };
 
+const content: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+	animation: 'anim 2s',
+	animationFillMode: 'forwards',
+};
+
 export const Loading: React.FC = () => {
 	return (
 		<AbsoluteFillElement style={container} id="remotion-comp-loading">
@@ -30,26 +38,24 @@ export const Loading: React.FC = () => {
 						opacity: 1
 					}
 				}
-				#remotion-comp-loading {
-					animation: anim 2s;
-					animation-fill-mode: forwards;
-				}
 			`}</style>
-			<svg
-				width={ICON_SIZE}
-				height={ICON_SIZE}
-				viewBox="-100 -100 400 400"
-				style={rotate}
-			>
-				<path
-					fill="#555"
-					stroke="#555"
-					strokeWidth="100"
-					strokeLinejoin="round"
-					d="M 2 172 a 196 100 0 0 0 195 5 A 196 240 0 0 0 100 2.259 A 196 240 0 0 0 2 172 z"
-				/>
-			</svg>
-			<p style={label}>Resolving {'<Suspense>'}...</p>
+			<div id="remotion-comp-loading-content" style={content}>
+				<svg
+					width={ICON_SIZE}
+					height={ICON_SIZE}
+					viewBox="-100 -100 400 400"
+					style={rotate}
+				>
+					<path
+						fill="#555"
+						stroke="#555"
+						strokeWidth="100"
+						strokeLinejoin="round"
+						d="M 2 172 a 196 100 0 0 0 195 5 A 196 240 0 0 0 100 2.259 A 196 240 0 0 0 2 172 z"
+					/>
+				</svg>
+				<p style={label}>Resolving {'<Suspense>'}...</p>
+			</div>
 		</AbsoluteFillElement>
 	);
 };

--- a/packages/core/src/loading-indicator.tsx
+++ b/packages/core/src/loading-indicator.tsx
@@ -15,7 +15,7 @@ const label: React.CSSProperties = {
 const container: React.CSSProperties = {
 	justifyContent: 'center',
 	alignItems: 'center',
-	backgroundColor: 'black',
+	backgroundColor: '#1f2428',
 };
 
 export const Loading: React.FC = () => {

--- a/packages/core/src/loading-indicator.tsx
+++ b/packages/core/src/loading-indicator.tsx
@@ -15,6 +15,7 @@ const label: React.CSSProperties = {
 const container: React.CSSProperties = {
 	justifyContent: 'center',
 	alignItems: 'center',
+	backgroundColor: 'black',
 };
 
 export const Loading: React.FC = () => {

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1490,6 +1490,11 @@ test('Loading indicator does not register an interactive sequence', () => {
 	);
 	expect(loadingIndicator).toBeTruthy();
 	expect(loadingIndicator?.style.backgroundColor).toBe('#1f2428');
+	expect(loadingIndicator?.style.animation).toBe('');
+	const loadingContent = container.querySelector<HTMLDivElement>(
+		'#remotion-comp-loading-content',
+	);
+	expect(loadingContent?.style.animation).toBe('anim 2s');
 	expect(registeredSequences).toHaveLength(0);
 });
 

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1489,7 +1489,7 @@ test('Loading indicator does not register an interactive sequence', () => {
 		'#remotion-comp-loading',
 	);
 	expect(loadingIndicator).toBeTruthy();
-	expect(loadingIndicator?.style.backgroundColor).toBe('black');
+	expect(loadingIndicator?.style.backgroundColor).toBe('#1f2428');
 	expect(registeredSequences).toHaveLength(0);
 });
 

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1485,7 +1485,11 @@ test('Loading indicator does not register an interactive sequence', () => {
 	);
 
 	expect(getByText('Resolving <Suspense>...')).toBeTruthy();
-	expect(container.querySelector('#remotion-comp-loading')).toBeTruthy();
+	const loadingIndicator = container.querySelector<HTMLDivElement>(
+		'#remotion-comp-loading',
+	);
+	expect(loadingIndicator).toBeTruthy();
+	expect(loadingIndicator?.style.backgroundColor).toBe('black');
 	expect(registeredSequences).toHaveLength(0);
 });
 


### PR DESCRIPTION
## Summary

- match the Suspense loading indicator background to the Studio canvas pane
- hide Studio's transparency checkerboard while the loading message is visible
- limit the existing fade-in to the spinner and message so the backdrop is immediately opaque
- assert the backdrop and foreground animation remain separated

## Testing

- `bun test src/test/sequence-register-once.test.tsx --test-name-pattern 'Loading indicator'`
- `bun run build`
- `bun run stylecheck`

Closes #10550
