### PR TITLE
`@remotion/studio`: Add Agent Skills settings

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -736,6 +736,34 @@ test.describe('visual mode', () => {
 				},
 			});
 		});
+		await page.route('**/api/remotion-skills-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						remotionUpgradeSkillAvailable: false,
+						remotionInteractivitySkillAvailable: false,
+						skills: [
+							{
+								name: 'remotion-best-practices',
+								installedInProject: true,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-docs',
+								installedInProject: false,
+								installedGlobally: true,
+							},
+							{
+								name: 'remotion-studio',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+						],
+					},
+				},
+			});
+		});
 		try {
 			await page.goto(`${STUDIO_URL}/schema-test`);
 			await page.locator('[data-sidebar-toggle="right"]').click();
@@ -893,6 +921,44 @@ test.describe('visual mode', () => {
 				.poll(() => fs.readFileSync(configFile, 'utf8'))
 				.not.toContain('Config.setMaxTimelineTracks');
 			await expect(maxTimelineTracks).toHaveText('Default (Unlimited)');
+
+			await dialog.getByText('Skills', {exact: true}).click();
+			await expect(
+				dialog.getByText('Install missing skills', {exact: true}),
+			).toBeVisible();
+			await expect(
+				dialog.getByText(
+					'Skills give coding agents Remotion-specific instructions and best practices.',
+					{exact: true},
+				),
+			).toHaveCount(0);
+			await expect(
+				dialog.getByRole('heading', {name: 'Remotion Agent Skills'}),
+			).toHaveCount(0);
+			await expect(dialog.getByText('2 of 3 installed')).toHaveCount(0);
+			await expect(
+				dialog.getByText('/remotion-best-practices', {exact: true}),
+			).toBeVisible();
+			await expect(
+				dialog.getByText('/remotion-docs', {exact: true}),
+			).toBeVisible();
+			await expect(
+				dialog.getByText('/remotion-studio', {exact: true}),
+			).toBeVisible();
+			await expect(dialog.getByText('Project', {exact: true})).toBeVisible();
+			await expect(dialog.getByText('Global', {exact: true})).toBeVisible();
+			await expect(
+				dialog.getByText('Not installed', {exact: true}),
+			).toBeVisible();
+			await expect(
+				dialog.getByText('npx remotion skills add', {exact: true}),
+			).toBeVisible();
+			await expect(
+				dialog.getByRole('button', {name: 'Copy install command'}),
+			).toBeVisible();
+			await expect(
+				dialog.getByText('Changes save to', {exact: false}),
+			).toBeVisible();
 
 			await dialog.getByText('Apps', {exact: true}).click();
 			await expect(

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -750,12 +750,57 @@ test.describe('visual mode', () => {
 								installedGlobally: false,
 							},
 							{
+								name: 'remotion-captions',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-create',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
 								name: 'remotion-docs',
 								installedInProject: false,
 								installedGlobally: true,
 							},
 							{
+								name: 'remotion-interactivity',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-maps',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-markup',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-multimedia',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-render',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-saas',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
 								name: 'remotion-studio',
+								installedInProject: false,
+								installedGlobally: false,
+							},
+							{
+								name: 'remotion-upgrade',
 								installedInProject: false,
 								installedGlobally: false,
 							},
@@ -948,7 +993,7 @@ test.describe('visual mode', () => {
 			await expect(dialog.getByText('Project', {exact: true})).toBeVisible();
 			await expect(dialog.getByText('Global', {exact: true})).toBeVisible();
 			await expect(
-				dialog.getByText('Not installed', {exact: true}),
+				dialog.getByText('Not installed', {exact: true}).first(),
 			).toBeVisible();
 			await expect(
 				dialog.getByText('npx remotion skills add', {exact: true}),
@@ -956,6 +1001,24 @@ test.describe('visual mode', () => {
 			await expect(
 				dialog.getByRole('button', {name: 'Copy install command'}),
 			).toBeVisible();
+			const skillsList = dialog.getByRole('list', {
+				name: 'Remotion Agent Skills',
+			});
+			const skillsScrollContainer = skillsList.locator('..').locator('..');
+			await skillsScrollContainer.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+			});
+			const skillsScrollContainerBounds =
+				await skillsScrollContainer.boundingBox();
+			const lastSkillBounds = await skillsList
+				.getByRole('listitem')
+				.last()
+				.boundingBox();
+			expect(
+				skillsScrollContainerBounds!.y +
+					skillsScrollContainerBounds!.height -
+					(lastSkillBounds!.y + lastSkillBounds!.height),
+			).toBeGreaterThanOrEqual(16);
 			await expect(
 				dialog.getByText('Changes save to', {exact: false}),
 			).toBeVisible();

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -973,7 +973,7 @@ test.describe('visual mode', () => {
 			).toHaveCount(0);
 			await expect(
 				dialog.getByText(
-					'Not all skills are installed. To install skills, run this command in the project directory, then reload Studio and restart your coding agent.',
+					'Not all skills are installed. Run this command in the project directory, then reload Studio and restart your coding agent.',
 					{exact: true},
 				),
 			).toBeVisible();

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -969,24 +969,11 @@ test.describe('visual mode', () => {
 
 			await dialog.getByText('Skills', {exact: true}).click();
 			await expect(
-				dialog.getByText('Install missing skills', {exact: true}),
-			).toHaveCount(0);
-			await expect(
 				dialog.getByText(
 					'Not all skills are installed. Run this command in the project directory, then reload Studio and restart your coding agent.',
 					{exact: true},
 				),
 			).toBeVisible();
-			await expect(
-				dialog.getByText(
-					'Skills give coding agents Remotion-specific instructions and best practices.',
-					{exact: true},
-				),
-			).toHaveCount(0);
-			await expect(
-				dialog.getByRole('heading', {name: 'Remotion Agent Skills'}),
-			).toHaveCount(0);
-			await expect(dialog.getByText('2 of 3 installed')).toHaveCount(0);
 			await expect(
 				dialog.getByText('/remotion-best-practices', {exact: true}),
 			).toBeVisible();

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -970,6 +970,12 @@ test.describe('visual mode', () => {
 			await dialog.getByText('Skills', {exact: true}).click();
 			await expect(
 				dialog.getByText('Install missing skills', {exact: true}),
+			).toHaveCount(0);
+			await expect(
+				dialog.getByText(
+					'Not all skills are installed. To install skills, run this command in the project directory, then reload Studio and restart your coding agent.',
+					{exact: true},
+				),
 			).toBeVisible();
 			await expect(
 				dialog.getByText(

--- a/packages/studio-server/src/preview-server/routes/remotion-skills-info.ts
+++ b/packages/studio-server/src/preview-server/routes/remotion-skills-info.ts
@@ -6,7 +6,10 @@ import type {
 	GetRemotionSkillsInfoResponse,
 } from '@remotion/studio-shared';
 import {getRemotionSkillsDirectories} from '../../detect-outdated-remotion-skills';
-import type {RemotionSkillName} from '../../remotion-skill-names';
+import {
+	remotionSkillNames,
+	type RemotionSkillName,
+} from '../../remotion-skill-names';
 import type {ApiHandler} from '../api-types';
 
 export const getRemotionSkillsInfo = ({
@@ -20,16 +23,26 @@ export const getRemotionSkillsInfo = ({
 		cwd: remotionRoot,
 		homeDirectory,
 	});
-	const isSkillAvailable = (skillName: RemotionSkillName) =>
-		Object.values(skillsDirectories).some((skillsDirectory) =>
-			existsSync(path.join(skillsDirectory, skillName, 'SKILL.md')),
-		);
+	const skills = remotionSkillNames.map((name) => ({
+		name,
+		installedInProject: existsSync(
+			path.join(skillsDirectories.project, name, 'SKILL.md'),
+		),
+		installedGlobally: existsSync(
+			path.join(skillsDirectories.global, name, 'SKILL.md'),
+		),
+	}));
+	const isSkillAvailable = (skillName: RemotionSkillName) => {
+		const skill = skills.find(({name}) => name === skillName);
+		return Boolean(skill?.installedInProject || skill?.installedGlobally);
+	};
 
 	return {
 		remotionUpgradeSkillAvailable: isSkillAvailable('remotion-upgrade'),
 		remotionInteractivitySkillAvailable: isSkillAvailable(
 			'remotion-interactivity',
 		),
+		skills,
 	};
 };
 

--- a/packages/studio-server/src/test/remotion-skills-info.test.ts
+++ b/packages/studio-server/src/test/remotion-skills-info.test.ts
@@ -42,10 +42,31 @@ test('the skills info endpoint reports project skills', async () => {
 			response: {} as never,
 		});
 
-		expect(response).toEqual({
-			remotionUpgradeSkillAvailable: false,
-			remotionInteractivitySkillAvailable: true,
-		});
+		expect(response.remotionUpgradeSkillAvailable).toBe(false);
+		expect(response.remotionInteractivitySkillAvailable).toBe(true);
+		expect(response.skills.map(({name}) => name)).toEqual([
+			'remotion-best-practices',
+			'remotion-captions',
+			'remotion-create',
+			'remotion-docs',
+			'remotion-interactivity',
+			'remotion-maps',
+			'remotion-markup',
+			'remotion-multimedia',
+			'remotion-render',
+			'remotion-saas',
+			'remotion-studio',
+			'remotion-upgrade',
+		]);
+		expect(
+			response.skills.filter(({installedInProject}) => installedInProject),
+		).toEqual([
+			{
+				name: 'remotion-interactivity',
+				installedGlobally: false,
+				installedInProject: true,
+			},
+		]);
 	} finally {
 		rmSync(remotionRoot, {recursive: true, force: true});
 	}
@@ -68,10 +89,23 @@ test('global skills are also available to the endpoint response', () => {
 			'remotion-interactivity',
 		);
 
-		expect(getRemotionSkillsInfo({remotionRoot, homeDirectory})).toEqual({
-			remotionUpgradeSkillAvailable: true,
-			remotionInteractivitySkillAvailable: true,
-		});
+		const response = getRemotionSkillsInfo({remotionRoot, homeDirectory});
+		expect(response.remotionUpgradeSkillAvailable).toBe(true);
+		expect(response.remotionInteractivitySkillAvailable).toBe(true);
+		expect(
+			response.skills.filter(({installedGlobally}) => installedGlobally),
+		).toEqual([
+			{
+				name: 'remotion-interactivity',
+				installedGlobally: true,
+				installedInProject: false,
+			},
+			{
+				name: 'remotion-upgrade',
+				installedGlobally: true,
+				installedInProject: false,
+			},
+		]);
 	} finally {
 		rmSync(temporaryDirectory, {recursive: true, force: true});
 	}

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -1059,6 +1059,11 @@ export type GetRemotionSkillsInfoRequest = {};
 export type GetRemotionSkillsInfoResponse = {
 	remotionUpgradeSkillAvailable: boolean;
 	remotionInteractivitySkillAvailable: boolean;
+	skills: {
+		name: string;
+		installedInProject: boolean;
+		installedGlobally: boolean;
+	}[];
 };
 
 export type ProjectInfoRequest = {};

--- a/packages/studio/src/components/SettingsModal.tsx
+++ b/packages/studio/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useEffect, useState} from 'react';
 import {AppsIcon} from '../icons/apps';
 import {CertificateIcon} from '../icons/certificate';
 import {RemotionTriangleIcon} from '../icons/remotion-triangle';
+import {SkillsIcon} from '../icons/skills';
 import {FilmIcon} from '../icons/video';
 import {SetSelectedModalContext} from '../state/modals';
 import {DefaultEditorSettings} from './ConfigureDefaultEditorModal';
@@ -21,10 +22,11 @@ import {
 } from './RenderModal/render-modals';
 import {useSettings} from './SettingsContext';
 import {SettingsModalFooter} from './SettingsModalFooter';
+import {SkillsSettings} from './SkillsSettings';
 import {StudioSettings} from './StudioSettings';
 import {VerticalTab} from './Tabs/vertical';
 
-type SettingsTab = 'apps' | 'rendering' | 'studio' | 'license';
+type SettingsTab = 'apps' | 'rendering' | 'studio' | 'skills' | 'license';
 
 const hiddenPanel: React.CSSProperties = {
 	display: 'none',
@@ -106,6 +108,18 @@ export const SettingsModal: React.FC<{
 						</VerticalTab>
 						<VerticalTab
 							style={horizontalTab}
+							selected={tab === 'skills'}
+							onClick={() => selectTab('skills')}
+							renderIcon={(color) => (
+								<div style={iconContainer}>
+									<SkillsIcon color={color} style={icon} />
+								</div>
+							)}
+						>
+							Skills
+						</VerticalTab>
+						<VerticalTab
+							style={horizontalTab}
 							selected={tab === 'apps'}
 							onClick={() => selectTab('apps')}
 							renderIcon={(color) => (
@@ -143,6 +157,14 @@ export const SettingsModal: React.FC<{
 							className={VERTICAL_SCROLLBAR_CLASSNAME}
 						>
 							<LicenseSettings />
+						</div>
+					) : null}
+					{openedTabs.includes('skills') ? (
+						<div
+							style={tab === 'skills' ? settingsOptionsPanel : hiddenPanel}
+							className={VERTICAL_SCROLLBAR_CLASSNAME}
+						>
+							<SkillsSettings />
 						</div>
 					) : null}
 					{openedTabs.includes('rendering') ? (

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -38,13 +38,6 @@ const installationInstructions: React.CSSProperties = {
 	marginTop: 14,
 };
 
-const instructionsTitle: React.CSSProperties = {
-	color: WHITE,
-	fontSize: 13,
-	fontWeight: 600,
-	lineHeight: 1.4,
-};
-
 const commandField: React.CSSProperties = {
 	alignItems: 'center',
 	backgroundColor: 'rgba(0, 0, 0, 0.22)',
@@ -153,10 +146,10 @@ export const SkillsSettings: React.FC = () => {
 			) : null}
 			{missingSkills > 0 ? (
 				<div style={installationInstructions}>
-					<div style={instructionsTitle}>Install missing skills</div>
 					<p style={description}>
-						Run this command in the project directory, then reload Studio and
-						restart your coding agent.
+						Not all skills are installed. To install skills, run this command in
+						the project directory, then reload Studio and restart your coding
+						agent.
 					</p>
 					<div style={commandField}>
 						<pre style={command}>{INSTALL_COMMAND}</pre>

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -18,6 +18,7 @@ import {useSettings} from './SettingsContext';
 const INSTALL_COMMAND = 'npx remotion skills add';
 
 const container: React.CSSProperties = {
+	alignSelf: 'flex-start',
 	boxSizing: 'border-box',
 	flex: 1,
 	fontFamily: 'sans-serif',

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -31,11 +31,7 @@ const description: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	fontSize: 13,
 	lineHeight: 1.5,
-	margin: '4px 0 0',
-};
-
-const installationInstructions: React.CSSProperties = {
-	marginTop: 14,
+	margin: 0,
 };
 
 const commandField: React.CSSProperties = {
@@ -145,7 +141,7 @@ export const SkillsSettings: React.FC = () => {
 				</div>
 			) : null}
 			{missingSkills > 0 ? (
-				<div style={installationInstructions}>
+				<div>
 					<p style={description}>
 						Not all skills are installed. To install skills, run this command in
 						the project directory, then reload Studio and restart your coding

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -1,0 +1,212 @@
+import React, {useCallback, useMemo} from 'react';
+import {
+	BLUE,
+	BORDER_WHITE_ALPHA_12,
+	LIGHT_TEXT,
+	WHITE,
+} from '../helpers/colors';
+import {copyText} from '../helpers/copy-text';
+import {CheckCircleFilled} from '../icons/check-circle-filled';
+import {ClipboardIcon} from '../icons/clipboard';
+import {Minus} from '../icons/minus';
+import type {RenderInlineAction} from './InlineAction';
+import {InlineAction} from './InlineAction';
+import {ValidationMessage} from './NewComposition/ValidationMessage';
+import {showNotification} from './Notifications/NotificationCenter';
+import {useSettings} from './SettingsContext';
+
+const INSTALL_COMMAND = 'npx remotion skills add';
+
+const container: React.CSSProperties = {
+	boxSizing: 'border-box',
+	flex: 1,
+	fontFamily: 'sans-serif',
+	minWidth: 0,
+	padding: 16,
+	paddingBottom: 32,
+};
+
+const description: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontSize: 13,
+	lineHeight: 1.5,
+	margin: '4px 0 0',
+};
+
+const installationInstructions: React.CSSProperties = {
+	marginTop: 14,
+};
+
+const instructionsTitle: React.CSSProperties = {
+	color: WHITE,
+	fontSize: 13,
+	fontWeight: 600,
+	lineHeight: 1.4,
+};
+
+const commandField: React.CSSProperties = {
+	alignItems: 'center',
+	backgroundColor: 'rgba(0, 0, 0, 0.22)',
+	borderRadius: 4,
+	display: 'flex',
+	marginTop: 8,
+	padding: '5px 6px 5px 9px',
+};
+
+const command: React.CSSProperties = {
+	color: WHITE,
+	flex: 1,
+	fontFamily: 'monospace',
+	fontSize: 13,
+	lineHeight: '24px',
+	margin: 0,
+	minWidth: 0,
+	overflowX: 'auto',
+	whiteSpace: 'pre',
+};
+
+const copyIcon: React.CSSProperties = {
+	height: 12,
+	width: 12,
+};
+
+const list: React.CSSProperties = {
+	marginTop: 14,
+};
+
+const skillRow: React.CSSProperties = {
+	alignItems: 'center',
+	borderBottom: BORDER_WHITE_ALPHA_12,
+	display: 'flex',
+	gap: 10,
+	minHeight: 38,
+	padding: '0 10px',
+};
+
+const lastSkillRow: React.CSSProperties = {
+	...skillRow,
+	borderBottom: 'none',
+};
+
+const statusIcon: React.CSSProperties = {
+	flexShrink: 0,
+	height: 14,
+	width: 14,
+};
+
+const skillName: React.CSSProperties = {
+	color: WHITE,
+	flex: 1,
+	fontFamily: 'monospace',
+	fontSize: 13,
+	lineHeight: 1.4,
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
+const status: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontSize: 12,
+	lineHeight: 1.4,
+	whiteSpace: 'nowrap',
+};
+
+const loading: React.CSSProperties = {
+	...description,
+	marginTop: 14,
+};
+
+export const SkillsSettings: React.FC = () => {
+	const {error, remotionSkillsInfo} = useSettings();
+	const installedSkills = useMemo(() => {
+		return (
+			remotionSkillsInfo?.skills.filter(
+				({installedGlobally, installedInProject}) =>
+					installedGlobally || installedInProject,
+			).length ?? 0
+		);
+	}, [remotionSkillsInfo]);
+	const missingSkills =
+		(remotionSkillsInfo?.skills.length ?? 0) - installedSkills;
+
+	const onCopy = useCallback(() => {
+		copyText(INSTALL_COMMAND).catch((err) => {
+			showNotification(`Could not copy: ${err.message}`, 2000);
+		});
+	}, []);
+	const renderCopyAction: RenderInlineAction = useCallback((color) => {
+		return <ClipboardIcon color={color} style={copyIcon} />;
+	}, []);
+
+	return (
+		<div style={container}>
+			{remotionSkillsInfo === null && error === null ? (
+				<p style={loading}>Checking installed skills...</p>
+			) : null}
+			{remotionSkillsInfo === null && error ? (
+				<div style={{marginTop: 14}}>
+					<ValidationMessage message={error} align="flex-start" type="error" />
+				</div>
+			) : null}
+			{missingSkills > 0 ? (
+				<div style={installationInstructions}>
+					<div style={instructionsTitle}>Install missing skills</div>
+					<p style={description}>
+						Run this command in the project directory, then reload Studio and
+						restart your coding agent.
+					</p>
+					<div style={commandField}>
+						<pre style={command}>{INSTALL_COMMAND}</pre>
+						<InlineAction
+							variant={null}
+							onClick={onCopy}
+							renderAction={renderCopyAction}
+							title="Copy install command"
+						/>
+					</div>
+				</div>
+			) : null}
+			{remotionSkillsInfo ? (
+				<div style={list} role="list" aria-label="Remotion Agent Skills">
+					{remotionSkillsInfo.skills.map((skill, index) => {
+						const installed =
+							skill.installedInProject || skill.installedGlobally;
+						const installedLocation =
+							skill.installedInProject && skill.installedGlobally
+								? 'Project and global'
+								: skill.installedInProject
+									? 'Project'
+									: skill.installedGlobally
+										? 'Global'
+										: 'Not installed';
+
+						return (
+							<div
+								key={skill.name}
+								role="listitem"
+								style={
+									index === remotionSkillsInfo.skills.length - 1
+										? lastSkillRow
+										: skillRow
+								}
+							>
+								{installed ? (
+									<CheckCircleFilled
+										aria-hidden
+										style={{...statusIcon, fill: BLUE}}
+									/>
+								) : (
+									<Minus aria-hidden color={LIGHT_TEXT} style={statusIcon} />
+								)}
+								<span style={skillName}>/{skill.name}</span>
+								<span style={status}>{installedLocation}</span>
+							</div>
+						);
+					})}
+				</div>
+			) : null}
+		</div>
+	);
+};

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -23,8 +23,7 @@ const container: React.CSSProperties = {
 	flex: 1,
 	fontFamily: 'sans-serif',
 	minWidth: 0,
-	padding: 16,
-	paddingBottom: 32,
+	padding: '16px 16px 0',
 };
 
 const description: React.CSSProperties = {

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -143,9 +143,8 @@ export const SkillsSettings: React.FC = () => {
 			{missingSkills > 0 ? (
 				<div>
 					<p style={description}>
-						Not all skills are installed. To install skills, run this command in
-						the project directory, then reload Studio and restart your coding
-						agent.
+						Not all skills are installed. Run this command in the project
+						directory, then reload Studio and restart your coding agent.
 					</p>
 					<div style={commandField}>
 						<pre style={command}>{INSTALL_COMMAND}</pre>

--- a/packages/studio/src/icons/skills.tsx
+++ b/packages/studio/src/icons/skills.tsx
@@ -1,0 +1,23 @@
+import type {SVGProps} from 'react';
+
+export const SkillsIcon: React.FC<
+	SVGProps<SVGSVGElement> & {readonly color: string}
+> = ({color, ...props}) => {
+	return (
+		<svg {...props} fill="none" viewBox="0 0 16 16">
+			<path
+				d="M8 0.9 14.05 4.35v7.3L8 15.1 1.95 11.65v-7.3L8 0.9Z"
+				stroke={color}
+				strokeLinejoin="round"
+				strokeWidth="1.1"
+			/>
+			<path
+				d="m1.95 4.35 6.05 3.55 6.05-3.55M8 7.9v7.2M1.95 8 8 11.55 14.05 8"
+				stroke={color}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				strokeWidth="1.1"
+			/>
+		</svg>
+	);
+};


### PR DESCRIPTION
## Summary

- add a Skills tab to Studio settings
- show project and global installation status for Remotion Agent Skills
- provide copyable installation instructions for missing skills

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio-server/src/test/remotion-skills-info.test.ts`
- `bunx playwright test e2e/studio.test.mts --grep "settings reuse reactive runtime config and license toggle"` (from `packages/example`)
