### PR TITLE
`@remotion/renderer`: Lazily start Rust process

### DIFF
--- a/packages/renderer/src/compositor/compositor.ts
+++ b/packages/renderer/src/compositor/compositor.ts
@@ -57,6 +57,62 @@ export const startLongRunningCompositor = ({
 	});
 };
 
+export const makeLazyCompositor = ({
+	maximumFrameCacheItemsInBytes,
+	logLevel,
+	indent,
+	binariesDirectory,
+	extraThreads,
+}: {
+	maximumFrameCacheItemsInBytes: number | null;
+	logLevel: LogLevel;
+	indent: boolean;
+	binariesDirectory: string | null;
+	extraThreads: number;
+}): Compositor => {
+	let compositor: Compositor | null = null;
+	let shutDown = false;
+
+	const getCompositor = () => {
+		if (shutDown) {
+			throw new Error('Compositor has already been shut down');
+		}
+
+		if (!compositor) {
+			compositor = startLongRunningCompositor({
+				maximumFrameCacheItemsInBytes,
+				logLevel,
+				indent,
+				binariesDirectory,
+				extraThreads,
+			});
+		}
+
+		return compositor;
+	};
+
+	return {
+		executeCommand: (type, payload) => {
+			return Promise.resolve().then(() => {
+				return getCompositor().executeCommand(type, payload);
+			});
+		},
+		finishCommands: () => {
+			return compositor?.finishCommands() ?? Promise.resolve();
+		},
+		waitForDone: () => {
+			return compositor?.waitForDone() ?? Promise.resolve();
+		},
+		shutDownOrKill: () => {
+			shutDown = true;
+			return compositor?.shutDownOrKill() ?? Promise.resolve();
+		},
+		get pid() {
+			return compositor?.pid ?? null;
+		},
+	};
+};
+
 type RunningStatus =
 	| {
 			type: 'running';

--- a/packages/renderer/src/offthread-video-server.ts
+++ b/packages/renderer/src/offthread-video-server.ts
@@ -3,9 +3,8 @@ import {URLSearchParams} from 'node:url';
 import {downloadAsset} from './assets/download-and-map-assets-to-file';
 import type {DownloadMap} from './assets/download-map';
 import type {Compositor} from './compositor/compositor';
-import {startCompositor} from './compositor/compositor';
+import {makeLazyCompositor} from './compositor/compositor';
 import type {LogLevel} from './log-level';
-import {isEqualOrBelowLogLevel} from './log-level';
 import {Log} from './logger';
 import {validateOffthreadVideoCacheSizeInBytes} from './options/offthreadvideo-cache-size';
 
@@ -67,13 +66,9 @@ export const startOffthreadVideoServer = ({
 	compositor: Compositor;
 } => {
 	validateOffthreadVideoCacheSizeInBytes(offthreadVideoCacheSizeInBytes);
-	const compositor = startCompositor({
-		type: 'StartLongRunningProcess',
-		payload: {
-			concurrency: offthreadVideoThreads,
-			maximum_frame_cache_size_in_bytes: offthreadVideoCacheSizeInBytes,
-			verbose: isEqualOrBelowLogLevel(logLevel, 'verbose'),
-		},
+	const compositor = makeLazyCompositor({
+		extraThreads: offthreadVideoThreads,
+		maximumFrameCacheItemsInBytes: offthreadVideoCacheSizeInBytes,
 		logLevel,
 		indent,
 		binariesDirectory,

--- a/packages/renderer/src/render-frames.ts
+++ b/packages/renderer/src/render-frames.ts
@@ -663,7 +663,11 @@ const internalRenderFramesRaw = ({
 			}),
 		])
 			.then((res) => {
-				server?.compositor
+				if (!server || server.compositor.pid === null) {
+					return resolve(res);
+				}
+
+				server.compositor
 					.executeCommand('CloseAllVideos', {})
 					.then(() => {
 						Log.verbose(

--- a/packages/renderer/src/test/lazy-compositor.test.ts
+++ b/packages/renderer/src/test/lazy-compositor.test.ts
@@ -1,0 +1,43 @@
+import {expect, test} from 'bun:test';
+import path from 'node:path';
+import {exampleVideos} from '@remotion/example-videos';
+import {cleanDownloadMap, makeDownloadMap} from '../assets/download-map';
+import {serveStatic} from '../serve-static';
+
+test('starts the compositor when the first frame is requested', async () => {
+	const downloadMap = makeDownloadMap(48000);
+	const server = await serveStatic(path.dirname(exampleVideos.framerWebm), {
+		port: null,
+		downloadMap,
+		remotionRoot: process.cwd(),
+		offthreadVideoThreads: 1,
+		logLevel: 'info',
+		indent: false,
+		offthreadVideoCacheSizeInBytes: null,
+		binariesDirectory: null,
+		forceIPv4: false,
+	});
+
+	try {
+		expect(server.compositor.pid).toBeNull();
+
+		const params = new URLSearchParams({
+			src: `http://localhost:${server.port}/${path.basename(exampleVideos.framerWebm)}`,
+			time: '0',
+			transparent: 'false',
+			toneMapped: 'false',
+		});
+		const response = await fetch(
+			`http://localhost:${server.port}/proxy?${params}`,
+		);
+		const frame = await response.arrayBuffer();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toMatch(/^image\/(bmp|png)$/);
+		expect(frame.byteLength).toBeGreaterThan(0);
+		expect(server.compositor.pid).toBeNumber();
+	} finally {
+		await server.close();
+		cleanDownloadMap(downloadMap);
+	}
+}, 90000);


### PR DESCRIPTION
## Summary

- lazily create the Rust compositor when the first command is executed
- avoid starting the compositor during render cleanup when it was never needed
- add an HTTP integration test covering startup and first frame extraction

## Testing

- `bun test packages/renderer/src/test/lazy-compositor.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10514
