### PR TITLE
`@remotion/studio`: Add padding to explorer lists

### DIFF
--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -45,6 +45,8 @@ const label: React.CSSProperties = {
 
 const baseList: React.CSSProperties = {
 	overflowY: 'auto',
+	paddingTop: 4,
+	paddingBottom: 4,
 };
 
 export const AssetSelector: React.FC<{

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -161,6 +161,8 @@ export const CompositionSelector: React.FC = () => {
 		return {
 			flex: 1,
 			overflowY: 'auto',
+			paddingTop: 4,
+			paddingBottom: 4,
 			backgroundColor: rootDragHovered ? WHITE_ALPHA_12 : BACKGROUND,
 		};
 	}, [rootDragHovered]);


### PR DESCRIPTION
## Summary

- add vertical padding to the composition list in the Studio explorer
- apply the same top and bottom padding to the assets list
- keep both explorer tabs aligned with the existing Studio list spacing

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- visually verified both list edges in the example Studio
