### PR TITLE
`@remotion/studio`: Copy agent context from inspector rows

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -5,6 +5,7 @@ import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-sou
 import {canUseEffectOperations} from '../../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {TIMELINE_BLUE, WHITE_ALPHA_80} from '../../helpers/colors';
+import {formatContextForAgents} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {
 	EXPANDED_SECTION_PADDING_RIGHT,
@@ -15,6 +16,7 @@ import {deleteEffects, reorderEffect} from '../effect-operations-api';
 import type {GetIsExpanded} from '../ExpandedTracksProvider';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
+import {getCopyContextForAgentsMenuItem} from './get-copy-context-for-agents-menu-item';
 import {saveEffectProp} from './save-effect-prop';
 import {
 	TimelineExpandArrowButton,
@@ -214,15 +216,28 @@ export const TimelineEffectItem: React.FC<{
 	}, [deleteDisabled, effectIndex, nodePath, validatedLocation.source]);
 
 	const getContextMenuItems = useCallback((): ComboboxValue[] => {
-		if (!previewConnected) {
-			return [];
-		}
-
 		if (selection.selectable) {
 			selection.onSelect({shiftKey: false, toggleKey: false});
 		}
 
-		const items: ComboboxValue[] = [];
+		const items: ComboboxValue[] = [
+			getCopyContextForAgentsMenuItem({
+				contextForAgents: formatContextForAgents({
+					location: validatedLocation,
+					name: `Effect "${label}"`,
+					root: window.remotion_cwd,
+				}),
+			}),
+		];
+
+		if (!previewConnected) {
+			return items;
+		}
+
+		items.push({
+			type: 'divider',
+			id: 'copy-context-for-agents-divider',
+		});
 
 		if (documentationLink) {
 			items.push({
@@ -268,9 +283,11 @@ export const TimelineEffectItem: React.FC<{
 	}, [
 		deleteDisabled,
 		documentationLink,
+		label,
 		onDeleteEffectFromSource,
 		previewConnected,
 		selection,
+		validatedLocation,
 	]);
 
 	const onToggle = useCallback(

--- a/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectPropItem.tsx
@@ -15,6 +15,7 @@ import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {canUseEffectOperations} from '../../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {formatContextForAgents} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {openOriginalPositionInEditorAtProperty} from '../../helpers/open-in-editor';
 import type {EffectSchemaFieldInfo} from '../../helpers/timeline-layout';
@@ -24,6 +25,7 @@ import {saveEffectProps} from '../effect-operations-api';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {useEditorOpening} from '../use-default-editor-info';
 import {callAddEffectKeyframe} from './call-add-keyframe';
+import {getCopyContextForAgentsMenuItem} from './get-copy-context-for-agents-menu-item';
 import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {saveEffectProp} from './save-effect-prop';
 import {enqueueSavePropChange} from './save-prop-queue';
@@ -558,6 +560,17 @@ export const TimelineEffectPropItem: React.FC<{
 		}
 
 		return [
+			getCopyContextForAgentsMenuItem({
+				contextForAgents: formatContextForAgents({
+					location: validatedLocation,
+					name: `Effect property "${field.key}"`,
+					root: window.remotion_cwd,
+				}),
+			}),
+			{
+				type: 'divider',
+				id: 'copy-context-for-agents-divider',
+			},
 			{
 				type: 'item',
 				id: 'reset-effect-field',
@@ -571,7 +584,7 @@ export const TimelineEffectPropItem: React.FC<{
 				value: 'reset-effect-field',
 			},
 		];
-	}, [canShowReset, onReset, selection]);
+	}, [canShowReset, field.key, onReset, selection, validatedLocation]);
 
 	const onPropertyDoubleClick = useCallback<
 		React.MouseEventHandler<HTMLDivElement>

--- a/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequencePropItem.tsx
@@ -13,6 +13,7 @@ import type {
 import {Internals} from 'remotion';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {formatContextForAgents} from '../../helpers/format-file-location';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {openOriginalPositionInEditorAtProperty} from '../../helpers/open-in-editor';
 import type {
@@ -25,6 +26,7 @@ import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {useEditorOpening} from '../use-default-editor-info';
 import {callAddSequenceKeyframe} from './call-add-keyframe';
+import {getCopyContextForAgentsMenuItem} from './get-copy-context-for-agents-menu-item';
 import {getSequencePropResetChanges} from './get-sequence-prop-reset-changes';
 import {getKeyframeDisplayOffset} from './get-timeline-keyframes';
 import {saveSequenceProps} from './save-sequence-prop';
@@ -546,6 +548,17 @@ export const TimelineSequencePropItem: React.FC<{
 		}
 
 		return [
+			getCopyContextForAgentsMenuItem({
+				contextForAgents: formatContextForAgents({
+					location: validatedLocation,
+					name: `Property "${field.key}"`,
+					root: window.remotion_cwd,
+				}),
+			}),
+			{
+				type: 'divider',
+				id: 'copy-context-for-agents-divider',
+			},
 			{
 				type: 'item',
 				id: 'reset-sequence-field',
@@ -559,7 +572,7 @@ export const TimelineSequencePropItem: React.FC<{
 				value: 'reset-sequence-field',
 			},
 		];
-	}, [canShowReset, onReset, selection]);
+	}, [canShowReset, field.key, onReset, selection, validatedLocation]);
 
 	const onPropertyDoubleClick = useCallback<
 		React.MouseEventHandler<HTMLDivElement>

--- a/packages/studio/src/components/Timeline/get-copy-context-for-agents-menu-item.ts
+++ b/packages/studio/src/components/Timeline/get-copy-context-for-agents-menu-item.ts
@@ -1,0 +1,32 @@
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {showNotification} from '../Notifications/NotificationCenter';
+
+export const getCopyContextForAgentsMenuItem = ({
+	contextForAgents,
+}: {
+	readonly contextForAgents: string | null;
+}): ComboboxValue => {
+	return {
+		type: 'item',
+		id: 'copy-context-for-agents',
+		keyHint: null,
+		label: 'Copy context for agents',
+		leftItem: null,
+		disabled: !contextForAgents,
+		onClick: () => {
+			if (!contextForAgents) {
+				return;
+			}
+
+			navigator.clipboard.writeText(contextForAgents).catch((err) => {
+				showNotification(
+					`Could not copy to clipboard: ${(err as Error).message}`,
+					1000,
+				);
+			});
+		},
+		quickSwitcherLabel: null,
+		subMenu: null,
+		value: 'copy-context-for-agents',
+	};
+};

--- a/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
+++ b/packages/studio/src/components/Timeline/get-sequence-context-menu-items.ts
@@ -12,6 +12,7 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {openInFileExplorer} from '../RenderQueue/actions';
 import {getPreferredEditorId} from '../use-default-editor-info';
+import {getCopyContextForAgentsMenuItem} from './get-copy-context-for-agents-menu-item';
 import type {TimelineAssetLinkInfo} from './timeline-asset-link';
 import {openTimelineAssetLink} from './timeline-asset-link';
 
@@ -190,29 +191,7 @@ export const getSequenceContextMenuItems = ({
 					value: 'open-in-another-app',
 				}
 			: null,
-		{
-			type: 'item' as const,
-			id: 'copy-context-for-agents',
-			keyHint: null,
-			label: 'Copy context for agents',
-			leftItem: null,
-			disabled: !contextForAgents,
-			onClick: () => {
-				if (!contextForAgents) {
-					return;
-				}
-
-				navigator.clipboard.writeText(contextForAgents).catch((err) => {
-					showNotification(
-						`Could not copy to clipboard: ${(err as Error).message}`,
-						1000,
-					);
-				});
-			},
-			quickSwitcherLabel: null,
-			subMenu: null,
-			value: 'copy-context-for-agents',
-		},
+		getCopyContextForAgentsMenuItem({contextForAgents}),
 		assetLinkInfo
 			? {
 					type: 'item' as const,

--- a/packages/studio/src/test/sequence-context-menu-items.test.ts
+++ b/packages/studio/src/test/sequence-context-menu-items.test.ts
@@ -2,6 +2,7 @@ import {afterEach, expect, test} from 'bun:test';
 import type {TSequence} from 'remotion';
 import {getOpenInMenuItems} from '../components/get-open-in-menu-items';
 import type {ComboboxValue} from '../components/NewComposition/ComboBox';
+import {getCopyContextForAgentsMenuItem} from '../components/Timeline/get-copy-context-for-agents-menu-item';
 import {getSequenceContextMenuItems} from '../components/Timeline/get-sequence-context-menu-items';
 import {getTimelineMediaStartFrame} from '../components/Timeline/get-timeline-media-start-frame';
 import {
@@ -67,6 +68,31 @@ const renameSequenceItem: ComboboxValue = {
 };
 
 const noop = () => undefined;
+
+test('copy context menu items write their agent context to the clipboard', () => {
+	const copiedTexts: string[] = [];
+	Object.defineProperty(globalThis, 'navigator', {
+		configurable: true,
+		value: {
+			clipboard: {
+				writeText: (text: string) => {
+					copiedTexts.push(text);
+					return Promise.resolve();
+				},
+			},
+		},
+	});
+
+	const item = getCopyContextForAgentsMenuItem({
+		contextForAgents: 'Property "style.opacity" in src/Video.tsx:10',
+	});
+	if (item.type !== 'item') {
+		throw new Error('Expected a copy context menu item');
+	}
+
+	item.onClick('copy-context-for-agents', null);
+	expect(copiedTexts).toEqual(['Property "style.opacity" in src/Video.tsx:10']);
+});
 
 test('the file manager entry is only shown on macOS', () => {
 	installTestWindow();


### PR DESCRIPTION
## Summary

- add “Copy context for agents” to sequence property, effect, and effect property context menus
- include the exact property key or effect label with the project-relative source location
- share the clipboard menu action with the existing sequence context menu

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src`
