### PR TITLE
`@remotion/browser-studio`: Resolve packages from immutable builds

### DIFF
--- a/packages/browser-studio/bundle.ts
+++ b/packages/browser-studio/bundle.ts
@@ -45,7 +45,7 @@ if (!output.success) {
 }
 
 const externalVersionSensitiveImport =
-	/^[^'"\n]*\bfrom\s*["']@remotion\/(?:player|studio-shared)["'];?\s*$|^\s*import\s*["']@remotion\/(?:player|studio-shared)["'];?\s*$/m;
+	/^[^'"\n]*\bfrom\s*["']@remotion\/(?:player|studio-shared|timeline-utils)["'];?\s*$|^\s*import\s*["']@remotion\/(?:player|studio-shared|timeline-utils)["'];?\s*$/m;
 
 for (const file of output.outputs) {
 	const str = await file.text();

--- a/packages/browser-studio/e2e/app.tsx
+++ b/packages/browser-studio/e2e/app.tsx
@@ -40,9 +40,24 @@ createRoot(root).render(
 				window as typeof window & {__browserStudioProject: VirtualProject}
 			).__browserStudioProject = nextProject;
 		}}
-		workspacePackageBaseUrl={
-			new URL('/__remotion_browser_studio_workspace__/', window.location.href)
-				.href
+		remotionPackageSource={
+			new URLSearchParams(window.location.search).get('source') === 'release'
+				? {
+						baseUrl: new URL(
+							`/__remotion_browser_studio_release__/${VERSION}/`,
+							window.location.href,
+						).href,
+						type: 'release',
+						version: VERSION,
+					}
+				: {
+						baseUrl: new URL(
+							'/__remotion_browser_studio_workspace__/commits/e2e/',
+							window.location.href,
+						).href,
+						commit: 'e2e',
+						type: 'workspace',
+					}
 		}
 	/>,
 );

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -112,17 +112,52 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 
 	expect(pageErrors).toEqual([]);
 	expect(workspacePackageRequests).toContain(
-		'/__remotion_browser_studio_workspace__/packages/core/dist/esm/index.mjs',
+		'/__remotion_browser_studio_workspace__/commits/e2e/packages/core/dist/esm/index.mjs',
 	);
 	expect(workspacePackageRequests).toContain(
-		'/__remotion_browser_studio_workspace__/packages/studio/dist/esm/previewEntry.mjs',
+		'/__remotion_browser_studio_workspace__/commits/e2e/packages/studio/dist/esm/previewEntry.mjs',
 	);
 	expect(workspacePackageRequests).toContain(
-		'/__remotion_browser_studio_workspace__/packages/transitions/dist/esm/fade.mjs',
+		'/__remotion_browser_studio_workspace__/commits/e2e/packages/transitions/dist/esm/fade.mjs',
 	);
 	expect(remoteRemotionRequests).toEqual([]);
 	expect(applyCodemodRequests).toEqual([]);
 	expect(updateAvailableRequests).toEqual([]);
