### PR TITLE
`@remotion/captions`: Add ESM export

### DIFF
--- a/packages/captions/bundle.ts
+++ b/packages/captions/bundle.ts
@@ -1,0 +1,17 @@
+import {build} from 'bun';
+
+if (process.env.NODE_ENV !== 'production') {
+	throw new Error('This script must be run using NODE_ENV=production');
+}
+
+const output = await build({
+	entrypoints: ['src/index.ts'],
+	naming: '[name].mjs',
+});
+
+const [file] = output.outputs;
+const text = await file.text();
+
+await Bun.write('dist/esm/index.mjs', text);
+
+export {};

--- a/packages/captions/package.json
+++ b/packages/captions/package.json
@@ -6,6 +6,8 @@
 	"version": "4.0.514",
 	"description": "Primitives for dealing with captions",
 	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"module": "dist/esm/index.mjs",
 	"bugs": {
 		"url": "https://github.com/remotion-dev/remotion/issues"
 	},
@@ -14,7 +16,7 @@
 		"format": "oxfmt src",
 		"lint": "eslint src",
 		"test": "bun test src",
-		"make": "tsgo -d"
+		"make": "tsgo -d && bun --env-file=../.env.bundle bundle.ts"
 	},
 	"author": "Jonny Burger <jonny@remotion.dev>",
 	"license": "MIT",
@@ -28,6 +30,15 @@
 	"keywords": [
 		"remotion"
 	],
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"module": "./dist/esm/index.mjs",
+			"import": "./dist/esm/index.mjs",
+			"require": "./dist/index.js"
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
## Summary

- declare explicit CommonJS and ESM entry points for `@remotion/captions`
- add the ESM bundle to the package build
- export `package.json` through the package export map

## Testing

- `bun test src` in `packages/captions`
- Node CommonJS `require('@remotion/captions')`
- Node ESM `import('@remotion/captions')`
- `bun run build`
- `bun run stylecheck`
