### PR TITLE
`@remotion/studio`: Render timeline media at Retina resolution

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -59,6 +59,8 @@ const waveformCanvasStyle: React.CSSProperties = {
 
 const volumeCanvasStyle: React.CSSProperties = {
 	position: 'absolute',
+	width: '100%',
+	height: '100%',
 };
 
 const parseVolume = (volume: string | number): WaveformVolume => {
@@ -249,8 +251,9 @@ const AudioWaveformInner: React.FC<{
 			return;
 		}
 
-		const h = height;
-		const w = Math.ceil(visualizationWidth);
+		const pixelRatio = window.devicePixelRatio;
+		const h = Math.ceil(height * pixelRatio);
+		const w = Math.ceil(visualizationWidth * pixelRatio);
 
 		if (canUseWorkerPath) {
 			const worker = waveformWorker.current;
@@ -316,16 +319,18 @@ const AudioWaveformInner: React.FC<{
 			return;
 		}
 
-		const h = height;
+		const pixelRatio = window.devicePixelRatio;
+		const h = Math.ceil(height * pixelRatio);
+		const w = Math.ceil(visualizationWidth * pixelRatio);
 		const context = volumeCanvasElement.getContext('2d');
 		if (!context) {
 			return;
 		}
 
-		volumeCanvasElement.width = Math.ceil(visualizationWidth);
+		volumeCanvasElement.width = w;
 		volumeCanvasElement.height = h;
 
-		context.clearRect(0, 0, visualizationWidth, h);
+		context.clearRect(0, 0, w, h);
 		if (!Array.isArray(visibleVolume)) {
 			return;
 		}
@@ -336,8 +341,8 @@ const AudioWaveformInner: React.FC<{
 			const x =
 				visibleVolume.length <= 1
 					? 0
-					: (index / (visibleVolume.length - 1)) * visualizationWidth;
-			const y = (1 - v) * (h - TIMELINE_BORDER * 2) + 1;
+					: (index / (visibleVolume.length - 1)) * w;
+			const y = (1 - v) * (h - TIMELINE_BORDER * 2 * pixelRatio) + pixelRatio;
 			if (index === 0) {
 				context.moveTo(x, y);
 			} else {
@@ -345,6 +350,7 @@ const AudioWaveformInner: React.FC<{
 			}
 		});
 		context.strokeStyle = WHITE_ALPHA_70;
+		context.lineWidth = pixelRatio;
 		context.stroke();
 	}, [height, shouldRenderVolumeOverlay, visibleVolume, visualizationWidth]);
 

--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -103,10 +103,13 @@ const TimelineVideoInfoSegment: React.FC<{
 		}
 
 		const controller = new AbortController();
+		const pixelRatio = window.devicePixelRatio;
 
 		const canvas = document.createElement('canvas');
-		canvas.width = visualizationWidth;
-		canvas.height = TIMELINE_LAYER_FILMSTRIP_HEIGHT;
+		canvas.width = Math.ceil(visualizationWidth * pixelRatio);
+		canvas.height = Math.ceil(TIMELINE_LAYER_FILMSTRIP_HEIGHT * pixelRatio);
+		canvas.style.width = visualizationWidth + 'px';
+		canvas.style.height = TIMELINE_LAYER_FILMSTRIP_HEIGHT + 'px';
 		const ctx = canvas.getContext('2d');
 		if (!ctx) {
 			return;
@@ -115,20 +118,11 @@ const TimelineVideoInfoSegment: React.FC<{
 		current.appendChild(canvas);
 
 		const drawRepeatedFrame = (frame: VideoFrame) => {
-			const thumbnailWidth = Math.max(
-				1,
-				frame.displayWidth / window.devicePixelRatio,
-			);
+			const thumbnailWidth = Math.max(1, frame.displayWidth);
 
 			ctx.clearRect(0, 0, canvas.width, canvas.height);
 			for (let x = 0; x < canvas.width; x += thumbnailWidth) {
-				ctx.drawImage(
-					frame,
-					x,
-					0,
-					thumbnailWidth,
-					TIMELINE_LAYER_FILMSTRIP_HEIGHT,
-				);
+				ctx.drawImage(frame, x, 0, thumbnailWidth, canvas.height);
 			}
 		};
 
@@ -198,9 +192,7 @@ const TimelineVideoInfoSegment: React.FC<{
 					let frame: VideoFrame | undefined;
 					try {
 						frame = sample.toVideoFrame();
-						const scale =
-							(TIMELINE_LAYER_FILMSTRIP_HEIGHT / frame.displayHeight) *
-							window.devicePixelRatio;
+						const scale = canvas.height / frame.displayHeight;
 
 						const transformed = resizeVideoFrame({
 							frame,
@@ -243,7 +235,7 @@ const TimelineVideoInfoSegment: React.FC<{
 
 		const targetCanvas = tiledLoop ? document.createElement('canvas') : canvas;
 		targetCanvas.width = tiledLoop
-			? Math.max(1, Math.ceil(tiledLoop.loopWidth))
+			? Math.max(1, Math.ceil(tiledLoop.loopWidth * pixelRatio))
 			: canvas.width;
 		targetCanvas.height = canvas.height;
 		const targetCtx = tiledLoop ? targetCanvas.getContext('2d') : ctx;
@@ -256,7 +248,7 @@ const TimelineVideoInfoSegment: React.FC<{
 		const filledSlots = new Map<number, number | undefined>();
 
 		const {fromSeconds, toSeconds} = times;
-		const targetWidth = tiledLoop ? targetCanvas.width : visualizationWidth;
+		const targetWidth = targetCanvas.width;
 		const repeatTarget = () => {
 			if (!tiledLoop) {
 				return;
@@ -270,10 +262,11 @@ const TimelineVideoInfoSegment: React.FC<{
 			const phase =
 				(tiledLoop.displayOffsetInFrames %
 					tiledLoop.loopDisplay.durationInFrames) *
-				(tiledLoop.loopWidth / tiledLoop.loopDisplay.durationInFrames);
+				((tiledLoop.loopWidth * pixelRatio) /
+					tiledLoop.loopDisplay.durationInFrames);
 			pattern.setTransform(
 				new DOMMatrix([
-					tiledLoop.loopWidth / targetCanvas.width,
+					(tiledLoop.loopWidth * pixelRatio) / targetCanvas.width,
 					0,
 					0,
 					1,
@@ -293,7 +286,7 @@ const TimelineVideoInfoSegment: React.FC<{
 				fromSeconds,
 				toSeconds,
 				aspectRatio: aspectRatio.current,
-				frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+				frameHeight: canvas.height,
 			});
 
 			fillWithCachedFrames({
@@ -303,8 +296,8 @@ const TimelineVideoInfoSegment: React.FC<{
 				src,
 				segmentDuration: toSeconds - fromSeconds,
 				fromSeconds,
-				devicePixelRatio: window.devicePixelRatio,
-				frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+				devicePixelRatio: 1,
+				frameHeight: canvas.height,
 			});
 			repeatTarget();
 			const unfilled = Array.from(filledSlots.keys()).filter(
@@ -335,7 +328,7 @@ const TimelineVideoInfoSegment: React.FC<{
 					toSeconds,
 					naturalWidth: targetWidth,
 					aspectRatio: aspectRatio.current,
-					frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+					frameHeight: canvas.height,
 				});
 				fillWithCachedFrames({
 					ctx: targetCtx,
@@ -344,8 +337,8 @@ const TimelineVideoInfoSegment: React.FC<{
 					src,
 					segmentDuration: toSeconds - fromSeconds,
 					fromSeconds,
-					devicePixelRatio: window.devicePixelRatio,
-					frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+					devicePixelRatio: 1,
+					frameHeight: canvas.height,
 				});
 				repeatTarget();
 
@@ -358,9 +351,7 @@ const TimelineVideoInfoSegment: React.FC<{
 				let frame: VideoFrame | undefined;
 				try {
 					frame = sample.toVideoFrame();
-					const scale =
-						(TIMELINE_LAYER_FILMSTRIP_HEIGHT / frame.displayHeight) *
-						window.devicePixelRatio;
+					const scale = canvas.height / frame.displayHeight;
 
 					const transformed = resizeVideoFrame({
 						frame,
@@ -386,7 +377,7 @@ const TimelineVideoInfoSegment: React.FC<{
 						toSeconds,
 						naturalWidth: targetWidth,
 						aspectRatio: aspectRatio.current,
-						frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+						frameHeight: canvas.height,
 					});
 					fillFrameWhereItFits({
 						ctx: targetCtx,
@@ -395,8 +386,8 @@ const TimelineVideoInfoSegment: React.FC<{
 						frame: transformed,
 						segmentDuration: toSeconds - fromSeconds,
 						fromSeconds,
-						devicePixelRatio: window.devicePixelRatio,
-						frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+						devicePixelRatio: 1,
+						frameHeight: canvas.height,
 					});
 					repeatTarget();
 				} catch (e) {
@@ -423,8 +414,8 @@ const TimelineVideoInfoSegment: React.FC<{
 					src,
 					segmentDuration: toSeconds - fromSeconds,
 					fromSeconds,
-					devicePixelRatio: window.devicePixelRatio,
-					frameHeight: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
+					devicePixelRatio: 1,
+					frameHeight: canvas.height,
 				});
 				repeatTarget();
 			})


### PR DESCRIPTION
## Summary

- render Studio audio waveform canvases at the display pixel ratio
- render video filmstrips, frozen frames, cached frames, and loop tiles at Retina resolution
- preserve the existing CSS dimensions and timeline layout

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run formatting lint test make --filter='@remotion/studio'` (598 tests passed)
