### PR TITLE
`@remotion/media`: paint completed frame of a superseded seek to fix paused-scrub freeze

### DIFF
--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -186,6 +186,15 @@ export const videoIteratorManager = async ({
 		}
 
 		if (nonce.isStale()) {
+			// A superseded seek has still paid for a completed decode. During a
+			// paused scrub, every seek is superseded by the next pointer move
+			// before its decode lands, so returning here undrawn would discard
+			// every frame and freeze the preview for the whole drag. Painting
+			// the completed frame is safe: the newer seek is already queued and
+			// lands last, so this is monotonic progress toward the target.
+			if (!videoFrameIterator.isDestroyed() && iterator.initialFrame) {
+				await drawFrame(iterator.initialFrame);
+			}
 			return;
 		}
 

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -192,6 +192,7 @@ export const videoIteratorManager = async ({
 			if (!videoFrameIterator.isDestroyed() && iterator.initialFrame) {
 				await drawFrame(iterator.initialFrame);
 			}
+
 			return;
 		}
 

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -186,12 +186,9 @@ export const videoIteratorManager = async ({
 		}
 
 		if (nonce.isStale()) {
-			// A superseded seek has still paid for a completed decode. During a
-			// paused scrub, every seek is superseded by the next pointer move
-			// before its decode lands, so returning here undrawn would discard
-			// every frame and freeze the preview for the whole drag. Painting
-			// the completed frame is safe: the newer seek is already queued and
-			// lands last, so this is monotonic progress toward the target.
+			// During a paused scrub, every seek goes stale before its decode
+			// lands, so returning undrawn would discard every frame and freeze
+			// the preview. Painting is safe: the newer seek always lands last.
 			if (!videoFrameIterator.isDestroyed() && iterator.initialFrame) {
 				await drawFrame(iterator.initialFrame);
 			}


### PR DESCRIPTION
Fixes #10661

During paused scrubbing, every seek's nonce goes stale before its decode completes, so `startVideoIterator` discarded 100% of decoded frames undrawn and the preview froze for the entire drag.

This paints the already-completed frame before returning when the nonce is stale. The superseding seek is already queued and always lands last, so the painted frame is monotonic progress toward the target, never a step backwards.

Guarded on `videoFrameIterator.isDestroyed()` and `iterator.initialFrame` (media ended), matching the guards on the non-stale path below it.

Verified in a production editor built on `@remotion/player` + `@remotion/media`: paused scrubbing repaints continuously instead of freezing, with no regressions observed in playback, seek-while-playing, or rapid seek-direction changes over several weeks of use.
