### PR TITLE
Elements: Improve Studio drag handle

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -149,6 +149,7 @@
 	flex-direction: column;
 	line-height: 1.3;
 	text-align: center;
+	white-space: nowrap;
 }
 
 .dragHandleText strong {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -237,13 +237,13 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									});
 									setElementDragImage(event.dataTransfer, posterRef.current);
 								}}
-								title="Hover over your Studio browser tab, then drop on the canvas or timeline"
+								title="Drag into your Studio browser tab to choose where the element is placed on the canvas or timeline"
 							>
 								<span aria-hidden="true" className={styles.dragHandleIcon}>
 									⠿
 								</span>
 								<span className={styles.dragHandleText}>
-									<strong>Drag to your Studio canvas or timeline</strong>
+									<strong>Drag into Studio</strong>
 								</span>
 							</div>
 							{installStatus.type === 'success' ||


### PR DESCRIPTION
## Summary

- Shorten the Element page drag handle label so it stays on one line
- Explain in the tooltip that dragging lets users choose the canvas or timeline position

## Verification

- `bun run build`
- `bun run stylecheck`