+});
+
+test('loads Browser Studio from one immutable release artifact set', async ({
+	page,
+}) => {
+	const releasePackageRequests: string[] = [];
+	const remoteRemotionRequests: string[] = [];
+	page.on('request', (request) => {
+		const requestUrl = new URL(request.url());
+		if (
+			requestUrl.pathname.startsWith('/__remotion_browser_studio_release__/')
+		) {
+			releasePackageRequests.push(requestUrl.pathname);
+		}
+
+		if (
+			requestUrl.hostname === 'esm.sh' &&
+			(decodeURIComponent(requestUrl.pathname).includes('/@remotion/') ||
+				/^\/remotion(?:@|\/|$)/.test(requestUrl.pathname))
+		) {
+			remoteRemotionRequests.push(request.url());
+		}
+	});
+
+	await page.goto('/?source=release');
+	const studio = page.frameLocator('iframe');
+	await expect(studio.getByTitle('/project').getByText('MyComp')).toBeVisible();
+	await studio.locator('[data-compname="MyComp"]').click();
+	await expect(
+		studio.locator('.remotion-studio-composition-container'),
+	).toBeVisible();
+	expect(releasePackageRequests).toContain(
+		`/__remotion_browser_studio_release__/${await page.evaluate(() => (window as typeof window & {__browserStudioRemotionVersion: string}).__browserStudioRemotionVersion)}/packages/studio/dist/esm/previewEntry.mjs`,
+	);
+	expect(remoteRemotionRequests).toEqual([]);
 });
 
 test('drops and imports an Element payload with the deployment Remotion version', async ({

--- a/packages/browser-studio/e2e/server.ts
+++ b/packages/browser-studio/e2e/server.ts
@@ -5,7 +5,12 @@ const port = Number(process.env.PORT ?? 62338);
 const outputPath = path.join(import.meta.dir, '..', 'dist', 'e2e');
 const repoDir = path.join(import.meta.dir, '..', '..', '..');
 const workspacePackagesDir = path.join(repoDir, 'packages');
-const workspacePackagePath = '/__remotion_browser_studio_workspace__/';
+const browserStudioPackageJsonArtifactFilename =
+	'__remotion_browser_studio_package.json';
+const remotionPackagePaths = [
+	'/__remotion_browser_studio_workspace__/commits/e2e/',
+	'/__remotion_browser_studio_release__/',
+];
 
 const compile = () =>
 	new Promise<void>((resolve, reject) => {
@@ -88,8 +93,19 @@ Bun.serve({
 			});
 		}
 
-		if (url.pathname.startsWith(workspacePackagePath)) {
-			const relativePath = url.pathname.slice(workspacePackagePath.length);
+		const remotionPackagePath = remotionPackagePaths.find((prefix) =>
+			url.pathname.startsWith(prefix),
+		);
+		if (remotionPackagePath) {
+			const pathAfterSource = url.pathname.slice(remotionPackagePath.length);
+			const artifactRelativePath = remotionPackagePath.includes('_release__')
+				? pathAfterSource.slice(pathAfterSource.indexOf('/') + 1)
+				: pathAfterSource;
+			const relativePath = artifactRelativePath.endsWith(
+				`/${browserStudioPackageJsonArtifactFilename}`,
+			)
+				? `${artifactRelativePath.slice(0, -browserStudioPackageJsonArtifactFilename.length)}package.json`
+				: artifactRelativePath;
 			const workspaceFilePath = path.join(
 				repoDir,
 				path.normalize(relativePath),

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -138,7 +138,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	dependencyResolver,
 	onCompileStateChange,
 	onProjectChange,
-	workspacePackageBaseUrl,
+	remotionPackageSource,
 }) => {
 	const [state, setState] = useState<CompileState>(makeInitialState);
 	const [iframeHtml, setIframeHtml] = useState<string | null>(null);
@@ -210,7 +210,10 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	);
 	const resolveElementDependencies = useCallback(
 		(dependencies: readonly {name: string; version: string | null}[]) => {
-			const remotionVersion = browserStudioDependencyVersions.remotion;
+			const remotionVersion =
+				remotionPackageSource?.type === 'release'
+					? remotionPackageSource.version
+					: browserStudioDependencyVersions.remotion;
 			if (!remotionVersion) {
 				throw new Error('Browser Studio Remotion version is unavailable');
 			}
@@ -258,7 +261,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 			});
 			return Promise.resolve(versions);
 		},
-		[],
+		[remotionPackageSource],
 	);
 
 	const browserStudioOperations = useMemo(
@@ -440,7 +443,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 				...installedDependencyResolutions,
 			},
 			project: activeProjectRef.current,
-			workspacePackageBaseUrl: workspacePackageBaseUrl ?? null,
+			remotionPackageSource: remotionPackageSource ?? null,
 		};
 
 		worker.postMessage(request);
@@ -458,7 +461,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 		installedDependencyResolutions,
 		publicFileManager,
 		readOnly,
-		workspacePackageBaseUrl,
+		remotionPackageSource,
 		activeProject.entryPoint,
 		activeProject.rootDir,
 	]);

--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -17,7 +17,7 @@ import {
 } from './virtual-files';
 import {
 	getBrowserStudioWorkspacePackageExports,
-	resolveBrowserStudioWorkspacePackage,
+	resolveBrowserStudioRemotionPackage,
 } from './workspace-package-exports';
 
 type BuiltinMemFs = typeof RspackBrowser.builtinMemFs;
