### PR TITLE
remotion.media: Increase loudness

### DIFF
--- a/packages/remotion-media/clean.ts
+++ b/packages/remotion-media/clean.ts
@@ -4,3 +4,4 @@ await $`rm -rf files`;
 await $`rm -rf out`;
 await $`rm -rf dist`;
 await $`rm -f tone.wav`;
+await $`rm -f tone-loop.wav`;

--- a/packages/remotion-media/clean.ts
+++ b/packages/remotion-media/clean.ts
@@ -3,3 +3,4 @@ import {$} from 'bun';
 await $`rm -rf files`;
 await $`rm -rf out`;
 await $`rm -rf dist`;
+await $`rm -f tone.wav`;

--- a/packages/remotion-media/clean.ts
+++ b/packages/remotion-media/clean.ts
@@ -4,4 +4,3 @@ await $`rm -rf files`;
 await $`rm -rf out`;
 await $`rm -rf dist`;
 await $`rm -f tone.wav`;
-await $`rm -f tone-loop.wav`;

--- a/packages/remotion-media/generate.ts
+++ b/packages/remotion-media/generate.ts
@@ -271,13 +271,14 @@ const getOutputName = ({
 };
 
 const tonePath = 'tone.wav';
-const toneLoopPath = 'tone-loop.wav';
+const toneLoopPath = path.join('out', 'tone-loop.wav');
 
 const base8k = path.join('out', '8k.mp4');
 const baseMute = path.join('out', 'mute.mp4');
 
 if (!(await Bun.file(tonePath).exists())) {
 	if (!(await Bun.file(toneLoopPath).exists())) {
+		mkdirSync(path.dirname(toneLoopPath), {recursive: true});
 		await $`bunx remotion render src/compositions/index.ts Tone ${toneLoopPath} --codec=wav --frames=0-299`;
 	}
 

--- a/packages/remotion-media/generate.ts
+++ b/packages/remotion-media/generate.ts
@@ -1,6 +1,6 @@
+import {$} from 'bun';
 import {copyFileSync, existsSync, mkdirSync} from 'fs';
 import path from 'path';
-import {$} from 'bun';
 
 const audioCodecs = [
 	'aac',
@@ -274,6 +274,10 @@ const tonePath = 'tone.wav';
 
 const base8k = path.join('out', '8k.mp4');
 const baseMute = path.join('out', 'mute.mp4');
+
+if (!(await Bun.file(tonePath).exists())) {
+	await $`bunx remotion render src/compositions/index.ts Tone ${tonePath} --codec=wav --frames=0-299`;
+}
 
 const generateCodecVariant = async ({
 	outputPath,

--- a/packages/remotion-media/generate.ts
+++ b/packages/remotion-media/generate.ts
@@ -1,6 +1,6 @@
-import {$} from 'bun';
 import {copyFileSync, existsSync, mkdirSync} from 'fs';
 import path from 'path';
+import {$} from 'bun';
 
 const audioCodecs = [
 	'aac',

--- a/packages/remotion-media/generate.ts
+++ b/packages/remotion-media/generate.ts
@@ -271,13 +271,27 @@ const getOutputName = ({
 };
 
 const tonePath = 'tone.wav';
+const toneLoopPath = 'tone-loop.wav';
 
 const base8k = path.join('out', '8k.mp4');
 const baseMute = path.join('out', 'mute.mp4');
 
 if (!(await Bun.file(tonePath).exists())) {
-	await $`bunx remotion render src/compositions/index.ts Tone ${tonePath} --codec=wav --frames=0-299`;
+	if (!(await Bun.file(toneLoopPath).exists())) {
+		await $`bunx remotion render src/compositions/index.ts Tone ${toneLoopPath} --codec=wav --frames=0-299`;
+	}
+
+	await $`ffmpeg -stream_loop -1 -i ${toneLoopPath} -t 1800 -c:a copy ${tonePath} -y`;
 }
+
+const getEncodedVideoPath = async (videoEncoder: string) => {
+	const encodedVideoPath = path.join('out', `${videoEncoder}.mkv`);
+	if (!(await Bun.file(encodedVideoPath).exists())) {
+		await $`ffmpeg -i ${baseMute} -t 10 -c:v ${videoEncoder} -an ${encodedVideoPath} -y`;
+	}
+
+	return encodedVideoPath;
+};
 
 const generateCodecVariant = async ({
 	outputPath,
@@ -289,12 +303,14 @@ const generateCodecVariant = async ({
 	audioEncoder: string | null;
 }) => {
 	if (videoEncoder && audioEncoder) {
-		await $`ffmpeg -i ${baseMute} -i ${tonePath} -t 10 -c:v ${videoEncoder} -c:a ${audioEncoder} ${outputPath} -y`;
+		const encodedVideoPath = await getEncodedVideoPath(videoEncoder);
+		await $`ffmpeg -i ${encodedVideoPath} -i ${tonePath} -t 10 -c:v copy -c:a ${audioEncoder} ${outputPath} -y`;
 		return;
 	}
 
 	if (videoEncoder && !audioEncoder) {
-		await $`ffmpeg -i ${baseMute} -t 10 -c:v ${videoEncoder} -an ${outputPath} -y`;
+		const encodedVideoPath = await getEncodedVideoPath(videoEncoder);
+		await $`ffmpeg -i ${encodedVideoPath} -t 10 -c:v copy -an ${outputPath} -y`;
 		return;
 	}
 

--- a/packages/remotion-media/src/compositions/Tone.tsx
+++ b/packages/remotion-media/src/compositions/Tone.tsx
@@ -1,12 +1,15 @@
-import {Audio, staticFile} from 'remotion';
+import {Audio, staticFile, useVideoConfig} from 'remotion';
 
 export const Tone = () => {
+	const {fps} = useVideoConfig();
+
 	return (
 		<Audio
 			src={staticFile('tone-1k-60s.wav')}
 			loop
+			allowAmplificationDuringRender
 			volume={(f) => {
-				return (Math.sin(f * Math.PI * 2 * 30 * 10) + 1) / 2;
+				return (Math.sin((f / fps) * Math.PI * 2 * 10) + 1) * 8;
 			}}
 		/>
 	);

--- a/packages/remotion-media/variants.json
+++ b/packages/remotion-media/variants.json
@@ -1,1378 +1,1101 @@
 [
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video.mp4",
-      "video-h264.mp4",
-      "video-aac.mp4",
-      "video-h264-aac.mp4"
-    ],
-    "size": 2004344,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "flac",
-    "container": "mp4",
-    "fileNames": [
-      "video-flac.mp4",
-      "video-h264-flac.mp4"
-    ],
-    "size": 2067676,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "mp3",
-    "container": "mp4",
-    "fileNames": [
-      "video-mp3.mp4",
-      "video-h264-mp3.mp4"
-    ],
-    "size": 2002055,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "pcm",
-    "container": "mp4",
-    "fileNames": [
-      "video-pcm.mp4",
-      "video-h264-pcm.mp4"
-    ],
-    "size": 3758531,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "none",
-    "container": "mp4",
-    "fileNames": [
-      "video-none.mp4",
-      "video-h264-none.mp4"
-    ],
-    "size": 1837459,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-h265.mp4",
-      "video-h265-aac.mp4"
-    ],
-    "size": 1449988,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "flac",
-    "container": "mp4",
-    "fileNames": [
-      "video-h265-flac.mp4"
-    ],
-    "size": 1513320,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "mp3",
-    "container": "mp4",
-    "fileNames": [
-      "video-h265-mp3.mp4"
-    ],
-    "size": 1447699,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "pcm",
-    "container": "mp4",
-    "fileNames": [
-      "video-h265-pcm.mp4"
-    ],
-    "size": 3205011,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "none",
-    "container": "mp4",
-    "fileNames": [
-      "video-h265-none.mp4"
-    ],
-    "size": 1281506,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio.wav",
-      "audio-pcm.wav"
-    ],
-    "size": 1920078,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "mp3",
-    "container": "mp3",
-    "fileNames": [
-      "audio.mp3",
-      "audio-mp3.mp3"
-    ],
-    "size": 160748,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "flac",
-    "container": "flac",
-    "fileNames": [
-      "audio.flac",
-      "audio-flac.flac"
-    ],
-    "size": 238029,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "opus",
-    "container": "webm",
-    "fileNames": [
-      "video-opus.webm",
-      "video-vp8-opus.webm"
-    ],
-    "size": 1139832,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "vorbis",
-    "container": "webm",
-    "fileNames": [
-      "video-vorbis.webm",
-      "video-vp8-vorbis.webm"
-    ],
-    "size": 988924,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "none",
-    "container": "webm",
-    "fileNames": [
-      "video-none.webm",
-      "video-vp8-none.webm"
-    ],
-    "size": 879717,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "opus",
-    "container": "webm",
-    "fileNames": [
-      "video-vp9-opus.webm"
-    ],
-    "size": 2687740,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "vorbis",
-    "container": "webm",
-    "fileNames": [
-      "video-vp9-vorbis.webm"
-    ],
-    "size": 2536832,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "none",
-    "container": "webm",
-    "fileNames": [
-      "video-vp9-none.webm"
-    ],
-    "size": 2475792,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mkv",
-    "fileNames": [
-      "video.mkv",
-      "video-h264.mkv",
-      "video-aac.mkv",
-      "video-h264-aac.mkv"
-    ],
-    "size": 1998157,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "flac",
-    "container": "mkv",
-    "fileNames": [
-      "video-flac.mkv",
-      "video-h264-flac.mkv"
-    ],
-    "size": 2064844,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "mp3",
-    "container": "mkv",
-    "fileNames": [
-      "video-mp3.mkv",
-      "video-h264-mp3.mkv"
-    ],
-    "size": 1997796,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "opus",
-    "container": "mkv",
-    "fileNames": [
-      "video-opus.mkv",
-      "video-h264-opus.mkv"
-    ],
-    "size": 2046112,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "vorbis",
-    "container": "mkv",
-    "fileNames": [
-      "video-vorbis.mkv",
-      "video-h264-vorbis.mkv"
-    ],
-    "size": 1895206,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "none",
-    "container": "mkv",
-    "fileNames": [
-      "video-none.mkv",
-      "video-h264-none.mkv"
-    ],
-    "size": 1835744,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "aac",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265.mkv",
-      "video-h265-aac.mkv"
-    ],
-    "size": 1443421,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "flac",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265-flac.mkv"
-    ],
-    "size": 1510107,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "mp3",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265-mp3.mkv"
-    ],
-    "size": 1443060,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "opus",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265-opus.mkv"
-    ],
-    "size": 1491376,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "vorbis",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265-vorbis.mkv"
-    ],
-    "size": 1340470,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "none",
-    "container": "mkv",
-    "fileNames": [
-      "video-h265-none.mkv"
-    ],
-    "size": 1279427,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "aac",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8.mkv",
-      "video-vp8-aac.mkv"
-    ],
-    "size": 1091961,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "flac",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8-flac.mkv"
-    ],
-    "size": 1158645,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "mp3",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8-mp3.mkv"
-    ],
-    "size": 1091600,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "opus",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8-opus.mkv"
-    ],
-    "size": 1139916,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "vorbis",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8-vorbis.mkv"
-    ],
-    "size": 989008,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp8",
-    "audioCodec": "none",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp8-none.mkv"
-    ],
-    "size": 879797,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "aac",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9.mkv",
-      "video-vp9-aac.mkv"
-    ],
-    "size": 2639869,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "flac",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9-flac.mkv"
-    ],
-    "size": 2706553,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "mp3",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9-mp3.mkv"
-    ],
-    "size": 2639508,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "opus",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9-opus.mkv"
-    ],
-    "size": 2687824,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "vorbis",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9-vorbis.mkv"
-    ],
-    "size": 2536916,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "none",
-    "container": "mkv",
-    "fileNames": [
-      "video-vp9-none.mkv"
-    ],
-    "size": 2475872,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "aac",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores.mkv",
-      "video-prores-aac.mkv"
-    ],
-    "size": 140913397,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "flac",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores-flac.mkv"
-    ],
-    "size": 140979889,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "mp3",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores-mp3.mkv"
-    ],
-    "size": 140913036,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "opus",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores-opus.mkv"
-    ],
-    "size": 140961353,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "vorbis",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores-vorbis.mkv"
-    ],
-    "size": 140810147,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "none",
-    "container": "mkv",
-    "fileNames": [
-      "video-prores-none.mkv"
-    ],
-    "size": 140749103,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mov",
-    "fileNames": [
-      "video.mov",
-      "video-h264.mov",
-      "video-aac.mov",
-      "video-h264-aac.mov"
-    ],
-    "size": 2005769,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "pcm",
-    "container": "mov",
-    "fileNames": [
-      "video-pcm.mov",
-      "video-h264-pcm.mov"
-    ],
-    "size": 3759864,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "none",
-    "container": "mov",
-    "fileNames": [
-      "video-none.mov",
-      "video-h264-none.mov"
-    ],
-    "size": 1837432,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "aac",
-    "container": "mov",
-    "fileNames": [
-      "video-h265.mov",
-      "video-h265-aac.mov"
-    ],
-    "size": 1450905,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "pcm",
-    "container": "mov",
-    "fileNames": [
-      "video-h265-pcm.mov"
-    ],
-    "size": 3205000,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h265",
-    "audioCodec": "none",
-    "container": "mov",
-    "fileNames": [
-      "video-h265-none.mov"
-    ],
-    "size": 1281483,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "aac",
-    "container": "mov",
-    "fileNames": [
-      "video-prores.mov",
-      "video-prores-aac.mov"
-    ],
-    "size": 140909556,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "pcm",
-    "container": "mov",
-    "fileNames": [
-      "video-prores-pcm.mov"
-    ],
-    "size": 142664203,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "prores",
-    "audioCodec": "none",
-    "container": "mov",
-    "fileNames": [
-      "video-prores-none.mov"
-    ],
-    "size": 140740422,
-    "category": "codecs"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-360p.mp4"
-    ],
-    "size": 29890124,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-480p.mp4"
-    ],
-    "size": 30139639,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-720p.mp4"
-    ],
-    "size": 30665190,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-1080p.mp4"
-    ],
-    "size": 31546672,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-1440p.mp4"
-    ],
-    "size": 32472765,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-2160p.mp4"
-    ],
-    "size": 34551604,
-    "category": "dimensions"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-5s.mp4"
-    ],
-    "size": 2061494,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-10s.mp4"
-    ],
-    "size": 4335492,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-30s.mp4"
-    ],
-    "size": 12756307,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-1m.mp4"
-    ],
-    "size": 25266299,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-5m.mp4"
-    ],
-    "size": 125505256,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-10m.mp4"
-    ],
-    "size": 249892924,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-30m.mp4"
-    ],
-    "size": 748895261,
-    "category": "durations"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-24fps.mp4"
-    ],
-    "size": 3703572,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-25fps.mp4"
-    ],
-    "size": 3771048,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-29.97fps.mp4"
-    ],
-    "size": 4242299,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-30fps.mp4"
-    ],
-    "size": 4239032,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-59.94fps.mp4"
-    ],
-    "size": 5860974,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-60fps.mp4"
-    ],
-    "size": 5862694,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-120fps.mp4"
-    ],
-    "size": 8960805,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "video-240fps.mp4"
-    ],
-    "size": 17746946,
-    "category": "fps"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "dialogue.wav"
-    ],
-    "size": 4787658,
-    "category": "audio"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "pcm",
-    "container": "mov",
-    "fileNames": [
-      "multiple-audio-streams.mov"
-    ],
-    "size": 66906020,
-    "category": "audio"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-8000hz.wav"
-    ],
-    "size": 160078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-11025hz.wav"
-    ],
-    "size": 220578,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-12000hz.wav"
-    ],
-    "size": 240078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-16000hz.wav"
-    ],
-    "size": 320078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-22050hz.wav"
-    ],
-    "size": 441078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-24000hz.wav"
-    ],
-    "size": 480078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-32000hz.wav"
-    ],
-    "size": 640078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-44100hz.wav"
-    ],
-    "size": 882078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-48000hz.wav"
-    ],
-    "size": 960078,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-88200hz.wav"
-    ],
-    "size": 1764102,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-96000hz.wav"
-    ],
-    "size": 1920102,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-176400hz.wav"
-    ],
-    "size": 3528102,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "audio-192000hz.wav"
-    ],
-    "size": 3840102,
-    "category": "sample-rates"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "mp4",
-    "fileNames": [
-      "greenscreen.mp4"
-    ],
-    "size": 888217,
-    "category": "greenscreen"
-  },
-  {
-    "videoCodec": "vp9",
-    "audioCodec": "opus",
-    "container": "webm",
-    "fileNames": [
-      "first-frame-at-4sec.webm"
-    ],
-    "size": 911894,
-    "category": "edge-cases"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "whoosh.wav"
-    ],
-    "size": 13620,
-    "category": "sound-effects",
-    "attribution": "Woosh by 1bob -- https://freesound.org/s/831936/ -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "whip.wav"
-    ],
-    "size": 66732,
-    "category": "sound-effects",
-    "attribution": "SWSH_Badminton Racquet_Recording_01_JW Audio by JW_Audio -- https://freesound.org/s/838766/ -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "page-turn.wav"
-    ],
-    "size": 35334,
-    "category": "sound-effects",
-    "attribution": "Draw Knife 1 by kenney.nl -- https://kenney.nl -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "switch.wav"
-    ],
-    "size": 58290,
-    "category": "sound-effects",
-    "attribution": "UI Audio - Switch 35 by kenney.nl -- https://kenney.nl -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "mouse-click.wav"
-    ],
-    "size": 70110,
-    "category": "sound-effects",
-    "attribution": "Mouse Click Sound.mp3 by Pixeliota -- https://freesound.org/s/678248/ -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "shutter-modern.wav"
-    ],
-    "size": 43224,
-    "category": "sound-effects",
-    "attribution": "DSLR Shutter fast 006.wav by ristooooo1 -- https://freesound.org/s/539136/ -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "shutter-old.wav"
-    ],
-    "size": 55600,
-    "category": "sound-effects",
-    "attribution": "Werra.wav by hmilleo -- https://freesound.org/s/409093/ -- License: Creative Commons 0"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "bruh.wav"
-    ],
-    "size": 207438,
-    "category": "sound-effects",
-    "attribution": "Bruh Sound Effect -- https://soundeffects.fandom.com/wiki/Bruh_Sound_Effect"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "windows-xp-error.wav"
-    ],
-    "size": 87630,
-    "category": "sound-effects",
-    "attribution": "Windows XP Error -- https://www.myinstants.com/en/instant/windows-xp-error/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "vine-boom.wav"
-    ],
-    "size": 221516,
-    "category": "sound-effects",
-    "attribution": "Vine Boom Sound -- https://www.myinstants.com/en/instant/vine-boom-sound-70972/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "ding.wav"
-    ],
-    "size": 520782,
-    "category": "sound-effects",
-    "attribution": "Ding Sound Effect -- https://www.myinstants.com/en/instant/ding-sound-effect/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "fah.wav"
-    ],
-    "size": 340042,
-    "category": "sound-effects",
-    "attribution": "Fah meme -- https://www.myinstants.com/en/instant/fahhhhhhhhhhhhhh-3525/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "spongebob-fail.wav"
-    ],
-    "size": 597032,
-    "category": "sound-effects",
-    "attribution": "SpongeBob fail -- https://www.myinstants.com/en/instant/spongebob-fail-11236/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "omg-hell-nah.wav"
-    ],
-    "size": 776526,
-    "category": "sound-effects",
-    "attribution": "Oh my god bro hell nah -- https://www.myinstants.com/en/instant/oh-my-god-bro-oh-hell-nah-man-42939/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "price-is-right-fail.wav"
-    ],
-    "size": 797276,
-    "category": "sound-effects",
-    "attribution": "Price Is Right fail horn -- https://www.myinstants.com/en/instant/fail-horn/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "romance-meme.wav"
-    ],
-    "size": 1024962,
-    "category": "sound-effects",
-    "attribution": "Romance meme -- https://www.myinstants.com/en/instant/romanceeeeeeeeeeeeee-29042/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "bone-crack.wav"
-    ],
-    "size": 188494,
-    "category": "sound-effects",
-    "attribution": "Bone crack -- https://www.myinstants.com/en/instant/bone-crack-23901/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "anime-wow.wav"
-    ],
-    "size": 737358,
-    "category": "sound-effects",
-    "attribution": "Anime wow -- https://www.myinstants.com/en/instant/anime-wow/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "yippee.wav"
-    ],
-    "size": 467166,
-    "category": "sound-effects",
-    "attribution": "Yippee -- https://www.myinstants.com/en/instant/yippeeeeeeeeeeeeee-34261/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "loading-lag.wav"
-    ],
-    "size": 475214,
-    "category": "sound-effects",
-    "attribution": "Loading lag -- https://www.myinstants.com/en/instant/lagging-loading-11339/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "wilhelm-scream.wav"
-    ],
-    "size": 368718,
-    "category": "sound-effects",
-    "attribution": "Wilhelm scream -- https://www.myinstants.com/en/instant/man-screaming-aaaah-32768/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "mac-quack.wav"
-    ],
-    "size": 61610,
-    "category": "sound-effects",
-    "attribution": "Mac quack -- https://www.myinstants.com/en/instant/mac-quack-83896/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "skedaddle.wav"
-    ],
-    "size": 1155150,
-    "category": "sound-effects",
-    "attribution": "Skedaddle -- https://www.myinstants.com/en/instant/skedaddle-78470/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "snapchat-notification.wav"
-    ],
-    "size": 38724,
-    "category": "sound-effects",
-    "attribution": "Snapchat notification -- https://www.myinstants.com/en/instant/notification-snap-43481/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "nelly-ahh.wav"
-    ],
-    "size": 258170,
-    "category": "sound-effects",
-    "attribution": "Nelly ahh -- https://www.myinstants.com/en/instant/nelly-ahh-89172/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "sanctuary-guardian-what.wav"
-    ],
-    "size": 1589326,
-    "category": "sound-effects",
-    "attribution": "Sanctuary Guardian what meme -- https://www.myinstants.com/en/instant/what-bottom-text-meme-sanctuary-guardian-s-24591/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "minecraft-hurt.wav"
-    ],
-    "size": 64628,
-    "category": "sound-effects",
-    "attribution": "Minecraft hurt -- https://www.myinstants.com/en/instant/minecraft-hurt/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "oh-my-god-vine.wav"
-    ],
-    "size": 285014,
-    "category": "sound-effects",
-    "attribution": "Oh my god vine -- https://www.myinstants.com/en/instant/oh-ma-gaud-vine-78004/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "illuminati-confirmed.wav"
-    ],
-    "size": 1382666,
-    "category": "sound-effects",
-    "attribution": "Illuminati confirmed -- https://www.myinstants.com/en/instant/illuminati-confirmed-meme-99730/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "dramatic-boomer.wav"
-    ],
-    "size": 235206,
-    "category": "sound-effects",
-    "attribution": "Dramatic boomer -- https://www.myinstants.com/en/instant/dramatic-boomer-29428/"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "pcm",
-    "container": "wav",
-    "fileNames": [
-      "triggered.wav"
-    ],
-    "size": 122958,
-    "category": "sound-effects",
-    "attribution": "Triggered -- https://www.myinstants.com/en/instant/core-sound-effect-57998/"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "m3u8",
-    "fileNames": [
-      "video.m3u8",
-      "hls-ts.m3u8",
-      "hls-ts-0.ts",
-      "hls-ts-1.ts"
-    ],
-    "size": 173,
-    "category": "hls"
-  },
-  {
-    "videoCodec": "h264",
-    "audioCodec": "aac",
-    "container": "m3u8",
-    "fileNames": [
-      "hls-fmp4.m3u8",
-      "hls-fmp4-0.m4s",
-      "hls-fmp4-1.m4s",
-      "hls-fmp4-init.mp4"
-    ],
-    "size": 214,
-    "category": "hls"
-  },
-  {
-    "videoCodec": "none",
-    "audioCodec": "aac",
-    "container": "m3u8",
-    "fileNames": [
-      "audio.m3u8",
-      "audio-0.ts",
-      "audio-1.ts",
-      "audio-2.ts",
-      "audio-3.ts",
-      "audio-4.ts",
-      "audio-5.ts"
-    ],
-    "size": 287,
-    "category": "hls"
-  }
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": [
+			"video.mp4",
+			"video-h264.mp4",
+			"video-aac.mp4",
+			"video-h264-aac.mp4"
+		],
+		"size": 2004344,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "flac",
+		"container": "mp4",
+		"fileNames": ["video-flac.mp4", "video-h264-flac.mp4"],
+		"size": 2067676,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "mp3",
+		"container": "mp4",
+		"fileNames": ["video-mp3.mp4", "video-h264-mp3.mp4"],
+		"size": 2002055,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "pcm",
+		"container": "mp4",
+		"fileNames": ["video-pcm.mp4", "video-h264-pcm.mp4"],
+		"size": 3758531,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "none",
+		"container": "mp4",
+		"fileNames": ["video-none.mp4", "video-h264-none.mp4"],
+		"size": 1837459,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-h265.mp4", "video-h265-aac.mp4"],
+		"size": 1449988,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "flac",
+		"container": "mp4",
+		"fileNames": ["video-h265-flac.mp4"],
+		"size": 1513320,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "mp3",
+		"container": "mp4",
+		"fileNames": ["video-h265-mp3.mp4"],
+		"size": 1447699,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "pcm",
+		"container": "mp4",
+		"fileNames": ["video-h265-pcm.mp4"],
+		"size": 3205011,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "none",
+		"container": "mp4",
+		"fileNames": ["video-h265-none.mp4"],
+		"size": 1281506,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio.wav", "audio-pcm.wav"],
+		"size": 1920078,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "mp3",
+		"container": "mp3",
+		"fileNames": ["audio.mp3", "audio-mp3.mp3"],
+		"size": 160748,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "flac",
+		"container": "flac",
+		"fileNames": ["audio.flac", "audio-flac.flac"],
+		"size": 238029,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "opus",
+		"container": "webm",
+		"fileNames": ["video-opus.webm", "video-vp8-opus.webm"],
+		"size": 1139832,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "vorbis",
+		"container": "webm",
+		"fileNames": ["video-vorbis.webm", "video-vp8-vorbis.webm"],
+		"size": 988924,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "none",
+		"container": "webm",
+		"fileNames": ["video-none.webm", "video-vp8-none.webm"],
+		"size": 879717,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "opus",
+		"container": "webm",
+		"fileNames": ["video-vp9-opus.webm"],
+		"size": 2687740,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "vorbis",
+		"container": "webm",
+		"fileNames": ["video-vp9-vorbis.webm"],
+		"size": 2536832,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "none",
+		"container": "webm",
+		"fileNames": ["video-vp9-none.webm"],
+		"size": 2475792,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mkv",
+		"fileNames": [
+			"video.mkv",
+			"video-h264.mkv",
+			"video-aac.mkv",
+			"video-h264-aac.mkv"
+		],
+		"size": 1998157,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "flac",
+		"container": "mkv",
+		"fileNames": ["video-flac.mkv", "video-h264-flac.mkv"],
+		"size": 2064844,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "mp3",
+		"container": "mkv",
+		"fileNames": ["video-mp3.mkv", "video-h264-mp3.mkv"],
+		"size": 1997796,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "opus",
+		"container": "mkv",
+		"fileNames": ["video-opus.mkv", "video-h264-opus.mkv"],
+		"size": 2046112,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "vorbis",
+		"container": "mkv",
+		"fileNames": ["video-vorbis.mkv", "video-h264-vorbis.mkv"],
+		"size": 1895206,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "none",
+		"container": "mkv",
+		"fileNames": ["video-none.mkv", "video-h264-none.mkv"],
+		"size": 1835744,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "aac",
+		"container": "mkv",
+		"fileNames": ["video-h265.mkv", "video-h265-aac.mkv"],
+		"size": 1443421,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "flac",
+		"container": "mkv",
+		"fileNames": ["video-h265-flac.mkv"],
+		"size": 1510107,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "mp3",
+		"container": "mkv",
+		"fileNames": ["video-h265-mp3.mkv"],
+		"size": 1443060,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "opus",
+		"container": "mkv",
+		"fileNames": ["video-h265-opus.mkv"],
+		"size": 1491376,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "vorbis",
+		"container": "mkv",
+		"fileNames": ["video-h265-vorbis.mkv"],
+		"size": 1340470,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "none",
+		"container": "mkv",
+		"fileNames": ["video-h265-none.mkv"],
+		"size": 1279427,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "aac",
+		"container": "mkv",
+		"fileNames": ["video-vp8.mkv", "video-vp8-aac.mkv"],
+		"size": 1091961,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "flac",
+		"container": "mkv",
+		"fileNames": ["video-vp8-flac.mkv"],
+		"size": 1158645,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "mp3",
+		"container": "mkv",
+		"fileNames": ["video-vp8-mp3.mkv"],
+		"size": 1091600,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "opus",
+		"container": "mkv",
+		"fileNames": ["video-vp8-opus.mkv"],
+		"size": 1139916,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "vorbis",
+		"container": "mkv",
+		"fileNames": ["video-vp8-vorbis.mkv"],
+		"size": 989008,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp8",
+		"audioCodec": "none",
+		"container": "mkv",
+		"fileNames": ["video-vp8-none.mkv"],
+		"size": 879797,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "aac",
+		"container": "mkv",
+		"fileNames": ["video-vp9.mkv", "video-vp9-aac.mkv"],
+		"size": 2639869,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "flac",
+		"container": "mkv",
+		"fileNames": ["video-vp9-flac.mkv"],
+		"size": 2706553,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "mp3",
+		"container": "mkv",
+		"fileNames": ["video-vp9-mp3.mkv"],
+		"size": 2639508,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "opus",
+		"container": "mkv",
+		"fileNames": ["video-vp9-opus.mkv"],
+		"size": 2687824,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "vorbis",
+		"container": "mkv",
+		"fileNames": ["video-vp9-vorbis.mkv"],
+		"size": 2536916,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "none",
+		"container": "mkv",
+		"fileNames": ["video-vp9-none.mkv"],
+		"size": 2475872,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "aac",
+		"container": "mkv",
+		"fileNames": ["video-prores.mkv", "video-prores-aac.mkv"],
+		"size": 140913397,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "flac",
+		"container": "mkv",
+		"fileNames": ["video-prores-flac.mkv"],
+		"size": 140979889,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "mp3",
+		"container": "mkv",
+		"fileNames": ["video-prores-mp3.mkv"],
+		"size": 140913036,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "opus",
+		"container": "mkv",
+		"fileNames": ["video-prores-opus.mkv"],
+		"size": 140961353,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "vorbis",
+		"container": "mkv",
+		"fileNames": ["video-prores-vorbis.mkv"],
+		"size": 140810147,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "none",
+		"container": "mkv",
+		"fileNames": ["video-prores-none.mkv"],
+		"size": 140749103,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mov",
+		"fileNames": [
+			"video.mov",
+			"video-h264.mov",
+			"video-aac.mov",
+			"video-h264-aac.mov"
+		],
+		"size": 2005769,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "pcm",
+		"container": "mov",
+		"fileNames": ["video-pcm.mov", "video-h264-pcm.mov"],
+		"size": 3759864,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "none",
+		"container": "mov",
+		"fileNames": ["video-none.mov", "video-h264-none.mov"],
+		"size": 1837432,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "aac",
+		"container": "mov",
+		"fileNames": ["video-h265.mov", "video-h265-aac.mov"],
+		"size": 1450905,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "pcm",
+		"container": "mov",
+		"fileNames": ["video-h265-pcm.mov"],
+		"size": 3205000,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h265",
+		"audioCodec": "none",
+		"container": "mov",
+		"fileNames": ["video-h265-none.mov"],
+		"size": 1281483,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "aac",
+		"container": "mov",
+		"fileNames": ["video-prores.mov", "video-prores-aac.mov"],
+		"size": 140909556,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "pcm",
+		"container": "mov",
+		"fileNames": ["video-prores-pcm.mov"],
+		"size": 142664203,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "prores",
+		"audioCodec": "none",
+		"container": "mov",
+		"fileNames": ["video-prores-none.mov"],
+		"size": 140740422,
+		"category": "codecs"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-360p.mp4"],
+		"size": 29890124,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-480p.mp4"],
+		"size": 30139639,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-720p.mp4"],
+		"size": 30665190,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-1080p.mp4"],
+		"size": 31546672,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-1440p.mp4"],
+		"size": 32472765,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-2160p.mp4"],
+		"size": 34551604,
+		"category": "dimensions"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-5s.mp4"],
+		"size": 2061494,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-10s.mp4"],
+		"size": 4335492,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-30s.mp4"],
+		"size": 12756307,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-1m.mp4"],
+		"size": 25266299,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-5m.mp4"],
+		"size": 125505256,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-10m.mp4"],
+		"size": 249892924,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-30m.mp4"],
+		"size": 748895261,
+		"category": "durations"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-24fps.mp4"],
+		"size": 3703572,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-25fps.mp4"],
+		"size": 3771048,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-29.97fps.mp4"],
+		"size": 4242299,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-30fps.mp4"],
+		"size": 4239032,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-59.94fps.mp4"],
+		"size": 5860974,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-60fps.mp4"],
+		"size": 5862694,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-120fps.mp4"],
+		"size": 8960805,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["video-240fps.mp4"],
+		"size": 17746946,
+		"category": "fps"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["dialogue.wav"],
+		"size": 4787658,
+		"category": "audio"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "pcm",
+		"container": "mov",
+		"fileNames": ["multiple-audio-streams.mov"],
+		"size": 66906020,
+		"category": "audio"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-8000hz.wav"],
+		"size": 160078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-11025hz.wav"],
+		"size": 220578,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-12000hz.wav"],
+		"size": 240078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-16000hz.wav"],
+		"size": 320078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-22050hz.wav"],
+		"size": 441078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-24000hz.wav"],
+		"size": 480078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-32000hz.wav"],
+		"size": 640078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-44100hz.wav"],
+		"size": 882078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-48000hz.wav"],
+		"size": 960078,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-88200hz.wav"],
+		"size": 1764102,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-96000hz.wav"],
+		"size": 1920102,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-176400hz.wav"],
+		"size": 3528102,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["audio-192000hz.wav"],
+		"size": 3840102,
+		"category": "sample-rates"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "mp4",
+		"fileNames": ["greenscreen.mp4"],
+		"size": 888217,
+		"category": "greenscreen"
+	},
+	{
+		"videoCodec": "vp9",
+		"audioCodec": "opus",
+		"container": "webm",
+		"fileNames": ["first-frame-at-4sec.webm"],
+		"size": 911894,
+		"category": "edge-cases"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["whoosh.wav"],
+		"size": 13620,
+		"category": "sound-effects",
+		"attribution": "Woosh by 1bob -- https://freesound.org/s/831936/ -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["whip.wav"],
+		"size": 66732,
+		"category": "sound-effects",
+		"attribution": "SWSH_Badminton Racquet_Recording_01_JW Audio by JW_Audio -- https://freesound.org/s/838766/ -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["page-turn.wav"],
+		"size": 35334,
+		"category": "sound-effects",
+		"attribution": "Draw Knife 1 by kenney.nl -- https://kenney.nl -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["switch.wav"],
+		"size": 58290,
+		"category": "sound-effects",
+		"attribution": "UI Audio - Switch 35 by kenney.nl -- https://kenney.nl -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["mouse-click.wav"],
+		"size": 70110,
+		"category": "sound-effects",
+		"attribution": "Mouse Click Sound.mp3 by Pixeliota -- https://freesound.org/s/678248/ -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["shutter-modern.wav"],
+		"size": 43224,
+		"category": "sound-effects",
+		"attribution": "DSLR Shutter fast 006.wav by ristooooo1 -- https://freesound.org/s/539136/ -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["shutter-old.wav"],
+		"size": 55600,
+		"category": "sound-effects",
+		"attribution": "Werra.wav by hmilleo -- https://freesound.org/s/409093/ -- License: Creative Commons 0"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["bruh.wav"],
+		"size": 207438,
+		"category": "sound-effects",
+		"attribution": "Bruh Sound Effect -- https://soundeffects.fandom.com/wiki/Bruh_Sound_Effect"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["windows-xp-error.wav"],
+		"size": 87630,
+		"category": "sound-effects",
+		"attribution": "Windows XP Error -- https://www.myinstants.com/en/instant/windows-xp-error/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["vine-boom.wav"],
+		"size": 221516,
+		"category": "sound-effects",
+		"attribution": "Vine Boom Sound -- https://www.myinstants.com/en/instant/vine-boom-sound-70972/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["ding.wav"],
+		"size": 520782,
+		"category": "sound-effects",
+		"attribution": "Ding Sound Effect -- https://www.myinstants.com/en/instant/ding-sound-effect/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["fah.wav"],
+		"size": 340042,
+		"category": "sound-effects",
+		"attribution": "Fah meme -- https://www.myinstants.com/en/instant/fahhhhhhhhhhhhhh-3525/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["spongebob-fail.wav"],
+		"size": 597032,
+		"category": "sound-effects",
+		"attribution": "SpongeBob fail -- https://www.myinstants.com/en/instant/spongebob-fail-11236/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["omg-hell-nah.wav"],
+		"size": 776526,
+		"category": "sound-effects",
+		"attribution": "Oh my god bro hell nah -- https://www.myinstants.com/en/instant/oh-my-god-bro-oh-hell-nah-man-42939/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["price-is-right-fail.wav"],
+		"size": 797276,
+		"category": "sound-effects",
+		"attribution": "Price Is Right fail horn -- https://www.myinstants.com/en/instant/fail-horn/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["romance-meme.wav"],
+		"size": 1024962,
+		"category": "sound-effects",
+		"attribution": "Romance meme -- https://www.myinstants.com/en/instant/romanceeeeeeeeeeeeee-29042/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["bone-crack.wav"],
+		"size": 188494,
+		"category": "sound-effects",
+		"attribution": "Bone crack -- https://www.myinstants.com/en/instant/bone-crack-23901/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["anime-wow.wav"],
+		"size": 737358,
+		"category": "sound-effects",
+		"attribution": "Anime wow -- https://www.myinstants.com/en/instant/anime-wow/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["yippee.wav"],
+		"size": 467166,
+		"category": "sound-effects",
+		"attribution": "Yippee -- https://www.myinstants.com/en/instant/yippeeeeeeeeeeeeee-34261/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["loading-lag.wav"],
+		"size": 475214,
+		"category": "sound-effects",
+		"attribution": "Loading lag -- https://www.myinstants.com/en/instant/lagging-loading-11339/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["wilhelm-scream.wav"],
+		"size": 368718,
+		"category": "sound-effects",
+		"attribution": "Wilhelm scream -- https://www.myinstants.com/en/instant/man-screaming-aaaah-32768/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["mac-quack.wav"],
+		"size": 61610,
+		"category": "sound-effects",
+		"attribution": "Mac quack -- https://www.myinstants.com/en/instant/mac-quack-83896/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["skedaddle.wav"],
+		"size": 1155150,
+		"category": "sound-effects",
+		"attribution": "Skedaddle -- https://www.myinstants.com/en/instant/skedaddle-78470/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["snapchat-notification.wav"],
+		"size": 38724,
+		"category": "sound-effects",
+		"attribution": "Snapchat notification -- https://www.myinstants.com/en/instant/notification-snap-43481/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["nelly-ahh.wav"],
+		"size": 258170,
+		"category": "sound-effects",
+		"attribution": "Nelly ahh -- https://www.myinstants.com/en/instant/nelly-ahh-89172/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["sanctuary-guardian-what.wav"],
+		"size": 1589326,
+		"category": "sound-effects",
+		"attribution": "Sanctuary Guardian what meme -- https://www.myinstants.com/en/instant/what-bottom-text-meme-sanctuary-guardian-s-24591/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["minecraft-hurt.wav"],
+		"size": 64628,
+		"category": "sound-effects",
+		"attribution": "Minecraft hurt -- https://www.myinstants.com/en/instant/minecraft-hurt/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["oh-my-god-vine.wav"],
+		"size": 285014,
+		"category": "sound-effects",
+		"attribution": "Oh my god vine -- https://www.myinstants.com/en/instant/oh-ma-gaud-vine-78004/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["illuminati-confirmed.wav"],
+		"size": 1382666,
+		"category": "sound-effects",
+		"attribution": "Illuminati confirmed -- https://www.myinstants.com/en/instant/illuminati-confirmed-meme-99730/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["dramatic-boomer.wav"],
+		"size": 235206,
+		"category": "sound-effects",
+		"attribution": "Dramatic boomer -- https://www.myinstants.com/en/instant/dramatic-boomer-29428/"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "pcm",
+		"container": "wav",
+		"fileNames": ["triggered.wav"],
+		"size": 122958,
+		"category": "sound-effects",
+		"attribution": "Triggered -- https://www.myinstants.com/en/instant/core-sound-effect-57998/"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "m3u8",
+		"fileNames": ["video.m3u8", "hls-ts.m3u8", "hls-ts-0.ts", "hls-ts-1.ts"],
+		"size": 173,
+		"category": "hls"
+	},
+	{
+		"videoCodec": "h264",
+		"audioCodec": "aac",
+		"container": "m3u8",
+		"fileNames": [
+			"hls-fmp4.m3u8",
+			"hls-fmp4-0.m4s",
+			"hls-fmp4-1.m4s",
+			"hls-fmp4-init.mp4"
+		],
+		"size": 214,
+		"category": "hls"
+	},
+	{
+		"videoCodec": "none",
+		"audioCodec": "aac",
+		"container": "m3u8",
+		"fileNames": [
+			"audio.m3u8",
+			"audio-0.ts",
+			"audio-1.ts",
+			"audio-2.ts",
+			"audio-3.ts",
+			"audio-4.ts",
+			"audio-5.ts"
+		],
+		"size": 287,
+		"category": "hls"
+	}
 ]

