### PR TITLE
`@remotion/studio`: Reduce asset inspector row spacing

### DIFF
--- a/packages/studio/src/components/InspectorInfoHeader.tsx
+++ b/packages/studio/src/components/InspectorInfoHeader.tsx
@@ -54,10 +54,10 @@ const inspectorSubtitle: React.CSSProperties = {
 	boxSizing: 'border-box',
 	fontFamily: 'sans-serif',
 	fontSize: 13,
-	height: 28,
-	lineHeight: '18px',
+	height: 20,
+	lineHeight: '20px',
 	margin: '0 4px',
-	padding: '5px 8px',
+	padding: '0 8px',
 	width: 'calc(100% - 8px)',
 };
 


### PR DESCRIPTION
## Summary

- reduce asset inspector metadata rows from 28px to 20px
- align asset metadata spacing with the composition inspector
- keep explicit typography and sizing so the global Studio CSS reset cannot inflate the rows

## Test plan

- `bun run build`
- `bun run stylecheck`
- visually verified a video asset in Remotion Studio
