### PR TITLE
Internal testbed: Concatenate related Studio E2E tests

### DIFF
--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -1,8 +1,8 @@
+import fs from 'fs';
+import assert from 'node:assert';
 import {expect, test, type Locator, type Page} from '@playwright/test';
 import {wave} from '@remotion/effects/wave';
 import {getAllSchemaKeys} from '@remotion/studio-shared';
-import fs from 'fs';
-import assert from 'node:assert';
 import {apiCall} from './api-call.mts';
 import {
 	EXPANDED_SIDEBAR_STATE,
@@ -116,185 +116,10 @@ test.describe('effect keyframes', () => {
 			.toBe(true);
 	});
 
-	test('accepts a scale value that is more precise than its interaction step', async ({
+	test('accepts precise inspector values and expands collapsed timeline tracks', async ({
 		page,
 	}) => {
-		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
-		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
-		await page.waitForFunction(
-			() => !document.body.innerText.includes('Loading...'),
-			{timeout: 30_000},
-		);
-
-		const scaleRow = page
-			.getByText('Scale', {exact: true})
-			.locator('..')
-			.locator('..');
-		const scaleDragger = scaleRow
-			.locator('button.__remotion_input_dragger')
-			.first();
-		await selectScalePrecisionAndWaitFor({page, locator: scaleDragger});
-		await scaleDragger.click();
-
-		const input = scaleRow.locator('input[type="text"]');
-		await expect(input).toBeVisible();
-		await input.fill('0.525');
-		await input.press('ArrowUp');
-		await expect(input).toHaveValue('0.535');
-		await input.fill('0.525');
-		await input.press('Enter');
-
-		await expect
-			.poll(
-				() => {
-					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
-					return content.includes('scale: 0.525');
-				},
-				{
-					message: 'Expected the precise scale value to be written to source',
-					timeout: 10_000,
-				},
-			)
-			.toBe(true);
-	});
-
-	test('accepts a rotation value that is more precise than its interaction step', async ({
-		page,
-	}) => {
-		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
-		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
-		await page.waitForFunction(
-			() => !document.body.innerText.includes('Loading...'),
-			{timeout: 30_000},
-		);
-
-		const rotationRow = page
-			.getByText('Rotation', {exact: true})
-			.locator('..')
-			.locator('..');
-		const rotationDragger = rotationRow.locator(
-			'button.__remotion_input_dragger',
-		);
-		await selectScalePrecisionAndWaitFor({page, locator: rotationDragger});
-		await rotationDragger.click();
-
-		const input = rotationRow.locator('input[type="text"]');
-		await expect(input).toBeVisible();
-		await input.fill('0.525');
-		await input.press('ArrowUp');
-		await expect(input).toHaveValue('1.525');
-		await input.fill('0.525');
-		await input.press('Enter');
-		await expect(input).toBeHidden();
-
-		await expect
-			.poll(
-				() => {
-					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
-					return content.includes("rotate: '0.525deg'");
-				},
-				{
-					message:
-						'Expected the precise rotation value to be written to source',
-					timeout: 10_000,
-				},
-			)
-			.toBe(true);
-	});
-
-	test('accepts a crop value that is more precise than its interaction step', async ({
-		page,
-	}) => {
-		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
-		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
-		await page.waitForFunction(
-			() => !document.body.innerText.includes('Loading...'),
-			{timeout: 30_000},
-		);
-
-		const expandCrop = page.getByRole('button', {
-			name: 'Expand Crop',
-			exact: true,
-		});
-		await selectScalePrecisionAndWaitFor({page, locator: expandCrop});
-		await expandCrop.click();
-
-		const cropRow = page
-			.getByText('Crop left', {exact: true})
-			.locator('..')
-			.locator('..');
-		await cropRow.locator('button.__remotion_input_dragger').click();
-
-		const input = cropRow.locator('input[type="text"]');
-		await expect(input).toBeVisible();
-		await input.fill('0.005');
-		await input.press('ArrowUp');
-		await expect(input).toHaveValue('0.015');
-		await input.fill('0.005');
-		await input.press('Enter');
-		await expect(input).toBeHidden();
-
-		await expect
-			.poll(
-				() => {
-					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
-					return content.includes('cropLeft={0.005}');
-				},
-				{
-					message: 'Expected the precise crop value to be written to source',
-					timeout: 10_000,
-				},
-			)
-			.toBe(true);
-	});
-
-	test('accepts an effect parameter that is more precise than its interaction step', async ({
-		page,
-	}) => {
-		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
-		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
-		await page.waitForFunction(
-			() => !document.body.innerText.includes('Loading...'),
-			{timeout: 30_000},
-		);
-
-		const waveRow = page.getByText('wave()', {exact: true});
-		await selectScalePrecisionAndWaitFor({page, locator: waveRow});
-		await waveRow.click();
-
-		const amplitudeRow = page
-			.getByText('Amplitude', {exact: true})
-			.locator('..')
-			.locator('..');
-		await amplitudeRow.locator('button.__remotion_input_dragger').click();
-
-		const input = amplitudeRow.locator('input[type="text"]');
-		await expect(input).toBeVisible();
-		await input.fill('60.525');
-		await input.press('ArrowUp');
-		await expect(input).toHaveValue('61.525');
-		await input.fill('60.525');
-		await input.press('Enter');
-		await expect(input).toBeHidden();
-
-		await expect
-			.poll(
-				() => {
-					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
-					return content.includes('amplitude: 60.525');
-				},
-				{
-					message:
-						'Expected the precise effect parameter to be written to source',
-					timeout: 10_000,
-				},
-			)
-			.toBe(true);
-	});
-
-	test('collapses timeline tracks until a property or effect is selected', async ({
-		page,
-	}) => {
+		test.setTimeout(120_000);
 		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
 		await expect(page).toHaveURL(/effect-keyframe-e2e/, {timeout: 15_000});
 		await page.waitForFunction(
@@ -338,7 +163,137 @@ test.describe('effect keyframes', () => {
 		}).toPass({timeout: 15_000});
 
 		await waveRow.click();
-
 		await expect(waveRow).toHaveCount(2);
+
+		const scaleRow = page
+			.getByText('Scale', {exact: true})
+			.locator('..')
+			.locator('..');
+		const scaleDragger = scaleRow
+			.locator('button.__remotion_input_dragger')
+			.first();
+		await selectScalePrecisionAndWaitFor({page, locator: scaleDragger});
+		await scaleDragger.click();
+
+		const scaleInput = scaleRow.locator('input[type="text"]');
+		await expect(scaleInput).toBeVisible();
+		await scaleInput.fill('0.525');
+		await scaleInput.press('ArrowUp');
+		await expect(scaleInput).toHaveValue('0.535');
+		await scaleInput.fill('0.525');
+		await scaleInput.press('Enter');
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('scale: 0.525');
+				},
+				{
+					message: 'Expected the precise scale value to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+
+		const rotationRow = page
+			.getByText('Rotation', {exact: true})
+			.locator('..')
+			.locator('..');
+		const rotationDragger = rotationRow.locator(
+			'button.__remotion_input_dragger',
+		);
+		await selectScalePrecisionAndWaitFor({page, locator: rotationDragger});
+		await rotationDragger.click();
+
+		const rotationInput = rotationRow.locator('input[type="text"]');
+		await expect(rotationInput).toBeVisible();
+		await rotationInput.fill('0.525');
+		await rotationInput.press('ArrowUp');
+		await expect(rotationInput).toHaveValue('1.525');
+		await rotationInput.fill('0.525');
+		await rotationInput.press('Enter');
+		await expect(rotationInput).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes("rotate: '0.525deg'");
+				},
+				{
+					message:
+						'Expected the precise rotation value to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+
+		const expandCrop = page.getByRole('button', {
+			name: 'Expand Crop',
+			exact: true,
+		});
+		await selectScalePrecisionAndWaitFor({page, locator: expandCrop});
+		await expandCrop.click();
+
+		const cropRow = page
+			.getByText('Crop left', {exact: true})
+			.locator('..')
+			.locator('..');
+		await cropRow.locator('button.__remotion_input_dragger').click();
+
+		const cropInput = cropRow.locator('input[type="text"]');
+		await expect(cropInput).toBeVisible();
+		await cropInput.fill('0.005');
+		await cropInput.press('ArrowUp');
+		await expect(cropInput).toHaveValue('0.015');
+		await cropInput.fill('0.005');
+		await cropInput.press('Enter');
+		await expect(cropInput).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('cropLeft={0.005}');
+				},
+				{
+					message: 'Expected the precise crop value to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
+
+		await selectScalePrecisionAndWaitFor({page, locator: waveRow});
+		await waveRow.click();
+
+		const amplitudeRow = page
+			.getByText('Amplitude', {exact: true})
+			.locator('..')
+			.locator('..');
+		await amplitudeRow.locator('button.__remotion_input_dragger').click();
+
+		const amplitudeInput = amplitudeRow.locator('input[type="text"]');
+		await expect(amplitudeInput).toBeVisible();
+		await amplitudeInput.fill('60.525');
+		await amplitudeInput.press('ArrowUp');
+		await expect(amplitudeInput).toHaveValue('61.525');
+		await amplitudeInput.fill('60.525');
+		await amplitudeInput.press('Enter');
+		await expect(amplitudeInput).toBeHidden();
+
+		await expect
+			.poll(
+				() => {
+					const content = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+					return content.includes('amplitude: 60.525');
+				},
+				{
+					message:
+						'Expected the precise effect parameter to be written to source',
+					timeout: 10_000,
+				},
+			)
+			.toBe(true);
 	});
 });

--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -73,9 +73,10 @@ test.describe('inspector section collapse', () => {
 		fs.writeFileSync(visualMode3DFile, visualMode3DSourceBefore);
 	});
 
-	test('Escape moves crop and rotation selections to the sequence', async ({
+	test('edits visual-mode-3d transforms and collapses inactive inspector sections', async ({
 		page,
 	}) => {
+		test.setTimeout(180_000);
 		await page.goto(`${STUDIO_URL}/visual-mode-3d`);
 		await expect(page).toHaveURL(/visual-mode-3d/, {timeout: 15_000});
 		await page.waitForFunction(
@@ -129,15 +130,7 @@ test.describe('inspector section collapse', () => {
 			page.locator('[data-remotion-studio-crop-preview]'),
 		).not.toBeVisible();
 		await expect(selectedOutline).toBeVisible();
-	});
 
-	test('selects 3D rotation from the sequence context menu', async ({page}) => {
-		await page.goto(`${STUDIO_URL}/visual-mode-3d`);
-		await expect(page).toHaveURL(/visual-mode-3d/, {timeout: 15_000});
-		await page.waitForFunction(
-			() => !document.body.innerText.includes('Loading...'),
-			{timeout: 30_000},
-		);
 		const tinyScaleEdges = page.locator(
 			'[data-remotion-studio-scale-edge-contains-selection="true"]',
 		);
@@ -243,9 +236,6 @@ test.describe('inspector section collapse', () => {
 			{x: edgeCenter.x, y: edgeCenter.y},
 		);
 		await expect.poll(read2DTransformScale).not.toBe(scaleBefore);
-		const canvasRotationSurface = page.locator(
-			'[data-remotion-studio-canvas-rotation]',
-		);
 		await expect(canvasRotationSurface).toBeVisible();
 
 		const transformOriginHandle = page
@@ -414,11 +404,8 @@ test.describe('inspector section collapse', () => {
 		await page.mouse.up();
 		await page.waitForTimeout(200);
 		expect(read2DTransformRotation()).toBe(rotationAfterInsideDrag);
-	});
 
-	test('collapses inactive static sections and lets the user expand them', async ({
-		page,
-	}) => {
+		fs.writeFileSync(visualMode3DFile, visualMode3DSourceBefore);
 		await page.goto(`${STUDIO_URL}/issue-8216`);
 		await expect(page).toHaveURL(/issue-8216/, {timeout: 15_000});
 		await page.waitForFunction(
@@ -529,32 +516,31 @@ test.describe('inspector section collapse', () => {
 			page.getByRole('button', {name: 'Rotation X', exact: true}),
 		).toHaveCount(0);
 		await page.getByTitle('Rotation', {exact: true}).click();
-		const compositionContainer = page.locator(
+		const laterCompositionContainer = page.locator(
 			'.remotion-studio-composition-container',
 		);
-		const compositionBox = await compositionContainer.boundingBox();
-		if (compositionBox === null) {
+		const laterCompositionBox = await laterCompositionContainer.boundingBox();
+		if (laterCompositionBox === null) {
 			throw new Error('Composition should have a visible layout');
 		}
 
 		await page.mouse.move(
-			compositionBox.x + compositionBox.width / 2,
-			compositionBox.y + compositionBox.height / 2,
-		);
-		const canvasRotationSurface = page.locator(
-			'[data-remotion-studio-canvas-rotation]',
+			laterCompositionBox.x + laterCompositionBox.width / 2,
+			laterCompositionBox.y + laterCompositionBox.height / 2,
 		);
 		await expect(canvasRotationSurface).toBeVisible();
 		await expect(
 			page.locator('[data-remotion-studio-transform-origin-handle]').first(),
 		).toBeVisible();
-		const rotationSurfaceBox = await canvasRotationSurface.boundingBox();
-		if (rotationSurfaceBox === null) {
+		const laterRotationSurfaceBox = await canvasRotationSurface.boundingBox();
+		if (laterRotationSurfaceBox === null) {
 			throw new Error('Canvas rotation surface should have a visible layout');
 		}
 
-		const startX = rotationSurfaceBox.x + rotationSurfaceBox.width * 0.25;
-		const startY = rotationSurfaceBox.y + rotationSurfaceBox.height * 0.25;
+		const startX =
+			laterRotationSurfaceBox.x + laterRotationSurfaceBox.width * 0.25;
+		const startY =
+			laterRotationSurfaceBox.y + laterRotationSurfaceBox.height * 0.25;
 		await page.mouse.move(startX, startY);
 		await page.mouse.down();
 		await page.mouse.move(startX + 60, startY + 80, {steps: 5});
@@ -570,8 +556,8 @@ test.describe('inspector section collapse', () => {
 		).toBeVisible();
 		await page.getByTitle('Rotation', {exact: true}).click();
 		await page.mouse.move(
-			compositionBox.x + compositionBox.width / 2,
-			compositionBox.y + compositionBox.height / 2,
+			laterCompositionBox.x + laterCompositionBox.width / 2,
+			laterCompositionBox.y + laterCompositionBox.height / 2,
 		);
 		await expect(canvasRotationSurface).toBeVisible();
 		const threeDRotationSurfaceBox = await canvasRotationSurface.boundingBox();

--- a/packages/example/e2e/json-editor.test.mts
+++ b/packages/example/e2e/json-editor.test.mts
@@ -6,19 +6,6 @@ import {startStudio, stopStudio} from './studio-server.mts';
 
 test.use({storageState: EXPANDED_SIDEBAR_STATE});
 
-async function openJsonEditor(page: import('@playwright/test').Page) {
-	await navigateToSchemaTest(page);
-
-	const jsonTab = page.getByRole('button', {name: 'JSON', exact: true});
-	await expect(jsonTab).toBeVisible({timeout: 10_000});
-	await jsonTab.click();
-
-	const textarea = page.locator('textarea');
-	await expect(textarea).toBeVisible({timeout: 10_000});
-	await expect(textarea).not.toHaveValue('', {timeout: 10_000});
-	return textarea;
-}
-
 test.describe('visual mode', () => {
 	test.beforeEach(async () => {
 		await startStudio();
@@ -28,13 +15,23 @@ test.describe('visual mode', () => {
 		await stopStudio();
 	});
 
-	test('should edit props via JSON editor and save on blur', async ({page}) => {
-		const textarea = await openJsonEditor(page);
+	test('should edit JSON props and reject invalid or schema-mismatching JSON', async ({
+		page,
+	}) => {
+		test.setTimeout(90_000);
+		await navigateToSchemaTest(page);
+
+		const jsonTab = page.getByRole('button', {name: 'JSON', exact: true});
+		await expect(jsonTab).toBeVisible({timeout: 10_000});
+		await jsonTab.click();
+
+		const textarea = page.locator('textarea');
+		await expect(textarea).toBeVisible({timeout: 10_000});
+		await expect(textarea).not.toHaveValue('', {timeout: 10_000});
 
 		const currentJson = await textarea.inputValue();
 		const parsed = JSON.parse(currentJson);
 		const newTitle = 'json-editor-e2e-test';
-
 		const beforeContent = fs.readFileSync(rootFile, 'utf-8');
 		expect(beforeContent).not.toContain(newTitle);
 
@@ -54,31 +51,25 @@ test.describe('visual mode', () => {
 				},
 			)
 			.toBe(true);
-	});
 
-	test('should show error and not save on blur when JSON is invalid', async ({
-		page,
-	}) => {
-		const textarea = await openJsonEditor(page);
-		const contentBefore = fs.readFileSync(rootFile, 'utf-8');
-
+		const contentAfterValidEdit = fs.readFileSync(rootFile, 'utf-8');
 		await textarea.fill('{invalid json');
 
 		const errorDiv = page.locator('[data-testid="json-props-error"]');
-
 		await expect(errorDiv).not.toBeEmpty({timeout: 5_000});
-
 		await textarea.blur();
 
 		await expect
-			.poll(() => fs.readFileSync(rootFile, 'utf-8') === contentBefore, {
-				timeout: 2_000,
-			})
+			.poll(
+				() => fs.readFileSync(rootFile, 'utf-8') === contentAfterValidEdit,
+				{
+					timeout: 2_000,
+				},
+			)
 			.toBe(true);
 
-		// Update the root file on disk — the textarea should auto-update and the error should clear
 		const updatedTitle = 'disk-update-clears-error';
-		const updatedContent = contentBefore.replace(
+		const updatedContent = contentAfterValidEdit.replace(
 			/title: '[^']*'/,
 			`title: '${updatedTitle}'`,
 		);
@@ -87,39 +78,28 @@ test.describe('visual mode', () => {
 		await expect(textarea).toHaveValue(new RegExp(updatedTitle), {
 			timeout: 10_000,
 		});
-
 		await expect(errorDiv).toBeEmpty({timeout: 5_000});
 
-		// Restore original file
-		fs.writeFileSync(rootFile, contentBefore);
+		fs.writeFileSync(rootFile, contentAfterValidEdit);
 
 		await expect(textarea).not.toHaveValue(new RegExp(updatedTitle), {
 			timeout: 10_000,
 		});
-	});
 
-	test('should show error and not save on blur when JSON does not match schema', async ({
-		page,
-	}) => {
-		const textarea = await openJsonEditor(page);
-		const currentJson = await textarea.inputValue();
-		const parsed = JSON.parse(currentJson);
-		const contentBefore = fs.readFileSync(rootFile, 'utf-8');
+		const jsonAfterRestore = JSON.parse(await textarea.inputValue());
+		jsonAfterRestore.delay = -1;
+		await textarea.fill(JSON.stringify(jsonAfterRestore, null, 2));
 
-		// delay: -1 violates the .min(0) constraint
-		parsed.delay = -1;
-		await textarea.fill(JSON.stringify(parsed, null, 2));
-
-		await expect(
-			page.locator('[data-testid="json-props-error"]'),
-		).not.toBeEmpty({timeout: 5_000});
-
+		await expect(errorDiv).not.toBeEmpty({timeout: 5_000});
 		await textarea.blur();
 
 		await expect
-			.poll(() => fs.readFileSync(rootFile, 'utf-8') === contentBefore, {
-				timeout: 2_000,
-			})
+			.poll(
+				() => fs.readFileSync(rootFile, 'utf-8') === contentAfterValidEdit,
+				{
+					timeout: 2_000,
+				},
+			)
 			.toBe(true);
 	});
 });

--- a/packages/example/e2e/node-path-cache.test.mts
+++ b/packages/example/e2e/node-path-cache.test.mts
@@ -1,7 +1,7 @@
-import {expect, test} from '@playwright/test';
-import {getAllSchemaKeys} from '@remotion/studio-shared';
 import fs from 'fs';
 import assert from 'node:assert';
+import {expect, test} from '@playwright/test';
+import {getAllSchemaKeys} from '@remotion/studio-shared';
 import {NoReactInternals} from 'remotion/no-react';
 import {apiCall} from './api-call.mts';
 import {newVideoFile} from './constants.mts';
@@ -45,7 +45,7 @@ test.describe('node-path cache for stale source maps', () => {
 	// resolution. When the same stale coordinates are sent again, the cached
 	// nodePath is reused (and verified against the current AST).
 
-	test('subscribe-to-sequence-props succeeds with stale line number after file reformatting', async () => {
+	test('subscribe-to-sequence-props recovers from stale line numbers and node paths', async () => {
 		const content = fs.readFileSync(newVideoFile, 'utf-8');
 		const lines = content.split('\n');
 		const videoLineIndex = lines.findIndex((l) => l.includes('<Video'));
@@ -108,18 +108,20 @@ test.describe('node-path cache for stale source maps', () => {
 		expect(result2.data.success && result2.data.nodePath).toEqual(
 			result1.data.success && result1.data.nodePath,
 		);
-	});
 
-	test('subscribe-to-sequence-props reconnects when a stale node path points to a different component', async () => {
-		const content = fs.readFileSync(newVideoFile, 'utf-8');
-		const lines = content.split('\n');
-		const videoLineIndex = lines.findIndex((l) => l.includes('<Video'));
-		expect(videoLineIndex).toBeGreaterThan(-1);
-		const videoLine = videoLineIndex + 1;
+		fs.writeFileSync(newVideoFile, originalContent);
 
-		const result1 = await apiCall('/api/subscribe-to-sequence-props', {
+		const identityContent = fs.readFileSync(newVideoFile, 'utf-8');
+		const identityLines = identityContent.split('\n');
+		const identityVideoLineIndex = identityLines.findIndex((l) =>
+			l.includes('<Video'),
+		);
+		expect(identityVideoLineIndex).toBeGreaterThan(-1);
+		const identityVideoLine = identityVideoLineIndex + 1;
+
+		const identityResult = await apiCall('/api/subscribe-to-sequence-props', {
 			fileName: 'src/NewVideo.tsx',
-			line: videoLine,
+			line: identityVideoLine,
 			column: 0,
 			nodePath: null,
 			componentIdentity: 'dev.remotion.media.Video',
@@ -127,37 +129,37 @@ test.describe('node-path cache for stale source maps', () => {
 			effects: [],
 			clientId: 'e2e-identity-mismatch-1',
 		});
-		expect(result1.success).toBe(true);
-		assert(result1.success);
-		expect(result1.data.success).toBe(true);
-		assert(result1.data.success);
-		expect(result1.data.status.canUpdate).toBe(true);
-		assert(result1.data.status.canUpdate);
-		expect(result1.data.status.props.debugOverlay).toEqual({
+		expect(identityResult.success).toBe(true);
+		assert(identityResult.success);
+		expect(identityResult.data.success).toBe(true);
+		assert(identityResult.data.success);
+		expect(identityResult.data.status.canUpdate).toBe(true);
+		assert(identityResult.data.status.canUpdate);
+		expect(identityResult.data.status.props.debugOverlay).toEqual({
 			status: 'static',
 			codeValue: true,
 			keyframeDisplayOffsetAdjustment: null,
 		});
 
-		const staleNodePath = result1.data.nodePath.nodePath;
-		const editedContent = content.replace(
+		const staleNodePath = identityResult.data.nodePath.nodePath;
+		const wrappedInSequence = identityContent.replace(
 			'return <Video src={src} debugOverlay />;',
 			'return (\n\t\t<Sequence>\n\t\t\t<Video src={src} debugOverlay />\n\t\t</Sequence>\n\t);',
 		);
-		expect(editedContent).not.toBe(content);
-		fs.writeFileSync(newVideoFile, editedContent);
+		expect(wrappedInSequence).not.toBe(identityContent);
+		fs.writeFileSync(newVideoFile, wrappedInSequence);
 
-		const editedLines = editedContent.split('\n');
-		const newVideoLineIndex = editedLines.findIndex((l) =>
+		const wrappedLines = wrappedInSequence.split('\n');
+		const wrappedVideoLineIndex = wrappedLines.findIndex((l) =>
 			l.includes('<Video'),
 		);
-		expect(newVideoLineIndex).toBeGreaterThan(-1);
-		const newVideoLine = newVideoLineIndex + 1;
-		expect(newVideoLine).not.toBe(videoLine);
+		expect(wrappedVideoLineIndex).toBeGreaterThan(-1);
+		const wrappedVideoLine = wrappedVideoLineIndex + 1;
+		expect(wrappedVideoLine).not.toBe(identityVideoLine);
 
-		const result2 = await apiCall('/api/subscribe-to-sequence-props', {
+		const reconnectResult = await apiCall('/api/subscribe-to-sequence-props', {
 			fileName: 'src/NewVideo.tsx',
-			line: newVideoLine,
+			line: wrappedVideoLine,
 			column: 0,
 			nodePath: staleNodePath,
 			componentIdentity: 'dev.remotion.media.Video',
@@ -165,17 +167,17 @@ test.describe('node-path cache for stale source maps', () => {
 			effects: [],
 			clientId: 'e2e-identity-mismatch-2',
 		});
-		expect(result2.success).toBe(true);
-		assert(result2.success);
-		expect(result2.data.success).toBe(true);
-		assert(result2.data.success);
-		expect(result2.data.status.canUpdate).toBe(true);
-		assert(result2.data.status.canUpdate);
-		expect(result2.data.status.props.debugOverlay).toEqual({
+		expect(reconnectResult.success).toBe(true);
+		assert(reconnectResult.success);
+		expect(reconnectResult.data.success).toBe(true);
+		assert(reconnectResult.data.success);
+		expect(reconnectResult.data.status.canUpdate).toBe(true);
+		assert(reconnectResult.data.status.canUpdate);
+		expect(reconnectResult.data.status.props.debugOverlay).toEqual({
 			status: 'static',
 			codeValue: true,
 			keyframeDisplayOffsetAdjustment: null,
 		});
-		expect(result2.data.nodePath.nodePath).not.toEqual(staleNodePath);
+		expect(reconnectResult.data.nodePath.nodePath).not.toEqual(staleNodePath);
 	});
 });

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -539,8 +539,7 @@ test.describe('visual mode', () => {
 	test('should play when a composition in the sidebar is focused', async ({
 		page,
 	}) => {
-		await page.goto(`${STUDIO_URL}/schema-test`);
-		await expect(page).toHaveURL(/schema-test/, {timeout: 15_000});
+		await navigateToSchemaTest(page);
 
 		const otherComposition = page.getByTitle('AnimatedBarChart', {exact: true});
 		await otherComposition.press('Space');
@@ -590,55 +589,10 @@ test.describe('visual mode', () => {
 		}
 	});
 
-	test('untoggling the free license removes it from the config', async ({
+	test('settings reuse reactive runtime config and license toggle', async ({
 		page,
 	}) => {
-		const configFile = path.join(exampleDir, 'remotion.config.ts');
-		const configBeforeTest = fs.readFileSync(configFile, 'utf8');
-
-		try {
-			await page.goto(STUDIO_URL);
-			const response = await fetch(`${STUDIO_URL}/api/update-config`, {
-				method: 'POST',
-				headers: {'content-type': 'application/json', origin: STUDIO_URL},
-				body: JSON.stringify({
-					clientId: 'license-settings-e2e',
-					updates: [
-						{
-							setter: 'setPublicLicenseKey',
-							type: 'set',
-							value: 'free-license',
-						},
-					],
-				}),
-			});
-			expect(await response.json()).toEqual({
-				success: true,
-				data: {success: true},
-			});
-			await expect
-				.poll(() => fs.readFileSync(configFile, 'utf8'))
-				.toContain("Config.setPublicLicenseKey('free-license');");
-
-			await page.getByRole('button', {name: /Search\.\.\./}).click();
-			const quickSwitcher = page.getByRole('dialog');
-			await quickSwitcher.getByRole('textbox').fill('> Settings');
-			await quickSwitcher.getByText('Settings...', {exact: true}).click();
-			const dialog = page.getByRole('dialog');
-			await dialog.getByText('License', {exact: true}).click();
-			const freeLicenseToggle = dialog.locator('input[name="free-license"]');
-			await expect(freeLicenseToggle).toBeChecked();
-			await freeLicenseToggle.click();
-
-			await expect
-				.poll(() => fs.readFileSync(configFile, 'utf8'))
-				.not.toContain('Config.setPublicLicenseKey');
-		} finally {
-			fs.writeFileSync(configFile, configBeforeTest);
-		}
-	});
-
-	test('settings reuse reactive runtime config', async ({page}) => {
+		test.setTimeout(120_000);
 		const configFile = path.join(exampleDir, 'remotion.config.ts');
 		const configBeforeTest = fs.readFileSync(configFile, 'utf8');
 		let editorInfoRequests = 0;
@@ -853,11 +807,16 @@ test.describe('visual mode', () => {
 				dialog.getByTitle('Default coding agent', {exact: true}),
 			).toContainText('Codex');
 			await dialog.getByText('License', {exact: true}).click();
-			await expect(dialog.locator('input[name="free-license"]')).toBeChecked();
+			const freeLicenseToggle = dialog.locator('input[name="free-license"]');
+			await expect(freeLicenseToggle).toBeChecked();
 			expect({codingAgentInfoRequests, editorInfoRequests}).toEqual({
 				codingAgentInfoRequests: 1,
 				editorInfoRequests: 1,
 			});
+			await freeLicenseToggle.click();
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.not.toContain('Config.setPublicLicenseKey');
 			await page.mouse.move(10, 100);
 			await page.mouse.down();
 			await page.mouse.move(13, 101);
@@ -1755,10 +1714,6 @@ test.describe('visual mode', () => {
 		expect(subMenuItemBox!.x).toBeGreaterThan(compositionBox!.x);
 	});
 
-	test('should navigate to schema-test composition', async ({page}) => {
-		await navigateToSchemaTest(page);
-	});
-
 	test('should not subscribe to package-owned sequence props', async ({
 		page,
 	}) => {
@@ -1811,7 +1766,10 @@ test.describe('visual mode', () => {
 		await expect(currentTime).not.toHaveAttribute('aria-label', '0');
 	});
 
-	test('should preview a sized Element drop on the Canvas', async ({page}) => {
+	test('should preview and place Canvas drops at the playhead', async ({
+		page,
+	}) => {
+		test.setTimeout(90_000);
 		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
 		await expect(
 			page.getByRole('button', {name: '0', exact: true}),
@@ -1875,15 +1833,7 @@ test.describe('visual mode', () => {
 			document.dispatchEvent(new DragEvent('dragend', {bubbles: true}));
 		});
 		await expect(preview).toBeHidden();
-	});
 
-	test('should place and select Canvas drops at the playhead', async ({
-		page,
-	}) => {
-		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
-		await expect(
-			page.getByRole('button', {name: '0', exact: true}),
-		).toBeVisible({timeout: 15_000});
 		if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
 			await page.locator('[data-sidebar-toggle="right"]').click();
 		}

--- a/packages/example/e2e/visual-controls.test.mts
+++ b/packages/example/e2e/visual-controls.test.mts
@@ -15,29 +15,30 @@ test.describe('visual controls', () => {
 		await stopStudio();
 	});
 
-	test('should edit rotation and update source file', async ({page}) => {
+	test('should edit rotation, label, nullable subtitle, and optional extra-rotation', async ({
+		page,
+	}) => {
+		test.setTimeout(90_000);
 		await openVisualControlsPanel(page);
 
-		// Find the rotation control's fieldset via the data-json-path label
 		const rotationFieldset = page
 			.locator('[data-json-path="rotation"]')
 			.locator('..');
 		await expect(rotationFieldset).toBeVisible({timeout: 10_000});
 
-		// Click the dragger button to activate the number input
-		const dragger = rotationFieldset.locator('button.__remotion_input_dragger');
-		await expect(dragger).toBeVisible({timeout: 5_000});
-		await dragger.click();
+		const rotationDragger = rotationFieldset.locator(
+			'button.__remotion_input_dragger',
+		);
+		await expect(rotationDragger).toBeVisible({timeout: 5_000});
+		await rotationDragger.click();
 
-		// Fill the now-visible input with a new value
-		const input = rotationFieldset.locator('input');
-		await expect(input).toBeVisible({timeout: 5_000});
+		const rotationInput = rotationFieldset.locator('input');
+		await expect(rotationInput).toBeVisible({timeout: 5_000});
 
 		const newRotation = '42';
-		await input.fill(newRotation);
-		await input.press('Enter');
+		await rotationInput.fill(newRotation);
+		await rotationInput.press('Enter');
 
-		// Wait for the source file to be updated on disk
 		await expect
 			.poll(
 				() => {
@@ -50,12 +51,7 @@ test.describe('visual controls', () => {
 				},
 			)
 			.toBe(true);
-	});
 
-	test('should edit label string and update source file', async ({page}) => {
-		await openVisualControlsPanel(page);
-
-		// Find the label string input by its name attribute
 		const labelInput = page.locator('input[name="label"]');
 		await expect(labelInput).toBeVisible({timeout: 10_000});
 
@@ -63,7 +59,6 @@ test.describe('visual controls', () => {
 		await labelInput.fill(newLabel);
 		await labelInput.blur();
 
-		// Wait for the source file to be updated on disk
 		await expect
 			.poll(
 				() => {
@@ -76,14 +71,7 @@ test.describe('visual controls', () => {
 				},
 			)
 			.toBe(true);
-	});
 
-	test('should edit nullable subtitle and update source file', async ({
-		page,
-	}) => {
-		await openVisualControlsPanel(page);
-
-		// Edit the subtitle text (nullable string, default 'A subtitle')
 		const subtitleInput = page.locator(
 			'input[name="subtitle"]:not([type="checkbox"])',
 		);
@@ -106,7 +94,6 @@ test.describe('visual controls', () => {
 			)
 			.toBe(true);
 
-		// Now toggle to null via the checkbox
 		const nullCheckbox = page.locator(
 			'input[name="subtitle"][type="checkbox"]',
 		);
@@ -126,41 +113,34 @@ test.describe('visual controls', () => {
 				},
 			)
 			.toBe(true);
-	});
 
-	test('should edit optional extra-rotation and update source file', async ({
-		page,
-	}) => {
-		await openVisualControlsPanel(page);
-
-		// The extra-rotation control defaults to undefined.
-		// First, enable it by unchecking the "undefined" checkbox.
 		const undefinedToggle = page.locator(
 			'input[name="extra-rotation"][type="checkbox"]',
 		);
 		await expect(undefinedToggle).toBeVisible({timeout: 10_000});
 		await undefinedToggle.uncheck();
 
-		// Now find the dragger and interact with it
-		const fieldset = page
+		const extraRotationFieldset = page
 			.locator('[data-json-path="extra-rotation"]')
 			.locator('..');
-		const dragger = fieldset.locator('button.__remotion_input_dragger');
-		await expect(dragger).toBeVisible({timeout: 10_000});
-		await dragger.click();
+		const extraRotationDragger = extraRotationFieldset.locator(
+			'button.__remotion_input_dragger',
+		);
+		await expect(extraRotationDragger).toBeVisible({timeout: 10_000});
+		await extraRotationDragger.click();
 
-		const input = fieldset.locator('input[type="text"]');
-		await expect(input).toBeVisible({timeout: 5_000});
+		const extraRotationInput =
+			extraRotationFieldset.locator('input[type="text"]');
+		await expect(extraRotationInput).toBeVisible({timeout: 5_000});
 
 		const newValue = '90';
-		await input.fill(newValue);
-		await input.press('Enter');
+		await extraRotationInput.fill(newValue);
+		await extraRotationInput.press('Enter');
 
 		await expect
 			.poll(
 				() => {
 					const content = fs.readFileSync(visualControlsFile, 'utf-8');
-					// The codemod may format the value on the next line
 					const match = content.match(/'extra-rotation',\s*(\d+)/);
 					return match?.[1] === newValue;
 				},
@@ -171,7 +151,6 @@ test.describe('visual controls', () => {
 			)
 			.toBe(true);
 
-		// Now toggle back to undefined via the checkbox
 		await expect(undefinedToggle).toBeVisible({timeout: 5_000});
 		await undefinedToggle.check();
 


### PR DESCRIPTION
## Summary
- Combine related Example Studio E2E workflows so one independently runnable test covers multiple assertions instead of restarting Studio per check.
- JSON editor, visual controls, effect-keyframe precision, node-path cache, inspector collapse, settings/license, and canvas drops now share setup.
- Distinct setups (search, canvas menus, copy-keyframes, read-only Studio) stay as separate tests.

## Test plan
- [x] `bunx playwright test e2e/json-editor.test.mts e2e/visual-controls.test.mts e2e/node-path-cache.test.mts e2e/effect-keyframes.test.mts e2e/inspector-section-collapse.test.mts --reporter=line`
- [x] `bunx playwright test e2e/studio.test.mts --grep "settings reuse reactive runtime config and license toggle|preview and place Canvas drops at the playhead|play when a composition in the sidebar is focused" --reporter=line`
- [ ] Example E2E CI job completes with fewer tests and no new failures