--- a/packages/remotion-media/variants.json
+++ b/packages/remotion-media/variants.json
@@ -9,7 +9,7 @@
       "video-aac.mp4",
       "video-h264-aac.mp4"
     ],
-    "size": 2005880,
+    "size": 2004344,
     "category": "codecs"
   },
   {
@@ -20,7 +20,7 @@
       "video-flac.mp4",
       "video-h264-flac.mp4"
     ],
-    "size": 1966571,
+    "size": 2067676,
     "category": "codecs"
   },
   {
@@ -31,7 +31,7 @@
       "video-mp3.mp4",
       "video-h264-mp3.mp4"
     ],
-    "size": 2003652,
+    "size": 2002055,
     "category": "codecs"
   },
   {
@@ -42,7 +42,7 @@
       "video-pcm.mp4",
       "video-h264-pcm.mp4"
     ],
-    "size": 3760128,
+    "size": 3758531,
     "category": "codecs"
   },
   {
@@ -64,7 +64,7 @@
       "video-h265.mp4",
       "video-h265-aac.mp4"
     ],
-    "size": 1449927,
+    "size": 1449988,
     "category": "codecs"
   },
   {
@@ -74,7 +74,7 @@
     "fileNames": [
       "video-h265-flac.mp4"
     ],
-    "size": 1410618,
+    "size": 1513320,
     "category": "codecs"
   },
   {
@@ -94,7 +94,7 @@
     "fileNames": [
       "video-h265-pcm.mp4"
     ],
-    "size": 3204175,
+    "size": 3205011,
     "category": "codecs"
   },
   {
@@ -137,7 +137,7 @@
       "audio.flac",
       "audio-flac.flac"
     ],
