### PR TITLE
`@remotion/studio`: Prevent inspector controls from opening the editor

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -390,7 +390,7 @@ test.describe('visual mode', () => {
 		}
 	});
 
-	test('should not open the editor when selecting text in the inspector', async ({
+	test('should only open the editor from non-interactive inspector content', async ({
 		page,
 	}) => {
 		await page.addInitScript(() => {
@@ -454,6 +454,29 @@ test.describe('visual mode', () => {
 			.toBe('overview');
 		// Headless Chromium does not consistently emit dblclick after selecting text.
 		await textField.dispatchEvent('dblclick');
+		const numberDragger = page
+			.locator('button.__remotion_input_dragger')
+			.first();
+		await expect(numberDragger).toBeVisible();
+		await numberDragger.dispatchEvent('dblclick');
+		const colorPicker = page.getByTitle('#8E9AB8', {exact: true});
+		await expect(colorPicker).toBeVisible();
+		await colorPicker.dispatchEvent('dblclick');
+
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+		const scaleEffectRow = page.getByText('scale()', {exact: true});
+		await expect(async () => {
+			await page.getByTitle('Scale precision', {exact: true}).first().click();
+			await expect(scaleEffectRow).toBeVisible({timeout: 1_000});
+		}).toPass({timeout: 15_000});
+		await scaleEffectRow.click();
+		const horizontalCheckbox = page.locator('input[name="horizontal"]');
+		await expect(horizontalCheckbox).toBeVisible();
+		await horizontalCheckbox.dispatchEvent('dblclick');
 		await page.waitForTimeout(100);
 		expect(openInEditorRequests).toEqual([]);
 	});

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -1,3 +1,4 @@
+import {scale} from '@remotion/effects/scale';
 import {wave} from '@remotion/effects/wave';
 import {Video} from '@remotion/media';
 import React from 'react';
@@ -28,7 +29,10 @@ export const EffectKeyframeE2e: React.FC = () => {
 				color="#1f2429"
 				cropLeft={0}
 				style={{rotate: '0deg', scale: 1}}
-				effects={[wave({})]}
+				effects={[
+					wave({}),
+					scale({scale: 1, horizontal: true, vertical: true}),
+				]}
 			/>
 			<Solid
 				name="Timeline expansion"

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -138,6 +138,26 @@ export const TimelineRowChrome: React.FC<{
 		[onSelect],
 	);
 
+	const onDoubleClickIfNotInteractive = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			const {target} = e;
+			if (
+				target instanceof Element &&
+				e.currentTarget.contains(
+					target.closest(
+						'button, input, select, textarea, a, [contenteditable="true"]',
+					),
+				)
+			) {
+				e.stopPropagation();
+				return;
+			}
+
+			onDoubleClick?.(e);
+		},
+		[onDoubleClick],
+	);
+
 	const highlightBackground = getTimelineRowHighlightBackground({
 		showSelectedBackground,
 		selected,
@@ -209,7 +229,7 @@ export const TimelineRowChrome: React.FC<{
 				onDrop={onDrop}
 				onPointerDown={selectable ? onPointerDown : undefined}
 				onContextMenu={selectable ? onContextMenu : undefined}
-				onDoubleClick={onDoubleClick}
+				onDoubleClick={onDoubleClickIfNotInteractive}
 				onPointerEnter={onPointerEnter}
 				onPointerLeave={onPointerLeave}
 			>
@@ -225,7 +245,7 @@ export const TimelineRowChrome: React.FC<{
 			onDrop={onDrop}
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onContextMenu={selectable ? onContextMenu : undefined}
-			onDoubleClick={onDoubleClick}
+			onDoubleClick={onDoubleClickIfNotInteractive}
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 			style={innerRowStyle}


### PR DESCRIPTION
## Summary

- prevent inspector row double-click actions from firing when the event originates from an interactive control
- cover checkboxes as well as text, number, and color controls
- add a boolean effect fixture for the browser regression workflow

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should only open the editor from non-interactive inspector content"`
- `bunx playwright test e2e/studio.test.mts --grep "should preserve the sequence inspector scroll position when adding an effect"`
