### PR TITLE
`@remotion/browser-studio`: Support remote asset drops

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -64,6 +64,7 @@ import type {
 } from 'remotion';
 import {createBrowserStudioProjectController} from './browser-studio-project-controller';
 import {makeBrowserStudioProjectArchive} from './download-project';
+import {downloadRemoteAssetInBrowserStudio} from './download-remote-asset';
 import {saveSequencePropsInProject} from './save-sequence-props';
 import type {VirtualProject} from './types';
 
@@ -1872,6 +1873,12 @@ export const createBrowserStudioOperations = ({
 		},
 		deleteJsxNode,
 		deleteStaticFile: controller.deleteStaticFile,
+		downloadRemoteAsset: (request) =>
+			downloadRemoteAssetInBrowserStudio({
+				getProject,
+				request,
+				writeStaticFile: controller.writeStaticFile,
+			}),
 		downloadProject: () =>
 			makeBrowserStudioProjectArchive({
 				dependencyVersions,

--- a/packages/browser-studio/src/download-remote-asset.ts
+++ b/packages/browser-studio/src/download-remote-asset.ts
@@ -1,0 +1,160 @@
+import {
+	detectFileType,
+	getRemoteAssetElement,
+	getRemoteAssetFilename,
+	isImageFileType,
+	maxRemoteAssetSize,
+	remoteAssetAcceptHeader,
+	remoteAssetDownloadTimeout,
+	type DownloadRemoteAssetRequest,
+	type DownloadRemoteAssetResponse,
+} from '@remotion/studio-shared';
+import type {VirtualProject, VirtualProjectPublicFile} from './types';
+
+const getPublicFileSize = (contents: VirtualProjectPublicFile) => {
+	if (typeof contents === 'string') {
+		return new TextEncoder().encode(contents).byteLength;
+	}
+
+	return contents instanceof Uint8Array
+		? contents.byteLength
+		: contents.sizeInBytes;
+};
+
+export const downloadRemoteAssetInBrowserStudio = async ({
+	getProject,
+	request,
+	writeStaticFile,
+}: {
+	getProject: () => VirtualProject;
+	request: DownloadRemoteAssetRequest;
+	writeStaticFile: (request: {
+		contents: string | ArrayBuffer;
+		filePath: string;
+	}) => Promise<void>;
+}): Promise<DownloadRemoteAssetResponse> => {
+	const url = new URL(request.url);
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+		throw new Error('Only HTTP(S) URLs can be imported');
+	}
+
+	if (url.username !== '' || url.password !== '') {
+		throw new Error('Remote asset URLs cannot include credentials');
+	}
+
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => {
+		abortController.abort();
+	}, remoteAssetDownloadTimeout);
+
+	let contents: Uint8Array;
+	try {
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				headers: {accept: remoteAssetAcceptHeader},
+				signal: abortController.signal,
+			});
+		} catch (error) {
+			if (error instanceof Error && error.name === 'AbortError') {
+				throw new Error('Timed out downloading remote asset');
+			}
+
+			throw new Error(
+				`Could not fetch remote asset. The URL may not allow cross-origin requests (CORS): ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+
+		if (!response.ok) {
+			throw new Error(`Could not download remote asset: ${response.status}`);
+		}
+
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > maxRemoteAssetSize) {
+			abortController.abort();
+			throw new Error('Remote asset exceeds the 50MB size limit');
+		}
+
+		if (!response.body) {
+			const buffer = await response.arrayBuffer();
+			if (buffer.byteLength > maxRemoteAssetSize) {
+				throw new Error('Remote asset exceeds the 50MB size limit');
+			}
+
+			contents = new Uint8Array(buffer);
+		} else {
+			const reader = response.body.getReader();
+			const chunks: Uint8Array[] = [];
+			let size = 0;
+
+			while (true) {
+				const {done, value} = await reader.read();
+				if (done) {
+					break;
+				}
+
+				if (!value) {
+					continue;
+				}
+
+				size += value.byteLength;
+				if (size > maxRemoteAssetSize) {
+					abortController.abort();
+					await reader.cancel();
+					throw new Error('Remote asset exceeds the 50MB size limit');
+				}
+
+				chunks.push(value);
+			}
+
+			contents = new Uint8Array(size);
+			let offset = 0;
+			for (const chunk of chunks) {
+				contents.set(chunk, offset);
+				offset += chunk.byteLength;
+			}
+		}
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			throw new Error('Timed out downloading remote asset');
+		}
+
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	const fileType = detectFileType(contents);
+	if (!isImageFileType(fileType)) {
+		throw new Error('Remote asset is not a supported image');
+	}
+
+	const assetPath = getRemoteAssetFilename({fileType, url});
+	const existing = Object.entries(getProject().publicFiles ?? {}).find(
+		([path]) => path.replace(/^\/+/, '') === assetPath,
+	)?.[1];
+	if (
+		existing !== undefined &&
+		getPublicFileSize(existing) !== contents.byteLength
+	) {
+		throw new Error(
+			`File with name ${assetPath} already exists and is different`,
+		);
+	}
+
+	if (existing === undefined) {
+		await writeStaticFile({
+			contents: contents.slice().buffer,
+			filePath: assetPath,
+		});
+	}
+
+	return {
+		assetPath,
+		created: existing === undefined,
+		element: getRemoteAssetElement({assetPath, fileType}),
+		sizeInBytes: contents.byteLength,
+	};
+};

--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -206,6 +206,91 @@ test('mutates virtual files, emits events, and preserves undo and redo history',
 	expect(revokedUrls).toContain('blob:virtual-2');
 });
 
+test('downloads CORS-enabled remote assets and rejects failed cross-origin fetches', async () => {
+	const initialProject = createBlankTemplateProject();
+	let project = initialProject;
+	const operations = createBrowserStudioOperations({
+		dependencyVersions: {},
+		getStaticFiles: null,
+		getProject: () => project,
+		initialElement: null,
+		onProjectChange: (nextProject) => {
+			project = nextProject;
+		},
+		resolveDependencies: null,
+	});
+	const originalFetch = globalThis.fetch;
+	const requestedUrls: string[] = [];
+	const gif = new Uint8Array([
+		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x20, 0x03, 0x58, 0x02,
+	]);
+	globalThis.fetch = Object.assign(
+		(input: Parameters<typeof fetch>[0]) => {
+			const url = input.toString();
+			requestedUrls.push(url);
+			if (url.includes('cors-blocked')) {
+				return Promise.reject(new TypeError('Load failed'));
+			}
+
+			return Promise.resolve(
+				new Response(gif, {
+					headers: {'content-length': String(gif.byteLength)},
+					status: 200,
+				}),
+			);
+		},
+		{preconnect: originalFetch.preconnect},
+	);
+
+	try {
+		expect(
+			await operations.downloadRemoteAsset({
+				url: 'https://assets.example/path/remote-logo.png',
+			}),
+		).toEqual({
+			assetPath: 'remote-logo.gif',
+			created: true,
+			element: {
+				assetType: 'gif',
+				dimensions: {height: 600, width: 800},
+				durationInFrames: null,
+				position: null,
+				src: 'remote-logo.gif',
+				srcType: 'static',
+				type: 'asset',
+			},
+			sizeInBytes: gif.byteLength,
+		});
+		expect(project.publicFiles?.['remote-logo.gif']).toEqual(gif);
+
+		expect(await operations.undo()).toEqual({
+			nodePathMutation: null,
+			success: true,
+		});
+		expect(project.publicFiles?.['remote-logo.gif']).toBeUndefined();
+		expect(await operations.redo()).toEqual({
+			nodePathMutation: null,
+			success: true,
+		});
+		expect(project.publicFiles?.['remote-logo.gif']).toEqual(gif);
+
+		await expect(
+			operations.downloadRemoteAsset({
+				url: 'https://assets.example/cors-blocked.gif',
+			}),
+		).rejects.toThrow(
+			'Could not fetch remote asset. The URL may not allow cross-origin requests (CORS): Load failed',
+		);
+		expect(project.publicFiles?.['cors-blocked.gif']).toBeUndefined();
+		expect(requestedUrls).toEqual([
+			'https://assets.example/path/remote-logo.png',
+			'https://assets.example/cors-blocked.gif',
+		]);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
 test('previews and duplicates compositions as an undoable project mutation', async () => {
 	const initialProject = createBlankTemplateProject();
 	let project = initialProject;

--- a/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
+++ b/packages/studio-server/src/preview-server/routes/download-remote-asset.ts
@@ -4,77 +4,20 @@ import {isIP} from 'node:net';
 import path from 'node:path';
 import {
 	detectFileType,
+	getRemoteAssetElement,
+	getRemoteAssetFilename,
 	isImageFileType,
+	maxRemoteAssetSize,
+	remoteAssetAcceptHeader,
+	remoteAssetDownloadTimeout,
 	type DownloadRemoteAssetRequest,
 	type DownloadRemoteAssetResponse,
-	type ImageFileType,
-	type InsertableCompositionElement,
 } from '@remotion/studio-shared';
 import type {ApiHandler} from '../api-types';
 import {validateSameOrigin} from '../validate-same-origin';
 
-const maxRemoteAssetSize = 50 * 1024 * 1024;
-const remoteAssetDownloadTimeout = 15000;
 const maxRemoteAssetRedirects = 5;
-const remoteAssetAcceptHeader =
-	'image/png,image/apng,image/jpeg,image/webp,image/bmp,image/gif';
-
-const extensionsForFileType: Record<ImageFileType['type'], string[]> = {
-	png: ['png'],
-	apng: ['png', 'apng'],
-	jpeg: ['jpg', 'jpeg'],
-	webp: ['webp'],
-	bmp: ['bmp'],
-	gif: ['gif'],
-};
-
-const safeDecodeURIComponent = (value: string) => {
-	try {
-		return decodeURIComponent(value);
-	} catch {
-		return value;
-	}
-};
-
-const sanitizeAssetFilename = (filename: string) => {
-	return Array.from(filename)
-		.map((character) => {
-			const charCode = character.charCodeAt(0);
-			return charCode <= 31 || '<>:"/\\|?*'.includes(character)
-				? '-'
-				: character;
-		})
-		.join('')
-		.trim()
-		.replace(/^[. ]+|[. ]+$/g, '');
-};
-
-export const getRemoteAssetFilename = ({
-	fileType,
-	url,
-}: {
-	fileType: ImageFileType;
-	url: URL;
-}) => {
-	const basename = safeDecodeURIComponent(path.posix.basename(url.pathname));
-	const sanitized = sanitizeAssetFilename(basename);
-	const filenameWithoutFallback = sanitized === '' ? 'image' : sanitized;
-	const extensions = extensionsForFileType[fileType.type];
-	const extension = path
-		.extname(filenameWithoutFallback)
-		.slice(1)
-		.toLowerCase();
-
-	if (extensions.includes(extension)) {
-		return filenameWithoutFallback;
-	}
-
-	const withoutExtension = extension
-		? filenameWithoutFallback.slice(0, -(extension.length + 1))
-		: filenameWithoutFallback;
-	const safeName = withoutExtension === '' ? 'image' : withoutExtension;
-	return `${safeName}.${extensions[0]}`;
-};
+export {getRemoteAssetFilename};
 
 const isForbiddenIpv4Address = (address: string) => {
 	const parts = address.split('.').map((part) => Number(part));
@@ -334,21 +277,7 @@ export const downloadRemoteAssetHandler: ApiHandler<
 		writeFileSync(absolutePath, contents);
 	}
 
-	const element: InsertableCompositionElement = {
-		type: 'asset',
-		assetType:
-			fileType.type === 'gif'
-				? 'gif'
-				: fileType.type === 'apng' ||
-					  (fileType.type === 'webp' && fileType.animated)
-					? 'animated-image'
-					: 'image',
-		src: assetPath,
-		srcType: 'static',
-		dimensions: fileType.dimensions,
-		durationInFrames: null,
-		position: null,
-	};
+	const element = getRemoteAssetElement({assetPath, fileType});
 
 	return {
 		assetPath,

--- a/packages/studio-shared/src/browser-studio-operations.ts
+++ b/packages/studio-shared/src/browser-studio-operations.ts
@@ -22,6 +22,8 @@ import type {
 	DeleteEffectResponse,
 	DeleteStaticFileRequest,
 	DeleteStaticFileResponse,
+	DownloadRemoteAssetRequest,
+	DownloadRemoteAssetResponse,
 	FindInFileRequest,
 	FindInFileResponse,
 	DuplicateEffectRequest,
@@ -170,6 +172,9 @@ export type BrowserStudioOperations = {
 		data: Uint8Array;
 		fileName: string;
 	}>;
+	downloadRemoteAsset: (
+		request: DownloadRemoteAssetRequest,
+	) => Promise<DownloadRemoteAssetResponse>;
 	duplicateComposition: (
 		request: DuplicateCompositionRequest,
 	) => Promise<DuplicateCompositionResponse>;

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -195,6 +195,13 @@ export {
 	type ImageFileType,
 } from './detect-file-type';
 export {
+	getRemoteAssetElement,
+	getRemoteAssetFilename,
+	maxRemoteAssetSize,
+	remoteAssetAcceptHeader,
+	remoteAssetDownloadTimeout,
+} from './remote-asset';
+export {
 	parseEasingClipboardData,
 	parseEasingClipboardDataResult,
 	type EasingClipboardData,

--- a/packages/studio-shared/src/remote-asset.ts
+++ b/packages/studio-shared/src/remote-asset.ts
@@ -1,0 +1,80 @@
+import type {InsertableCompositionElement} from './api-requests';
+import type {ImageFileType} from './detect-file-type';
+
+export const maxRemoteAssetSize = 50 * 1024 * 1024;
+export const remoteAssetDownloadTimeout = 15_000;
+export const remoteAssetAcceptHeader =
+	'image/png,image/apng,image/jpeg,image/webp,image/bmp,image/gif';
+
+const extensionsForFileType: Record<ImageFileType['type'], string[]> = {
+	png: ['png'],
+	apng: ['png', 'apng'],
+	jpeg: ['jpg', 'jpeg'],
+	webp: ['webp'],
+	bmp: ['bmp'],
+	gif: ['gif'],
+};
+
+export const getRemoteAssetFilename = ({
+	fileType,
+	url,
+}: {
+	fileType: ImageFileType;
+	url: URL;
+}) => {
+	const encodedBasename = url.pathname.slice(url.pathname.lastIndexOf('/') + 1);
+	let basename: string;
+	try {
+		basename = decodeURIComponent(encodedBasename);
+	} catch {
+		basename = encodedBasename;
+	}
+
+	const sanitized = Array.from(basename)
+		.map((character) => {
+			const charCode = character.charCodeAt(0);
+			return charCode <= 31 || '<>:"/\\|?*'.includes(character)
+				? '-'
+				: character;
+		})
+		.join('')
+		.trim()
+		.replace(/^[. ]+|[. ]+$/g, '');
+	const filenameWithoutFallback = sanitized === '' ? 'image' : sanitized;
+	const extensions = extensionsForFileType[fileType.type];
+	const lastDot = filenameWithoutFallback.lastIndexOf('.');
+	const extension =
+		lastDot > 0 ? filenameWithoutFallback.slice(lastDot + 1).toLowerCase() : '';
+
+	if (extensions.includes(extension)) {
+		return filenameWithoutFallback;
+	}
+
+	const withoutExtension = extension
+		? filenameWithoutFallback.slice(0, -(extension.length + 1))
+		: filenameWithoutFallback;
+	const safeName = withoutExtension === '' ? 'image' : withoutExtension;
+	return `${safeName}.${extensions[0]}`;
+};
+
+export const getRemoteAssetElement = ({
+	assetPath,
+	fileType,
+}: {
+	assetPath: string;
+	fileType: ImageFileType;
+}): InsertableCompositionElement => ({
+	type: 'asset',
+	assetType:
+		fileType.type === 'gif'
+			? 'gif'
+			: fileType.type === 'apng' ||
+				  (fileType.type === 'webp' && fileType.animated)
+				? 'animated-image'
+				: 'image',
+	src: assetPath,
+	srcType: 'static',
+	dimensions: fileType.dimensions,
+	durationInFrames: null,
+	position: null,
+});

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -751,6 +751,11 @@ const insertCompositionElement = async ({
 const downloadRemoteAsset = (
 	url: string,
 ): Promise<DownloadRemoteAssetResponse> => {
+	const browserStudioOperations = getBrowserStudioOperations();
+	if (browserStudioOperations) {
+		return browserStudioOperations.downloadRemoteAsset({url});
+	}
+
 	return callApi('/api/download-remote-asset', {url});
 };
 

--- a/packages/studio/src/test/make-browser-studio-operations.ts
+++ b/packages/studio/src/test/make-browser-studio-operations.ts
@@ -12,6 +12,7 @@ export const makeBrowserStudioOperations = (
 		consumeInitialElement: () => null,
 		deleteJsxNode: () => unusedOperation('deleteJsxNode'),
 		deleteStaticFile: () => unusedOperation('deleteStaticFile'),
+		downloadRemoteAsset: () => unusedOperation('downloadRemoteAsset'),
 		downloadProject: () => unusedOperation('downloadProject'),
 		duplicateComposition: () => unusedOperation('duplicateComposition'),
 		effects: {


### PR DESCRIPTION
## Summary

- route remote asset drops through an explicit Browser Studio operation
- fetch CORS-enabled images into the virtual public folder with timeout and size limits
- share remote filename and element detection with Studio Server
- cover successful imports, undo/redo, and CORS-style fetch failures

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/browser-studio-project-operations.test.ts` in `packages/browser-studio`
- `bun test src/test/download-remote-asset.test.ts` in `packages/studio-server`

Closes #10578

Part of #9807