-    "size": 135327,
+    "size": 238029,
     "category": "codecs"
   },
   {
@@ -148,7 +148,7 @@
       "video-opus.webm",
       "video-vp8-opus.webm"
     ],
-    "size": 1065491,
+    "size": 1139832,
     "category": "codecs"
   },
   {
@@ -159,7 +159,7 @@
       "video-vorbis.webm",
       "video-vp8-vorbis.webm"
     ],
-    "size": 937784,
+    "size": 988924,
     "category": "codecs"
   },
   {
@@ -180,7 +180,7 @@
     "fileNames": [
       "video-vp9-opus.webm"
     ],
-    "size": 2661566,
+    "size": 2687740,
     "category": "codecs"
   },
   {
@@ -190,7 +190,7 @@
     "fileNames": [
       "video-vp9-vorbis.webm"
     ],
-    "size": 2533859,
+    "size": 2536832,
     "category": "codecs"
   },
   {
@@ -213,7 +213,7 @@
       "video-aac.mkv",
       "video-h264-aac.mkv"
     ],
-    "size": 1999677,
+    "size": 1998157,
     "category": "codecs"
   },
   {
@@ -224,7 +224,7 @@
       "video-flac.mkv",
       "video-h264-flac.mkv"
     ],
-    "size": 1963723,
+    "size": 2064844,
     "category": "codecs"
   },
   {
@@ -235,7 +235,7 @@
       "video-mp3.mkv",
       "video-h264-mp3.mkv"
     ],
