### PR TITLE
Docs: Disable automatic Studio browser opening

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,7 +18,7 @@
 		"clear": "docusaurus clear",
 		"lint": "eslint src components",
 		"test": "bun test src",
-		"remotion": "remotion studio src/remotion/entry.ts",
+		"remotion": "remotion studio src/remotion/entry.ts --no-open",
 		"render-cards": "bun run render-cards.ts",
 		"render-element-previews": "bun run render-element-previews.ts",
 		"upload-element-preview": "bun run upload-element-preview.ts"


### PR DESCRIPTION
## Summary

- start the documentation Studio with the `--no-open` CLI flag
- keep the Studio server available without automatically launching a browser

## Testing

- `bunx oxfmt packages/docs/package.json --write`
- `bun run build`
- `bun run stylecheck`