@@ -241,13 +241,21 @@ const getBrowserStudioHmrRuntimePlugin = (
 const createCompiler = async ({
 	dependencyResolutions,
 	project,
-	workspacePackageBaseUrl,
+	remotionPackageSource,
 }: Extract<BrowserStudioWorkerCompileRequest, {type: 'init'}>) => {
 	const rspackBrowser = await loadRspackBrowser();
 	const {BrowserHttpImportEsmPlugin, builtinMemFs, rspack} = rspackBrowser;
 	writeInitialFiles({builtinMemFs, project});
 
 	const resolvedVersions = {...browserStudioDependencyVersions};
+	if (remotionPackageSource?.type === 'release') {
+		for (const name of Object.keys(resolvedVersions)) {
+			if (name === 'remotion' || name.startsWith('@remotion/')) {
+				resolvedVersions[name] = remotionPackageSource.version;
+			}
+		}
+	}
+
 	const workspacePackageExports = getBrowserStudioWorkspacePackageExports();
 	const resolvedUrls: Record<string, string> = {};
 	for (const [name, resolution] of Object.entries(dependencyResolutions)) {
@@ -282,7 +290,7 @@ const createCompiler = async ({
 				allowedUris: [
 					'https://esm.sh/',
 					`${self.location.origin}/`,
-					...(workspacePackageBaseUrl ? [workspacePackageBaseUrl] : []),
+					...(remotionPackageSource ? [remotionPackageSource.baseUrl] : []),
 				],
 				cacheLocation: false,
 			},
@@ -363,15 +371,13 @@ const createCompiler = async ({
 						return undefined;
 					}
 
-					if (workspacePackageBaseUrl) {
-						const workspacePackageUrl = resolveBrowserStudioWorkspacePackage({
-							baseUrl: workspacePackageBaseUrl,
-							packages: workspacePackageExports,
-							request,
-						});
-						if (workspacePackageUrl) {
-							return workspacePackageUrl;
-						}
+					const remotionPackageUrl = resolveBrowserStudioRemotionPackage({
+						packages: workspacePackageExports,
+						request,
+						source: remotionPackageSource,
+					});
+					if (remotionPackageUrl) {
+						return remotionPackageUrl;
 					}
 
 					const packageName = getPackageName(request);

--- a/packages/browser-studio/src/dev/copy-remotion-package-artifacts.ts
+++ b/packages/browser-studio/src/dev/copy-remotion-package-artifacts.ts
@@ -1,0 +1,128 @@
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'node:fs';
+import {dirname, isAbsolute, join, relative, sep} from 'node:path';
+import {browserStudioPackageJsonArtifactFilename} from '../workspace-package-exports';
+import {getBrowserStudioWorkspacePackageExportsForBuild} from './get-workspace-package-exports-for-build';
+
+export type BrowserStudioRemotionPackageArtifactManifest = {
+	readonly files: Record<string, string>;
+	readonly packages: ReturnType<
+		typeof getBrowserStudioWorkspacePackageExportsForBuild
+	>;
+	readonly source:
+		| {readonly type: 'workspace'; readonly commit: string}
+		| {readonly type: 'release'; readonly version: string};
+};
+
+export const copyBrowserStudioRemotionPackageArtifacts = ({
+	outputDir,
+	repoDir,
+	source,
+}: {
+	readonly outputDir: string;
+	readonly repoDir: string;
+	readonly source: BrowserStudioRemotionPackageArtifactManifest['source'];
+}) => {
+	if (!isAbsolute(outputDir) || !isAbsolute(repoDir)) {
+		throw new Error('Remotion package artifact paths must be absolute');
+	}
+
+	if (existsSync(outputDir)) {
+		throw new Error(
+			`Refusing to overwrite existing Remotion package artifacts at ${outputDir}`,
+		);
+	}
+
+	const packages = getBrowserStudioWorkspacePackageExportsForBuild();
+	for (const {exports, packageRoot} of Object.values(packages)) {
+		const pathsToCopy = new Set<string>();
+		for (const target of Object.values(exports)) {
+			if (!target.startsWith('./')) {
+				continue;
+			}
+
+			const relativeTarget = target.slice(2);
+			if (relativeTarget.startsWith('dist/esm/')) {
+				pathsToCopy.add('dist/esm');
+			} else if (relativeTarget.startsWith('dist/')) {
+				pathsToCopy.add('dist');
+			} else if (relativeTarget.includes('*')) {
+				pathsToCopy.add(
+					dirname(relativeTarget.slice(0, relativeTarget.indexOf('*'))),
+				);
+			} else {
+				pathsToCopy.add(relativeTarget);
+			}
+		}
+
+		for (const relativePath of pathsToCopy) {
+			if (
+				relativePath === '.' ||
+				relativePath.startsWith('..') ||
+				isAbsolute(relativePath)
+			) {
+				throw new Error(
+					`Invalid Remotion package artifact path: ${relativePath}`,
+				);
+			}
+
+			const sourcePath = join(
+				repoDir,
+				packageRoot,
+				relativePath === browserStudioPackageJsonArtifactFilename
+					? 'package.json'
+					: relativePath,
+			);
+			if (!existsSync(sourcePath)) {
+				throw new Error(
+					`Missing built Remotion package artifact: ${sourcePath}`,
+				);
+			}
+
+			const destinationPath = join(outputDir, packageRoot, relativePath);
+			mkdirSync(dirname(destinationPath), {recursive: true});
+			cpSync(sourcePath, destinationPath, {recursive: true});
+		}
+	}
+
+	const files: Record<string, string> = {};
+	const visit = (directory: string) => {
+		for (const entry of readdirSync(directory, {withFileTypes: true})) {
+			const absolutePath = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				visit(absolutePath);
+			} else if (entry.isFile()) {
+				const relativePath = relative(outputDir, absolutePath)
+					.split(sep)
+					.join('/');
+				files[relativePath] = new Bun.CryptoHasher('sha256')
+					.update(Uint8Array.from(readFileSync(absolutePath)))
+					.digest('hex');
+			}
+		}
+	};
+
+	visit(outputDir);
+
+	const manifest: BrowserStudioRemotionPackageArtifactManifest = {
+		files: Object.fromEntries(
+			Object.entries(files).sort(([left], [right]) =>
+				left.localeCompare(right),
+			),
+		),
+		packages,
+		source,
+	};
+	writeFileSync(
+		join(outputDir, 'manifest.json'),
+		`${JSON.stringify(manifest, null, 2)}\n`,
+	);
+
+	return manifest;
+};

--- a/packages/browser-studio/src/dev/get-dependency-versions-for-build.ts
+++ b/packages/browser-studio/src/dev/get-dependency-versions-for-build.ts
@@ -1,6 +1,7 @@
 import {readFileSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {isBrowserStudioArtifactPath} from './is-browser-studio-artifact-path';
 
 type PackageJson = {
 	readonly name?: string;
@@ -23,6 +24,10 @@ const getWorkspacePackageVersions = () => {
 	const workspacePackageVersions: Record<string, string> = {};
 
 	for (const packageJsonPath of packageJsonGlob.scanSync({cwd: repoDir})) {
+		if (isBrowserStudioArtifactPath(packageJsonPath)) {
+			continue;
+		}
+
 		const packageJson = readPackageJson(join(repoDir, packageJsonPath));
 
 		if (

--- a/packages/browser-studio/src/dev/get-workspace-package-exports-for-build.ts
+++ b/packages/browser-studio/src/dev/get-workspace-package-exports-for-build.ts
@@ -1,7 +1,11 @@
 import {readFileSync} from 'node:fs';
 import {dirname, join, relative, sep} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {BrowserStudioWorkspacePackageExports} from '../workspace-package-exports';
+import {
+	browserStudioPackageJsonArtifactFilename,
+	type BrowserStudioWorkspacePackageExports,
+} from '../workspace-package-exports';
+import {isBrowserStudioArtifactPath} from './is-browser-studio-artifact-path';
 
 type ConditionalExport = {
 	readonly default?: string;
@@ -34,6 +38,10 @@ export const getBrowserStudioWorkspacePackageExportsForBuild =
 		const packages: BrowserStudioWorkspacePackageExports = {};
 
 		for (const packageJsonPath of packageJsonGlob.scanSync({cwd: repoDir})) {
+			if (isBrowserStudioArtifactPath(packageJsonPath)) {
+				continue;
+			}
+
 			const absolutePackageJsonPath = join(repoDir, packageJsonPath);
 			const packageJson = readPackageJson(absolutePackageJsonPath);
 			if (
@@ -47,7 +55,10 @@ export const getBrowserStudioWorkspacePackageExportsForBuild =
 			const browserExports = Object.fromEntries(
 				Object.entries(packageJson.exports ?? {}).flatMap(
 					([subpath, value]) => {
-						const target = getBrowserExport(value);
+						const target =
+							subpath === './package.json'
+								? `./${browserStudioPackageJsonArtifactFilename}`
+								: getBrowserExport(value);
 						return target ? [[subpath, target]] : [];
 					},
 				),

--- a/packages/browser-studio/src/dev/index.tsx
+++ b/packages/browser-studio/src/dev/index.tsx
@@ -13,9 +13,13 @@ createRoot(root).render(
 		iframeSrc="/frame.html"
 		project={createBlankTemplateProject()}
 		readOnly={false}
-		workspacePackageBaseUrl={
-			new URL('/__remotion_browser_studio_workspace__/', window.location.href)
-				.href
-		}
+		remotionPackageSource={{
+			baseUrl: new URL(
+				'/__remotion_browser_studio_workspace__/',
+				window.location.href,
+			).href,
+			commit: 'local',
+			type: 'workspace',
+		}}
 	/>,
 );

--- a/packages/browser-studio/src/dev/is-browser-studio-artifact-path.ts
+++ b/packages/browser-studio/src/dev/is-browser-studio-artifact-path.ts
@@ -1,0 +1,2 @@
+export const isBrowserStudioArtifactPath = (path: string) =>
+	path.includes('/static/__remotion_browser_studio_workspace__/');

--- a/packages/browser-studio/src/dev/server.ts
+++ b/packages/browser-studio/src/dev/server.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import {fileURLToPath} from 'url';
 import {build} from 'bun';
+import {browserStudioPackageJsonArtifactFilename} from '../workspace-package-exports';
 import {getBrowserStudioDependencyVersionsForBuild} from './get-dependency-versions-for-build';
 import {getBrowserStudioReactRefreshFilesForBuild} from './get-react-refresh-files-for-build';
 import {getBrowserStudioSetupEnvironmentForBuild} from './get-setup-environment-for-build';
@@ -158,7 +159,14 @@ const start = async () => {
 			}
 
 			if (url.pathname.startsWith(workspacePackagePath)) {
-				const relativePath = url.pathname.slice(workspacePackagePath.length);
+				const requestedRelativePath = url.pathname.slice(
+					workspacePackagePath.length,
+				);
+				const relativePath = requestedRelativePath.endsWith(
+					`/${browserStudioPackageJsonArtifactFilename}`,
+				)
+					? `${requestedRelativePath.slice(0, -browserStudioPackageJsonArtifactFilename.length)}package.json`
+					: requestedRelativePath;
 				const workspaceAssetPath = path.join(
 					repoDir,
 					path.normalize(relativePath),

--- a/packages/browser-studio/src/dev/studio-render-entry-external.ts
+++ b/packages/browser-studio/src/dev/studio-render-entry-external.ts
@@ -2,7 +2,6 @@ export const studioRenderEntryExternal = [
 	'@jridgewell/trace-mapping',
 	'@remotion/media-utils',
 	'@remotion/renderer',
-	'@remotion/timeline-utils',
 	'@remotion/web-renderer',
 	'@remotion/zod-types',
 	'mediabunny',

--- a/packages/browser-studio/src/index.tsx
+++ b/packages/browser-studio/src/index.tsx
@@ -5,6 +5,7 @@ export type {
 	BrowserStudioDependencyResolver,
 	BrowserStudioError,
 	BrowserStudioProps,
+	BrowserStudioRemotionPackageSource,
 	CompileState,
 	VirtualFileSystem,
 	VirtualProject,

--- a/packages/browser-studio/src/test/dependency-versions.test.ts
+++ b/packages/browser-studio/src/test/dependency-versions.test.ts
@@ -3,6 +3,9 @@ import {readFileSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {getBrowserStudioDependencyVersionsForBuild} from '../dev/get-dependency-versions-for-build';
+import {getBrowserStudioWorkspacePackageExportsForBuild} from '../dev/get-workspace-package-exports-for-build';
+import {isBrowserStudioArtifactPath} from '../dev/is-browser-studio-artifact-path';
+import {browserStudioPackageJsonArtifactFilename} from '../workspace-package-exports';
 
 type PackageJson = {
 	readonly version?: string;
@@ -56,4 +59,18 @@ test('browser studio dependency versions are derived from package metadata', () 
 				!version.startsWith('workspace:') && !version.startsWith('catalog:'),
 		),
 	).toBe(true);
+});
+
+test('generated Browser Studio artifacts are not rediscovered as workspace packages', () => {
+	expect(
+		isBrowserStudioArtifactPath(
+			'packages/docs/static/__remotion_browser_studio_workspace__/commits/abc/packages/core/package.json',
+		),
+	).toBe(true);
+	expect(isBrowserStudioArtifactPath('packages/core/package.json')).toBe(false);
+	expect(
+		getBrowserStudioWorkspacePackageExportsForBuild().remotion.exports[
+			'./package.json'
+		],
+	).toBe(`./${browserStudioPackageJsonArtifactFilename}`);
 });

--- a/packages/browser-studio/src/test/remotion-package-source.test.ts
+++ b/packages/browser-studio/src/test/remotion-package-source.test.ts
@@ -1,0 +1,67 @@
+import {expect, test} from 'bun:test';
+import {
+	resolveBrowserStudioRemotionPackage,
+	type BrowserStudioWorkspacePackageExports,
+} from '../workspace-package-exports';
+
+const packages: BrowserStudioWorkspacePackageExports = {
+	'@remotion/timeline-utils': {
+		exports: {'.': './dist/esm/index.mjs'},
+		packageRoot: 'packages/timeline-utils',
+	},
+	remotion: {
+		exports: {'.': './dist/esm/index.mjs'},
+		packageRoot: 'packages/core',
+	},
+};
+
+test('resolves workspace and release artifacts without registry fallback', () => {
+	expect(
+		resolveBrowserStudioRemotionPackage({
+			packages,
+			request: '@remotion/timeline-utils',
+			source: {
+				baseUrl: 'https://assets.example.com/commits/abc123/',
+				commit: 'abc123',
+				type: 'workspace',
+			},
+		}),
+	).toBe(
+		'https://assets.example.com/commits/abc123/packages/timeline-utils/dist/esm/index.mjs',
+	);
+	expect(
+		resolveBrowserStudioRemotionPackage({
+			packages,
+			request: 'remotion',
+			source: {
+				baseUrl: 'https://assets.example.com/releases/4.0.514/',
+				type: 'release',
+				version: '4.0.514',
+			},
+		}),
+	).toBe(
+		'https://assets.example.com/releases/4.0.514/packages/core/dist/esm/index.mjs',
+	);
+	expect(
+		resolveBrowserStudioRemotionPackage({
+			packages,
+			request: 'react',
+			source: {
+				baseUrl: 'https://assets.example.com/commits/abc123/',
+				commit: 'abc123',
+				type: 'workspace',
+			},
+		}),
+	).toBeNull();
+	expect(() =>
+		resolveBrowserStudioRemotionPackage({
+			packages,
+			request: '@remotion/not-in-this-build',
+			source: {
+				baseUrl: 'https://assets.example.com/commits/abc123/',
+				commit: 'abc123',
+				type: 'workspace',
+			},
+		}),
+	).toThrow('Refusing to fall back to the package registry');
+});

--- a/packages/browser-studio/src/types.ts
+++ b/packages/browser-studio/src/types.ts
@@ -53,18 +53,30 @@ export type BrowserStudioProps = {
 	project: VirtualProject;
 	readOnly: boolean;
 	iframeSrc?: string;
-	workspacePackageBaseUrl?: string;
+	remotionPackageSource?: BrowserStudioRemotionPackageSource;
 	dependencyResolver?: BrowserStudioDependencyResolver;
 	onCompileStateChange?: (state: CompileState) => void;
 	onProjectChange?: (project: VirtualProject) => void;
 };
+
+export type BrowserStudioRemotionPackageSource =
+	| {
+			readonly type: 'workspace';
+			readonly baseUrl: string;
+			readonly commit: string;
+	  }
+	| {
+			readonly type: 'release';
+			readonly baseUrl: string;
+			readonly version: string;
+	  };
 
 export type BrowserStudioWorkerCompileRequest =
 	| {
 			type: 'init';
 			project: VirtualProject;
 			dependencyResolutions: Record<string, BrowserStudioDependencyResolution>;
-			workspacePackageBaseUrl: string | null;
+			remotionPackageSource: BrowserStudioRemotionPackageSource | null;
 	  }
 	| {
 			type: 'update-project';

--- a/packages/browser-studio/src/workspace-package-exports.ts
+++ b/packages/browser-studio/src/workspace-package-exports.ts
@@ -1,3 +1,8 @@
+import type {BrowserStudioRemotionPackageSource} from './types';
+
+export const browserStudioPackageJsonArtifactFilename =
+	'__remotion_browser_studio_package.json';
+
 export type BrowserStudioWorkspacePackageExports = Record<
 	string,
 	{
@@ -79,4 +84,40 @@ export const resolveBrowserStudioWorkspacePackage = ({
 		`${workspacePackage.packageRoot}/${target.slice(2)}`,
 		normalizedBaseUrl,
 	).href;
+};
+
+export const resolveBrowserStudioRemotionPackage = ({
+	packages,
+	request,
+	source,
+}: {
+	readonly packages: BrowserStudioWorkspacePackageExports;
+	readonly request: string;
+	readonly source: BrowserStudioRemotionPackageSource | null;
+}) => {
+	if (source === null) {
+		return null;
+	}
+
+	const packageName = getPackageName(request);
+	if (packageName !== 'remotion' && !packageName.startsWith('@remotion/')) {
+		return null;
+	}
+
+	const resolved = resolveBrowserStudioWorkspacePackage({
+		baseUrl: source.baseUrl,
+		packages,
+		request,
+	});
+	if (resolved) {
+		return resolved;
+	}
+
+	const sourceId =
+		source.type === 'workspace'
+			? `workspace commit ${source.commit}`
+			: `release ${source.version}`;
+	throw new Error(
+		`The Remotion package ${packageName} is not part of the configured ${sourceId}. Refusing to fall back to the package registry.`,
+	);
 };

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -9,6 +9,7 @@
 .cache-loader
 .element-previews
 static/_raw
+static/__remotion_browser_studio_workspace__
 
 # Twoslash prewarm temp files
 .twoslash-work-*.json

--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -126,6 +126,9 @@ const docusaurusBuild = lowMemoryBuild
 
 await run('copy raw docs', 'bun', ['copy-raw-docs.ts']);
 await run('fetch prompt submissions', 'bun', ['fetch-prompt-submissions.ts']);
+await run('prepare Browser Studio workspace', 'bun', [
+	'prepare-browser-studio-workspace.ts',
+]);
 await run(
 	'Docusaurus build',
 	docusaurusBuild.command,

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -1,4 +1,5 @@
 import type {Config} from '@docusaurus/types';
+import {getBrowserStudioWorkspaceCommit} from './get-browser-studio-workspace-commit';
 import elementSourceDependencies from './plugins/element-source-dependencies.js';
 import remarkElementSource from './plugins/remark-element-source.js';
 import remarkExportRaw from './plugins/remark-export-raw.js';
@@ -27,6 +28,9 @@ const showGitLastUpdate =
 	process.env.REMOTION_DOCS_DISABLE_GIT_LAST_UPDATE !== '1';
 
 const config: Config = {
+	customFields: {
+		browserStudioWorkspaceCommit: getBrowserStudioWorkspaceCommit(),
+	},
 	title: 'Remotion | Make videos programmatically',
 	tagline: 'Make videos programmatically',
 	url: 'https://www.remotion.dev',

--- a/packages/docs/get-browser-studio-workspace-commit.ts
+++ b/packages/docs/get-browser-studio-workspace-commit.ts
@@ -1,0 +1,20 @@
+import {execFileSync} from 'node:child_process';
+
+export const getBrowserStudioWorkspaceCommit = () => {
+	let commit = process.env.REMOTION_BROWSER_STUDIO_WORKSPACE_COMMIT;
+	if (!commit) {
+		try {
+			commit = execFileSync('git', ['rev-parse', 'HEAD'], {
+				encoding: 'utf-8',
+			}).trim();
+		} catch {
+			commit = process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA;
+		}
+	}
+
+	if (!commit || !/^[a-f0-9]{40}$/.test(commit)) {
+		throw new Error(`Invalid Browser Studio workspace commit: ${commit}`);
+	}
+
+	return commit;
+};

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
 		"docusaurus": "docusaurus",
-		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0",
+		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && bun prepare-browser-studio-workspace.ts && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0",
 		"build-docs": "bun build-docs.ts",
 		"prewarm-twoslash": "bun prewarm-twoslash.ts",
 		"swizzle": "docusaurus swizzle",

--- a/packages/docs/prepare-browser-studio-workspace.ts
+++ b/packages/docs/prepare-browser-studio-workspace.ts
@@ -1,0 +1,24 @@
+import {rmSync} from 'node:fs';
+import {join} from 'node:path';
+import {copyBrowserStudioRemotionPackageArtifacts} from '../browser-studio/src/dev/copy-remotion-package-artifacts';
+import {getBrowserStudioWorkspaceCommit} from './get-browser-studio-workspace-commit';
+
+const repoDir = join(import.meta.dir, '..', '..');
+const workspaceRoot = join(
+	import.meta.dir,
+	'static',
+	'__remotion_browser_studio_workspace__',
+);
+const commit = getBrowserStudioWorkspaceCommit();
+const outputDir = join(workspaceRoot, 'commits', commit);
+
+rmSync(workspaceRoot, {force: true, recursive: true});
+const manifest = copyBrowserStudioRemotionPackageArtifacts({
+	outputDir,
+	repoDir,
+	source: {commit, type: 'workspace'},
+});
+
+process.stdout.write(
+	`Prepared ${Object.keys(manifest.files).length} Browser Studio workspace artifacts for ${commit}.\n`,
+);

--- a/packages/docs/src/pages/experimental_new/index.tsx
+++ b/packages/docs/src/pages/experimental_new/index.tsx
@@ -1,10 +1,11 @@
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {
 	BrowserStudio,
 	createBlankTemplateProject,
 } from '@remotion/browser-studio';
-import type React from 'react';
+import React from 'react';
 
 const page: React.CSSProperties = {
 	backgroundColor: '#111111',
@@ -43,6 +44,13 @@ const standaloneCss = `
 `;
 
 const NewRemotionProject = () => {
+	const {siteConfig} = useDocusaurusContext();
+	const browserStudioWorkspaceCommit =
+		siteConfig.customFields?.browserStudioWorkspaceCommit;
+	if (typeof browserStudioWorkspaceCommit !== 'string') {
+		throw new Error('Browser Studio workspace commit is not configured');
+	}
+
 	return (
 		<>
 			<Head>
@@ -56,6 +64,14 @@ const NewRemotionProject = () => {
 							iframeSrc="/experimental_new/frame.html"
 							project={createBlankTemplateProject()}
 							readOnly={false}
+							remotionPackageSource={{
+								baseUrl: new URL(
+									`/__remotion_browser_studio_workspace__/commits/${browserStudioWorkspaceCommit}/`,
+									window.location.href,
+								).href,
+								commit: browserStudioWorkspaceCommit,
+								type: 'workspace',
+							}}
 						/>
 					)}
 				</BrowserOnly>

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -57,6 +57,7 @@
 	],
 	"exclude": [
 		"copy-convert.ts",
+		"prepare-browser-studio-workspace.ts",
 		"render-cards.ts",
 		"render-element-previews.ts",
 		"upload-element-preview.ts"

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -15,6 +15,10 @@ export const config: VercelConfig = {
 		'cd .. && timeout 20m bunx turbo run build-docs --no-update-notifier --concurrency=2',
 	headers: [
 		routes.header('/assets/(.*)', browserStudioAssetHeaders),
+		routes.header(
+			'/__remotion_browser_studio_workspace__/commits/(.*)',
+			browserStudioAssetHeaders,
+		),
 		routes.header('/_raw/docs/(.*).md', [
 			{key: 'Content-Type', value: 'text/plain; charset=utf-8'},
 			{key: 'Vary', value: 'Accept'},


### PR DESCRIPTION
## Summary

- add explicit workspace and release Remotion package sources to Browser Studio
- generate commit-addressed, hashed workspace package artifacts for the `/experimental_new` deployment
- prevent configured Remotion sources from falling back to registry packages
- keep generated package metadata from being rediscovered as monorepo workspaces

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/browser-studio && bun run test`
- `cd packages/browser-studio && bun run testbrowserstudio`
- production Docusaurus build and Browser Studio deployment smoke test

## Preview

- [Browser Studio workspace deployment](https://remotion-git-codex-browser-studio-immutable-pac-7d18a8-remotion.vercel.app/experimental_new)