-    "size": 1999377,
+    "size": 1997796,
     "category": "codecs"
   },
   {
@@ -246,7 +246,7 @@
       "video-opus.mkv",
       "video-h264-opus.mkv"
     ],
-    "size": 2021519,
+    "size": 2046112,
     "category": "codecs"
   },
   {
@@ -257,7 +257,7 @@
       "video-vorbis.mkv",
       "video-h264-vorbis.mkv"
     ],
-    "size": 1893814,
+    "size": 1895206,
     "category": "codecs"
   },
   {
@@ -279,7 +279,7 @@
       "video-h265.mkv",
       "video-h265-aac.mkv"
     ],
-    "size": 1443360,
+    "size": 1443421,
     "category": "codecs"
   },
   {
@@ -289,7 +289,7 @@
     "fileNames": [
       "video-h265-flac.mkv"
     ],
-    "size": 1407405,
+    "size": 1510107,
     "category": "codecs"
   },
   {
@@ -309,7 +309,7 @@
     "fileNames": [
       "video-h265-opus.mkv"
     ],
-    "size": 1465202,
+    "size": 1491376,
     "category": "codecs"
   },
   {
@@ -319,7 +319,7 @@
     "fileNames": [
       "video-h265-vorbis.mkv"
     ],
-    "size": 1337497,
+    "size": 1340470,
     "category": "codecs"
   },
   {
@@ -340,7 +340,7 @@
       "video-vp8.mkv",
       "video-vp8-aac.mkv"
     ],
