### PR TITLE
`@remotion/studio`: Use query-string routing in Browser Studio

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -705,6 +705,7 @@ test.describe('visual mode', () => {
 					name: 'Default (PNG)',
 					exact: true,
 				})
+				.last()
 				.click();
 			await expect
 				.poll(() => fs.readFileSync(configFile, 'utf8'))

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -34,7 +34,8 @@ export const reloadUrl = () => {
 
 export const getRoute = () => {
 	if (getUrlHandlingType() === 'query-string') {
-		return window.location.search.substring(1);
+		const route = window.location.search.substring(1);
+		return route.startsWith('/') ? route : '';
 	}
 
 	return window.location.pathname;

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -1,7 +1,7 @@
 type UrlHandling = 'spa' | 'query-string';
 
 const getUrlHandlingType = (): UrlHandling => {
-	if (window.remotion_isReadOnlyStudio) {
+	if (window.remotion_isReadOnlyStudio || window.remotion_browserStudio) {
 		return 'query-string';
 	}
 

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, expect, test} from 'bun:test';
-import {replaceUrl} from '../helpers/url-state';
+import {getRoute, replaceUrl} from '../helpers/url-state';
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
 	globalThis,
@@ -32,4 +32,29 @@ test('replaces the current Studio URL', () => {
 	replaceUrl('/assets/renamed.mp4');
 
 	expect(replaceStateCalls).toEqual([[{}, 'Studio', '/assets/renamed.mp4']]);
+});
+
+test('uses query-string routing in Browser Studio', () => {
+	const replaceStateCalls: unknown[][] = [];
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			history: {
+				replaceState: (...args: unknown[]) => replaceStateCalls.push(args),
+			},
+			location: {
+				pathname: '/experimental_new',
+				search: '',
+			},
+			remotion_browserStudio: {},
+			remotion_isReadOnlyStudio: false,
+		},
+	});
+
+	expect(getRoute()).toBe('');
+	replaceUrl('/assets/other.mp4');
+	expect(replaceStateCalls).toEqual([
+		[{}, 'Studio', '/experimental_new?/assets/other.mp4'],
+	]);
 });

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -45,7 +45,7 @@ test('uses query-string routing in Browser Studio', () => {
 			},
 			location: {
 				pathname: '/experimental_new',
-				search: '',
+				search: '?source=release',
 			},
 			remotion_browserStudio: {},
 			remotion_isReadOnlyStudio: false,


### PR DESCRIPTION
## Summary

- use query-string routing for Browser Studio, matching readonly Studio
- prevent the embedding pathname from being interpreted as a composition ID
- add regression coverage for the initial `/experimental_new` route

## Testing

- `bun test packages/studio/src/test/url-state.test.ts`
- `bun run build`
- `bun run stylecheck`
