### PR TITLE
Elements: Declutter sidebar navigation

### DIFF
--- a/packages/docs/elements-sidebars.ts
+++ b/packages/docs/elements-sidebars.ts
@@ -39,7 +39,7 @@ const sidebars: SidebarsConfig = {
 					label,
 					link: {type: 'doc' as const, id: `${category}/index`},
 					collapsible: true,
-					collapsed: false,
+					collapsed: true,
 					items: Object.entries(elementRegistry)
 						.filter(([, metadata]) => metadata.category === category)
 						.sort(([, a], [, b]) =>

--- a/packages/docs/elements/captions/moving-pill-captions/index.mdx
+++ b/packages/docs/elements/captions/moving-pill-captions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Moving Pill Captions
+sidebar_label: Moving Pill
 description: Synchronized captions with a pill that moves between spoken words.
 image: https://remotion.media/elements/captions-moving-pill-captions-preview.png
 ---

--- a/packages/docs/elements/captions/popping-word-captions/index.mdx
+++ b/packages/docs/elements/captions/popping-word-captions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Popping Word Captions
+sidebar_label: Popping Word
 description: Synchronized captions that pop each spoken word into focus.
 image: https://remotion.media/elements/captions-popping-word-captions-preview.png
 ---

--- a/packages/docs/elements/captions/word-highlight-captions/index.mdx
+++ b/packages/docs/elements/captions/word-highlight-captions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Word Highlight Captions
+sidebar_label: Word Highlight
 description: Synchronized captions that highlight each spoken word.
 image: https://remotion.media/elements/captions-word-highlight-captions-preview.png
 ---

--- a/packages/docs/elements/data/index.mdx
+++ b/packages/docs/elements/data/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Data
-description: Animated data visualization Elements for Remotion videos.
+title: Charts & Data
+description: Animated charts and data visualization Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
 
-# Data
+# Charts & Data
 
 <ElementLibrary category="data" />

--- a/packages/docs/elements/text/index.mdx
+++ b/packages/docs/elements/text/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Text
-description: Drop-in text Elements for Remotion videos.
+title: Text Effects
+description: Drop-in text effect Elements for Remotion videos.
 ---
 
 import {ElementLibrary} from '@site/src/components/Elements/ElementLibrary';
 
-# Text
+# Text Effects
 
 <ElementLibrary category="text" />

--- a/packages/docs/elements/youtube/youtube-comment-highlight/index.mdx
+++ b/packages/docs/elements/youtube/youtube-comment-highlight/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: YouTube Comment Highlight
+sidebar_label: Comment Highlight
 description: A YouTube-style card for featuring a viewer comment.
 image: https://remotion.media/elements/youtube-youtube-comment-highlight-preview.png
 ---

--- a/packages/docs/elements/youtube/youtube-end-card/index.mdx
+++ b/packages/docs/elements/youtube/youtube-end-card/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: YouTube End Card
+sidebar_label: End Card
 description: A clean YouTube endcard with social links and space for recommended videos.
 image: https://remotion.media/elements/overlays-social-endcard-preview.png
 ---

--- a/packages/docs/elements/youtube/youtube-subscribe-nudge/index.mdx
+++ b/packages/docs/elements/youtube/youtube-subscribe-nudge/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: YouTube Subscribe Nudge
+sidebar_label: Subscribe Nudge
 description: An animated creator-branded subscribe prompt with a subscribed-state confirmation.
 image: https://remotion.media/elements/youtube-youtube-subscribe-nudge-preview.png
 ---

--- a/packages/docs/src/components/Elements/element-registry.ts
+++ b/packages/docs/src/components/Elements/element-registry.ts
@@ -1,12 +1,12 @@
 export const elementCategories = [
 	{category: 'backgrounds', label: 'Backgrounds'},
 	{category: 'captions', label: 'Captions'},
+	{category: 'data', label: 'Charts & Data'},
 	{category: 'commerce', label: 'Commerce'},
-	{category: 'data', label: 'Data'},
 	{category: 'maps', label: 'Maps'},
 	{category: 'overlays', label: 'Overlays'},
 	{category: 'storytelling', label: 'Storytelling'},
-	{category: 'text', label: 'Text'},
+	{category: 'text', label: 'Text Effects'},
 	{category: 'youtube', label: 'YouTube'},
 ] as const;
 

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -507,22 +507,22 @@ describe('Elements sidebar', () => {
 				],
 			},
 			{
-				category: 'commerce',
-				label: 'Commerce',
-				items: [
-					'commerce/product-discount-callout/index',
-					'commerce/product-offer/index',
-				],
-			},
-			{
 				category: 'data',
-				label: 'Data',
+				label: 'Charts & Data',
 				items: [
 					'data/horizontal-bar-chart/index',
 					'data/line-chart/index',
 					'data/number-counter/index',
 					'data/pie-chart/index',
 					'data/vertical-bar-chart/index',
+				],
+			},
+			{
+				category: 'commerce',
+				label: 'Commerce',
+				items: [
+					'commerce/product-discount-callout/index',
+					'commerce/product-offer/index',
 				],
 			},
 			{
@@ -548,7 +548,7 @@ describe('Elements sidebar', () => {
 			},
 			{
 				category: 'text',
-				label: 'Text',
+				label: 'Text Effects',
 				items: [
 					'text/circle-marker/index',
 					'text/crossed-off/index',
@@ -574,7 +574,7 @@ describe('Elements sidebar', () => {
 				label,
 				link: {type: 'doc', id: `${category}/index`},
 				collapsible: true,
-				collapsed: false,
+				collapsed: true,
 				items,
 			})),
 		);


### PR DESCRIPTION
## Summary

- collapse Element categories by default to reduce sidebar clutter
- clarify and alphabetize category names
- shorten repetitive Captions and YouTube sidebar labels while preserving full page titles

## Verification

- `bun test src/test/elements.test.ts` in `packages/docs`
- `bun run build`
- `bun run stylecheck`

## Preview

- [Moving Pill Captions](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/captions/moving-pill-captions)
- [Popping Word Captions](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/captions/popping-word-captions)
- [Word Highlight Captions](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/captions/word-highlight-captions)
- [Charts & Data](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/data)
- [Text Effects](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/text)
- [YouTube Comment Highlight](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/youtube/youtube-comment-highlight)
- [YouTube End Card](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/youtube/youtube-end-card)
- [YouTube Subscribe Nudge](https://remotion-git-elements-sidebar-improvement-remotion.vercel.app/elements/youtube/youtube-subscribe-nudge)
