### PR TITLE
`@remotion/studio`: Increase forward timeline overscan

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineViewport.tsx
+++ b/packages/studio/src/components/Timeline/TimelineViewport.tsx
@@ -13,13 +13,20 @@ type TimelineRenderWindow = {
 export const TimelineViewportContext =
 	createContext<TimelineRenderWindow | null>(null);
 
-const getRenderWindow = (scrollable: HTMLDivElement): TimelineRenderWindow => {
+export const getTimelineRenderWindow = (
+	scrollable: HTMLDivElement,
+): TimelineRenderWindow => {
 	const viewportWidth = scrollable.clientWidth;
 	if (viewportWidth === 0) {
 		return {left: 0, width: 0};
 	}
 
-	const currentSection = Math.floor(scrollable.scrollLeft / viewportWidth);
+	// Move the render window half a viewport before the visible viewport reaches
+	// its right edge. This keeps at least half a viewport rendered ahead while
+	// retaining the three-viewport-wide window.
+	const currentSection = Math.floor(
+		(scrollable.scrollLeft + viewportWidth / 2) / viewportWidth,
+	);
 	const left = Math.max(0, (currentSection - 1) * viewportWidth);
 
 	return {
@@ -43,7 +50,7 @@ export const TimelineViewportProvider: React.FC<{
 			return;
 		}
 
-		const next = getRenderWindow(element);
+		const next = getTimelineRenderWindow(element);
 		setRenderWindow((previous) => {
 			if (previous.left === next.left && previous.width === next.width) {
 				return previous;

--- a/packages/studio/src/test/timeline-viewport.test.ts
+++ b/packages/studio/src/test/timeline-viewport.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'bun:test';
+import {getTimelineRenderWindow} from '../components/Timeline/TimelineViewport';
+
+const getRenderWindow = (scrollLeft: number) => {
+	return getTimelineRenderWindow({
+		clientWidth: 100,
+		scrollLeft,
+	} as HTMLDivElement);
+};
+
+test('advances the render window half a viewport before its right edge', () => {
+	expect(getRenderWindow(0)).toEqual({left: 0, width: 300});
+	expect(getRenderWindow(149.999)).toEqual({left: 0, width: 300});
+	expect(getRenderWindow(150)).toEqual({left: 100, width: 300});
+	expect(getRenderWindow(249.999)).toEqual({left: 100, width: 300});
+	expect(getRenderWindow(250)).toEqual({left: 200, width: 300});
+
+	const beforeBoundary = getRenderWindow(249.999);
+	const renderedAhead =
+		beforeBoundary.left + beforeBoundary.width - (249.999 + 100);
+	expect(renderedAhead).toBeGreaterThanOrEqual(50);
+});


### PR DESCRIPTION
## Summary

- advance the three-viewport timeline render window half a viewport earlier
- retain at least half a viewport of rendered content ahead while scrolling right
- cover render-window boundary transitions with a focused regression test

## Verification

- `bun test src/test/timeline-viewport.test.ts` in `packages/studio`
- `bun run build`
- `bun run stylecheck`
