### PR TITLE
`@remotion/media`: Release broadcast ImageBitmaps after sending

### DIFF
--- a/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
+++ b/packages/media/src/video-extraction/add-broadcast-channel-listener.ts
@@ -190,7 +190,13 @@ export const addBroadcastChannelListener = () => {
 						durationInSeconds: durationInSeconds ?? null,
 					};
 
-					window.remotion_broadcastChannel!.postMessage(response);
+					try {
+						window.remotion_broadcastChannel!.postMessage(response);
+					} finally {
+						// BroadcastChannel clones ImageBitmaps instead of transferring them.
+						// Release the sender-side GPU resource after synchronous serialization.
+						imageBitmap?.close();
+					}
 				} catch (error) {
 					const response: MessageFromMainTab = {
 						type: 'response-error',


### PR DESCRIPTION
## Summary

- close the main render tab's `ImageBitmap` after `BroadcastChannel` serializes the frame response
- avoid retaining sender-side GPU resources across frame extraction requests

## Testing

- `bunx turbo run test --filter=@remotion/media`
- `bun run build`
- `bun run stylecheck`

Closes #10701
