### PR TITLE
Elements: Add preview overwrite option

### DIFF
--- a/.agents/skills/upload-element-previews/SKILL.md
+++ b/.agents/skills/upload-element-previews/SKILL.md
@@ -18,6 +18,8 @@ bun run upload-element-preview \
   --source=<render|submission>
 ```
 
-4. Replace `image`, `posterUrl`, and `videoUrl` with the printed `remotion.media` URLs.
+To refresh an already-published preview, add `--overwrite`. The uploader accepts it only when the Element definition already uses the exact expected `https://remotion.media/elements/...` PNG and MP4 URLs.
+
+4. For a new preview, replace `image`, `posterUrl`, and `videoUrl` with the printed `remotion.media` URLs. An overwritten preview keeps its existing URLs.
 5. If using `submission`, delete the local review assets. If using `render`, leave `.element-previews` uncommitted.
 6. Commit and push when the work belongs on a branch.

--- a/packages/docs/elements/contributing.mdx
+++ b/packages/docs/elements/contributing.mdx
@@ -39,7 +39,7 @@ To make previews visible in the pull request deployment:
 Preview workflows:
 
 - External contributors render previews, commit them to static/elements, and use local URLs so the pull request deployment can show them.
-- Maintainers can use the upload-element-previews skill after rendering locally (source=render) or from a contributor's committed assets (source=submission). The uploader verifies the assets, publishes them to remotion.media, and prints the replacement URLs. Delete the static review assets after a submission upload.
+- Maintainers can use the upload-element-previews skill after rendering locally (source=render) or from a contributor's committed assets (source=submission). The uploader verifies the assets, publishes them to remotion.media, and prints the replacement URLs. To refresh an already-published preview, pass --overwrite; it is accepted only when the definition uses the exact expected remotion.media URLs. Delete the static review assets after a submission upload.
 */}
 
 ## 3. Open the pull request

--- a/packages/docs/src/test/upload-element-preview.test.ts
+++ b/packages/docs/src/test/upload-element-preview.test.ts
@@ -74,28 +74,23 @@ test('upload-element-preview only overwrites the exact hosted preview URLs', () 
 			args: string[];
 			posterUrl: string;
 			videoUrl: string;
-		}) => {
-			return spawnSync(process.execPath, [runnerPath, ...args], {
+		}) =>
+			spawnSync(process.execPath, [runnerPath, ...args], {
 				cwd: temporaryDirectory,
 				encoding: 'utf8',
 				env: {
 					...process.env,
 					AWS_ACCESS_KEY_ID: '',
-					AWS_SECRET_ACCESS_KEY: '',
-					CLOUDFLARE_API_TOKEN: '',
-					CLOUDFLARE_ZONE_ID: '',
 					TEST_POSTER_URL: posterUrl,
 					TEST_VIDEO_URL: videoUrl,
 				},
 			});
-		};
 
 		const helpResult = runUpload({
 			args: ['--help'],
 			posterUrl: expectedHostedPosterUrl,
 			videoUrl: expectedHostedVideoUrl,
 		});
-		expect(helpResult.error).toBeUndefined();
 		expect(helpResult.status).toBe(0);
 		expect(helpResult.stdout).toContain('[--overwrite]');
 		expect(helpResult.stdout).toContain(
@@ -107,7 +102,6 @@ test('upload-element-preview only overwrites the exact hosted preview URLs', () 
 			posterUrl: expectedLocalPosterUrl,
 			videoUrl: expectedLocalVideoUrl,
 		});
-		expect(localReviewResult.error).toBeUndefined();
 		expect(localReviewResult.status).toBe(1);
 		expect(localReviewResult.stderr).toContain(
 			'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY',
@@ -118,13 +112,9 @@ test('upload-element-preview only overwrites the exact hosted preview URLs', () 
 			posterUrl: expectedHostedPosterUrl,
 			videoUrl: expectedHostedVideoUrl,
 		});
