### PR TITLE
`@remotion/studio`: Move property chevrons next to labels

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -15,7 +15,10 @@ import type {GetIsExpanded} from '../ExpandedTracksProvider';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {saveEffectProp} from './save-effect-prop';
-import {TimelineExpandArrowButton} from './TimelineExpandArrowButton';
+import {
+	TimelineExpandArrowButton,
+	TimelineExpandArrowSpacer,
+} from './TimelineExpandArrowButton';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineRowChrome} from './TimelineRowChrome';
 import {
@@ -44,6 +47,15 @@ const rowLabel: React.CSSProperties = {
 const rowStyle: React.CSSProperties = {
 	height: TREE_GROUP_ROW_HEIGHT,
 	cursor: 'default',
+};
+
+const labelContainerStyle: React.CSSProperties = {
+	alignItems: 'center',
+	alignSelf: 'stretch',
+	display: 'flex',
+	flex: 1,
+	minWidth: 0,
+	paddingRight: EXPANDED_SECTION_PADDING_RIGHT,
 };
 
 const reorderWrapper: React.CSSProperties = {
@@ -303,8 +315,11 @@ export const TimelineEffectItem: React.FC<{
 			alignItems: 'center',
 			color: getTimelineColor(selection.selected, true),
 			display: 'inline-flex',
-			marginRight: EXPANDED_SECTION_PADDING_RIGHT,
+			flexShrink: 1,
 			minWidth: 0,
+			overflow: 'hidden',
+			textOverflow: 'ellipsis',
+			whiteSpace: 'nowrap',
 			boxShadow:
 				containsSelection && !selection.selected
 					? `inset 0 0 0 2px ${TIMELINE_SELECTED_LABEL_BACKGROUND}`
@@ -465,14 +480,7 @@ export const TimelineEffectItem: React.FC<{
 					<TimelineLayerEyeSpacer />
 				)
 			}
-			arrow={
-				<TimelineExpandArrowButton
-					isExpanded={isExpanded}
-					onClick={() => toggleTrack(nodePathInfo)}
-					label={`${label} section`}
-					disabled={false}
-				/>
-			}
+			arrow={<TimelineExpandArrowSpacer />}
 			style={rowStyle}
 			selected={selection.selected}
 			selectable={selection.selectable}
@@ -482,9 +490,17 @@ export const TimelineEffectItem: React.FC<{
 			isFieldRow={false}
 			outerHeight={null}
 		>
-			<span title={label} style={labelStyle}>
-				{label}
-			</span>
+			<div style={labelContainerStyle}>
+				<span title={label} style={labelStyle}>
+					{label}
+				</span>
+				<TimelineExpandArrowButton
+					isExpanded={isExpanded}
+					onClick={() => toggleTrack(nodePathInfo)}
+					label={`${label} section`}
+					disabled={false}
+				/>
+			</div>
 		</TimelineRowChrome>
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandArrowButton.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 import {LIGHT_GRAY, WHITE} from '../../helpers/colors';
+import {CaretDown} from '../../icons/caret';
 
 const arrowButton: React.CSSProperties = {
 	background: 'none',
@@ -24,8 +25,6 @@ const arrowSpacer: React.CSSProperties = {
 	...arrowButton,
 	cursor: 'default',
 };
-
-const svgStyle: React.CSSProperties = {display: 'block'};
 
 export const TimelineExpandArrowButton: React.FC<{
 	readonly isExpanded: boolean;
@@ -55,7 +54,7 @@ export const TimelineExpandArrowButton: React.FC<{
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			...arrowButton,
-			transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
+			transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)',
 			cursor: disabled ? 'default' : 'pointer',
 			opacity: disabled ? 0.5 : 1,
 		};
@@ -72,9 +71,7 @@ export const TimelineExpandArrowButton: React.FC<{
 			aria-expanded={isExpanded}
 			aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${label}`}
 		>
-			<svg width="12" height="12" viewBox="0 0 8 8" style={svgStyle}>
-				<path d="M2 1L6 4L2 7Z" fill={LIGHT_GRAY} />
-			</svg>
+			<CaretDown color={LIGHT_GRAY} />
 		</button>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -91,6 +91,7 @@ const labelContainerStyle: React.CSSProperties = {
 	alignItems: 'center',
 	alignSelf: 'stretch',
 	display: 'flex',
+	flex: 1,
 	flexDirection: 'row',
 	minWidth: 0,
 };
@@ -1229,18 +1230,7 @@ const TimelineSequenceItemInner: React.FC<{
 					<TimelineLayerEyeSpacer />
 				)
 			}
-			arrow={
-				hasExpandableContent && nodePathInfo !== null ? (
-					<TimelineSequenceExpandArrow
-						disabled={!previewInteractive}
-						isExpanded={isExpanded}
-						nodePathInfo={nodePathInfo}
-						sequence={sequence}
-					/>
-				) : (
-					<TimelineExpandArrowSpacer />
-				)
-			}
+			arrow={<TimelineExpandArrowSpacer />}
 			style={rowStyle}
 			selected={selected}
 			selectable={selectable}
@@ -1279,6 +1269,14 @@ const TimelineSequenceItemInner: React.FC<{
 					onCancelEditing={onCancelRenaming}
 					onSaveName={onSaveName}
 				/>
+				{hasExpandableContent && nodePathInfo !== null ? (
+					<TimelineSequenceExpandArrow
+						disabled={!previewInteractive}
+						isExpanded={isExpanded}
+						nodePathInfo={nodePathInfo}
+						sequence={sequence}
+					/>
+				) : null}
 				{numberOfHiddenDuplicates > 0 ? (
 					<>
 						<Spacing x={0.5} />

--- a/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceName.tsx
@@ -44,7 +44,7 @@ export const TimelineSequenceName: React.FC<{
 			alignSelf: 'stretch',
 			...getTimelineSelectedLabelStyle(selected, false),
 			display: 'inline-flex',
-			flexShrink: 0,
+			flexShrink: 1,
 			fontFamily: 'inherit',
 			fontSize: 12,
 			lineHeight: 'normal',


### PR DESCRIPTION
## Summary

- Move property disclosure chevrons next to sequence and effect labels so the indentation gutter only communicates structural hierarchy
- Reuse Studio's dropdown chevron and rotate it according to the expanded state
- Keep the chevron visible in narrow layouts by allowing long labels to shrink and truncate

## Testing

- `bun run build`
- `bun run stylecheck`
