### PR TITLE
`@remotion/browser-studio`: Fix links and File menu divider

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -64,6 +64,16 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			expect(popup.url()).toBe('https://remotion.dev/');
 			await popup.close();
 			await studio.getByRole('button', {name: 'File', exact: true}).click();
+			const fileMenu = studio
+				.locator('[data-remotion-menu-tree-id]')
+				.filter({hasText: 'New composition...'});
+			await expect(fileMenu).toBeVisible();
+			await expect(
+				fileMenu.getByText('New folder...', {exact: true}),
+			).toBeVisible();
+			await expect(fileMenu.getByRole('separator')).toHaveCount(0, {
+				timeout: 1000,
+			});
 			await expect(
 				studio.getByRole('button', {
 					name: 'Open in File Manager',

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -4,7 +4,7 @@ import {
 	StudioProtocolInternals,
 } from '@remotion/studio-protocol';
 
-test('loads Browser Studio and can add, delete, and duplicate', async ({
+test('loads Browser Studio, opens external links, and can add, delete, and duplicate', async ({
 	page,
 }) => {
 	const pageErrors: Error[] = [];
@@ -42,6 +42,9 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 		pageErrors.push(error);
 		rejectPageError(error);
 	});
+	await page.context().route('https://remotion.dev/**', async (route) => {
+		await route.fulfill({body: 'About Remotion', contentType: 'text/html'});
+	});
 
 	await Promise.race([
 		(async () => {
@@ -53,6 +56,13 @@ test('loads Browser Studio and can add, delete, and duplicate', async ({
 			await expect(
 				studio.locator('.remotion-studio-composition-container'),
 			).toBeVisible();
+			await studio.locator('button:has(svg[viewBox="0 0 415 426"])').click();
+			const popupPromise = page.waitForEvent('popup');
+			await studio.getByText('About Remotion', {exact: true}).click();
+			const popup = await popupPromise;
+			await popup.waitForLoadState('domcontentloaded');
+			expect(popup.url()).toBe('https://remotion.dev/');
+			await popup.close();
 			await studio.getByRole('button', {name: 'File', exact: true}).click();
 			await expect(
 				studio.getByRole('button', {

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -564,7 +564,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 					ref={iframeRef}
 					allow="cross-origin-isolated"
 					onLoad={() => setIframeLoaded(true)}
-					sandbox="allow-scripts allow-same-origin allow-downloads"
+					sandbox="allow-scripts allow-same-origin allow-downloads allow-popups allow-popups-to-escape-sandbox"
 					src={iframeSrc ?? 'about:blank'}
 					style={iframeStyle}
 					title="Remotion Studio"

--- a/packages/studio/src/components/Menu/MenuDivider.tsx
+++ b/packages/studio/src/components/Menu/MenuDivider.tsx
@@ -9,5 +9,5 @@ const menuDivider: React.CSSProperties = {
 };
 
 export const MenuDivider: React.FC = () => {
-	return <div style={menuDivider} />;
+	return <div role="separator" style={menuDivider} />;
 };

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -72,7 +72,7 @@ const getFileMenu = ({
 		window.remotion_fileSystemPlatform,
 	);
 	const browserStudioOperations = getBrowserStudioOperations();
-	const items: ComboboxValue[] = [
+	const newProjectItems: ComboboxValue[] = [
 		readOnlyStudio
 			? null
 			: {
@@ -117,12 +117,8 @@ const getFileMenu = ({
 					quickSwitcherLabel: 'New folder...',
 					disabled: previewServerState !== 'connected',
 				},
-		readOnlyStudio
-			? null
-			: {
-					type: 'divider' as const,
-					id: 'new-project-item-divider',
-				},
+	].filter(NoReactInternals.truthy);
+	const projectItems: ComboboxValue[] = [
 		window.remotion_isReadOnlyStudio
 			? {
 					id: 'input-props-override',
@@ -202,6 +198,16 @@ const getFileMenu = ({
 			: null,
 
 		getGitMenuItem(),
+	].filter(NoReactInternals.truthy);
+	const items: ComboboxValue[] = [
+		...newProjectItems,
+		newProjectItems.length > 0 && projectItems.length > 0
+			? {
+					type: 'divider' as const,
+					id: 'new-project-item-divider',
+				}
+			: null,
+		...projectItems,
 	].filter(NoReactInternals.truthy);
 	if (items.length === 0) {
 		return null;


### PR DESCRIPTION
## Summary

- allow Browser Studio's sandboxed iframe to open external links in normal browser tabs
- let opened destinations escape the Studio iframe sandbox
- only render the File menu divider when visible actions exist on both sides
- expose menu dividers with the semantic separator role
- cover the external-link and File-menu behavior in the Browser Studio Playwright workflow

## Test plan

- `bunx playwright test e2e/browser-studio.test.ts -g "opens external links"`
- `bun test src/test` in `packages/browser-studio`
- `bun run build`
- `bun run stylecheck`