-    "size": 1043733,
+    "size": 1091961,
     "category": "codecs"
   },
   {
@@ -350,7 +350,7 @@
     "fileNames": [
       "video-vp8-flac.mkv"
     ],
-    "size": 1007776,
+    "size": 1158645,
     "category": "codecs"
   },
   {
@@ -360,7 +360,7 @@
     "fileNames": [
       "video-vp8-mp3.mkv"
     ],
-    "size": 1043433,
+    "size": 1091600,
     "category": "codecs"
   },
   {
@@ -370,7 +370,7 @@
     "fileNames": [
       "video-vp8-opus.mkv"
     ],
-    "size": 1065575,
+    "size": 1139916,
     "category": "codecs"
   },
   {
@@ -380,7 +380,7 @@
     "fileNames": [
       "video-vp8-vorbis.mkv"
     ],
-    "size": 937868,
+    "size": 989008,
     "category": "codecs"
   },
   {
@@ -401,7 +401,7 @@
       "video-vp9.mkv",
       "video-vp9-aac.mkv"
     ],
-    "size": 2639808,
+    "size": 2639869,
     "category": "codecs"
   },
   {
@@ -411,7 +411,7 @@
     "fileNames": [
       "video-vp9-flac.mkv"
     ],
-    "size": 2603851,
+    "size": 2706553,
     "category": "codecs"
   },
   {
@@ -431,7 +431,7 @@
     "fileNames": [
       "video-vp9-opus.mkv"
     ],
-    "size": 2661650,
+    "size": 2687824,
     "category": "codecs"
   },
   {
@@ -441,7 +441,7 @@
     "fileNames": [
       "video-vp9-vorbis.mkv"
     ],
-    "size": 2533943,
+    "size": 2536916,
     "category": "codecs"
   },
   {
@@ -462,7 +462,7 @@
       "video-prores.mkv",
       "video-prores-aac.mkv"
     ],
