### PR TITLE
`@remotion/studio`: Hide server-only Browser Studio actions

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -8,10 +8,8 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
-	const applyCodemodRequests: string[] = [];
 	const remoteRemotionRequests: string[] = [];
-	const renderPersistenceRequests: string[] = [];
-	const updateAvailableRequests: string[] = [];
+	const studioApiRequests: string[] = [];
 	const workspacePackageRequests: string[] = [];
 	let rejectPageError: (error: Error) => void = () => undefined;
 	const pageError = new Promise<never>((_resolve, reject) => {
@@ -19,19 +17,11 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 	});
 	page.on('request', (request) => {
 		const requestUrl = new URL(request.url());
-		if (requestUrl.pathname === '/api/apply-codemod') {
-			applyCodemodRequests.push(request.url());
-		}
-
-		if (requestUrl.pathname === '/api/update-available') {
-			updateAvailableRequests.push(request.url());
-		}
-
 		if (
-			requestUrl.pathname === '/api/upload-output' ||
-			requestUrl.pathname === '/api/register-client-render'
+			requestUrl.pathname.startsWith('/api/') &&
+			requestUrl.origin === new URL(page.url()).origin
 		) {
-			renderPersistenceRequests.push(request.url());
+			studioApiRequests.push(requestUrl.pathname);
 		}
 
 		if (
@@ -63,17 +53,47 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 			await expect(
 				studio.locator('.remotion-studio-composition-container'),
 			).toBeVisible();
+			await studio.getByRole('button', {name: 'File', exact: true}).click();
+			await expect(
+				studio.getByRole('button', {
+					name: 'Open in File Manager',
+					exact: true,
+				}),
+			).toHaveCount(0);
+			await page.keyboard.press('Escape');
+
+			await studio.getByRole('button', {name: /Search/}).click();
+			const quickSwitcher = studio.getByRole('dialog');
+			const quickSwitcherInput = quickSwitcher.getByRole('textbox');
+			await quickSwitcherInput.fill('> Settings');
+			await expect(
+				quickSwitcher.getByText('Settings...', {exact: true}),
+			).toHaveCount(0);
+			await quickSwitcherInput.fill('> Restart Studio Server');
+			await expect(
+				quickSwitcher.getByText('Restart Studio Server', {exact: true}),
+			).toHaveCount(0);
+			await quickSwitcherInput.press('Escape');
 
 			await studio.locator('[data-compname="MyComp"]').click();
 			await studio.getByRole('button', {name: 'Render on web'}).click();
 			await expect(
 				studio.getByText('Input Props', {exact: true}),
 			).toBeVisible();
+			await expect(
+				studio.getByRole('button', {name: 'License', exact: true}),
+			).toHaveCount(0);
 			await studio.getByText('Still', {exact: true}).click();
 			const downloadPromise = page.waitForEvent('download');
 			await studio.getByRole('button', {name: 'Render still'}).click();
 			const download = await downloadPromise;
 			expect(download.suggestedFilename()).toBe('MyComp.png');
+			await expect(
+				studio.getByRole('button', {name: 'Download', exact: true}),
+			).toBeVisible();
+			await expect(
+				studio.getByRole('button', {name: 'Remove', exact: true}),
+			).toHaveCount(0);
 			const inspector = studio.getByRole('button', {name: 'Inspector'});
 			await expect(inspector).toBeVisible();
 			await inspector.click();
@@ -142,9 +162,7 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 		'/__remotion_browser_studio_workspace__/commits/e2e/packages/transitions/dist/esm/fade.mjs',
 	);
 	expect(remoteRemotionRequests).toEqual([]);
-	expect(applyCodemodRequests).toEqual([]);
-	expect(renderPersistenceRequests).toEqual([]);
-	expect(updateAvailableRequests).toEqual([]);
+	expect(studioApiRequests).toEqual([]);
 });
 
 test('loads Browser Studio from one immutable release artifact set', async ({

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -133,6 +133,7 @@ export const getAssetContextMenuItems = ({
 	openAssetInExplorer,
 	renameAsset,
 	deleteAsset,
+	fileExplorerAvailable,
 	fileExplorerDisabled,
 	mutationsDisabled,
 }: {
@@ -143,10 +144,11 @@ export const getAssetContextMenuItems = ({
 	openAssetInExplorer: () => void;
 	renameAsset: () => void;
 	deleteAsset: () => void;
+	fileExplorerAvailable: boolean;
 	fileExplorerDisabled: boolean;
 	mutationsDisabled: boolean;
 }): ComboboxValue[] => {
-	return [
+	const items: (ComboboxValue | null)[] = [
 		getOpenInNewWindowMenuItem(`/assets/${relativePath}`),
 		{
 			type: 'divider',
@@ -178,18 +180,20 @@ export const getAssetContextMenuItems = ({
 			type: 'divider',
 			id: 'asset-file-actions-divider',
 		},
-		{
-			id: 'open-asset-in-explorer',
-			keyHint: null,
-			label: `Show in ${fileManagerName}`,
-			leftItem: null,
-			onClick: openAssetInExplorer,
-			quickSwitcherLabel: `Show asset in ${fileManagerName}`,
-			subMenu: null,
-			type: 'item',
-			value: 'open-asset-in-explorer',
-			disabled: fileExplorerDisabled,
-		},
+		fileExplorerAvailable
+			? {
+					id: 'open-asset-in-explorer',
+					keyHint: null,
+					label: `Show in ${fileManagerName}`,
+					leftItem: null,
+					onClick: openAssetInExplorer,
+					quickSwitcherLabel: `Show asset in ${fileManagerName}`,
+					subMenu: null,
+					type: 'item',
+					value: 'open-asset-in-explorer',
+					disabled: fileExplorerDisabled,
+				}
+			: null,
 		{
 			id: 'rename-asset',
 			keyHint: null,
@@ -215,6 +219,8 @@ export const getAssetContextMenuItems = ({
 			disabled: mutationsDisabled,
 		},
 	];
+
+	return items.filter(NoReactInternals.truthy);
 };
 
 const AssetFolderItem: React.FC<{
@@ -631,6 +637,7 @@ const AssetSelectorItem: React.FC<{
 			openAssetInExplorer,
 			renameAsset,
 			deleteAsset,
+			fileExplorerAvailable: getBrowserStudioOperations() === null,
 			fileExplorerDisabled,
 			mutationsDisabled,
 		});

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -1,4 +1,5 @@
 import React, {useContext, useEffect} from 'react';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {SelectedModalContext, SetSelectedModalContext} from '../state/modals';
@@ -33,8 +34,13 @@ export const Modals: React.FC<{
 		StudioServerConnectionCtx,
 	);
 	const canRender = previewServerState.type === 'connected';
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 
 	useEffect(() => {
+		if (isBrowserStudio) {
+			return;
+		}
+
 		return subscribeToEvent('license-key-install-request', (event) => {
 			if (event.type !== 'license-key-install-request') {
 				return;
@@ -46,7 +52,7 @@ export const Modals: React.FC<{
 				initialPublicLicenseKey: event.licenseKey,
 			});
 		});
-	}, [setSelectedModal, subscribeToEvent]);
+	}, [isBrowserStudio, setSelectedModal, subscribeToEvent]);
 
 	return (
 		<>
@@ -96,13 +102,15 @@ export const Modals: React.FC<{
 			{modalContextType && modalContextType.type === 'input-props-override' && (
 				<OverrideInputPropsModal />
 			)}
-			{modalContextType && modalContextType.type === 'settings' && (
-				<SettingsModal
-					key={`${modalContextType.initialTab}-${modalContextType.initialPublicLicenseKey}`}
-					initialTab={modalContextType.initialTab}
-					initialPublicLicenseKey={modalContextType.initialPublicLicenseKey}
-				/>
-			)}
+			{!isBrowserStudio &&
+				modalContextType &&
+				modalContextType.type === 'settings' && (
+					<SettingsModal
+						key={`${modalContextType.initialTab}-${modalContextType.initialPublicLicenseKey}`}
+						initialTab={modalContextType.initialTab}
+						initialPublicLicenseKey={modalContextType.initialPublicLicenseKey}
+					/>
+				)}
 			{modalContextType && modalContextType.type === 'web-render' && (
 				<WebRenderModalWithLoader {...modalContextType} />
 			)}
@@ -194,9 +202,13 @@ export const Modals: React.FC<{
 			{modalContextType && modalContextType.type === 'fix-computed-value' && (
 				<FixComputedValueModal state={modalContextType} />
 			)}
-			{modalContextType && modalContextType.type === 'install-packages' && (
-				<InstallPackageModal packageManager={modalContextType.packageManager} />
-			)}
+			{!isBrowserStudio &&
+				modalContextType &&
+				modalContextType.type === 'install-packages' && (
+					<InstallPackageModal
+						packageManager={modalContextType.packageManager}
+					/>
+				)}
 
 			{modalContextType && modalContextType.type === 'quick-switcher' && (
 				<QuickSwitcher

--- a/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
+++ b/packages/studio/src/components/RenderModal/GuiRenderStatus.tsx
@@ -5,6 +5,7 @@ import type {
 	StitchingProgressInput,
 } from '@remotion/studio-shared';
 import React, {useCallback, useMemo} from 'react';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {FAIL_COLOR, LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {Spacing} from '../layout';
 import {openInFileExplorer} from '../RenderQueue/actions';
@@ -189,6 +190,7 @@ const DownloadsProgress: React.FC<{
 const OpenFile: React.FC<{
 	readonly job: RenderJob;
 }> = ({job}) => {
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const labelStyle = useMemo(() => {
 		return {
 			...label,
@@ -209,9 +211,13 @@ const OpenFile: React.FC<{
 		<div style={progressItem}>
 			<SuccessIcon />
 			<Spacing x={1} />
-			<button style={labelStyle} type="button" onClick={onClick}>
-				{job.outName}
-			</button>
+			{isBrowserStudio ? (
+				<div style={labelStyle}>{job.outName}</div>
+			) : (
+				<button style={labelStyle} type="button" onClick={onClick}>
+					{job.outName}
+				</button>
+			)}
 			<div style={right}>
 				<RenderQueueOpenInFinderItem job={job} />
 			</div>

--- a/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback} from 'react';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {WHITE} from '../../helpers/colors';
 import {getFileManagerName} from '../../helpers/get-file-manager-name';
 import {ExpandedFolderIconSolid} from '../../icons/folder';
@@ -69,6 +70,7 @@ export const RenderModalOutputName = ({
 	const fileManagerName = getFileManagerName(
 		window.remotion_fileSystemPlatform,
 	);
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 
 	return (
 		<div style={outputNameRow}>
@@ -101,12 +103,14 @@ export const RenderModalOutputName = ({
 								align="flex-end"
 								message={
 									<span style={existsMessageStyle}>
-										<InlineAction
-											variant={null}
-											onClick={openExistingOutput}
-											renderAction={renderOpenIcon}
-											title={`Open in ${fileManagerName}`}
-										/>
+										{isBrowserStudio ? null : (
+											<InlineAction
+												variant={null}
+												onClick={openExistingOutput}
+												renderAction={renderOpenIcon}
+												title={`Open in ${fileManagerName}`}
+											/>
+										)}
 										Exists, will be overwritten
 									</span>
 								}

--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '@remotion/web-renderer';
 import {useCallback, useContext, useMemo, useState} from 'react';
 import {ShortcutHint} from '../../error-overlay/remotion-overlay/ShortcutHint';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {AudioIcon} from '../../icons/audio';
 import {CertificateIcon} from '../../icons/certificate';
 import {FileIcon} from '../../icons/file';
@@ -220,6 +221,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 				: 'still',
 	);
 	const [tab, setTab] = useState<TabType>('general');
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const [imageFormat, setImageFormat] = useState<RenderStillOnWebImageFormat>(
 		() => initialStillImageFormat ?? 'png',
 	);
@@ -710,24 +712,26 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 					>
 						Other
 					</VerticalTab>
-					<VerticalTab
-						style={horizontalTab}
-						selected={false}
-						onClick={() =>
-							setSelectedModal({
-								type: 'settings',
-								initialTab: 'license',
-								initialPublicLicenseKey: publicLicenseKey,
-							})
-						}
-						renderIcon={(color) => (
-							<div style={iconContainer}>
-								<CertificateIcon color={color} style={icon} />
-							</div>
-						)}
-					>
-						License
-					</VerticalTab>
+					{isBrowserStudio ? null : (
+						<VerticalTab
+							style={horizontalTab}
+							selected={false}
+							onClick={() =>
+								setSelectedModal({
+									type: 'settings',
+									initialTab: 'license',
+									initialPublicLicenseKey: publicLicenseKey,
+								})
+							}
+							renderIcon={(color) => (
+								<div style={iconContainer}>
+									<CertificateIcon color={color} style={icon} />
+								</div>
+							)}
+						>
+							License
+						</VerticalTab>
+					)}
 				</div>
 				<div style={optionsPanel} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 					{tab === 'general' ? (

--- a/packages/studio/src/components/RenderQueue/RenderQueueItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueItem.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import type {CanvasContent} from 'remotion';
 import {Internals} from 'remotion';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {getBackgroundFromHoverState} from '../../helpers/colors';
 import {pushUrl} from '../../helpers/url-state';
 import {Row, Spacing} from '../layout';
@@ -74,6 +75,7 @@ export const RenderQueueItem: React.FC<{
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
 
 	const isClientJob = isClientRenderJob(job);
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const {canDrag, isDragging, onDragEnd, onDragStart} =
 		useRenderOutputFileDrag(job);
 
@@ -229,13 +231,13 @@ export const RenderQueueItem: React.FC<{
 					{canRepeat ? <RenderQueueRepeatItem job={job} /> : null}
 					{job.status === 'running' ? (
 						<RenderQueueCancelButton job={job} />
-					) : (
+					) : isBrowserStudio ? null : (
 						<RenderQueueRemoveItem job={job} />
 					)}
 					{job.status === 'done' ? (
 						clientBlobInfo ? (
 							<RenderQueueDownloadItem job={job as ClientRenderJob} />
-						) : (
+						) : isBrowserStudio ? null : (
 							<RenderQueueOpenInFinderItem job={job} />
 						)
 					) : null}

--- a/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {CURRENT_COLOR} from '../../helpers/colors';
 import {ExpandedFolderIconSolid} from '../../icons/folder';
 import type {RenderInlineAction} from '../InlineAction';
@@ -10,6 +11,7 @@ import type {AnyRenderJob} from './context';
 export const RenderQueueOpenInFinderItem: React.FC<{
 	readonly job: AnyRenderJob;
 }> = ({job}) => {
+	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const onClick: React.MouseEventHandler = useCallback(
 		(e) => {
 			e.stopPropagation();
@@ -34,7 +36,7 @@ export const RenderQueueOpenInFinderItem: React.FC<{
 		[icon],
 	);
 
-	return (
+	return isBrowserStudio ? null : (
 		<InlineAction
 			renderAction={renderAction}
 			onClick={onClick}

--- a/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
@@ -77,6 +77,7 @@ export const RenderQueueRemoveItem: React.FC<{
 		<InlineAction
 			renderAction={renderAction}
 			onClick={onClick}
+			title="Remove"
 			variant={null}
 		/>
 	);

--- a/packages/studio/src/error-overlay/remotion-overlay/log-studio-error.ts
+++ b/packages/studio/src/error-overlay/remotion-overlay/log-studio-error.ts
@@ -1,10 +1,15 @@
 import type {LogStudioErrorRequest} from '@remotion/studio-shared';
 import {callApi} from '../../components/call-api';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 
 const loggedErrors = new Set<string>();
 const maxLoggedErrors = 100;
 
 export const logStudioErrorData = (data: LogStudioErrorRequest) => {
+	if (getBrowserStudioOperations() !== null) {
+		return;
+	}
+
 	const key = JSON.stringify([data.name, data.message, data.stack]);
 
 	if (loggedErrors.has(key)) {

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -177,7 +177,7 @@ const getFileMenu = ({
 					quickSwitcherLabel: 'Download project',
 				}
 			: null,
-		!readOnlyStudio && downloadProject
+		!readOnlyStudio && downloadProject && browserStudioOperations === null
 			? {
 					type: 'divider' as const,
 					id: 'open-project-divider',
@@ -218,7 +218,7 @@ const getFileMenu = ({
 					disabled: previewServerState !== 'connected',
 				}
 			: null,
-		!readOnlyStudio
+		!readOnlyStudio && browserStudioOperations === null
 			? {
 					id: 'open-project-in-explorer',
 					value: 'open-project-in-explorer',
@@ -355,6 +355,7 @@ export const useMenuStructure = (
 	const isFullscreenSupported = checkFullscreenSupport();
 
 	const {remotion_packageManager} = window;
+	const browserStudioOperations = getBrowserStudioOperations();
 
 	const sizePreselectIndex = sizes.findIndex(
 		(s) => String(size.size) === String(s.size),
@@ -441,26 +442,28 @@ export const useMenuStructure = (
 						subMenu: null,
 						quickSwitcherLabel: 'Help: Changelog',
 					},
-					{
-						id: 'settings',
-						value: 'settings',
-						label: 'Settings...',
-						onClick: () => {
-							closeMenu();
-							setSelectedModal({
-								type: 'settings',
-								initialTab: 'rendering',
-								initialPublicLicenseKey:
-									window.remotion_renderDefaults?.publicLicenseKey ?? null,
-							});
-						},
-						type: 'item' as const,
-						keyHint: null,
-						leftItem: null,
-						subMenu: null,
-						quickSwitcherLabel: 'Settings...',
-						disabled: readOnlyStudio || type !== 'connected',
-					},
+					browserStudioOperations === null
+						? {
+								id: 'settings',
+								value: 'settings',
+								label: 'Settings...',
+								onClick: () => {
+									closeMenu();
+									setSelectedModal({
+										type: 'settings',
+										initialTab: 'rendering',
+										initialPublicLicenseKey:
+											window.remotion_renderDefaults?.publicLicenseKey ?? null,
+									});
+								},
+								type: 'item' as const,
+								keyHint: null,
+								leftItem: null,
+								subMenu: null,
+								quickSwitcherLabel: 'Settings...',
+								disabled: readOnlyStudio || type !== 'connected',
+							}
+						: null,
 					{
 						id: 'acknowledgements',
 						value: 'acknowledgements',
@@ -475,24 +478,28 @@ export const useMenuStructure = (
 						subMenu: null,
 						quickSwitcherLabel: 'Help: Acknowledgements',
 					},
-					{
-						type: 'divider' as const,
-						id: 'timeline-divider-1',
-					},
-					{
-						id: 'restart-studio',
-						value: 'restart-studio',
-						label: 'Restart Studio Server',
-						onClick: () => {
-							closeMenu();
-							restartStudio();
-						},
-						type: 'item' as const,
-						keyHint: null,
-						leftItem: null,
-						subMenu: null,
-						quickSwitcherLabel: 'Restart Studio Server',
-					},
+					browserStudioOperations === null
+						? {
+								type: 'divider' as const,
+								id: 'timeline-divider-1',
+							}
+						: null,
+					browserStudioOperations === null
+						? {
+								id: 'restart-studio',
+								value: 'restart-studio',
+								label: 'Restart Studio Server',
+								onClick: () => {
+									closeMenu();
+									restartStudio();
+								},
+								type: 'item' as const,
+								keyHint: null,
+								leftItem: null,
+								subMenu: null,
+								quickSwitcherLabel: 'Restart Studio Server',
+							}
+						: null,
 				].filter(NoReactInternals.truthy),
 				quickSwitcherLabel: null,
 			},
@@ -1145,6 +1152,7 @@ export const useMenuStructure = (
 		defaultEditorName,
 		keyboardShortcutsDisabled,
 		studioAskAIEnabled,
+		browserStudioOperations,
 		size.size,
 		setSize,
 		setEditorZoomGestures,

--- a/packages/studio/src/test/asset-context-menu.test.ts
+++ b/packages/studio/src/test/asset-context-menu.test.ts
@@ -34,6 +34,7 @@ test('keeps copy and open-in-new-window asset actions enabled in read-only Studi
 		openAssetInExplorer: noop,
 		renameAsset: noop,
 		deleteAsset: noop,
+		fileExplorerAvailable: true,
 		...availability,
 	});
 
@@ -43,6 +44,25 @@ test('keeps copy and open-in-new-window asset actions enabled in read-only Studi
 	expect(getItem(items, 'open-asset-in-explorer').disabled).toBe(true);
 	expect(getItem(items, 'rename-asset').disabled).toBe(true);
 	expect(getItem(items, 'delete-asset').disabled).toBe(true);
+});
+
+test('hides file-manager asset actions in Browser Studio', () => {
+	const items = getAssetContextMenuItems({
+		relativePath: 'nested/video.mp4',
+		fileManagerName: 'Finder',
+		copyFileName: noop,
+		copyStaticFilePath: noop,
+		openAssetInExplorer: noop,
+		renameAsset: noop,
+		deleteAsset: noop,
+		fileExplorerAvailable: false,
+		fileExplorerDisabled: true,
+		mutationsDisabled: false,
+	});
+
+	expect(items.find((item) => item.id === 'open-asset-in-explorer')).toBe(
+		undefined,
+	);
 });
 
 test('only offers file-manager actions when a local public folder is available', () => {

--- a/packages/studio/src/test/browser-studio-log-errors.test.ts
+++ b/packages/studio/src/test/browser-studio-log-errors.test.ts
@@ -1,0 +1,42 @@
+import {afterEach, expect, test} from 'bun:test';
+import {logStudioErrorData} from '../error-overlay/remotion-overlay/log-studio-error';
+import {makeBrowserStudioOperations} from './make-browser-studio-operations';
+
+const originalFetch = globalThis.fetch;
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+		return;
+	}
+
+	Reflect.deleteProperty(globalThis, 'window');
+});
+
+test('does not send Studio errors to the server from Browser Studio', () => {
+	const fetchCalls: string[] = [];
+	globalThis.fetch = ((input) => {
+		fetchCalls.push(String(input));
+		return Promise.reject(new Error('Unexpected request'));
+	}) as typeof fetch;
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			remotion_browserStudio: makeBrowserStudioOperations({}),
+		},
+	});
+
+	logStudioErrorData({
+		message: 'Browser Studio error',
+		name: 'Error',
+		stack: 'stack',
+		symbolicatedStackFrames: null,
+	});
+
+	expect(fetchCalls).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- hide file explorer, Studio restart, render removal, and Settings actions in Browser Studio
- make Studio error logging a no-op in Browser Studio
- cover the Browser Studio workflow with a zero-server-API assertion and focused unit tests

Closes the browser-only exclusions in #9807.

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/asset-context-menu.test.ts src/test/browser-studio-log-errors.test.ts` in `packages/studio`
- `bunx playwright test e2e/browser-studio.test.ts --grep 'loads Browser Studio and can add, delete, and duplicate'` in `packages/browser-studio`
