### PR TITLE
`@remotion/studio`: Prevent selected child sequences from shifting twice

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -901,27 +901,57 @@ export const getTimelineSequenceFromDragTargets = ({
 			? selectedSequenceItems.map((item) => item.nodePathInfo)
 			: [draggedNodePathInfo];
 	const tracks = calculateTimeline({sequences, overrideIdsToNodePaths});
-	const targets = new Map<string, TimelineSequenceFromDragTarget>();
-	const includedKeyframeNodePaths = new Set<string>();
 	const sequencesById = new Map(
 		sequences.map((sequence) => [sequence.id, sequence]),
 	);
-
-	for (const nodePathInfo of targetNodePathInfos) {
+	const selectedSequences = targetNodePathInfos.flatMap((nodePathInfo) => {
 		const track = findSequenceTrack({tracks, nodePathInfo});
 		const originalSequence = track
-			? sequences.find((sequence) => sequence.id === track.sequence.id)
-			: null;
-		if (
-			!track ||
-			!track.nodePathInfo ||
-			!originalSequence ||
-			!isFromDraggableSequence(originalSequence)
-		) {
+			? sequencesById.get(track.sequence.id)
+			: undefined;
+		if (!track?.nodePathInfo || !originalSequence) {
+			return [];
+		}
+
+		return [
+			{
+				nodePath: track.nodePathInfo.sequenceSubscriptionKey,
+				originalSequence,
+			},
+		];
+	});
+	if (selectedSequences.length !== targetNodePathInfos.length) {
+		return null;
+	}
+
+	const selectedSequenceIds = new Set(
+		selectedSequences.map(({originalSequence}) => originalSequence.id),
+	);
+	const sequencesWithoutSelectedAncestors = selectedSequences.filter(
+		({originalSequence}) => {
+			let parentId = originalSequence.parent;
+			while (parentId !== null) {
+				if (selectedSequenceIds.has(parentId)) {
+					return false;
+				}
+
+				parentId = sequencesById.get(parentId)?.parent ?? null;
+			}
+
+			return true;
+		},
+	);
+	const targets = new Map<string, TimelineSequenceFromDragTarget>();
+	const includedKeyframeNodePaths = new Set<string>();
+
+	for (const {
+		nodePath,
+		originalSequence,
+	} of sequencesWithoutSelectedAncestors) {
+		if (!isFromDraggableSequence(originalSequence)) {
 			return null;
 		}
 
-		const nodePath = track.nodePathInfo.sequenceSubscriptionKey;
 		if (!canUpdateFrom({propStatuses, nodePath})) {
 			return null;
 		}

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -2596,6 +2596,62 @@ test('Timeline from drag applies the same delta to selected sequences', () => {
 	).toEqual([12, 22]);
 });
 
+test('Timeline from drag only moves selected sequences without selected ancestors', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const parentNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const childNodePathInfo = makeNodePathInfo(['body', 0, 'children', 0], []);
+	const videoNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const sequences = [
+		makeTimelineSequence({
+			schema,
+			id: 'parent',
+			overrideId: 'parent',
+			from: 10,
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'child',
+			overrideId: 'child',
+			parentId: 'parent',
+			from: 5,
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'video',
+			overrideId: 'video',
+			from: 20,
+			type: 'video',
+		}),
+	];
+	const targets = getTimelineSequenceFromDragTargets({
+		draggedNodePathInfo: parentNodePathInfo,
+		selectedItems: [
+			{type: 'sequence', nodePathInfo: parentNodePathInfo},
+			{type: 'sequence', nodePathInfo: childNodePathInfo},
+			{type: 'sequence', nodePathInfo: videoNodePathInfo},
+		],
+		sequences,
+		overrideIdsToNodePaths: {
+			parent: parentNodePathInfo.sequenceSubscriptionKey,
+			child: childNodePathInfo.sequenceSubscriptionKey,
+			video: videoNodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeFromPropStatuses([
+			parentNodePathInfo.sequenceSubscriptionKey,
+			childNodePathInfo.sequenceSubscriptionKey,
+			videoNodePathInfo.sequenceSubscriptionKey,
+		]),
+	});
+
+	expect(targets?.map((target) => target.initialFrom)).toEqual([10, 20]);
+	expect(
+		getTimelineSequenceFromDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -4,
+		}).map((change) => change.value),
+	).toEqual([6, 16]);
+});
+
 test('Timeline from drag moves all owned sequence keyframes by the same delta', () => {
 	const schema = {
 		'style.translate': {type: 'translate', default: '0px 0px'},


### PR DESCRIPTION
## Summary

- exclude selected sequences from direct `from` updates when one of their ancestors is also selected
- preserve the existing descendant keyframe shifting behavior
- add a regression test covering a selected parent, child, and independent video

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10465
