### PR TITLE
`@remotion/studio`: Prevent double-click after timeline drag

### DIFF
--- a/packages/example/e2e/sequence-shift-keyframes.test.mts
+++ b/packages/example/e2e/sequence-shift-keyframes.test.mts
@@ -29,6 +29,38 @@ test.describe('moving sequence keyframes', () => {
 	test('moves nested outer-clock descendant keyframes without double-shifting local-clock descendants', async ({
 		page,
 	}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(window, 'remotion_editorName', {
+				configurable: true,
+				get: () => 'Test editor',
+				set: () => undefined,
+			});
+		});
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultEditor: 'vscode',
+						installedEditors: [
+							{
+								id: 'vscode',
+								name: 'Test editor',
+								nameWithType: 'Test editor',
+							},
+						],
+					},
+				},
+			});
+		});
+		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/open-in-editor', async (route) => {
+			openInEditorRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {success: true, data: {success: true}},
+			});
+		});
+
 		await page.goto(`${STUDIO_URL}/sequence-shift-repro`);
 		await page.waitForFunction(
 			() => !document.body.innerText.includes('Loading...'),
@@ -74,7 +106,29 @@ test.describe('moving sequence keyframes', () => {
 			throw new Error('Expected the parent sequence to have a bounding box');
 		}
 
+		await page.waitForTimeout(1_000);
+		await parent.dblclick();
+		await expect.poll(() => openInEditorRequests.length).toBe(1);
+		openInEditorRequests.length = 0;
+		await page.waitForTimeout(500);
+		await page.evaluate(() => {
+			Reflect.set(window, 'remotionTimelineDoubleClicks', 0);
+			document.addEventListener(
+				'dblclick',
+				() => {
+					const doubleClicks = Reflect.get(
+						window,
+						'remotionTimelineDoubleClicks',
+					);
+					Reflect.set(window, 'remotionTimelineDoubleClicks', doubleClicks + 1);
+				},
+				{capture: true},
+			);
+		});
+
 		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.down();
+		await page.mouse.up();
 		await page.mouse.down();
 		try {
 			await page.mouse.move(
@@ -101,5 +155,14 @@ test.describe('moving sequence keyframes', () => {
 			/translate: interpolate\(\s*frame,\s*\[16, 26\],\s*\['0px 0px', '300px 0px'\]/,
 		);
 		expect(source).toContain('opacity: interpolate(frame, [4, 14], [0, 1])');
+		await page.waitForTimeout(100);
+		const doubleClicks = await page.evaluate(() =>
+			Reflect.get(window, 'remotionTimelineDoubleClicks'),
+		);
+		if (doubleClicks === 0) {
+			await parent.dispatchEvent('dblclick');
+		}
+
+		expect(openInEditorRequests).toEqual([]);
 	});
 });

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -340,8 +340,19 @@ const TimelineSequenceInner: React.FC<{
 	const selectComposition = useSelectComposition();
 	const confirm = useConfirmationDialog();
 	const {onSelect, selectable} = useTimelineRowSelection(nodePathInfo);
+	const {onPointerDown: onMoveDragPointerDown, shouldSuppressDoubleClick} =
+		useTimelineSequenceFromDrag({
+			nodePathInfo,
+			windowWidth,
+			timelineDurationInFrames: video?.durationInFrames ?? 1,
+		});
 	const onSequenceDoubleClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (shouldSuppressDoubleClick()) {
+				e.stopPropagation();
+				return;
+			}
+
 			if (isTimelineSelectionModifierEvent(e)) {
 				e.stopPropagation();
 				return;
@@ -380,6 +391,7 @@ const TimelineSequenceInner: React.FC<{
 			s,
 			selectComposition,
 			sequenceFrameOffset,
+			shouldSuppressDoubleClick,
 		],
 	);
 	const canHandleSequenceDoubleClick =
@@ -554,12 +566,6 @@ const TimelineSequenceInner: React.FC<{
 		validatedLocation?.source,
 	]);
 	const {frozenFrame} = s;
-
-	const {onPointerDown: onMoveDragPointerDown} = useTimelineSequenceFromDrag({
-		nodePathInfo,
-		windowWidth,
-		timelineDurationInFrames: video?.durationInFrames ?? 1,
-	});
 
 	if (!video) {
 		throw new TypeError('Expected video config');

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -48,6 +48,7 @@ import {
 
 const HANDLE_WIDTH = 6;
 export const timelineSequenceFromDragSnapThresholdPx = 10;
+const timelineSequenceFromDragThresholdPx = 3;
 
 const baseStyle: React.CSSProperties = {
 	position: 'absolute',
@@ -1377,8 +1378,10 @@ export const useTimelineSequenceFromDrag = ({
 	const {editorSnapping} = useContext(EditorSnappingContext);
 
 	const [dragging, setDragging] = useState(false);
+	const suppressNextDoubleClickRef = useRef(false);
 	const dragStateRef = useRef<{
 		initialClientX: number;
+		hasDragged: boolean;
 		latestDeltaFrames: number;
 		pxPerFrame: number;
 		pointerId: number;
@@ -1417,6 +1420,7 @@ export const useTimelineSequenceFromDrag = ({
 		}
 
 		dragStateRef.current = null;
+		suppressNextDoubleClickRef.current = dragState.hasDragged;
 		document.body.style.userSelect = '';
 		document.body.style.webkitUserSelect = '';
 		setDragging(false);
@@ -1523,8 +1527,10 @@ export const useTimelineSequenceFromDrag = ({
 			}
 
 			e.preventDefault();
+			suppressNextDoubleClickRef.current = false;
 			dragStateRef.current = {
 				initialClientX: e.clientX,
+				hasDragged: false,
 				latestDeltaFrames: 0,
 				pxPerFrame,
 				pointerId: e.pointerId,
@@ -1558,6 +1564,10 @@ export const useTimelineSequenceFromDrag = ({
 			}
 
 			const dx = e.clientX - dragState.initialClientX;
+			if (Math.abs(dx) >= timelineSequenceFromDragThresholdPx) {
+				dragState.hasDragged = true;
+			}
+
 			const deltaFrames = getTimelineSequenceFromDragDelta({
 				deltaFrames: Math.round(dx / dragState.pxPerFrame),
 				pxPerFrame: dragState.pxPerFrame,
@@ -1650,9 +1660,19 @@ export const useTimelineSequenceFromDrag = ({
 		});
 	}, [dragging, finishDrag]);
 
+	const shouldSuppressDoubleClick = useCallback(() => {
+		if (!suppressNextDoubleClickRef.current) {
+			return false;
+		}
+
+		suppressNextDoubleClickRef.current = false;
+		return true;
+	}, []);
+
 	return {
 		dragging,
 		onPointerDown,
+		shouldSuppressDoubleClick,
 	};
 };
 


### PR DESCRIPTION
## Summary

- suppress timeline sequence double-click actions after a drag gesture
- add browser coverage for click-then-drag behavior while preserving intentional double-clicks

## Test plan

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bun run test:e2e -- sequence-shift-keyframes.test.mts --repeat-each=2`

Closes #10710
