### PR TITLE
`@remotion/studio`: Keep selected editing handles above canvas polygons

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -608,6 +608,94 @@ test.describe('visual mode', () => {
 		}
 	});
 
+	test('should keep selected editing handles above overlapping outlines', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/outline-selection-cases`);
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+		await page.keyboard.press('g');
+		const currentFrameInput = page.locator('input:focus');
+		await expect(currentFrameInput).toBeVisible();
+		await currentFrameInput.fill('2160');
+		await currentFrameInput.press('Enter');
+
+		const target = page.locator(
+			'[data-timeline-marquee-item="true"][title="Editable transform target"]',
+		);
+		await expect(target).toBeVisible();
+		await target.click();
+
+		const rightScaleEdge = page.locator(
+			'[data-remotion-studio-scale-edge="right"][data-remotion-studio-scale-edge-contains-selection="true"]',
+		);
+		await expect(rightScaleEdge).toBeVisible();
+		const scaleEdgePoint = await rightScaleEdge.evaluate((element) => {
+			if (!(element instanceof SVGLineElement)) {
+				throw new Error('Scale edge should be an SVG line');
+			}
+
+			const matrix = element.getScreenCTM();
+			if (matrix === null) {
+				throw new Error('Scale edge should have a screen transform');
+			}
+
+			const first = new DOMPoint(
+				element.x1.baseVal.value,
+				element.y1.baseVal.value,
+			).matrixTransform(matrix);
+			const second = new DOMPoint(
+				element.x2.baseVal.value,
+				element.y2.baseVal.value,
+			).matrixTransform(matrix);
+			const [top, bottom] =
+				first.y < second.y ? [first, second] : [second, first];
+
+			return {
+				x: top.x + (bottom.x - top.x) * 0.2,
+				y: top.y + (bottom.y - top.y) * 0.2,
+			};
+		});
+		expect(
+			await page.evaluate(
+				({x, y}) =>
+					document
+						.elementFromPoint(x, y)
+						?.getAttribute('data-remotion-studio-scale-edge') ?? null,
+				scaleEdgePoint,
+			),
+		).toBe('right');
+
+		const topRightRotationCorner = page.locator(
+			'[data-remotion-studio-rotation-corner="top-right"][data-remotion-studio-rotation-corner-contains-selection="true"]',
+		);
+		await expect(topRightRotationCorner).toBeVisible();
+		const rotationCornerBox = await topRightRotationCorner.boundingBox();
+		if (rotationCornerBox === null) {
+			throw new Error('Rotation corner should have a visible layout');
+		}
+
+		expect(
+			await page.evaluate(
+				({x, y}) =>
+					document
+						.elementFromPoint(x, y)
+						?.getAttribute('data-remotion-studio-rotation-corner') ?? null,
+				{
+					x: rotationCornerBox.x + rotationCornerBox.width / 2,
+					y: rotationCornerBox.y + rotationCornerBox.height / 2,
+				},
+			),
+		).toBe('top-right');
+
+		await topRightRotationCorner.click({button: 'right'});
+		await expect(
+			page.getByRole('button', {name: 'Duplicate', exact: true}),
+		).toBeVisible();
+	});
+
 	test('should compensate DOM measurements with useCurrentScale() on direct load', async ({
 		page,
 	}) => {

--- a/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
+++ b/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
@@ -527,7 +527,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 260,
 							backgroundColor: '#7c3aed',
 							borderRadius: 30,
-							translate: '0px 0px',
+							translate: '-7px 87px',
 						}}
 					>
 						<ShapeLabel>Selected B</ShapeLabel>
@@ -635,7 +635,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 480,
 							backgroundColor: '#2563eb',
 							borderRadius: 32,
-							translate: '0px 0px',
+							translate: '-71.7px 116.5px',
 						}}
 					>
 						<ShapeLabel>Select the large target first</ShapeLabel>
@@ -650,7 +650,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 220,
 							backgroundColor: '#d97706',
 							borderRadius: 24,
-							translate: '0px 0px',
+							translate: '-26.8px 181.5px',
 						}}
 					>
 						<ShapeLabel>Unselected overlap</ShapeLabel>
@@ -681,7 +681,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 500,
 							backgroundColor: '#2563eb',
 							borderRadius: 32,
-							translate: '0px 0px',
+							translate: '81.2px 80.3px',
 						}}
 					>
 						<ShapeLabel>Selected parent</ShapeLabel>
@@ -695,7 +695,7 @@ export const OutlineSelectionCases: React.FC = () => {
 								height: 290,
 								backgroundColor: '#e11d48',
 								borderRadius: 24,
-								translate: '0px 0px',
+								translate: '-51.1px -4.4px',
 							}}
 						>
 							<ShapeLabel>Drag parent from here</ShapeLabel>
@@ -727,7 +727,8 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 400,
 							backgroundColor: '#7c3aed',
 							borderRadius: 34,
-							translate: '0px 0px',
+							translate: '73.7px -167.8px',
+							rotate: '-19.9deg',
 						}}
 					>
 						<ShapeLabel>Select one of my properties, then drag me</ShapeLabel>
@@ -742,9 +743,9 @@ export const OutlineSelectionCases: React.FC = () => {
 			>
 				<CaseFrame
 					caseNumber={13}
-					status="Partial"
+					status="Baseline"
 					title="All selected editing handles stay on top"
-					summary="Transform-origin and UV handles are already globally raised, but scale and rotation controls can be covered by a later polygon."
+					summary="Transform-origin, UV, crop, scale, and rotation handles are globally raised above every outline polygon."
 					desiredBehavior="Every visible handle belonging to a selected outline is rendered and hit-tested above every unselected polygon."
 					instructions="Select Editable transform target and activate its transform controls. The amber polygon must not block any handle near the top-right corner."
 				>
@@ -762,10 +763,10 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 360,
 							backgroundColor: '#7c3aed',
 							borderRadius: 34,
-							rotate: '8deg',
+							rotate: '12.4deg',
 							scale: 1,
-							transformOrigin: '50% 50%',
-							translate: '0px 0px',
+							transformOrigin: '100% 0%',
+							translate: '33.6px 50.4px',
 						}}
 					>
 						<ShapeLabel>Selected transform target</ShapeLabel>
@@ -781,6 +782,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							backgroundColor: '#d97706',
 							borderRadius: 24,
 							translate: '0px 0px',
+							rotate: '15.7deg',
 						}}
 					>
 						<ShapeLabel>Must stay below handles</ShapeLabel>

--- a/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
+++ b/packages/example/src/VisualModeTests/OutlineSelectionCases.tsx
@@ -527,7 +527,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 260,
 							backgroundColor: '#7c3aed',
 							borderRadius: 30,
-							translate: '-7px 87px',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Selected B</ShapeLabel>
@@ -635,7 +635,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 480,
 							backgroundColor: '#2563eb',
 							borderRadius: 32,
-							translate: '-71.7px 116.5px',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Select the large target first</ShapeLabel>
@@ -650,7 +650,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 220,
 							backgroundColor: '#d97706',
 							borderRadius: 24,
-							translate: '-26.8px 181.5px',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Unselected overlap</ShapeLabel>
@@ -681,7 +681,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 500,
 							backgroundColor: '#2563eb',
 							borderRadius: 32,
-							translate: '81.2px 80.3px',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Selected parent</ShapeLabel>
@@ -695,7 +695,7 @@ export const OutlineSelectionCases: React.FC = () => {
 								height: 290,
 								backgroundColor: '#e11d48',
 								borderRadius: 24,
-								translate: '-51.1px -4.4px',
+								translate: '0px 0px',
 							}}
 						>
 							<ShapeLabel>Drag parent from here</ShapeLabel>
@@ -727,8 +727,7 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 400,
 							backgroundColor: '#7c3aed',
 							borderRadius: 34,
-							translate: '73.7px -167.8px',
-							rotate: '-19.9deg',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Select one of my properties, then drag me</ShapeLabel>
@@ -763,10 +762,10 @@ export const OutlineSelectionCases: React.FC = () => {
 							height: 360,
 							backgroundColor: '#7c3aed',
 							borderRadius: 34,
-							rotate: '12.4deg',
+							rotate: '8deg',
 							scale: 1,
-							transformOrigin: '100% 0%',
-							translate: '33.6px 50.4px',
+							transformOrigin: '50% 50%',
+							translate: '0px 0px',
 						}}
 					>
 						<ShapeLabel>Selected transform target</ShapeLabel>
@@ -782,7 +781,6 @@ export const OutlineSelectionCases: React.FC = () => {
 							backgroundColor: '#d97706',
 							borderRadius: 24,
 							translate: '0px 0px',
-							rotate: '15.7deg',
 						}}
 					>
 						<ShapeLabel>Must stay below handles</ShapeLabel>

--- a/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
+++ b/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
@@ -1,9 +1,4 @@
-import React, {useLayoutEffect, useMemo, useRef} from 'react';
-import {timelineSequenceNodePathToKey} from '../helpers/timeline-node-path-key';
-import {
-	useIsTimelineSequenceHovered,
-	useSetTimelineSequenceHover,
-} from '../state/timeline-sequence-hover';
+import React, {useMemo} from 'react';
 import {getSelectedOutlineControlLayout} from './selected-outline-control-layout';
 import type {SelectedOutline} from './selected-outline-geometry';
 import type {
@@ -20,6 +15,7 @@ import type {
 	TimelineSelection,
 	TimelineSelectionInteraction,
 } from './Timeline/TimelineSelection';
+import {useSelectedOutlineControlTarget} from './use-selected-outline-control-target';
 
 export const SelectedOutlineEditingHandles: React.FC<{
 	readonly dragging: boolean;
@@ -51,51 +47,14 @@ export const SelectedOutlineEditingHandles: React.FC<{
 	onSelect,
 	outline,
 }) => {
-	const setHoveredSequence = useSetTimelineSequenceHover();
-	const targetRef = useRef(layoutTarget);
-	useLayoutEffect(() => {
-		targetRef.current = layoutTarget;
-	}, [layoutTarget]);
-	const hoveredNodePathKey = useMemo(
-		() =>
-			layoutTarget === undefined
-				? null
-				: timelineSequenceNodePathToKey(
-						layoutTarget.nodePathInfo.sequenceSubscriptionKey,
-					),
-		[layoutTarget],
-	);
-	const hovered = useIsTimelineSequenceHovered(hoveredNodePathKey);
-	const controlTarget =
-		layoutTarget !== undefined && (layoutTarget.containsSelection || hovered)
-			? getLatestTargetByKey(layoutTarget.key)
-			: undefined;
+	const {controlTarget, hovered, onHoverChange} =
+		useSelectedOutlineControlTarget({
+			getLatestTargetByKey,
+			layoutTarget,
+		});
 	const controlLayout = useMemo(
 		() => getSelectedOutlineControlLayout(outline.points),
 		[outline.points],
-	);
-	const onHoverChange = React.useCallback(
-		(key: string | null) => {
-			setHoveredSequence((currentHover) => {
-				if (key !== null) {
-					const hoverTarget = targetRef.current;
-					if (hoverTarget === undefined || hoverTarget.key !== key) {
-						return currentHover;
-					}
-
-					return {
-						key,
-						nodePathKey: timelineSequenceNodePathToKey(
-							hoverTarget.nodePathInfo.sequenceSubscriptionKey,
-						),
-						source: 'canvas',
-					};
-				}
-
-				return currentHover?.source === 'canvas' ? null : currentHover;
-			});
-		},
-		[setHoveredSequence],
 	);
 	const onContextMenuOpen = React.useCallback(() => {
 		return getContextMenuOpenByKey(outline.key)?.() ?? false;

--- a/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
+++ b/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
@@ -1,0 +1,156 @@
+import React, {useLayoutEffect, useMemo, useRef} from 'react';
+import {timelineSequenceNodePathToKey} from '../helpers/timeline-node-path-key';
+import {
+	useIsTimelineSequenceHovered,
+	useSetTimelineSequenceHover,
+} from '../state/timeline-sequence-hover';
+import {getSelectedOutlineControlLayout} from './selected-outline-control-layout';
+import type {SelectedOutline} from './selected-outline-geometry';
+import type {
+	SelectedOutlineContextMenuOpenHandler,
+	SelectedOutlineLayoutTarget,
+	SelectedOutlineRotationDragTarget,
+	SelectedOutlineScaleDragTarget,
+	SelectedOutlineTarget,
+} from './selected-outline-types';
+import {SelectedOutlineCropControls} from './SelectedOutlineCropControls';
+import {SelectedOutlineRotationCornerHandle} from './SelectedOutlineRotationCornerHandle';
+import {SelectedOutlineScaleEdgeLine} from './SelectedOutlineScaleEdgeLine';
+import type {
+	TimelineSelection,
+	TimelineSelectionInteraction,
+} from './Timeline/TimelineSelection';
+
+export const SelectedOutlineEditingHandles: React.FC<{
+	readonly dragging: boolean;
+	readonly getAllRotationDragTargets: () => readonly SelectedOutlineRotationDragTarget[];
+	readonly getAllScaleDragTargets: () => readonly SelectedOutlineScaleDragTarget[];
+	readonly getContextMenuOpenByKey: (
+		key: string,
+	) => SelectedOutlineContextMenuOpenHandler | undefined;
+	readonly getLatestTargetByKey: (
+		key: string,
+	) => SelectedOutlineTarget | undefined;
+	readonly layoutTarget: SelectedOutlineLayoutTarget | undefined;
+	readonly onContextMenuOpenChange: (open: boolean) => void;
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly onSelect: (
+		item: TimelineSelection,
+		interaction: TimelineSelectionInteraction,
+	) => void;
+	readonly outline: SelectedOutline;
+}> = ({
+	dragging,
+	getAllRotationDragTargets,
+	getAllScaleDragTargets,
+	getContextMenuOpenByKey,
+	getLatestTargetByKey,
+	layoutTarget,
+	onContextMenuOpenChange,
+	onDraggingChange,
+	onSelect,
+	outline,
+}) => {
+	const setHoveredSequence = useSetTimelineSequenceHover();
+	const targetRef = useRef(layoutTarget);
+	useLayoutEffect(() => {
+		targetRef.current = layoutTarget;
+	}, [layoutTarget]);
+	const hoveredNodePathKey = useMemo(
+		() =>
+			layoutTarget === undefined
+				? null
+				: timelineSequenceNodePathToKey(
+						layoutTarget.nodePathInfo.sequenceSubscriptionKey,
+					),
+		[layoutTarget],
+	);
+	const hovered = useIsTimelineSequenceHovered(hoveredNodePathKey);
+	const controlTarget =
+		layoutTarget !== undefined && (layoutTarget.containsSelection || hovered)
+			? getLatestTargetByKey(layoutTarget.key)
+			: undefined;
+	const controlLayout = useMemo(
+		() => getSelectedOutlineControlLayout(outline.points),
+		[outline.points],
+	);
+	const onHoverChange = React.useCallback(
+		(key: string | null) => {
+			setHoveredSequence((currentHover) => {
+				if (key !== null) {
+					const hoverTarget = targetRef.current;
+					if (hoverTarget === undefined || hoverTarget.key !== key) {
+						return currentHover;
+					}
+
+					return {
+						key,
+						nodePathKey: timelineSequenceNodePathToKey(
+							hoverTarget.nodePathInfo.sequenceSubscriptionKey,
+						),
+						source: 'canvas',
+					};
+				}
+
+				return currentHover?.source === 'canvas' ? null : currentHover;
+			});
+		},
+		[setHoveredSequence],
+	);
+	const onContextMenuOpen = React.useCallback(() => {
+		return getContextMenuOpenByKey(outline.key)?.() ?? false;
+	}, [getContextMenuOpenByKey, outline.key]);
+
+	return (
+		<>
+			<SelectedOutlineCropControls
+				outline={outline}
+				onDraggingChange={onDraggingChange}
+				target={controlTarget}
+			/>
+			{controlTarget?.cropDrag === null &&
+			(layoutTarget?.containsSelection || hovered)
+				? controlLayout.scaleEdges.map((edge) => (
+						<SelectedOutlineScaleEdgeLine
+							key={edge}
+							getAllScaleDragTargets={getAllScaleDragTargets}
+							dragging={dragging}
+							edge={edge}
+							hitWidth={
+								edge === 'top' || edge === 'bottom'
+									? controlLayout.scaleHitWidth.horizontal
+									: controlLayout.scaleHitWidth.vertical
+							}
+							outline={outline}
+							onContextMenuOpen={onContextMenuOpen}
+							onContextMenuOpenChange={onContextMenuOpenChange}
+							onDraggingChange={onDraggingChange}
+							onHoverChange={onHoverChange}
+							onSelect={onSelect}
+							target={controlTarget}
+						/>
+					))
+				: null}
+			{controlTarget?.cropDrag === null &&
+			(layoutTarget?.containsSelection || hovered)
+				? controlLayout.rotationCorners.map(({corner, point}) => (
+						<SelectedOutlineRotationCornerHandle
+							key={corner}
+							getAllRotationDragTargets={getAllRotationDragTargets}
+							corner={corner}
+							dragging={dragging}
+							handlePoint={point}
+							outline={outline}
+							onContextMenuOpen={onContextMenuOpen}
+							onContextMenuOpenChange={onContextMenuOpenChange}
+							onDraggingChange={onDraggingChange}
+							onHoverChange={onHoverChange}
+							onSelect={onSelect}
+							radius={controlLayout.rotationHandleRadius}
+							target={controlTarget}
+						/>
+					))
+				: null}
+		</>
+	);
+};

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -20,23 +20,18 @@ import {useConfirmationDialog} from './ConfirmationDialog';
 import {deleteJsxNode} from './delete-jsx-node-api';
 import {useSelectComposition} from './InitialCompositionLoader';
 import {showNotification} from './Notifications/NotificationCenter';
-import {getSelectedOutlineControlLayout} from './selected-outline-control-layout';
 import type {SelectedOutline} from './selected-outline-geometry';
 import {type SelectedOutlineSnapPoint} from './selected-outline-snap';
 import {
 	cropFieldKeys,
 	rotateFieldKey,
+	type SelectedOutlineContextMenuOpenHandler,
 	type SelectedOutlineDragTarget,
 	type SelectedOutlineLayoutTarget,
-	type SelectedOutlineRotationDragTarget,
-	type SelectedOutlineScaleDragTarget,
 	type SelectedOutlineTarget,
 } from './selected-outline-types';
 import {SelectedOutlineCanvasRotation} from './SelectedOutlineCanvasRotation';
-import {SelectedOutlineCropControls} from './SelectedOutlineCropControls';
 import {SelectedOutlinePolygon} from './SelectedOutlinePolygon';
-import {SelectedOutlineRotationCornerHandle} from './SelectedOutlineRotationCornerHandle';
-import {SelectedOutlineScaleEdgeLine} from './SelectedOutlineScaleEdgeLine';
 import {disableSequenceInteractivity} from './Timeline/disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './Timeline/duplicate-selected-timeline-item';
 import {getSequenceContextMenuItems} from './Timeline/get-sequence-context-menu-items';
@@ -58,8 +53,6 @@ type SelectedOutlineElementProps = {
 	readonly dragging: boolean;
 	readonly getAllDragOutlines: () => readonly SelectedOutline[];
 	readonly getAllDragTargets: () => readonly SelectedOutlineDragTarget[];
-	readonly getAllRotationDragTargets: () => readonly SelectedOutlineRotationDragTarget[];
-	readonly getAllScaleDragTargets: () => readonly SelectedOutlineScaleDragTarget[];
 	readonly getLatestTargetByKey: (
 		key: string,
 	) => SelectedOutlineTarget | undefined;
@@ -74,6 +67,10 @@ type SelectedOutlineElementProps = {
 		item: TimelineSelection,
 		interaction: TimelineSelectionInteraction,
 	) => void;
+	readonly registerContextMenuOpen: (
+		key: string,
+		handler: SelectedOutlineContextMenuOpenHandler | null,
+	) => void;
 	readonly scale: number;
 };
 
@@ -85,8 +82,6 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	dragging,
 	getAllDragOutlines,
 	getAllDragTargets,
-	getAllRotationDragTargets,
-	getAllScaleDragTargets,
 	getLatestTargetByKey,
 	layoutTarget,
 	outline,
@@ -94,6 +89,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	onContextMenuOpenChange,
 	onSnapPointsChange,
 	onSelect,
+	registerContextMenuOpen,
 	scale,
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -116,10 +112,6 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	const {setManuallyEnabled} = useContext(Transform3DModeStateContext);
 	const setHoveredSequence = useSetTimelineSequenceHover();
 	const targetRef = useRef(layoutTarget);
-	const controlLayout = useMemo(
-		() => getSelectedOutlineControlLayout(outline.points),
-		[outline.points],
-	);
 	useLayoutEffect(() => {
 		targetRef.current = layoutTarget;
 	}, [layoutTarget]);
@@ -504,6 +496,12 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		setSelectedModal,
 		setPropStatuses,
 	]);
+	useLayoutEffect(() => {
+		registerContextMenuOpen(outline.key, onContextMenuOpen);
+		return () => {
+			registerContextMenuOpen(outline.key, null);
+		};
+	}, [onContextMenuOpen, outline.key, registerContextMenuOpen]);
 
 	return (
 		<>
@@ -539,54 +537,6 @@ const SelectedOutlineElementUnmemoized: React.FC<
 					transform3DMode={controlTarget.rotationDrag.transform3DMode}
 				/>
 			) : null}
-			<SelectedOutlineCropControls
-				outline={outline}
-				onDraggingChange={onDraggingChange}
-				target={controlTarget}
-			/>
-			{controlTarget?.cropDrag === null &&
-			(layoutTarget?.containsSelection || hovered)
-				? controlLayout.scaleEdges.map((edge) => (
-						<SelectedOutlineScaleEdgeLine
-							key={edge}
-							getAllScaleDragTargets={getAllScaleDragTargets}
-							dragging={dragging}
-							edge={edge}
-							hitWidth={
-								edge === 'top' || edge === 'bottom'
-									? controlLayout.scaleHitWidth.horizontal
-									: controlLayout.scaleHitWidth.vertical
-							}
-							outline={outline}
-							onContextMenuOpen={onContextMenuOpen}
-							onContextMenuOpenChange={onContextMenuOpenChange}
-							onDraggingChange={onDraggingChange}
-							onHoverChange={onHoverChange}
-							onSelect={onSelect}
-							target={controlTarget}
-						/>
-					))
-				: null}
-			{controlTarget?.cropDrag === null &&
-			(layoutTarget?.containsSelection || hovered)
-				? controlLayout.rotationCorners.map(({corner, point}) => (
-						<SelectedOutlineRotationCornerHandle
-							key={corner}
-							getAllRotationDragTargets={getAllRotationDragTargets}
-							corner={corner}
-							dragging={dragging}
-							handlePoint={point}
-							outline={outline}
-							onContextMenuOpen={onContextMenuOpen}
-							onContextMenuOpenChange={onContextMenuOpenChange}
-							onDraggingChange={onDraggingChange}
-							onHoverChange={onHoverChange}
-							onSelect={onSelect}
-							radius={controlLayout.rotationHandleRadius}
-							target={controlTarget}
-						/>
-					))
-				: null}
 		</>
 	);
 };

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useLayoutEffect, useMemo, useRef} from 'react';
+import React, {useContext, useLayoutEffect} from 'react';
 import type {ResolvedStackLocation} from 'remotion';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
@@ -9,12 +9,7 @@ import {
 	openInCodingAgent as launchCodingAgent,
 	openOriginalPositionInEditor,
 } from '../helpers/open-in-editor';
-import {timelineSequenceNodePathToKey} from '../helpers/timeline-node-path-key';
 import {SetSelectedModalContext} from '../state/modals';
-import {
-	useIsTimelineSequenceHovered,
-	useSetTimelineSequenceHover,
-} from '../state/timeline-sequence-hover';
 import {Transform3DModeStateContext} from '../state/transform-3d-mode';
 import {useConfirmationDialog} from './ConfirmationDialog';
 import {deleteJsxNode} from './delete-jsx-node-api';
@@ -47,6 +42,7 @@ import {
 	useEditorOpening,
 } from './use-default-editor-info';
 import {useSelectAsset} from './use-select-asset';
+import {useSelectedOutlineControlTarget} from './use-selected-outline-control-target';
 type SelectedOutlineElementProps = {
 	readonly compositionHeight: number;
 	readonly compositionWidth: number;
@@ -110,57 +106,11 @@ const SelectedOutlineElementUnmemoized: React.FC<
 	const {compositions} = useContext(Internals.CompositionManager);
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const {setManuallyEnabled} = useContext(Transform3DModeStateContext);
-	const setHoveredSequence = useSetTimelineSequenceHover();
-	const targetRef = useRef(layoutTarget);
-	useLayoutEffect(() => {
-		targetRef.current = layoutTarget;
-	}, [layoutTarget]);
-	const getTarget = React.useCallback(() => {
-		const currentTarget = targetRef.current;
-		if (currentTarget === undefined) {
-			return undefined;
-		}
-
-		return getLatestTargetByKey(currentTarget.key);
-	}, [getLatestTargetByKey]);
-	const getLayoutTarget = React.useCallback(() => targetRef.current, []);
-	const hoveredNodePathKey = useMemo(
-		() =>
-			layoutTarget === undefined
-				? null
-				: timelineSequenceNodePathToKey(
-						layoutTarget.nodePathInfo.sequenceSubscriptionKey,
-					),
-		[layoutTarget],
-	);
-	const hovered = useIsTimelineSequenceHovered(hoveredNodePathKey);
-	const controlTarget =
-		layoutTarget !== undefined && (layoutTarget.containsSelection || hovered)
-			? getLatestTargetByKey(layoutTarget.key)
-			: undefined;
-	const onHoverChange = React.useCallback(
-		(key: string | null) => {
-			setHoveredSequence((currentHover) => {
-				if (key !== null) {
-					const hoverTarget = targetRef.current;
-					if (hoverTarget === undefined || hoverTarget.key !== key) {
-						return currentHover;
-					}
-
-					return {
-						key,
-						nodePathKey: timelineSequenceNodePathToKey(
-							hoverTarget.nodePathInfo.sequenceSubscriptionKey,
-						),
-						source: 'canvas',
-					};
-				}
-
-				return currentHover?.source === 'canvas' ? null : currentHover;
-			});
-		},
-		[setHoveredSequence],
-	);
+	const {controlTarget, getLayoutTarget, getTarget, hovered, onHoverChange} =
+		useSelectedOutlineControlTarget({
+			getLatestTargetByKey,
+			layoutTarget,
+		});
 
 	const resolveOriginalLocation = React.useCallback(
 		async (resolveTarget: SelectedOutlineTarget) => {

--- a/packages/studio/src/components/SelectedOutlineRenderer.tsx
+++ b/packages/studio/src/components/SelectedOutlineRenderer.tsx
@@ -17,9 +17,11 @@ import {
 } from './selected-outline-measurement';
 import {orderOutlinesForRendering} from './selected-outline-order';
 import type {
+	SelectedOutlineContextMenuOpenHandler,
 	SelectedOutlineLayoutTarget,
 	SelectedOutlineTarget,
 } from './selected-outline-types';
+import {SelectedOutlineEditingHandles} from './SelectedOutlineEditingHandles';
 import {SelectedOutlineElement} from './SelectedOutlineElement';
 import {
 	SelectedOutlineSnapIndicators,
@@ -110,6 +112,23 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	const resizeObserverRef = useRef<ResizeObserver | null>(null);
 	const resizeObserverAnimationFrameRef = useRef<number | null>(null);
 	const observedOutlineElementsRef = useRef<ReadonlySet<Element>>(new Set());
+	const contextMenuOpenHandlersRef = useRef(
+		new Map<string, SelectedOutlineContextMenuOpenHandler>(),
+	);
+	const registerContextMenuOpen = useCallback(
+		(key: string, handler: SelectedOutlineContextMenuOpenHandler | null) => {
+			if (handler === null) {
+				contextMenuOpenHandlersRef.current.delete(key);
+			} else {
+				contextMenuOpenHandlersRef.current.set(key, handler);
+			}
+		},
+		[],
+	);
+	const getContextMenuOpenByKey = useCallback(
+		(key: string) => contextMenuOpenHandlersRef.current.get(key),
+		[],
+	);
 
 	const updateOutlines = useCallback(() => {
 		const targets = getOutlineTargets();
@@ -327,16 +346,31 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 					dragging={dragging}
 					getAllDragOutlines={getAllDragOutlines}
 					getAllDragTargets={getAllDragTargets}
-					getAllRotationDragTargets={getAllRotationDragTargets}
-					getAllScaleDragTargets={getAllScaleDragTargets}
 					getLatestTargetByKey={getLatestOutlineTargetByKey}
 					outline={outline}
 					onDraggingChange={onDraggingChange}
 					onContextMenuOpenChange={onContextMenuOpenChange}
 					onSnapPointsChange={onSnapPointsChange}
 					onSelect={onSelect}
+					registerContextMenuOpen={registerContextMenuOpen}
 					scale={scale}
 					layoutTarget={targetsByKey.get(outline.key)}
+				/>
+			))}
+			{/* Render editing handles after all outline polygons so selected controls stay visible and hit-testable over unrelated sequences. */}
+			{outlinesForRendering.map((outline) => (
+				<SelectedOutlineEditingHandles
+					key={`${outline.key}-editing-handles`}
+					dragging={dragging}
+					getAllRotationDragTargets={getAllRotationDragTargets}
+					getAllScaleDragTargets={getAllScaleDragTargets}
+					getContextMenuOpenByKey={getContextMenuOpenByKey}
+					getLatestTargetByKey={getLatestOutlineTargetByKey}
+					layoutTarget={targetsByKey.get(outline.key)}
+					onContextMenuOpenChange={onContextMenuOpenChange}
+					onDraggingChange={onDraggingChange}
+					onSelect={onSelect}
+					outline={outline}
 				/>
 			))}
 			{/* Keep UV controls above every transparent outline polygon so SVG hit-testing reaches the handles first. */}

--- a/packages/studio/src/components/use-selected-outline-control-target.ts
+++ b/packages/studio/src/components/use-selected-outline-control-target.ts
@@ -1,0 +1,74 @@
+import React, {useLayoutEffect, useMemo, useRef} from 'react';
+import {timelineSequenceNodePathToKey} from '../helpers/timeline-node-path-key';
+import {
+	useIsTimelineSequenceHovered,
+	useSetTimelineSequenceHover,
+} from '../state/timeline-sequence-hover';
+import type {
+	SelectedOutlineLayoutTarget,
+	SelectedOutlineTarget,
+} from './selected-outline-types';
+
+export const useSelectedOutlineControlTarget = ({
+	getLatestTargetByKey,
+	layoutTarget,
+}: {
+	readonly getLatestTargetByKey: (
+		key: string,
+	) => SelectedOutlineTarget | undefined;
+	readonly layoutTarget: SelectedOutlineLayoutTarget | undefined;
+}) => {
+	const setHoveredSequence = useSetTimelineSequenceHover();
+	const targetRef = useRef(layoutTarget);
+	useLayoutEffect(() => {
+		targetRef.current = layoutTarget;
+	}, [layoutTarget]);
+	const getTarget = React.useCallback(() => {
+		const currentTarget = targetRef.current;
+		if (currentTarget === undefined) {
+			return undefined;
+		}
+
+		return getLatestTargetByKey(currentTarget.key);
+	}, [getLatestTargetByKey]);
+	const getLayoutTarget = React.useCallback(() => targetRef.current, []);
+	const hoveredNodePathKey = useMemo(
+		() =>
+			layoutTarget === undefined
+				? null
+				: timelineSequenceNodePathToKey(
+						layoutTarget.nodePathInfo.sequenceSubscriptionKey,
+					),
+		[layoutTarget],
+	);
+	const hovered = useIsTimelineSequenceHovered(hoveredNodePathKey);
+	const controlTarget =
+		layoutTarget !== undefined && (layoutTarget.containsSelection || hovered)
+			? getLatestTargetByKey(layoutTarget.key)
+			: undefined;
+	const onHoverChange = React.useCallback(
+		(key: string | null) => {
+			setHoveredSequence((currentHover) => {
+				if (key !== null) {
+					const hoverTarget = targetRef.current;
+					if (hoverTarget === undefined || hoverTarget.key !== key) {
+						return currentHover;
+					}
+
+					return {
+						key,
+						nodePathKey: timelineSequenceNodePathToKey(
+							hoverTarget.nodePathInfo.sequenceSubscriptionKey,
+						),
+						source: 'canvas',
+					};
+				}
+
+				return currentHover?.source === 'canvas' ? null : currentHover;
+			});
+		},
+		[setHoveredSequence],
+	);
+
+	return {controlTarget, getLayoutTarget, getTarget, hovered, onHoverChange};
+};


### PR DESCRIPTION
## Summary

- render crop, scale, and corner-rotation handles after all canvas outline polygons
- preserve handle hover, drag, selection, and context-menu behavior in the global handle layer
- add a Playwright regression test for scale and rotation hit-testing over the overlapping polygon fixture
- mark the selected-handles visual-mode case as a baseline

## Testing

- `bunx playwright test e2e/studio.test.mts --grep "should keep selected editing handles above overlapping outlines"`
- `bun run build`
- `bun run stylecheck`

Closes #10459
