### PR TITLE
`@remotion/studio`: Preserve property selection during outline dragging

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -12,6 +12,12 @@ import {navigateToLostNodePathE2e, navigateToSchemaTest} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
 const macCursorsFile = path.join(exampleDir, 'src', 'MacCursors', 'index.tsx');
+const outlineSelectionCasesFile = path.join(
+	exampleDir,
+	'src',
+	'VisualModeTests',
+	'OutlineSelectionCases.tsx',
+);
 
 const dropAssetOnCanvas = async ({
 	assetPath,
@@ -511,6 +517,95 @@ test.describe('visual mode', () => {
 			.locator('.remotion-studio-composition-container')
 			.dispatchEvent('pointerleave');
 		await expect(duplicateButton).toBeVisible();
+	});
+
+	test('should preserve property selection while dragging its outline', async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
+		const sourceBefore = fs.readFileSync(outlineSelectionCasesFile, 'utf-8');
+
+		try {
+			await page.goto(`${STUDIO_URL}/outline-selection-cases`);
+			await page.waitForFunction(
+				() => !document.body.innerText.includes('Loading...'),
+				{timeout: 30_000},
+			);
+			await page.keyboard.press('g');
+			const currentFrameInput = page.locator('input:focus');
+			await expect(currentFrameInput).toBeVisible();
+			await currentFrameInput.fill('2010');
+			await currentFrameInput.press('Enter');
+
+			const canvas = page.locator('.remotion-studio-composition-container');
+			const target = canvas
+				.getByText('Select one of my properties, then drag me', {exact: true})
+				.locator('..');
+			await expect(target).toBeVisible({timeout: 15_000});
+			await expect(page.getByText('Baseline', {exact: true})).toBeVisible();
+
+			const timelineItem = page
+				.getByTitle('Property-selected sequence', {exact: true})
+				.first();
+			const offsetProperty = page.getByTitle('Offset', {exact: true});
+			await expect(async () => {
+				await expect(timelineItem).toBeVisible({timeout: 1000});
+				await timelineItem.click();
+				await page.keyboard.press('p');
+				await expect(offsetProperty).toBeVisible({timeout: 1000});
+			}).toPass({timeout: 15_000});
+			await offsetProperty.click();
+			const offsetSelection = offsetProperty.locator('..');
+			await expect(offsetSelection).toHaveCSS(
+				'background-color',
+				'rgba(255, 255, 255, 0.1)',
+			);
+
+			const outline = canvas.locator(
+				'> svg[aria-hidden="true"] polygon[data-remotion-prevent-selection-clear="true"][stroke-opacity="1"]',
+			);
+			await expect(outline).toHaveCount(1);
+
+			const targetBefore = await target.boundingBox();
+			const outlineBefore = await outline.boundingBox();
+			if (targetBefore === null || outlineBefore === null) {
+				throw new Error('Expected the selected outline to have a bounding box');
+			}
+
+			const dragStart = {
+				x: outlineBefore.x + outlineBefore.width / 2,
+				y: outlineBefore.y + outlineBefore.height / 2,
+			};
+			await page.mouse.move(dragStart.x, dragStart.y);
+			await page.mouse.down();
+			await expect(offsetSelection).toHaveCSS(
+				'background-color',
+				'rgba(255, 255, 255, 0.1)',
+			);
+			await page.mouse.move(dragStart.x + 60, dragStart.y, {steps: 5});
+			await page.mouse.up();
+
+			await expect
+				.poll(async () => (await target.boundingBox())?.x ?? null)
+				.toBeCloseTo(targetBefore.x + 60, 0);
+			await expect(offsetSelection).toHaveCSS(
+				'background-color',
+				'rgba(255, 255, 255, 0.1)',
+			);
+			await expect
+				.poll(() => {
+					const source = fs.readFileSync(outlineSelectionCasesFile, 'utf-8');
+					const targetIndex = source.indexOf(
+						'name="Property-selected sequence"',
+					);
+					return source
+						.slice(targetIndex, targetIndex + 1000)
+						.match(/translate: '([^']+)'/)?.[1];
+				})
+				.not.toBe('0px 0px');
+		} finally {
+			fs.writeFileSync(outlineSelectionCasesFile, sourceBefore);
+		}
 	});
 
 	test('should compensate DOM measurements with useCurrentScale() on direct load', async ({

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -19,6 +19,7 @@ import {TimelineVirtualizationTestbed} from './TimelineVirtualizationTestbed';
 import {VisualControls} from './VisualControls';
 import {VisualMode3D} from './VisualMode3D';
 import {AffineFrameClock} from './VisualModeTests/AffineFrameClock';
+import {OutlineSelectionCases} from './VisualModeTests/OutlineSelectionCases';
 import {SequenceShiftRepro} from './VisualModeTests/SequenceShiftRepro';
 
 const UseCurrentScaleOnLoad: React.FC = () => {
@@ -190,6 +191,14 @@ export const E2eTestRoot: React.FC = () => {
 				height={720}
 				fps={30}
 				durationInFrames={60}
+			/>
+			<Composition
+				id="outline-selection-cases"
+				component={OutlineSelectionCases}
+				width={1920}
+				height={1080}
+				fps={30}
+				durationInFrames={2340}
 			/>
 			<Composition
 				id="sequence-shift-repro"

--- a/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
+++ b/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
@@ -711,11 +711,11 @@ export const OutlineSelectionCases: React.FC = () => {
 			>
 				<CaseFrame
 					caseNumber={12}
-					status="Gap"
+					status="Baseline"
 					title="Property selection survives outline dragging"
-					summary="A selected property raises its containing sequence, but pointer-down on the polygon can promote selection to the whole sequence."
-					desiredBehavior="Dragging the sequence outline preserves the property or keyframe selection while translating the owning sequence."
-					instructions="Select a property of Property-selected sequence, then drag the purple rectangle. The property selection should remain active."
+					summary="Click and drag gestures are arbitrated after the movement threshold, so dragging an outline does not replace its selected property."
+					desiredBehavior="Clicking the outline selects the sequence. Dragging it preserves the property or keyframe selection while translating the owning sequence."
+					instructions="Select a property of Property-selected sequence. Click the purple rectangle to select the sequence, or reselect the property and drag the rectangle to move it without changing selection."
 				>
 					<Interactive.Div
 						name="Property-selected sequence"

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -510,6 +510,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 			<SelectedOutlinePolygon
 				compositionHeight={compositionHeight}
 				compositionWidth={compositionWidth}
+				containsSelection={layoutTarget?.containsSelection === true}
 				directlySelected={layoutTarget?.selected === true}
 				dragging={dragging}
 				getAllDragOutlines={getAllDragOutlines}

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -65,6 +65,7 @@ import type {
 const SelectedOutlinePolygonUnmemoized: React.FC<{
 	readonly compositionHeight: number;
 	readonly compositionWidth: number;
+	readonly containsSelection: boolean;
 	readonly directlySelected: boolean;
 	readonly dragging: boolean;
 	readonly getAllDragOutlines: () => readonly SelectedOutline[];
@@ -94,6 +95,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 }> = ({
 	compositionHeight,
 	compositionWidth,
+	containsSelection,
 	directlySelected,
 	dragging,
 	getAllDragOutlines,
@@ -196,7 +198,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				!selected &&
 				!interaction.shiftKey &&
 				!interaction.toggleKey &&
-				pointerInsideSelectedOutline;
+				(containsSelection || pointerInsideSelectedOutline);
 			if (!deferSelection && shouldUpdateSelection) {
 				onSelect(target.selection, interaction);
 			}
@@ -454,6 +456,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			clearDragOverrides,
 			compositionHeight,
 			compositionWidth,
+			containsSelection,
 			editorShowGuides,
 			editorSnapping,
 			getAllDragOutlines,


### PR DESCRIPTION
## Summary

- defer outline selection when the owning sequence contains the current property or keyframe selection
- preserve plain-click behavior while keeping property selection intact during drags
- mark outline-selection case 12 as baseline and cover it with a Studio Playwright regression test

## Tests

- `bunx playwright test e2e/studio.test.mts --grep "should preserve property selection while dragging its outline"`
- `bunx turbo run test --filter=@remotion/studio` (605 tests)
- `bun run build`
- `bun run stylecheck`

Closes #10458