-    "size": 140913336,
+    "size": 140913397,
     "category": "codecs"
   },
   {
@@ -472,7 +472,7 @@
     "fileNames": [
       "video-prores-flac.mkv"
     ],
-    "size": 140877186,
+    "size": 140979889,
     "category": "codecs"
   },
   {
@@ -492,7 +492,7 @@
     "fileNames": [
       "video-prores-opus.mkv"
     ],
-    "size": 140935179,
+    "size": 140961353,
     "category": "codecs"
   },
   {
@@ -502,7 +502,7 @@
     "fileNames": [
       "video-prores-vorbis.mkv"
     ],
-    "size": 140807173,
+    "size": 140810147,
     "category": "codecs"
   },
   {
@@ -525,7 +525,7 @@
       "video-aac.mov",
       "video-h264-aac.mov"
     ],
-    "size": 2005957,
+    "size": 2005769,
     "category": "codecs"
   },
   {
@@ -536,7 +536,7 @@
       "video-pcm.mov",
       "video-h264-pcm.mov"
     ],
-    "size": 3760113,
+    "size": 3759864,
     "category": "codecs"
   },
   {
@@ -558,7 +558,7 @@
       "video-h265.mov",
       "video-h265-aac.mov"
     ],
-    "size": 1450008,
+    "size": 1450905,
     "category": "codecs"
   },
   {
@@ -568,7 +568,7 @@
     "fileNames": [
       "video-h265-pcm.mov"
     ],
-    "size": 3204164,
+    "size": 3205000,
     "category": "codecs"
   },
   {
@@ -589,7 +589,7 @@
       "video-prores.mov",
       "video-prores-aac.mov"
     ],