-		expect(protectedHostedResult.error).toBeUndefined();
 		expect(protectedHostedResult.status).toBe(1);
 		expect(protectedHostedResult.stderr).toContain(
 			'must use its exact local review URLs',
-		);
-		expect(protectedHostedResult.stderr).not.toContain(
-			'Uploading requires AWS_ACCESS_KEY_ID',
 		);
 
 		const overwriteResult = runUpload({
@@ -132,12 +122,10 @@ test('upload-element-preview only overwrites the exact hosted preview URLs', () 
 			posterUrl: expectedHostedPosterUrl,
 			videoUrl: expectedHostedVideoUrl,
 		});
-		expect(overwriteResult.error).toBeUndefined();
 		expect(overwriteResult.status).toBe(1);
 		expect(overwriteResult.stderr).toContain(
 			'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY',
 		);
-		expect(overwriteResult.stderr).not.toContain('cannot be overwritten');
 
 		for (const rejectedUrls of [
 			{
@@ -158,13 +146,9 @@ test('upload-element-preview only overwrites the exact hosted preview URLs', () 
 				posterUrl: rejectedUrls.posterUrl,
 				videoUrl: rejectedUrls.videoUrl,
 			});
-			expect(rejectedOverwriteResult.error).toBeUndefined();
 			expect(rejectedOverwriteResult.status).toBe(1);
 			expect(rejectedOverwriteResult.stderr).toContain(
 				'cannot be overwritten because its preview URLs do not exactly match',
-			);
-			expect(rejectedOverwriteResult.stderr).not.toContain(
-				'Uploading requires AWS_ACCESS_KEY_ID',
 			);
 		}
 	} finally {

--- a/packages/docs/src/test/upload-element-preview.test.ts
+++ b/packages/docs/src/test/upload-element-preview.test.ts
@@ -1,0 +1,173 @@
+import {expect, test} from 'bun:test';
+import {spawnSync} from 'child_process';
+import {mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'fs';
+import {tmpdir} from 'os';
+import path from 'path';
+
+test('upload-element-preview only overwrites the exact hosted preview URLs', () => {
+	const temporaryDirectory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-upload-element-preview-'),
+	);
+
+	try {
+		const uploaderPath = path.join(
+			__dirname,
+			'..',
+			'..',
+			'upload-element-preview.ts',
+		);
+		const uploaderSource = readFileSync(uploaderPath, 'utf8');
+		const runnerSource = uploaderSource.replace(
+			"from './src/components/Elements/element-definitions';",
+			"from './element-definitions';",
+		);
+		expect(runnerSource).not.toBe(uploaderSource);
+
+		const runnerPath = path.join(
+			temporaryDirectory,
+			'upload-element-preview.ts',
+		);
+		writeFileSync(runnerPath, runnerSource);
+		writeFileSync(
+			path.join(temporaryDirectory, 'element-definitions.ts'),
+			`export const elementDefinitions = {
+	fixture: {
+		slug: 'test/example',
+		preview: {
+			posterUrl: process.env.TEST_POSTER_URL,
+			videoUrl: process.env.TEST_VIDEO_URL,
+		},
+	},
+};
+`,
+		);
+
+		const previewDirectory = path.join(
+			temporaryDirectory,
+			'.element-previews',
+			'test',
+			'example',
+		);
+		mkdirSync(previewDirectory, {recursive: true});
+		writeFileSync(
+			path.join(previewDirectory, 'preview.png'),
+			Uint8Array.from([
+				0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0,
+			]),
+		);
+		writeFileSync(
+			path.join(previewDirectory, 'preview.mp4'),
+			Uint8Array.from([0, 0, 0, 8, 0x66, 0x74, 0x79, 0x70, 0, 0, 0, 0]),
+		);
+
+		const expectedLocalPosterUrl = '/elements/test-example-preview.png';
+		const expectedLocalVideoUrl = '/elements/test-example-preview.mp4';
+		const expectedHostedPosterUrl =
+			'https://remotion.media/elements/test-example-preview.png';
+		const expectedHostedVideoUrl =
+			'https://remotion.media/elements/test-example-preview.mp4';
+		const runUpload = ({
+			args,
+			posterUrl,
+			videoUrl,
+		}: {
+			args: string[];
+			posterUrl: string;
+			videoUrl: string;
+		}) => {
+			return spawnSync(process.execPath, [runnerPath, ...args], {
+				cwd: temporaryDirectory,
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					AWS_ACCESS_KEY_ID: '',
+					AWS_SECRET_ACCESS_KEY: '',
+					CLOUDFLARE_API_TOKEN: '',
+					CLOUDFLARE_ZONE_ID: '',
+					TEST_POSTER_URL: posterUrl,
+					TEST_VIDEO_URL: videoUrl,
+				},
+			});
+		};
+
+		const helpResult = runUpload({
+			args: ['--help'],
+			posterUrl: expectedHostedPosterUrl,
+			videoUrl: expectedHostedVideoUrl,
+		});
+		expect(helpResult.error).toBeUndefined();
+		expect(helpResult.status).toBe(0);
+		expect(helpResult.stdout).toContain('[--overwrite]');
+		expect(helpResult.stdout).toContain(
+			'only when the definition uses its exact https://remotion.media/elements/... URLs',
+		);
+
+		const localReviewResult = runUpload({
+			args: ['--element=test/example', '--source=render'],
+			posterUrl: expectedLocalPosterUrl,
+			videoUrl: expectedLocalVideoUrl,
+		});
+		expect(localReviewResult.error).toBeUndefined();
+		expect(localReviewResult.status).toBe(1);
+		expect(localReviewResult.stderr).toContain(
+			'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY',
+		);
+
+		const protectedHostedResult = runUpload({
+			args: ['--element=test/example', '--source=render'],
+			posterUrl: expectedHostedPosterUrl,
+			videoUrl: expectedHostedVideoUrl,
+		});
+		expect(protectedHostedResult.error).toBeUndefined();
+		expect(protectedHostedResult.status).toBe(1);
+		expect(protectedHostedResult.stderr).toContain(
+			'must use its exact local review URLs',
+		);
+		expect(protectedHostedResult.stderr).not.toContain(
+			'Uploading requires AWS_ACCESS_KEY_ID',
+		);
+
+		const overwriteResult = runUpload({
+			args: ['--element=test/example', '--source=render', '--overwrite'],
+			posterUrl: expectedHostedPosterUrl,
+			videoUrl: expectedHostedVideoUrl,
+		});
+		expect(overwriteResult.error).toBeUndefined();
+		expect(overwriteResult.status).toBe(1);
+		expect(overwriteResult.stderr).toContain(
+			'Uploading requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY',
+		);
+		expect(overwriteResult.stderr).not.toContain('cannot be overwritten');
+
+		for (const rejectedUrls of [
+			{
+				posterUrl: 'https://remotion.media/elements/test-other-preview.png',
+				videoUrl: expectedHostedVideoUrl,
+			},
+			{
+				posterUrl: expectedHostedPosterUrl,
+				videoUrl: 'https://remotion.media/elements/test-other-preview.mp4',
+			},
+			{
+				posterUrl: 'https://example.com/elements/test-example-preview.png',
+				videoUrl: expectedHostedVideoUrl,
+			},
+		]) {
+			const rejectedOverwriteResult = runUpload({
+				args: ['--element=test/example', '--source=render', '--overwrite'],
+				posterUrl: rejectedUrls.posterUrl,
+				videoUrl: rejectedUrls.videoUrl,
+			});
+			expect(rejectedOverwriteResult.error).toBeUndefined();
+			expect(rejectedOverwriteResult.status).toBe(1);
+			expect(rejectedOverwriteResult.stderr).toContain(
+				'cannot be overwritten because its preview URLs do not exactly match',
+			);
+			expect(rejectedOverwriteResult.stderr).not.toContain(
+				'Uploading requires AWS_ACCESS_KEY_ID',
+			);
+		}
+	} finally {
+		rmSync(temporaryDirectory, {force: true, recursive: true});
+	}
+});

--- a/packages/docs/upload-element-preview.ts
+++ b/packages/docs/upload-element-preview.ts
@@ -245,11 +245,7 @@ if (!purgeResponse.ok || !purgeResult.success) {
 }
 
 console.log('Cleared the CDN cache for both preview URLs.');
-console.log(
-	usesHostedPreviewUrls
-		? 'Upload verified. Preview URLs remain:'
-		: 'Upload verified. Replace the review URLs with:',
-);
+console.log('Upload verified. Preview URLs:');
 console.log(expectedHostedPosterUrl);
 console.log(expectedHostedVideoUrl);
 if (source === 'submission') {

--- a/packages/docs/upload-element-preview.ts
+++ b/packages/docs/upload-element-preview.ts
@@ -5,13 +5,14 @@ import {elementDefinitions} from './src/components/Elements/element-definitions'
 
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
 	console.log(`Usage:
-  bun run upload-element-preview --element=<category>/<slug> --source=render
-  bun run upload-element-preview --element=<category>/<slug> --source=submission
+  bun run upload-element-preview --element=<category>/<slug> --source=render [--overwrite]
+  bun run upload-element-preview --element=<category>/<slug> --source=submission [--overwrite]
 
-Use render to upload files from .element-previews. Use submission to upload committed files from static/elements. The command prints the hosted URLs and any cleanup required after a verified upload.`);
+Use render to upload files from .element-previews. Use submission to upload committed files from static/elements. By default, the Element definition must use its exact local /elements/... review URLs. Use --overwrite to refresh an already-published preview only when the definition uses its exact https://remotion.media/elements/... URLs. The command prints the hosted URLs and any cleanup required after a verified upload.`);
 	process.exit(0);
 }
 
+const overwrite = process.argv.includes('--overwrite');
 const elementArguments = process.argv.filter((argument) =>
 	argument.startsWith('--element='),
 );
@@ -50,13 +51,28 @@ if (!definition) {
 const assetSlug = definition.slug.replaceAll('/', '-');
 const expectedPosterUrl = `/elements/${assetSlug}-preview.png` as const;
 const expectedVideoUrl = `/elements/${assetSlug}-preview.mp4` as const;
-if (
-	definition.preview.posterUrl !== expectedPosterUrl ||
-	definition.preview.videoUrl !== expectedVideoUrl
-) {
-	throw new Error(
-		`${definition.slug} must use its local review URLs before its previews can be uploaded`,
-	);
+const expectedHostedPosterUrl =
+	`https://remotion.media${expectedPosterUrl}` as const;
+const expectedHostedVideoUrl =
+	`https://remotion.media${expectedVideoUrl}` as const;
+const usesLocalReviewUrls =
+	definition.preview.posterUrl === expectedPosterUrl &&
+	definition.preview.videoUrl === expectedVideoUrl;
+const usesHostedPreviewUrls =
+	definition.preview.posterUrl === expectedHostedPosterUrl &&
+	definition.preview.videoUrl === expectedHostedVideoUrl;
+if (!usesLocalReviewUrls) {
+	if (!overwrite) {
+		throw new Error(
+			`${definition.slug} must use its exact local review URLs (${expectedPosterUrl} and ${expectedVideoUrl}) before its previews can be uploaded. To refresh an already-published preview, use --overwrite while the definition uses ${expectedHostedPosterUrl} and ${expectedHostedVideoUrl}.`,
+		);
+	}
+
+	if (!usesHostedPreviewUrls) {
+		throw new Error(
+			`${definition.slug} cannot be overwritten because its preview URLs do not exactly match ${expectedHostedPosterUrl} and ${expectedHostedVideoUrl}.`,
+		);
+	}
 }
 
 const sourceDirectory =
@@ -229,9 +245,13 @@ if (!purgeResponse.ok || !purgeResult.success) {
 }
 
 console.log('Cleared the CDN cache for both preview URLs.');
-console.log('Upload verified. Replace the review URLs with:');
-console.log(`https://remotion.media${expectedPosterUrl}`);
-console.log(`https://remotion.media${expectedVideoUrl}`);
+console.log(
+	usesHostedPreviewUrls
+		? 'Upload verified. Preview URLs remain:'
+		: 'Upload verified. Replace the review URLs with:',
+);
+console.log(expectedHostedPosterUrl);
+console.log(expectedHostedVideoUrl);
 if (source === 'submission') {
 	console.log('Then delete the two files from packages/docs/static/elements.');
 } else {


### PR DESCRIPTION
## Summary

- Add an explicit `--overwrite` option for refreshing published Element previews.
- Preserve the local review URL guard by default and only allow overwrites for the exact expected hosted PNG and MP4 URLs.
- Document the refresh workflow and cover the CLI safety checks with an integration test.

## Testing

- `bun test packages/docs/src/test/upload-element-preview.test.ts`
- `bun run build`
- `bun run stylecheck`

## Preview

- [Contributing an Element](https://remotion-git-element-preview-overwrite-remotion.vercel.app/elements/contributing)
