### PR TITLE
`@remotion/studio-server`: Support multiplication by numeric constants

### DIFF
--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -304,6 +304,7 @@ import {VideoTestingTrim} from './VideoTesting/trim';
 import {RemotionMediaVideoTexture} from './VideoTexture';
 import {VisualControls} from './VisualControls';
 import {AffineFrameClock} from './VisualModeTests/AffineFrameClock';
+import {ConstantMultiplication} from './VisualModeTests/ConstantMultiplication';
 import {FastUpdates} from './VisualModeTests/FastUpdates';
 import {FastUpdatesNested} from './VisualModeTests/FastUpdatesNested';
 import {
@@ -2886,6 +2887,14 @@ export const Index: React.FC = () => {
 				durationInFrames={180}
 			/>
 			<Folder name="VisualModeTests">
+				<Composition
+					id="constant-multiplication"
+					component={ConstantMultiplication}
+					width={1280}
+					height={720}
+					fps={30}
+					durationInFrames={300}
+				/>
 				<Composition
 					id="affine-frame-clock"
 					component={AffineFrameClock}

--- a/packages/example/src/VisualModeTests/ConstantMultiplication.tsx
+++ b/packages/example/src/VisualModeTests/ConstantMultiplication.tsx
@@ -1,0 +1,40 @@
+import {AbsoluteFill, Sequence} from 'remotion';
+
+const fps = 30;
+
+export const ConstantMultiplication = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				backgroundColor: '#08111f',
+				color: '#e8eef8',
+				fontFamily: 'sans-serif',
+				justifyContent: 'center',
+			}}
+		>
+			<Sequence
+				name="Numeric constant: from={-8 * fps}"
+				from={-8 * fps}
+				layout="none"
+			>
+				<div
+					style={{
+						backgroundColor: '#12335b',
+						border: '2px solid #4ea1ff',
+						borderRadius: 24,
+						padding: '36px 48px',
+						textAlign: 'center',
+					}}
+				>
+					<div style={{fontSize: 42, fontWeight: 700}}>
+						Constant multiplication
+					</div>
+					<code style={{display: 'block', fontSize: 28, marginTop: 20}}>
+						{'from={-8 * fps}'}
+					</code>
+				</div>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio-codemods/src/sequence-props/video-config-values.ts
+++ b/packages/studio-codemods/src/sequence-props/video-config-values.ts
@@ -11,17 +11,23 @@ export const getVideoConfigIdentifierValues = ({
 	ast: File;
 	videoConfigValues: VideoConfigValues | null;
 }): VideoConfigIdentifierValues => {
-	if (videoConfigValues === null) {
-		return {};
-	}
-
 	const candidates = new Map<string, number>();
 	const otherDeclarations = new Set<string>();
+	const addCandidate = (identifier: string, value: number) => {
+		if (candidates.has(identifier) || otherDeclarations.has(identifier)) {
+			candidates.delete(identifier);
+			otherDeclarations.add(identifier);
+			return;
+		}
+
+		candidates.set(identifier, value);
+	};
 
 	recast.types.visit(ast, {
 		visitVariableDeclarator(path) {
 			const {id, init} = path.node;
 			const isVideoConfigDeclaration =
+				videoConfigValues !== null &&
 				id.type === 'ObjectPattern' &&
 				init?.type === 'CallExpression' &&
 				init.callee.type === 'Identifier' &&
@@ -50,11 +56,25 @@ export const getVideoConfigIdentifierValues = ({
 
 					const value = videoConfigValues[configKey as keyof VideoConfigValues];
 					if (Number.isFinite(value)) {
-						candidates.set(property.value.name, value);
+						addCandidate(property.value.name, value);
 					}
 				}
 			} else if (id.type === 'Identifier') {
-				otherDeclarations.add(id.name);
+				const declaration = path.parentPath.node;
+				const numericConstant =
+					declaration.type === 'VariableDeclaration' &&
+					declaration.kind === 'const' &&
+					init?.type === 'NumericLiteral' &&
+					Number.isFinite(init.value)
+						? init.value
+						: null;
+
+				if (numericConstant !== null) {
+					addCandidate(id.name, numericConstant);
+				} else {
+					candidates.delete(id.name);
+					otherDeclarations.add(id.name);
+				}
 			}
 
 			this.traverse(path);

--- a/packages/studio-codemods/src/test/update-sequence-props.test.ts
+++ b/packages/studio-codemods/src/test/update-sequence-props.test.ts
@@ -55,3 +55,43 @@ test('patches an opening element without reprinting its siblings', () => {
 };
 `);
 });
+
+test('preserves multiplication by a numeric constant', () => {
+	const input = `import {Sequence} from 'remotion';
+
+const fps = 30;
+
+export const ShortAudioLoop = () => {
+	return <Sequence from={-8 * fps} layout="none" />;
+};
+`;
+	const ast = parseAst(input);
+	let nodePath = null;
+	recast.types.visit(ast, {
+		visitJSXOpeningElement(path) {
+			if (path.node.loc?.start.line === 6) {
+				nodePath = getNodePathForRecastPath(path, ast);
+				return false;
+			}
+
+			return this.traverse(path);
+		},
+	});
+	if (!nodePath) {
+		throw new Error('Could not find the Sequence');
+	}
+
+	const {output} = updateMultipleSequenceProps({
+		input,
+		changes: [
+			{
+				nodePath,
+				updates: [{key: 'from', value: -300, defaultValue: null}],
+				schema: NoReactInternals.sequenceSchema,
+				videoConfigValues: null,
+			},
+		],
+	});
+
+	expect(output).toContain('from={-10 * fps}');
+});

--- a/packages/studio-server/src/helpers/video-config-values.ts
+++ b/packages/studio-server/src/helpers/video-config-values.ts
@@ -11,17 +11,23 @@ export const getVideoConfigIdentifierValues = ({
 	ast: File;
 	videoConfigValues: VideoConfigValues | null;
 }): VideoConfigIdentifierValues => {
-	if (videoConfigValues === null) {
-		return {};
-	}
-
 	const candidates = new Map<string, number>();
 	const otherDeclarations = new Set<string>();
+	const addCandidate = (identifier: string, value: number) => {
+		if (candidates.has(identifier) || otherDeclarations.has(identifier)) {
+			candidates.delete(identifier);
+			otherDeclarations.add(identifier);
+			return;
+		}
+
+		candidates.set(identifier, value);
+	};
 
 	recast.types.visit(ast, {
 		visitVariableDeclarator(path) {
 			const {id, init} = path.node;
 			const isVideoConfigDeclaration =
+				videoConfigValues !== null &&
 				id.type === 'ObjectPattern' &&
 				init?.type === 'CallExpression' &&
 				init.callee.type === 'Identifier' &&
@@ -50,11 +56,25 @@ export const getVideoConfigIdentifierValues = ({
 
 					const value = videoConfigValues[configKey as keyof VideoConfigValues];
 					if (Number.isFinite(value)) {
-						candidates.set(property.value.name, value);
+						addCandidate(property.value.name, value);
 					}
 				}
 			} else if (id.type === 'Identifier') {
-				otherDeclarations.add(id.name);
+				const declaration = path.parentPath.node;
+				const numericConstant =
+					declaration.type === 'VariableDeclaration' &&
+					declaration.kind === 'const' &&
+					init?.type === 'NumericLiteral' &&
+					Number.isFinite(init.value)
+						? init.value
+						: null;
+
+				if (numericConstant !== null) {
+					addCandidate(id.name, numericConstant);
+				} else {
+					candidates.delete(id.name);
+					otherDeclarations.add(id.name);
+				}
 			}
 
 			this.traverse(path);

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -299,6 +299,39 @@ export const Example: React.FC = () => {
 	});
 });
 
+test('computeSequencePropsStatus should parse multiplication by a numeric constant', () => {
+	const input = `import {Sequence} from 'remotion';
+
+const fps = 30;
+
+export const ShortAudioLoop = () => {
+	return <Sequence from={-8 * fps} layout="none" />;
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 6),
+		componentIdentity: null,
+		keys: ['from'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	expect(result.props.from).toEqual({
+		status: 'static',
+		keyframeDisplayOffsetAdjustment: null,
+		codeValue: -240,
+		numericExpression: {
+			type: 'video-config-multiplication',
+			identifier: 'fps',
+			multiplier: -8,
+			multiplicand: 30,
+			factorPosition: 'left',
+			value: -240,
+		},
+	});
+});
+
 test('computeSequencePropsStatus should expand a static border shorthand', () => {
 	const input = `import {AbsoluteFill} from 'remotion';
 


### PR DESCRIPTION
## Summary

- recognize uniquely declared numeric constants in Studio interactivity expressions
- preserve constant-backed multiplication when updating a value, such as changing `-8 * fps` to `-10 * fps`
- cover both expression analysis and codemod write-back
- add a `constant-multiplication` composition to the Visual Mode testbed

Closes #10666

## Testing

- `bun test packages/studio-codemods/src/test/update-sequence-props.test.ts packages/studio-server/src/test/compute-sequence-props-status.test.ts`
- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint formatting --filter='@remotion/example'`
- `bunx tsc --project packages/example/tsconfig.json --noEmit`
- `bunx remotion still constant-multiplication --output /tmp/constant-multiplication.png --log=error`

An additional package-wide test sweep passed 584 tests; four unrelated existing logging/editor-launch tests failed.
