### PR TITLE
`@remotion/media`: Avoid buffering deadlock when a loop starts in silence

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -283,7 +283,10 @@ export const audioIteratorManager = ({
 		) => number | null;
 		playbackRate: number;
 		scheduleAudioNode: ScheduleAudioNode;
-		onScheduled: (sourceDurationInSeconds: number) => void;
+		onScheduled: (
+			sourceDurationInSeconds: number,
+			timelineTimestamp: number,
+		) => void;
 		onDone: () => void;
 		onDestroyed: () => void;
 		logLevel: LogLevel;
@@ -331,7 +334,10 @@ export const audioIteratorManager = ({
 					return;
 				}
 
-				onScheduled(result.value.sourceDurationInSeconds);
+				onScheduled(
+					result.value.sourceDurationInSeconds,
+					result.value.timelineTimestamp,
+				);
 				notifyNodeScheduled();
 
 				onAudioChunk({
@@ -443,7 +449,7 @@ export const audioIteratorManager = ({
 		audioIteratorsCreated++;
 		audioBufferIterator = iterator;
 
-		let bufferedDuration = 0;
+		let bufferedUntil = startFromSecond;
 		let hasUnblockedPlayback = false;
 		const unblockPlayback = () => {
 			if (hasUnblockedPlayback) {
@@ -460,12 +466,17 @@ export const audioIteratorManager = ({
 			getTargetTime,
 			playbackRate,
 			scheduleAudioNode,
-			onScheduled: (sourceDurationInSeconds) => {
-				bufferedDuration += sourceDurationInSeconds;
+			onScheduled: (sourceDurationInSeconds, timelineTimestamp) => {
+				bufferedUntil = Math.max(
+					bufferedUntil,
+					timelineTimestamp + sourceDurationInSeconds,
+				);
+				const bufferedDuration = bufferedUntil - startFromSecond;
 				// Need to schedule a bit into the future to unblock the buffer state,
 				// otherwise we might be scheduling too late. This must be based on
-				// duration, not chunk count, because large PCM chunks can exceed the
-				// scheduling horizon before enough chunks are queued:
+				// timeline coverage, not audible duration or chunk count: silence is
+				// already safe to play, and large PCM chunks can exceed the scheduling
+				// horizon before enough chunks are queued:
 				// https://github.com/remotion-dev/remotion/issues/9394
 				if (hasEnoughAudioToStartPlayback(bufferedDuration)) {
 					unblockPlayback();
@@ -588,12 +599,19 @@ export const audioIteratorManager = ({
 			}
 
 			const currentIteratorTimestamp = audioBufferIterator.guessNextTimestamp();
+			const iteratorHasAdvancedThroughSilence =
+				loop &&
+				currentAnchor !== null &&
+				unloopedNewTime >= currentAnchor.unloopedStartInSeconds &&
+				currentIteratorTimestamp >= timeToCheck;
 			if (
-				currentIteratorTimestamp < timeToCheck &&
-				Math.abs(currentIteratorTimestamp - timeToCheck) < 1
+				iteratorHasAdvancedThroughSilence ||
+				(currentIteratorTimestamp < timeToCheck &&
+					Math.abs(currentIteratorTimestamp - timeToCheck) < 1)
 			) {
 				processNext();
-				// iterator is less than 1 second behind, we will just let it run
+				// The iterator has either advanced beyond the current time, meaning
+				// the gap is known silence, or is less than 1 second behind. Let it run.
 				return;
 			}
 		}

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -186,6 +186,33 @@ test('PCM chunks unblock playback based on duration before six chunks or EOF', a
 	manager.destroyIterator();
 });
 
+// https://github.com/remotion-dev/remotion/issues/10658
+test('silence before the next loop pass counts toward startup buffering', async () => {
+	const {
+		manager,
+		seek,
+		scheduledChunks,
+		audioContextCurrentTime,
+		getPlaybackUnblocks,
+	} = await prepare({
+		src: 'https://remotion.media/audio-shorter-than-video.mp4',
+		mediaEndTimestamp: 10,
+		sequenceDurationInSeconds: 12,
+		loop: true,
+	});
+
+	audioContextCurrentTime.current = 8;
+	seek({time: 8});
+	await manager.waitForNScheduledNodes(1);
+
+	expect(scheduledChunks[0]).toBeCloseTo(10);
+	expect(getPlaybackUnblocks()).toBe(1);
+
+	seek({time: 8 + 1 / 30});
+	expect(manager.getAudioIteratorsCreated()).toBe(1);
+	manager.destroyIterator();
+});
+
 test('media player should work', async () => {
 	const {manager, scheduledChunks, seek, audioContextCurrentTime} =
 		await prepare();


### PR DESCRIPTION
Fixes a preview playback deadlock when a looped media item starts inside the silent range between its audio track ending and the media loop boundary.

Startup buffering now measures scheduled timeline coverage instead of only summing audible sample duration. The iterator is also reused while it has already advanced through known loop silence.

Includes a focused browser regression test using the short-audio fixture introduced in #10657.

## Test plan

- `bunx vitest src/test/audio-iterator.test.ts src/test/looping-audio-timestamps.test.ts --browser --run` from `packages/media`
- `bun run build`
- `bun run stylecheck`

Closes #10658
