### PR TITLE
`@remotion/studio`: Reject restart in Browser Studio

### DIFF
--- a/packages/studio/src/api/restart-studio.ts
+++ b/packages/studio/src/api/restart-studio.ts
@@ -6,10 +6,15 @@
 import type {RestartStudioResponse} from '@remotion/studio-shared';
 import {getRemotionEnvironment} from 'remotion';
 import {callApi} from '../components/call-api';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 
 export const restartStudio = (): Promise<RestartStudioResponse> => {
 	if (!getRemotionEnvironment().isStudio) {
 		throw new Error('restartStudio() is only available in the Studio');
+	}
+
+	if (getBrowserStudioOperations() !== null) {
+		throw new Error('restartStudio() is not supported in Browser Studio');
 	}
 
 	if (window.remotion_isReadOnlyStudio) {

--- a/packages/studio/src/test/restart-studio.test.ts
+++ b/packages/studio/src/test/restart-studio.test.ts
@@ -1,0 +1,41 @@
+import {afterEach, expect, test} from 'bun:test';
+import {restartStudio} from '../api/restart-studio';
+import {makeBrowserStudioOperations} from './make-browser-studio-operations';
+
+const originalFetch = globalThis.fetch;
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+		return;
+	}
+
+	Reflect.deleteProperty(globalThis, 'window');
+});
+
+test('rejects restarting Browser Studio without making a server request', () => {
+	const fetchCalls: string[] = [];
+	globalThis.fetch = ((input) => {
+		fetchCalls.push(String(input));
+		return Promise.reject(new Error('Unexpected request'));
+	}) as typeof fetch;
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			remotion_browserStudio: makeBrowserStudioOperations({}),
+			remotion_isPlayer: false,
+			remotion_isReadOnlyStudio: false,
+			remotion_isStudio: true,
+		},
+	});
+
+	expect(() => restartStudio()).toThrow(
+		'restartStudio() is not supported in Browser Studio',
+	);
+	expect(fetchCalls).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- reject `restartStudio()` with an explicit unsupported-operation error in Browser Studio
- prevent Browser Studio from requesting the unavailable `/api/restart-studio` endpoint
- add regression coverage for the public API behavior

## Test plan

- `bun test packages/studio/src/test/restart-studio.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10707
