### PR TITLE
`@remotion/studio`: Prevent horizontal inspector scrolling

### DIFF
--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -20,6 +20,7 @@ export const container: React.CSSProperties = {
 
 export const scrollableContainer: React.CSSProperties = {
 	...container,
+	overflowX: 'hidden',
 	overflowY: 'auto',
 };
 
@@ -149,6 +150,7 @@ export const selectedContainer: React.CSSProperties = {
 	backgroundColor: BACKGROUND,
 	flex: 1,
 	minHeight: 0,
+	overflowX: 'hidden',
 	overflowY: 'auto',
 };
 


### PR DESCRIPTION
## Summary

- prevent horizontal scrolling in shared Studio inspector containers
- preserve vertical scrolling for overflowing inspector content

## Testing

- `bun run build`
- `bun run stylecheck`
