### PR TITLE
`@remotion/studio-codemods`: Gracefully reject unexported composition drops

### DIFF
--- a/packages/studio-codemods/src/insert-jsx-element.ts
+++ b/packages/studio-codemods/src/insert-jsx-element.ts
@@ -2291,6 +2291,48 @@ const ensureCompositionComponentImport = async ({
 		return sourceLocation.exportName;
 	}
 
+	if (sourceLocation.exportName !== 'default') {
+		const sourceAst = parseAstForReadOnly(
+			await readSourceFile({
+				environment,
+				fileName: sourceLocation.fileName,
+			}),
+		);
+		const hasNamedExport = sourceAst.program.body.some((node) => {
+			if (
+				node.type !== 'ExportNamedDeclaration' ||
+				node.exportKind === 'type'
+			) {
+				return false;
+			}
+
+			if (
+				node.declaration &&
+				(node.declaration.type === 'FunctionDeclaration' ||
+					node.declaration.type === 'ClassDeclaration' ||
+					node.declaration.type === 'VariableDeclaration') &&
+				declarationBindsName(node.declaration, sourceLocation.exportName)
+			) {
+				return true;
+			}
+
+			return node.specifiers.some((specifier) => {
+				return (
+					specifier.type === 'ExportSpecifier' &&
+					specifier.exportKind !== 'type' &&
+					getSpecifierLocalName(specifier) === sourceLocation.exportName &&
+					getExportedName(specifier.exported) === sourceLocation.exportName
+				);
+			});
+		});
+
+		if (!hasNamedExport) {
+			throw new Error(
+				`Cannot add composition "${compositionId}" because its component "${sourceLocation.exportName}" is not exported from ${sourceLocation.source}. Export the component and try again.`,
+			);
+		}
+	}
+
 	const sourcePath = getImportPathBetweenFiles({
 		environment,
 		fromFile: destinationFileName,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -1913,6 +1913,96 @@ test('inserts a composition as a duration-aware Sequence', async () => {
 	}
 });
 
+test('rejects inserting a composition whose component is not exported', async () => {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
+	try {
+		await fs.writeFile(
+			path.join(tempDir, 'Root.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				"import {SourceComposition} from './Source';",
+				"import {Target} from './Target';",
+				'export const RemotionRoot = () => {',
+				'\treturn (',
+				'\t\t<>',
+				'\t\t\t<SourceComposition />',
+				'\t\t\t<Composition id="target" component={Target} />',
+				'\t\t</>',
+				'\t);',
+				'};',
+				'',
+			].join('\n'),
+		);
+		await fs.writeFile(
+			path.join(tempDir, 'Source.tsx'),
+			[
+				"import {Composition} from 'remotion';",
+				'const Source: React.FC = () => {',
+				'\treturn <div>source</div>;',
+				'};',
+				'export const SourceComposition = () => {',
+				'\treturn <Composition id="source" component={Source} />;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		const targetContents = [
+			"import {AbsoluteFill} from 'remotion';",
+			'',
+			'export const Target: React.FC = () => {',
+			'\treturn <AbsoluteFill>target</AbsoluteFill>;',
+			'};',
+			'',
+		].join('\n');
+		const targetFile = path.join(tempDir, 'Target.tsx');
+		await fs.writeFile(targetFile, targetContents);
+
+		const response = await insertJsxElementHandler({
+			input: {
+				compositionFile: 'Root.tsx',
+				compositionId: 'target',
+				element: {
+					type: 'composition',
+					compositionId: 'source',
+					compositionFile: 'Source.tsx',
+					durationInFrames: 100,
+					width: 1080,
+					height: 540,
+					serializedResolvedPropsWithCustomSchema: JSON.stringify({}),
+					position: null,
+				},
+				from: null,
+			},
+			entryPoint: path.join(tempDir, 'Root.tsx'),
+			remotionRoot: tempDir,
+			request: {} as never,
+			response: {} as never,
+			logLevel: 'error',
+			methods: {
+				removeJob: () => undefined,
+				cancelJob: () => undefined,
+				addJob: () => undefined,
+			},
+			publicDir: tempDir,
+			binariesDirectory: null,
+			configFile: null,
+			getDefaultCodingAgent: () => null,
+			getDefaultEditor: () => null,
+		});
+
+		expect(response.success).toBe(false);
+		if (!response.success) {
+			expect(response.reason).toBe(
+				'Cannot add composition "source" because its component "Source" is not exported from Source.tsx. Export the component and try again.',
+			);
+		}
+
+		expect(await fs.readFile(targetFile, 'utf-8')).toBe(targetContents);
+	} finally {
+		await fs.rm(tempDir, {recursive: true, force: true});
+	}
+});
+
 test('inserts a default-exported composition next to an existing namespace import', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {


### PR DESCRIPTION
## Summary

- Validate that a cross-file composition component is exported before generating its import
- Return an actionable Studio error without modifying the target source file
- Cover the failed insertion through the Studio Server route

## Testing

- `bun test packages/studio-server/src/test/resolve-composition-component.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #9698
