### PR TITLE
`@remotion/studio`: Hide Open in menu in Browser Studio

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -67,6 +67,12 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 			await expect(solid).toBeVisible();
 			await expect(studio.locator('svg[viewBox="0 0 24 16"]')).toBeVisible();
 			await solid.click();
+			await expect(
+				studio.getByRole('button', {name: 'Copy context for agents'}).first(),
+			).toBeAttached();
+			await expect(
+				studio.getByRole('button', {name: 'Open in another app'}),
+			).toHaveCount(0, {timeout: 1000});
 			await page.keyboard.press('Delete');
 			await expect(solid).toHaveCount(0);
 			await expect

--- a/packages/studio/src/components/InlineDropdown.tsx
+++ b/packages/studio/src/components/InlineDropdown.tsx
@@ -62,8 +62,8 @@ export const InlineDropdown = ({
 		(e) => {
 			e.preventDefault();
 			e.stopPropagation();
-			const invocationValues = getItems?.() ?? null;
-			if (invocationValues?.length === 0) {
+			const invocationValues = getItems?.() ?? values ?? [];
+			if (invocationValues.length === 0) {
 				return;
 			}
 
@@ -75,7 +75,7 @@ export const InlineDropdown = ({
 			});
 			onOpenChange?.(true);
 		},
-		[getItems, onOpenChange],
+		[getItems, onOpenChange, values],
 	);
 
 	const spaceToBottom = useMemo(() => {

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -2,6 +2,7 @@ import type {DefaultCodingAgent} from '@remotion/renderer';
 import type {EditorPickerId} from '@remotion/studio-shared';
 import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
 import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	LIGHT_TEXT,
@@ -239,7 +240,10 @@ export const InspectorOpenInEditor: React.FC<{
 		setSelectedModal,
 	]);
 
-	if (previewServerState.type !== 'connected') {
+	if (
+		previewServerState.type !== 'connected' ||
+		getBrowserStudioOperations() !== null
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

- hide local-app “Open in” controls in Browser Studio
- prevent inline dropdowns from opening with an empty static item list
- keep the browser-relevant “Copy context for agents” action available

## Testing

- `bun run testbrowserstudio --grep 'loads Browser Studio and can add, delete, and duplicate'`
- red/green verified by temporarily removing the Browser Studio gate
- `bun run build`
- `bun run stylecheck`