-    "size": 140908351,
+    "size": 140909556,
     "category": "codecs"
   },
   {
@@ -599,7 +599,7 @@
     "fileNames": [
       "video-prores-pcm.mov"
     ],
-    "size": 142663059,
+    "size": 142664203,
     "category": "codecs"
   },
   {
@@ -619,7 +619,7 @@
     "fileNames": [
       "video-360p.mp4"
     ],
-    "size": 35728439,
+    "size": 29890124,
     "category": "dimensions"
   },
   {
@@ -629,7 +629,7 @@
     "fileNames": [
       "video-480p.mp4"
     ],
-    "size": 35983115,
+    "size": 30139639,
     "category": "dimensions"
   },
   {
@@ -639,7 +639,7 @@
     "fileNames": [
       "video-720p.mp4"
     ],
-    "size": 36507967,
+    "size": 30665190,
     "category": "dimensions"
   },
   {
@@ -649,7 +649,7 @@
     "fileNames": [
       "video-1080p.mp4"
     ],
-    "size": 37378464,
+    "size": 31546672,
     "category": "dimensions"
   },
   {
@@ -659,7 +659,7 @@
     "fileNames": [
       "video-1440p.mp4"
     ],
-    "size": 38300807,
+    "size": 32472765,
     "category": "dimensions"
   },
   {
@@ -669,7 +669,7 @@
     "fileNames": [
       "video-2160p.mp4"
     ],
-    "size": 40365974,
+    "size": 34551604,
     "category": "dimensions"
   },
   {
@@ -679,7 +679,7 @@
     "fileNames": [
       "video-5s.mp4"
     ],
-    "size": 2061745,
+    "size": 2061494,
     "category": "durations"
   },
   {
@@ -689,7 +689,7 @@
     "fileNames": [
       "video-10s.mp4"
     ],
-    "size": 4335431,
+    "size": 4335492,
     "category": "durations"
   },
   {
@@ -699,7 +699,7 @@
     "fileNames": [
       "video-30s.mp4"
     ],
-    "size": 12756693,
+    "size": 12756307,
     "category": "durations"
   },
   {
@@ -709,7 +709,7 @@
     "fileNames": [
       "video-1m.mp4"
     ],
-    "size": 25266373,
+    "size": 25266299,
     "category": "durations"
   },
   {
@@ -719,7 +719,7 @@
     "fileNames": [
       "video-5m.mp4"
     ],
-    "size": 125507936,
+    "size": 125505256,
     "category": "durations"
   },
   {
@@ -729,7 +729,7 @@
     "fileNames": [
       "video-10m.mp4"
     ],
-    "size": 249897169,
+    "size": 249892924,
     "category": "durations"
   },
   {
@@ -739,7 +739,7 @@
     "fileNames": [
       "video-30m.mp4"
     ],
-    "size": 748909719,
+    "size": 748895261,
     "category": "durations"
   },
   {
@@ -749,7 +749,7 @@
     "fileNames": [
       "video-24fps.mp4"
     ],
-    "size": 3700056,
+    "size": 3703572,
     "category": "fps"
   },
   {
@@ -759,7 +759,7 @@
     "fileNames": [
       "video-25fps.mp4"
     ],
-    "size": 3795076,
+    "size": 3771048,
     "category": "fps"
   },
   {
@@ -769,7 +769,7 @@
     "fileNames": [
       "video-29.97fps.mp4"
     ],
-    "size": 4273776,
+    "size": 4242299,
     "category": "fps"
   },
   {
@@ -779,7 +779,7 @@
     "fileNames": [
       "video-30fps.mp4"
     ],
-    "size": 4275384,
+    "size": 4239032,
     "category": "fps"
   },
   {
@@ -789,7 +789,7 @@
     "fileNames": [
       "video-59.94fps.mp4"
     ],
-    "size": 5881638,
+    "size": 5860974,
     "category": "fps"
   },
   {
@@ -799,7 +799,7 @@
     "fileNames": [
       "video-60fps.mp4"
     ],
-    "size": 5887211,
+    "size": 5862694,
     "category": "fps"
   },
   {
@@ -809,7 +809,7 @@
     "fileNames": [
       "video-120fps.mp4"
     ],
-    "size": 9030640,
+    "size": 8960805,
     "category": "fps"
   },
   {
@@ -819,7 +819,7 @@
     "fileNames": [
       "video-240fps.mp4"
     ],
-    "size": 17780437,
+    "size": 17746946,
     "category": "fps"
   },
   {


### PR DESCRIPTION
## Summary

- Increase the gain of the generated tone so Studio waveforms are clearly visible
- Generate a reusable 10-second tone loop and extend it for all duration fixtures
- Encode each video codec once and remux the audio variants from that intermediate
- Refresh the media catalog sizes for every regenerated audio-dependent asset

## Verification

- `bun run build`
- `bun run stylecheck`
- Regenerated and uploaded 111 affected objects to R2
- Verified short, audio-only, 4K, 30-minute, high-FPS, and HLS assets through `remotion.media`
