### PR TITLE
`@remotion/browser-studio`: Install dependencies without restarting

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -292,13 +292,15 @@ test('confirms and imports an Element payload from the URL fragment', async ({
 	page,
 }) => {
 	const payload = createElementPayload({
-		dependencies: [],
+		dependencies: [{name: '@remotion/shapes', version: null}],
 		dimensions: {height: 180, width: 320},
 		displayName: 'Linked Element',
 		durationInFrames: 60,
 		installationMode: 'wrapped',
 		slug: 'linked-element',
-		sourceCode: `export const LinkedElement = () => <div>Grüezi 👋</div>;`,
+		sourceCode: `import {Rect} from '@remotion/shapes';
+
+export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;`,
 	});
 	const url = StudioProtocolInternals.makeBrowserStudioUrl({
 		endpoint: 'http://127.0.0.1:62338/',
@@ -329,6 +331,13 @@ test('confirms and imports an Element payload from the URL fragment', async ({
 		)
 		.toBeUndefined();
 
+	await studio.locator('body').evaluate(() => {
+		(
+			window as typeof window & {
+				__browserStudioInstallPreservedIframe?: boolean;
+			}
+		).__browserStudioInstallPreservedIframe = true;
+	});
 	await studio.getByRole('button', {name: /^Install/}).click();
 	await expect
 		.poll(() =>
@@ -350,8 +359,18 @@ test('confirms and imports an Element payload from the URL fragment', async ({
 		)
 		.toEqual({
 			composition: expect.stringContaining('<LinkedElement />'),
-			element: expect.stringContaining('Grüezi 👋'),
+			element: expect.stringContaining("import {Rect} from '@remotion/shapes'"),
 		});
+	expect(
+		await studio.locator('body').evaluate(
+			() =>
+				(
+					window as typeof window & {
+						__browserStudioInstallPreservedIframe?: boolean;
+					}
+				).__browserStudioInstallPreservedIframe,
+		),
+	).toBe(true);
 });
 
 test('reports inline SVG imports as unsupported without changing the project', async ({

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -144,8 +144,9 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	const [state, setState] = useState<CompileState>(makeInitialState);
 	const [iframeHtml, setIframeHtml] = useState<string | null>(null);
 	const [iframeLoaded, setIframeLoaded] = useState(false);
-	const [installedDependencyResolutions, setInstalledDependencyResolutions] =
-		useState<Record<string, BrowserStudioDependencyResolution>>({});
+	const installedDependencyResolutionsRef = useRef<
+		Record<string, BrowserStudioDependencyResolution>
+	>({});
 	const iframeRef = useRef<HTMLIFrameElement | null>(null);
 	const lastWrittenDocumentRef = useRef<Document | null>(null);
 	const lastWrittenHtmlRef = useRef<string | null>(null);
@@ -255,12 +256,10 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 					: (customResolution ?? version);
 			}
 
-			setInstalledDependencyResolutions((current) => {
-				const next = {...current, ...resolutions};
-				return JSON.stringify(current) === JSON.stringify(next)
-					? current
-					: next;
-			});
+			installedDependencyResolutionsRef.current = {
+				...installedDependencyResolutionsRef.current,
+				...resolutions,
+			};
 			return Promise.resolve(versions);
 		},
 		[remotionPackageSource],
@@ -443,7 +442,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 						},
 					),
 				),
-				...installedDependencyResolutions,
+				...installedDependencyResolutionsRef.current,
 			},
 			project: activeProjectRef.current,
 			remotionPackageSource: remotionPackageSource ?? null,
@@ -461,7 +460,6 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 		browserStudioOperations,
 		dependencyResolver,
 		hmrAssetManager,
-		installedDependencyResolutions,
 		publicFileManager,
 		readOnly,
 		remotionPackageSource,
@@ -482,6 +480,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 
 		lastSentProjectRef.current = activeProject;
 		worker.postMessage({
+			dependencyResolutions: installedDependencyResolutionsRef.current,
 			project: activeProject,
 			type: 'update-project',
 		} satisfies BrowserStudioWorkerCompileRequest);

--- a/packages/browser-studio/src/browser-studio-worker.ts
+++ b/packages/browser-studio/src/browser-studio-worker.ts
@@ -31,6 +31,8 @@ type CompilerSession = {
 	project: VirtualProject;
 	queuedProject: VirtualProject | null;
 	removedFiles: ReadonlySet<string> | undefined;
+	resolvedUrls: Record<string, string>;
+	resolvedVersions: Record<string, string>;
 	running: boolean;
 };
 
@@ -405,7 +407,13 @@ const createCompiler = async ({
 		resolve: {extensions: ['.tsx', '.ts', '.jsx', '.js', '.json']},
 	});
 
-	return {builtinMemFs, compiler, rspackBrowser};
+	return {
+		builtinMemFs,
+		compiler,
+		resolvedUrls,
+		resolvedVersions,
+		rspackBrowser,
+	};
 };
 
 const makeHmrEvent = ({
@@ -602,7 +610,8 @@ const startCompiler = async (
 		compilerSession = null;
 	}
 
-	const {builtinMemFs, compiler} = await createCompiler(request);
+	const {builtinMemFs, compiler, resolvedUrls, resolvedVersions} =
+		await createCompiler(request);
 	const session: CompilerSession = {
 		builtinMemFs,
 		compiler,
@@ -611,6 +620,8 @@ const startCompiler = async (
 		project: request.project,
 		queuedProject: null,
 		removedFiles: undefined,
+		resolvedUrls,
+		resolvedVersions,
 		running: false,
 	};
 	compilerSession = session;
@@ -622,6 +633,17 @@ const updateProject = (
 ) => {
 	if (!compilerSession) {
 		throw new Error('Cannot update Browser Studio before initializing it');
+	}
+
+	for (const [name, resolution] of Object.entries(
+		request.dependencyResolutions,
+	)) {
+		applyDependencyResolution({
+			name,
+			resolution,
+			resolvedUrls: compilerSession.resolvedUrls,
+			resolvedVersions: compilerSession.resolvedVersions,
+		});
 	}
 
 	if (compilerSession.running) {

--- a/packages/browser-studio/src/types.ts
+++ b/packages/browser-studio/src/types.ts
@@ -86,6 +86,7 @@ export type BrowserStudioWorkerCompileRequest =
 	| {
 			type: 'update-project';
 			project: VirtualProject;
+			dependencyResolutions: Record<string, BrowserStudioDependencyResolution>;
 	  };
 
 export type BrowserStudioHmrAsset = {


### PR DESCRIPTION
## Summary

- keep Browser Studio's Rspack compiler alive when an Element introduces dependencies
- update the worker's dependency resolution maps before applying the project HMR update
- verify URL-payload installation preserves the existing Studio iframe

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/browser-studio`
- `bun run testbrowserstudio -- --grep "URL fragment"` in `packages/browser-studio`
