### PR TITLE
`@remotion/studio`: Reveal keyframes during navigation

### DIFF
--- a/packages/studio/src/components/InspectorPanel/KeyframeEasingNavigator.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeEasingNavigator.tsx
@@ -4,6 +4,7 @@ import {LIGHT_TEXT, WHITE_ALPHA_25} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
 import {InlineAction} from '../InlineAction';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
+import {ensureFrameIsInViewport} from '../Timeline/timeline-scroll-logic';
 import {TimelineKeyframeDiamondIcon} from '../Timeline/TimelineKeyframeDiamondIcon';
 import {TimelineKeyframeEasingLineVisual} from '../Timeline/TimelineKeyframeEasingLine';
 import {
@@ -209,22 +210,27 @@ export const KeyframeEasingNavigator: React.FC<{
 		[selectItems],
 	);
 	const seekToItem = useCallback(
-		(item: NavigatorItem) => {
+		(item: NavigatorItem, direction: 'fit-left' | 'fit-right') => {
 			const frame = getNavigatorItemPlayheadFrame(item);
 			setFrame((current) => {
 				const next = {...current, [videoConfig.id]: frame};
 				Internals.persistCurrentFrame(next);
 				return next;
 			});
+			ensureFrameIsInViewport({
+				direction,
+				durationInFrames: videoConfig.durationInFrames,
+				frame,
+			});
 		},
-		[setFrame, videoConfig.id],
+		[setFrame, videoConfig.durationInFrames, videoConfig.id],
 	);
 	const selectPrevious = useCallback(() => {
 		if (previousItem === null) {
 			return;
 		}
 
-		seekToItem(previousItem);
+		seekToItem(previousItem, 'fit-left');
 		selectItem(previousItem);
 	}, [previousItem, seekToItem, selectItem]);
 	const selectNext = useCallback(() => {
@@ -232,7 +238,7 @@ export const KeyframeEasingNavigator: React.FC<{
 			return;
 		}
 
-		seekToItem(nextItem);
+		seekToItem(nextItem, 'fit-right');
 		selectItem(nextItem);
 	}, [nextItem, seekToItem, selectItem]);
 

--- a/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeControls.tsx
@@ -43,6 +43,7 @@ import {
 	getKeyframeDisplayOffset,
 	getTimelineKeyframes,
 } from './get-timeline-keyframes';
+import {ensureFrameIsInViewport} from './timeline-scroll-logic';
 import {TimelineKeyframeDiamondIcon} from './TimelineKeyframeDiamondIcon';
 import {useTimelineKeyframeTracks} from './TimelineKeyframeTracksContext';
 import {
@@ -674,21 +675,26 @@ export const TimelineKeyframeControls: React.FC<{
 	]);
 
 	const seekToDisplayFrame = useCallback(
-		(frame: number) => {
+		(frame: number, direction: 'fit-left' | 'fit-right') => {
 			setFrame((current) => {
 				const next = {...current, [videoConfig.id]: frame};
 				Internals.persistCurrentFrame(next);
 				return next;
 			});
+			ensureFrameIsInViewport({
+				direction,
+				durationInFrames: videoConfig.durationInFrames,
+				frame,
+			});
 		},
-		[setFrame, videoConfig.id],
+		[setFrame, videoConfig.durationInFrames, videoConfig.id],
 	);
 
 	const onPrevious = useCallback(
 		(e: React.PointerEvent<HTMLButtonElement>) => {
 			e.stopPropagation();
 			if (previousDisplayFrame !== null) {
-				seekToDisplayFrame(previousDisplayFrame);
+				seekToDisplayFrame(previousDisplayFrame, 'fit-left');
 			}
 		},
 		[previousDisplayFrame, seekToDisplayFrame],
@@ -698,7 +704,7 @@ export const TimelineKeyframeControls: React.FC<{
 		(e: React.PointerEvent<HTMLButtonElement>) => {
 			e.stopPropagation();
 			if (nextDisplayFrame !== null) {
-				seekToDisplayFrame(nextDisplayFrame);
+				seekToDisplayFrame(nextDisplayFrame, 'fit-right');
 			}
 		},
 		[nextDisplayFrame, seekToDisplayFrame],


### PR DESCRIPTION
## Summary

- Reveal an off-screen keyframe when navigating with the timeline property controls
- Apply the same viewport behavior to the keyframe and easing Inspector navigator
- Preserve the current viewport when the destination frame is already visible

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #9766
