### PR TITLE
`@remotion/studio`: Prevent composition not found flash

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1,7 +1,7 @@
-import {expect, test, type Page} from '@playwright/test';
-import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import fs from 'fs';
 import path from 'path';
+import {expect, test, type Page} from '@playwright/test';
+import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import {
 	STUDIO_URL,
 	effectKeyframeE2eFile,
@@ -89,9 +89,53 @@ test.describe('visual mode', () => {
 		await stopStudio();
 	});
 
-	test('should load the studio', async ({page}) => {
-		await page.goto(STUDIO_URL);
+	test('should load the studio without flashing a composition error', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			const state = {compositionNotFoundWasShown: false};
+			Object.defineProperty(window, '__remotion_initial_load_test', {
+				value: state,
+			});
+
+			const observer = new MutationObserver(() => {
+				if (
+					document.body?.innerText.includes(
+						'Composition with ID AnimatedBarChart not found.',
+					)
+				) {
+					state.compositionNotFoundWasShown = true;
+				}
+			});
+			observer.observe(document, {
+				childList: true,
+				characterData: true,
+				subtree: true,
+			});
+		});
+
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
 		await expect(page).toHaveTitle(/Remotion/i, {timeout: 15_000});
+		await expect(
+			page.locator('.remotion-studio-composition-container'),
+		).toBeVisible();
+		expect(
+			await page.evaluate(
+				() =>
+					(
+						window as typeof window & {
+							__remotion_initial_load_test: {
+								compositionNotFoundWasShown: boolean;
+							};
+						}
+					).__remotion_initial_load_test.compositionNotFoundWasShown,
+			),
+		).toBe(false);
+
+		await page.goto(`${STUDIO_URL}/does-not-exist`);
+		await expect(
+			page.getByText('Composition with ID does-not-exist not found.'),
+		).toBeVisible();
 	});
 
 	test('should virtualize a large timeline without hiding tracks', async ({

--- a/packages/studio/src/Studio.tsx
+++ b/packages/studio/src/Studio.tsx
@@ -8,6 +8,7 @@ import {StaticFilesProvider} from './components/use-static-files';
 import {FastRefreshProvider} from './FastRefreshProvider';
 import {injectCSS} from './helpers/inject-css';
 import {ResolveCompositionConfigInStudio} from './ResolveCompositionConfigInStudio';
+import {CompositionListProvider} from './state/composition-list';
 
 declare global {
 	interface Window {
@@ -45,7 +46,9 @@ const StudioInner: React.FC<{
 				<StaticFilesProvider>
 					<ResolveCompositionConfigInStudio>
 						<EditorContexts>
-							<Editor readOnlyStudio={readOnly} Root={rootComponent} />
+							<CompositionListProvider>
+								<Editor readOnlyStudio={readOnly} Root={rootComponent} />
+							</CompositionListProvider>
 							{readOnly
 								? null
 								: createPortal(

--- a/packages/studio/src/components/CanvasOrLoading.tsx
+++ b/packages/studio/src/components/CanvasOrLoading.tsx
@@ -3,6 +3,7 @@ import React, {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
 import {ErrorLoader} from '../error-overlay/remotion-overlay/ErrorLoader';
 import {BACKGROUND, WHITE} from '../helpers/colors';
+import {CompositionListContext} from '../state/composition-list';
 import {TimelineZoomCtx} from '../state/timeline-zoom';
 import {Canvas} from './Canvas';
 import {FramePersistor} from './FramePersistor';
@@ -33,6 +34,7 @@ export const CanvasOrLoading: React.FC<{
 	const resolved = Internals.useResolvedVideoConfig(null);
 	const {setZoom} = useContext(TimelineZoomCtx);
 	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {compositionListState} = useContext(CompositionListContext);
 	const {error: renderError} = useContext(RenderErrorContext);
 
 	useEffect(() => {
@@ -61,6 +63,10 @@ export const CanvasOrLoading: React.FC<{
 	}
 
 	if (!canvasContent) {
+		if (compositionListState !== 'ready') {
+			return null;
+		}
+
 		const compname = window.location.pathname.replace('/', '');
 
 		return (

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -1,5 +1,5 @@
 import {PlayerInternals} from '@remotion/player';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useLayoutEffect, useMemo, useState} from 'react';
 import {Internals} from 'remotion';
 import {useStudioConfigRevision} from '../helpers/client-id';
 import {BACKGROUND} from '../helpers/colors';
@@ -7,6 +7,7 @@ import {noop} from '../helpers/noop';
 import {getStudioCurrentScaleContext} from '../helpers/studio-fit-padding';
 import {getStudioBufferStateDelayInMilliseconds} from '../helpers/studio-runtime-config';
 import {drawRef} from '../state/canvas-ref';
+import {compositionListRenderedRef} from '../state/composition-list';
 import {ScaleLockProvider} from '../state/scale-lock';
 import {TimelineZoomContext} from '../state/timeline-zoom';
 import {HigherZIndex} from '../state/z-index';
@@ -25,6 +26,29 @@ const background: React.CSSProperties = {
 	height: '100%',
 	flexDirection: 'column',
 	position: 'absolute',
+};
+
+const RootCompositionLoader: React.FC<{
+	readonly Root: React.FC;
+}> = ({Root}) => {
+	return (
+		<>
+			<Root />
+			<CompositionListRenderMarker />
+		</>
+	);
+};
+
+const CompositionListRenderMarker: React.FC = () => {
+	useLayoutEffect(() => {
+		compositionListRenderedRef.current = true;
+
+		return () => {
+			compositionListRenderedRef.current = false;
+		};
+	}, []);
+
+	return null;
 };
 
 export const Editor: React.FC<{
@@ -90,7 +114,9 @@ export const Editor: React.FC<{
 								<Internals.CompositionRenderErrorContext.Provider
 									value={compositionRenderErrorContextValue}
 								>
-									{canvasMounted ? <MemoRoot /> : null}
+									{canvasMounted ? (
+										<RootCompositionLoader Root={MemoRoot} />
+									) : null}
 								</Internals.CompositionRenderErrorContext.Provider>
 								<Internals.CanUseRemotionHooksProvider>
 									<RenderErrorContext.Provider value={renderErrorContextValue}>

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -6,6 +6,10 @@ import {getKeysToExpand} from '../helpers/create-folder-tree';
 import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
 import {getRoute, pushUrl} from '../helpers/url-state';
+import {
+	CompositionListContext,
+	compositionListRenderedRef,
+} from '../state/composition-list';
 import {FolderContext} from '../state/folders';
 import {explorerSidebarTabs} from './ExplorerPanelRef';
 import {deriveCanvasContentFromUrl} from './load-canvas-content-from-url';
@@ -64,12 +68,19 @@ export const InitialCompositionLoader: React.FC = () => {
 		Internals.CompositionManager,
 	);
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
+	const {setCompositionListState} = useContext(CompositionListContext);
 	const selectComposition = useSelectComposition();
 	const selectAsset = useSelectAsset();
 	const staticFiles = useStaticFiles();
 
 	useEffect(() => {
 		const canvasContentFromUrl = deriveCanvasContentFromUrl();
+		const seenCompositionIds = window.remotion_seenCompositionIds ?? [];
+		const compositionListIsReady =
+			compositionListRenderedRef.current &&
+			seenCompositionIds.every((id) =>
+				compositions.some((composition) => composition.id === id),
+			);
 
 		if (canvasContent) {
 			// If the URL points to a different composition than the one currently
@@ -89,17 +100,24 @@ export const InitialCompositionLoader: React.FC = () => {
 				}
 			}
 
+			setCompositionListState('ready');
 			return;
 		}
 
 		if (canvasContentFromUrl && canvasContentFromUrl.type === 'composition') {
+			if (!compositionListIsReady) {
+				return;
+			}
+
 			const exists = compositions.find(
 				(c) => c.id === canvasContentFromUrl.compositionId,
 			);
 			if (exists) {
 				selectComposition(exists, false);
+				return;
 			}
 
+			setCompositionListState('ready');
 			return;
 		}
 
@@ -113,14 +131,21 @@ export const InitialCompositionLoader: React.FC = () => {
 			return;
 		}
 
+		if (!compositionListIsReady) {
+			return;
+		}
+
 		if (compositions.length > 0) {
 			selectComposition(compositions[0], true);
+		} else {
+			setCompositionListState('ready');
 		}
 	}, [
 		compositions,
 		canvasContent,
 		selectComposition,
 		setCanvasContent,
+		setCompositionListState,
 		selectAsset,
 	]);
 

--- a/packages/studio/src/state/composition-list.tsx
+++ b/packages/studio/src/state/composition-list.tsx
@@ -1,0 +1,37 @@
+import React, {createContext, useMemo, useState} from 'react';
+
+type CompositionListState = 'loading' | 'ready';
+
+export const compositionListRenderedRef = {current: false};
+
+export const CompositionListContext = createContext<{
+	compositionListState: CompositionListState;
+	setCompositionListState: React.Dispatch<
+		React.SetStateAction<CompositionListState>
+	>;
+}>({
+	compositionListState: 'loading',
+	setCompositionListState: () => {
+		throw new Error('CompositionListContext provider is missing');
+	},
+});
+
+export const CompositionListProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const [compositionListState, setCompositionListState] =
+		useState<CompositionListState>(() => {
+			compositionListRenderedRef.current = false;
+			return 'loading';
+		});
+	const value = useMemo(
+		() => ({compositionListState, setCompositionListState}),
+		[compositionListState],
+	);
+
+	return (
+		<CompositionListContext.Provider value={value}>
+			{children}
+		</CompositionListContext.Provider>
+	);
+};


### PR DESCRIPTION
## Summary

- track the initial Studio composition-list lifecycle separately from the selected canvas content
- wait until the root has rendered and every seen composition has registered before classifying a URL as missing
- keep the real “composition not found” state for invalid composition IDs

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep 'without flashing a composition error'`

The browser regression test observes the full initial DOM mutation history, verifies that a valid composition never flashes the error, and confirms that an invalid composition ID still displays it.
