### PR TITLE
`@remotion/studio`: Make Quick Switcher search separator-insensitive

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -522,11 +522,18 @@ test.describe('visual mode', () => {
 		).toHaveText('100', {timeout: 15_000});
 	});
 
-	test('should show the composition list', async ({page}) => {
+	test('should show and search the composition list', async ({page}) => {
 		await page.goto(STUDIO_URL);
 		await expect(page.getByRole('button', {name: 'Schema'})).toBeVisible({
 			timeout: 15_000,
 		});
+
+		await page.keyboard.press('ControlOrMeta+k');
+		await page
+			.getByPlaceholder('Search compositions...')
+			.fill('timeline virtualization');
+		await page.keyboard.press('Enter');
+		await expect(page).toHaveURL(/timeline-virtualization-testbed/);
 	});
 
 	test('should play when a composition in the sidebar is focused', async ({

--- a/packages/studio/src/components/QuickSwitcher/fuzzy-search.ts
+++ b/packages/studio/src/components/QuickSwitcher/fuzzy-search.ts
@@ -4,7 +4,7 @@ export function fuzzySearch(
 	query: string,
 	dataset: TQuickSwitcherResult[],
 ): TQuickSwitcherResult[] {
-	const q = query ? query.trim().toLowerCase() : '';
+	const q = query.trim().toLowerCase().replace(/[\s-]/g, '');
 
 	const matchingIndices: number[] = [];
 	if (q.length === 0) {


### PR DESCRIPTION
## Summary

- Ignore spaces and hyphens when matching Quick Switcher queries
- Cover space-separated composition search through the Studio UI

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test e2e/studio.test.mts --grep "should show and search the composition list"`

Closes #10620
