### PR TITLE
`@remotion/cli`: Fix skills command on Windows

### DIFF
--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -1,5 +1,6 @@
 import {spawn} from 'node:child_process';
 import type {LogLevel} from '@remotion/renderer';
+import {StudioServerInternals} from '@remotion/studio-server';
 import {chalk} from './chalk';
 import {Log} from './log';
 import {remotionSkillNames} from './remotion-skill-names';
@@ -69,6 +70,7 @@ export const skillsCommand = (
 		cwd,
 		env: environment,
 		stdio: 'inherit',
+		...StudioServerInternals.getPackageManagerSpawnOptions(),
 	});
 
 	return new Promise<void>((resolve, reject) => {

--- a/packages/cli/src/test/skills.test.ts
+++ b/packages/cli/src/test/skills.test.ts
@@ -22,7 +22,7 @@ const runSkillsCommand = ({
 }) => {
 	return new Promise<void>((resolve, reject) => {
 		const cliPath = path.join(__dirname, '..', '..', 'remotion-cli.js');
-		const child = spawn(process.execPath, [cliPath, 'skills', ...args], {
+		const child = spawn('node', [cliPath, 'skills', ...args], {
 			env: {
 				...process.env,
 				PATH: `${fakeNpxDirectory}${path.delimiter}${process.env.PATH}`,


### PR DESCRIPTION
## Summary

- launch the Remotion skills CLI with the shared Windows package-manager spawn options
- run the skills command integration test under Node so Windows exercises the affected runtime

## Test plan

- `bun test packages/cli/src/test/skills.test.ts packages/cli/src/test/update-remotion-skills.test.ts packages/cli/src/test/upgrade-windows.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9758
