### PR TITLE
`@remotion/studio`: Show arrow on Browse Elements action

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -202,7 +202,7 @@ export const MyComponent = () => {
 
 		await studioPage.locator('[data-sidebar-toggle="right"]').click();
 		const browseElements = studioPage.getByRole('button', {
-			name: 'Browse Elements...',
+			name: 'Browse Elements',
 		});
 		await expect(browseElements).toBeVisible();
 		const senderPagePromise = context.waitForEvent('page', {timeout: 10_000});

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import type {_InternalTypes} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {CURRENT_COLOR} from '../../helpers/colors';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {BrowseElementsIcon} from '../../icons/browse-elements';
 import {PicIcon} from '../../icons/frame';
@@ -66,6 +67,14 @@ const browseElementsIconContainerStyle: React.CSSProperties = {
 	marginLeft: -2,
 	marginRight: -2,
 	width: 22,
+};
+
+const browseElementsArrowStyle: React.CSSProperties = {
+	display: 'inline-block',
+	height: 12,
+	marginLeft: 4,
+	verticalAlign: -2,
+	width: 12,
 };
 
 const CompositionActions: React.FC<{
@@ -143,7 +152,21 @@ const CompositionActions: React.FC<{
 					)}
 					title="Open the Remotion Elements library in a new tab. Install an Element there to send it to this composition."
 				>
-					Browse Elements...
+					Browse Elements
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 16 16"
+						style={browseElementsArrowStyle}
+					>
+						<path
+							d="M4 12 12 4M6 4h6v6"
+							fill="none"
+							stroke={CURRENT_COLOR}
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth="1.5"
+						/>
+					</svg>
 				</InspectorQuickAction>
 			) : null}
 		</InspectorQuickActionsSection>


### PR DESCRIPTION
## Summary

- replace the trailing ellipsis in the Browse Elements action with a northeast arrow
- keep the arrow styling explicit so the Studio CSS reset does not alter it
- update the Studio protocol browser test for the new accessible name

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- verified the arrow's idle and hover computed styles in the running Studio
