### PR TITLE
Elements: Add component libraries page

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
 			collapsible: true,
 			collapsed: false,
 			items: [
+				'libraries',
 				'contributing',
 				{
 					type: 'html',

--- a/packages/docs/elements/libraries.mdx
+++ b/packages/docs/elements/libraries.mdx
@@ -1,0 +1,12 @@
+---
+title: Libraries
+sidebar_label: Libraries
+description: Component libraries that integrate with Remotion Studio.
+---
+
+# Libraries
+
+Component libraries that integrate with Remotion Studio through the [Studio Protocol](/docs/studio-protocol).
+
+- [Remotion Elements](/elements) - The official component library maintained by Remotion.
+- [Remocn](https://remocn.dev/docs/components) - A shadcn-style library of production-ready Remotion components for building product demo videos with AI agents.

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -473,7 +473,8 @@ describe('Elements sidebar', () => {
 			throw new Error('Elements root category must contain sidebar items');
 		}
 
-		expect(elementsCategory.items.slice(0, 2)).toEqual([
+		expect(elementsCategory.items.slice(0, 3)).toEqual([
+			'libraries',
 			'contributing',
 			{
 				type: 'html',
@@ -483,7 +484,7 @@ describe('Elements sidebar', () => {
 			},
 		]);
 
-		const categories = elementsCategory.items.slice(2);
+		const categories = elementsCategory.items.slice(3);
 		const expectedCategories = [
 			{
 				category: 'backgrounds',


### PR DESCRIPTION
## Summary

- add a Libraries page to the Elements docs for Studio Protocol-compatible component libraries
- list the official Remotion Elements library and Remocn's shadcn-style components for AI-built product demo videos
- expose the directory in the Elements sidebar and update its coverage

## Verification

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10614

## Preview

- [Libraries](https://remotion-git-elements-libraries-remotion.vercel.app/elements/libraries)
