### PR TITLE
`@remotion/studio`: Make all sequence inspector sections collapsible

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -434,6 +434,33 @@ test.describe('inspector section collapse', () => {
 		await expect(
 			page.getByRole('button', {name: 'Expand Crop', exact: true}),
 		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Collapse Transform', exact: true}),
+		).toBeVisible();
+		await page
+			.getByRole('button', {name: 'Collapse Transform', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Transform', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Show 3D transform controls'}),
+		).toHaveCount(0);
+		await page
+			.getByRole('button', {name: 'Expand Transform', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Show 3D transform controls'}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Collapse Effects', exact: true}),
+		).toBeVisible();
+		await page
+			.getByRole('button', {name: 'Collapse Effects', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Effects', exact: true}),
+		).toBeVisible();
 
 		await page
 			.getByRole('button', {name: 'Expand Border radius', exact: true})
@@ -488,6 +515,15 @@ test.describe('inspector section collapse', () => {
 		await page.locator('[title="Default premount"]').first().click();
 		await expect(
 			page.getByRole('button', {name: 'Expand Layout', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Collapse Source', exact: true}),
+		).toBeVisible();
+		await page
+			.getByRole('button', {name: 'Collapse Source', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Source', exact: true}),
 		).toBeVisible();
 
 		await page.goto(`${STUDIO_URL}/visual-mode-3d`);

--- a/packages/studio/src/components/CaptionInspector.tsx
+++ b/packages/studio/src/components/CaptionInspector.tsx
@@ -2,15 +2,12 @@ import type {Caption} from '@remotion/captions';
 import React from 'react';
 import {LIGHT_TEXT} from '../helpers/colors';
 import {CaptionTextEditor} from './CaptionTextEditor';
+import {CollapsibleInspectorSectionHeader} from './InspectorPanel/CollapsibleInspectorSectionHeader';
 import {
 	InspectorSectionDivider,
 	InspectorSectionHeader,
 } from './InspectorPanel/common';
-import {
-	sectionHeaderEnd,
-	sectionHeaderRow,
-	sectionHeaderTitle,
-} from './InspectorPanel/styles';
+import {sectionHeaderEnd} from './InspectorPanel/styles';
 
 const readOnlyStatus: React.CSSProperties = {
 	color: LIGHT_TEXT,
@@ -23,16 +20,20 @@ const readOnlyStatus: React.CSSProperties = {
 
 export const CaptionInspector: React.FC<{
 	readonly captions: Caption[];
+	readonly expanded: boolean;
 	readonly onTextChange: (captions: Caption[]) => void;
 	readonly onTextSave: ((captions: Caption[]) => void) | null;
 	readonly onTextCancel: (() => void) | null;
+	readonly onToggle: () => void;
 	readonly readOnly: boolean;
 	readonly readOnlyTitle: string | null;
 }> = ({
 	captions,
+	expanded,
 	onTextChange,
 	onTextSave,
 	onTextCancel,
+	onToggle,
 	readOnly,
 	readOnlyTitle,
 }) => {
@@ -40,24 +41,30 @@ export const CaptionInspector: React.FC<{
 		<>
 			<InspectorSectionDivider />
 			<InspectorSectionHeader>
-				<div style={sectionHeaderRow}>
-					<div style={sectionHeaderTitle}>Captions</div>
-					<div style={sectionHeaderEnd}>
-						{readOnly ? (
-							<div style={readOnlyStatus} title={readOnlyTitle ?? undefined}>
-								Read only
-							</div>
-						) : null}
-					</div>
-				</div>
+				<CollapsibleInspectorSectionHeader
+					action={
+						<div style={sectionHeaderEnd}>
+							{readOnly ? (
+								<div style={readOnlyStatus} title={readOnlyTitle ?? undefined}>
+									Read only
+								</div>
+							) : null}
+						</div>
+					}
+					expanded={expanded}
+					label="Captions"
+					onToggle={onToggle}
+				/>
 			</InspectorSectionHeader>
-			<CaptionTextEditor
-				captions={captions}
-				onChange={onTextChange}
-				onSave={onTextSave}
-				onCancel={onTextCancel}
-				readOnly={readOnly}
-			/>
+			{expanded ? (
+				<CaptionTextEditor
+					captions={captions}
+					onChange={onTextChange}
+					onSave={onTextSave}
+					onCancel={onTextCancel}
+					readOnly={readOnly}
+				/>
+			) : null}
 		</>
 	);
 };

--- a/packages/studio/src/components/InlineCaptionInspector.tsx
+++ b/packages/studio/src/components/InlineCaptionInspector.tsx
@@ -54,10 +54,20 @@ const getCaptionPatches = ({
 export const InlineCaptionInspector: React.FC<{
 	readonly captions: Caption[];
 	readonly controls: SequenceRegistrationControls;
+	readonly expanded: boolean;
 	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly onToggle: () => void;
 	readonly readOnlyStudio: boolean;
 	readonly validatedLocation: CodePosition;
-}> = ({captions, controls, nodePath, readOnlyStudio, validatedLocation}) => {
+}> = ({
+	captions,
+	controls,
+	expanded,
+	nodePath,
+	onToggle,
+	readOnlyStudio,
+	validatedLocation,
+}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
@@ -160,9 +170,11 @@ export const InlineCaptionInspector: React.FC<{
 	return (
 		<CaptionInspector
 			captions={draftCaptions}
+			expanded={expanded}
 			onTextChange={updateCaptions}
 			onTextSave={saveCaptions}
 			onTextCancel={cancelCaptions}
+			onToggle={onToggle}
 			readOnly={!canSave}
 			readOnlyTitle={canSave ? null : readOnlyTitle}
 		/>

--- a/packages/studio/src/components/InspectorPanel/CollapsibleInspectorSectionHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/CollapsibleInspectorSectionHeader.tsx
@@ -1,0 +1,58 @@
+import React, {useMemo, useState} from 'react';
+import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
+import {sectionHeaderRow} from './styles';
+
+const collapsibleSectionHeaderButton: React.CSSProperties = {
+	appearance: 'none',
+	backgroundColor: 'transparent',
+	border: 'none',
+	borderRadius: 3,
+	cursor: 'default',
+	display: 'block',
+	flex: 1,
+	fontFamily: 'Arial, Helvetica, sans-serif',
+	fontSize: 12,
+	fontWeight: 'bold',
+	lineHeight: '16px',
+	margin: 0,
+	minWidth: 0,
+	overflow: 'hidden',
+	padding: '4px 0',
+	textAlign: 'left',
+	textOverflow: 'ellipsis',
+	userSelect: 'none',
+	whiteSpace: 'nowrap',
+};
+
+export const CollapsibleInspectorSectionHeader: React.FC<{
+	readonly action: React.ReactNode;
+	readonly expanded: boolean;
+	readonly label: string;
+	readonly onToggle: () => void;
+}> = ({action, expanded, label, onToggle}) => {
+	const [hovered, setHovered] = useState(false);
+	const style = useMemo<React.CSSProperties>(() => {
+		return {
+			...collapsibleSectionHeaderButton,
+			color: hovered ? WHITE : LIGHT_TEXT,
+		};
+	}, [hovered]);
+
+	return (
+		<div style={sectionHeaderRow}>
+			<button
+				type="button"
+				aria-expanded={expanded}
+				aria-label={`${expanded ? 'Collapse' : 'Expand'} ${label}`}
+				className="__remotion-inspector-section-title"
+				onClick={onToggle}
+				onPointerEnter={() => setHovered(true)}
+				onPointerLeave={() => setHovered(false)}
+				style={style}
+			>
+				{label}
+			</button>
+			{action}
+		</div>
+	);
+};

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -29,12 +29,12 @@ import {Transform3DModeStateContext} from '../state/transform-3d-mode';
 import {AssetFileIcon} from './AssetFileIcon';
 import {InlineAction} from './InlineAction';
 import {InlineCaptionInspector} from './InlineCaptionInspector';
+import {CollapsibleInspectorSectionHeader} from './InspectorPanel/CollapsibleInspectorSectionHeader';
 import {InspectorSection} from './InspectorPanel/common';
 import {
 	getInspectorSectionActivity,
 	isSmartCollapsibleInspectorGroup,
 } from './InspectorPanel/inspector-section-collapse';
-import {sectionHeaderRow, sectionHeaderTitle} from './InspectorPanel/styles';
 import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	BORDER_RADIUS_SHORTHAND_KEY,
@@ -84,11 +84,6 @@ const emptyState: React.CSSProperties = {
 	padding: '0 12px',
 };
 
-const effectsHeaderTitle: React.CSSProperties = {
-	...sectionHeaderTitle,
-	flexShrink: 1,
-};
-
 const plusIcon: React.CSSProperties = {
 	width: 15,
 	height: 15,
@@ -104,61 +99,6 @@ const transform3DToggleIcon: React.CSSProperties = {
 	flexShrink: 0,
 	height: 14,
 	width: 14,
-};
-
-const collapsibleSectionHeaderButton: React.CSSProperties = {
-	appearance: 'none',
-	backgroundColor: 'transparent',
-	border: 'none',
-	borderRadius: 3,
-	cursor: 'default',
-	display: 'block',
-	flex: 1,
-	fontFamily: 'Arial, Helvetica, sans-serif',
-	fontSize: 12,
-	fontWeight: 'bold',
-	lineHeight: '16px',
-	margin: 0,
-	minWidth: 0,
-	overflow: 'hidden',
-	padding: '4px 0',
-	textAlign: 'left',
-	textOverflow: 'ellipsis',
-	userSelect: 'none',
-	whiteSpace: 'nowrap',
-};
-
-const CollapsibleInspectorSectionHeader: React.FC<{
-	readonly action: React.ReactNode;
-	readonly expanded: boolean;
-	readonly label: string;
-	readonly onToggle: () => void;
-}> = ({action, expanded, label, onToggle}) => {
-	const [hovered, setHovered] = useState(false);
-	const style = useMemo<React.CSSProperties>(() => {
-		return {
-			...collapsibleSectionHeaderButton,
-			color: hovered ? WHITE : LIGHT_TEXT,
-		};
-	}, [hovered]);
-
-	return (
-		<div style={sectionHeaderRow}>
-			<button
-				type="button"
-				aria-expanded={expanded}
-				aria-label={`${expanded ? 'Collapse' : 'Expand'} ${label}`}
-				className="__remotion-inspector-section-title"
-				onClick={onToggle}
-				onPointerEnter={() => setHovered(true)}
-				onPointerLeave={() => setHovered(false)}
-				style={style}
-			>
-				{label}
-			</button>
-			{action}
-		</div>
-	);
 };
 
 const assetSelectorIcon: React.CSSProperties = {
@@ -261,6 +201,7 @@ const persistInspectorCollapsedKeys = (keys: ReadonlySet<string>): void => {
 };
 
 type InspectorSectionExpansionOverrides = Readonly<Record<string, boolean>>;
+type AdditionalInspectorSectionId = 'captions' | 'effects';
 
 const loadInspectorSectionExpansionOverrides =
 	(): InspectorSectionExpansionOverrides => {
@@ -314,16 +255,16 @@ const persistInspectorSectionExpansionOverrides = (
 
 const getInspectorSectionExpansionKey = ({
 	nodePathInfo,
-	groupId,
+	sectionId,
 }: {
 	readonly nodePathInfo: SequenceNodePathInfo;
-	readonly groupId: SchemaFieldGroupInfo['id'];
+	readonly sectionId: SchemaFieldGroupInfo['id'] | AdditionalInspectorSectionId;
 }) => {
 	return JSON.stringify([
 		nodePathInfo.sequenceSubscriptionKey.absolutePath,
 		nodePathInfo.sequenceSubscriptionKey.nodePath,
 		nodePathInfo.index,
-		groupId,
+		sectionId,
 	]);
 };
 
@@ -575,7 +516,7 @@ export const InspectorSequenceSection: React.FC<{
 
 				const expansionKey = getInspectorSectionExpansionKey({
 					nodePathInfo,
-					groupId: group.id,
+					sectionId: group.id,
 				});
 				const activity = getControlGroupActivity(group);
 				if (activity === 'active' && next[expansionKey] !== true) {
@@ -595,17 +536,17 @@ export const InspectorSequenceSection: React.FC<{
 	}, [controlGroups, getControlGroupActivity, nodePathInfo]);
 	const isControlGroupExpanded = useCallback(
 		(group: InspectorControlGroup): boolean => {
-			if (!isSmartCollapsibleInspectorGroup(group.id)) {
-				return true;
-			}
-
 			const expansionKey = getInspectorSectionExpansionKey({
 				nodePathInfo,
-				groupId: group.id,
+				sectionId: group.id,
 			});
 			const override = sectionExpansionOverrides[expansionKey];
 			if (override !== undefined) {
 				return override;
+			}
+
+			if (!isSmartCollapsibleInspectorGroup(group.id)) {
+				return true;
 			}
 
 			const automaticExpansion = automaticSectionExpansion[expansionKey];
@@ -626,7 +567,7 @@ export const InspectorSequenceSection: React.FC<{
 		(group: InspectorControlGroup) => {
 			const expansionKey = getInspectorSectionExpansionKey({
 				nodePathInfo,
-				groupId: group.id,
+				sectionId: group.id,
 			});
 			const nextExpanded = !isControlGroupExpanded(group);
 			setSectionExpansionOverrides((previous) => {
@@ -637,6 +578,33 @@ export const InspectorSequenceSection: React.FC<{
 		},
 		[isControlGroupExpanded, nodePathInfo],
 	);
+	const isAdditionalSectionExpanded = useCallback(
+		(sectionId: AdditionalInspectorSectionId): boolean => {
+			const expansionKey = getInspectorSectionExpansionKey({
+				nodePathInfo,
+				sectionId,
+			});
+			return sectionExpansionOverrides[expansionKey] ?? true;
+		},
+		[nodePathInfo, sectionExpansionOverrides],
+	);
+	const toggleAdditionalSection = useCallback(
+		(sectionId: AdditionalInspectorSectionId) => {
+			const expansionKey = getInspectorSectionExpansionKey({
+				nodePathInfo,
+				sectionId,
+			});
+			const nextExpanded = !isAdditionalSectionExpanded(sectionId);
+			setSectionExpansionOverrides((previous) => {
+				const next = {...previous, [expansionKey]: nextExpanded};
+				persistInspectorSectionExpansionOverrides(next);
+				return next;
+			});
+		},
+		[isAdditionalSectionExpanded, nodePathInfo],
+	);
+	const captionsExpanded = isAdditionalSectionExpanded('captions');
+	const effectsExpanded = isAdditionalSectionExpanded('effects');
 	const visibleControlRows = controlGroups.flatMap((group) => {
 		return isControlGroupExpanded(group) ? group.rows : [];
 	});
@@ -779,16 +747,20 @@ export const InspectorSequenceSection: React.FC<{
 	);
 
 	const effectsHeader = (
-		<div style={sectionHeaderRow}>
-			<div style={effectsHeaderTitle}>Effects</div>
-			<InlineAction
-				variant={null}
-				disabled={!canAddEffect}
-				onClick={onAddEffect}
-				title={canAddEffect ? 'Add effect' : undefined}
-				renderAction={(color) => <Plus color={color} style={plusIcon} />}
-			/>
-		</div>
+		<CollapsibleInspectorSectionHeader
+			action={
+				<InlineAction
+					variant={null}
+					disabled={!canAddEffect}
+					onClick={onAddEffect}
+					title={canAddEffect ? 'Add effect' : undefined}
+					renderAction={(color) => <Plus color={color} style={plusIcon} />}
+				/>
+			}
+			expanded={effectsExpanded}
+			label="Effects"
+			onToggle={() => toggleAdditionalSection('effects')}
+		/>
 	);
 
 	const renderRow = ({node, depth}: FlatTreeRow) => {
@@ -815,26 +787,22 @@ export const InspectorSequenceSection: React.FC<{
 	};
 
 	const renderControlGroupHeader = (group: InspectorControlGroup) => {
-		const collapsible = isSmartCollapsibleInspectorGroup(group.id);
 		const expanded = isControlGroupExpanded(group);
-		if (collapsible) {
-			return (
-				<CollapsibleInspectorSectionHeader
-					action={
-						group.id === 'border-radius' && expanded ? borderRadiusAction : null
-					}
-					expanded={expanded}
-					label={group.label}
-					onToggle={() => toggleControlGroup(group)}
-				/>
-			);
-		}
-
 		return (
-			<div style={sectionHeaderRow}>
-				<div style={effectsHeaderTitle}>{group.label}</div>
-				{group.id === 'transforms' ? transform3DAction : null}
-			</div>
+			<CollapsibleInspectorSectionHeader
+				action={
+					expanded
+						? group.id === 'border-radius'
+							? borderRadiusAction
+							: group.id === 'transforms'
+								? transform3DAction
+								: null
+						: null
+				}
+				expanded={expanded}
+				label={group.label}
+				onToggle={() => toggleControlGroup(group)}
+			/>
 		);
 	};
 
@@ -882,14 +850,16 @@ export const InspectorSequenceSection: React.FC<{
 					<InlineCaptionInspector
 						captions={inlineCaptions}
 						controls={sequence.controls}
+						expanded={captionsExpanded}
 						nodePath={nodePathInfo.sequenceSubscriptionKey}
+						onToggle={() => toggleAdditionalSection('captions')}
 						readOnlyStudio={readOnlyStudio}
 						validatedLocation={validatedLocation}
 					/>
 				) : null}
 				{showEffectsSection ? (
 					<InspectorSection header={effectsHeader}>
-						{effectRows.length > 0 ? (
+						{effectsExpanded && effectRows.length > 0 ? (
 							<TimelineSelectionOrderProvider items={effectSelectableItems}>
 								{effectRows.map(renderRow)}
 							</TimelineSelectionOrderProvider>


### PR DESCRIPTION
## Summary

- make every sequence inspector section collapsible through a shared accessible header
- preserve the existing default state: inactive smart sections remain collapsed while Source, Transform, Effects, and Captions remain expanded
- persist manual expansion overrides per sequence and add end-to-end coverage for Source, Transform, and Effects

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/inspector-section-collapse.test.ts`
- `bunx playwright test e2e/inspector-section-collapse.test.mts` from `packages/example`
