### PR TITLE
Docs: Make document background opaque

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -145,6 +145,10 @@ h6 {
 	--box-stroke: gray;
 }
 
+html[data-theme] {
+	--ifm-background-color: var(--background);
+}
+
 [data-theme='light'] .docusaurus-highlight-code-line {
 	background-color: rgb(232, 232, 232);
 	display: block;


### PR DESCRIPTION
## Summary

- connect Infima's document background variable to the existing theme-aware docs background
- keep the docs canvas opaque in standalone and iframe contexts in both light and dark modes
- leave Studio iframe and Element Studio behavior unchanged

This fixes the regression exposed by #10696: when the docs website is embedded in an iframe, Infima's transparent document canvas allows the embedding page's background to show through.

## Verification

- `bunx oxfmt packages/docs/src/css/custom.css --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun run lint`
- `cd packages/docs && bun run test`
- manually compared before and after docs iframes over a contrasting host background in light and dark modes

