### PR TITLE
`@remotion/studio-server`: Do not drop props passed to interactive components via JSX spread

### DIFF
--- a/packages/studio-codemods/src/sequence-props.ts
+++ b/packages/studio-codemods/src/sequence-props.ts
@@ -1219,6 +1219,21 @@ const computeSequenceOnlyPropsRecord = ({
 	assetKeys: string[];
 	videoConfigValues: VideoConfigIdentifierValues;
 }): Record<string, CanUpdatePropStatus> => {
+	// Props may arrive through a JSX spread attribute ({...props}), which the
+	// parser cannot resolve. Since the spread may set or override any prop,
+	// treat all of them as computed so the runtime values pass through
+	// untouched and Visual Mode does not offer to edit them.
+	if (
+		jsxElement.attributes.some((attr) => attr.type === 'JSXSpreadAttribute')
+	) {
+		const computedProps: Record<string, CanUpdatePropStatus> = {};
+		for (const key of keys) {
+			computedProps[key] = computedStatus();
+		}
+
+		return computedProps;
+	}
+
 	const allProps = getPropsStatus(
 		jsxElement,
 		ast,

--- a/packages/studio-codemods/src/sequence-props.ts
+++ b/packages/studio-codemods/src/sequence-props.ts
@@ -684,6 +684,11 @@ const getPropsStatus = (
 
 	for (const attr of jsxElement.attributes) {
 		if (attr.type === 'JSXSpreadAttribute') {
+			// The spread may override every prop written before it
+			for (const key of Object.keys(props)) {
+				props[key] = computedStatus();
+			}
+
 			continue;
 		}
 
@@ -1060,6 +1065,7 @@ const getNestedPropStatus = ({
 	childKey,
 	videoConfigValues,
 	allowSpecialValues,
+	lastSpreadIndex,
 }: {
 	jsxElement: JSXOpeningElement;
 	ast: File;
@@ -1067,16 +1073,35 @@ const getNestedPropStatus = ({
 	childKey: string;
 	videoConfigValues: VideoConfigIdentifierValues;
 	allowSpecialValues: boolean;
+	lastSpreadIndex: number;
 }): CanUpdatePropStatus => {
-	const attr = jsxElement.attributes.find(
+	const attrIndex = jsxElement.attributes.findIndex(
 		(a) =>
 			a.type !== 'JSXSpreadAttribute' &&
 			a.name.type !== 'JSXNamespacedName' &&
 			a.name.name === parentKey,
-	) as JSXAttribute | undefined;
+	);
+	const attr =
+		attrIndex === -1
+			? undefined
+			: (jsxElement.attributes[attrIndex] as JSXAttribute);
 
-	if (!attr || !attr.value) {
+	if (attrIndex !== -1 && attrIndex < lastSpreadIndex) {
+		// A later spread may replace the whole parent object
+		return computedStatus();
+	}
+
+	if (!attr) {
+		if (lastSpreadIndex !== -1) {
+			// The spread may provide the parent object
+			return computedStatus();
+		}
+
 		// Parent attribute doesn't exist, nested prop can be added
+		return staticStatus(undefined, null);
+	}
+
+	if (!attr.value) {
 		return staticStatus(undefined, null);
 	}
 
@@ -1219,21 +1244,17 @@ const computeSequenceOnlyPropsRecord = ({
 	assetKeys: string[];
 	videoConfigValues: VideoConfigIdentifierValues;
 }): Record<string, CanUpdatePropStatus> => {
-	// Props may arrive through a JSX spread attribute ({...props}), which the
-	// parser cannot resolve. Since the spread may set or override any prop,
-	// treat all of them as computed so the runtime values pass through
-	// untouched and Visual Mode does not offer to edit them.
-	if (
-		jsxElement.attributes.some((attr) => attr.type === 'JSXSpreadAttribute')
-	) {
-		const computedProps: Record<string, CanUpdatePropStatus> = {};
-		for (const key of keys) {
-			computedProps[key] = computedStatus();
-		}
-
-		return computedProps;
-	}
-
+	// A JSX spread attribute ({...props}) is invisible to the parser and may
+	// set or override every prop that is not explicitly written after it.
+	// Affected props are treated as computed so the runtime values pass
+	// through untouched and Visual Mode does not offer to edit them.
+	// Attributes written after the last spread win at runtime and can be
+	// parsed as usual.
+	const lastSpreadIndex = jsxElement.attributes.reduce(
+		(highest, attr, index) =>
+			attr.type === 'JSXSpreadAttribute' ? index : highest,
+		-1,
+	);
 	const allProps = getPropsStatus(
 		jsxElement,
 		ast,
@@ -1253,6 +1274,18 @@ const computeSequenceOnlyPropsRecord = ({
 		}
 
 		if (key === 'children') {
+			const childrenAttrIndex = jsxElement.attributes.findIndex(
+				(attr) =>
+					attr.type === 'JSXAttribute' &&
+					attr.name.type === 'JSXIdentifier' &&
+					attr.name.name === 'children',
+			);
+			if (childrenAttrIndex !== -1 && childrenAttrIndex < lastSpreadIndex) {
+				// A later spread may override the children attribute
+				filteredProps[key] = computedStatus();
+				continue;
+			}
+
 			const staticChildrenAttribute = getStaticJsxChildrenAttribute(jsxElement);
 			if (staticChildrenAttribute) {
 				filteredProps[key] = staticStatus(staticChildrenAttribute.value, null);
@@ -1260,6 +1293,18 @@ const computeSequenceOnlyPropsRecord = ({
 			}
 
 			if (hasJsxChildrenAttribute(jsxElement)) {
+				filteredProps[key] = computedStatus();
+				continue;
+			}
+
+			// JSX element children are compiled after any spread and win over
+			// it. Only if the element body is empty may the spread provide the
+			// children.
+			const hasMeaningfulJsxChildren = jsxElementNode.children.some(
+				(candidate) =>
+					!(candidate.type === 'JSXText' && candidate.value.trim() === ''),
+			);
+			if (!hasMeaningfulJsxChildren && lastSpreadIndex !== -1) {
 				filteredProps[key] = computedStatus();
 				continue;
 			}
@@ -1280,9 +1325,13 @@ const computeSequenceOnlyPropsRecord = ({
 				childKey: key.slice(dotIndex + 1),
 				videoConfigValues,
 				allowSpecialValues: assetKeys.includes(key),
+				lastSpreadIndex,
 			});
 		} else if (key in allProps) {
 			filteredProps[key] = allProps[key];
+		} else if (lastSpreadIndex !== -1) {
+			// The spread may provide this prop
+			filteredProps[key] = computedStatus();
 		} else {
 			filteredProps[key] = staticStatus(undefined, null);
 		}

--- a/packages/studio-codemods/src/test/sequence-props-spread.test.ts
+++ b/packages/studio-codemods/src/test/sequence-props-spread.test.ts
@@ -1,0 +1,51 @@
+import {expect, test} from 'bun:test';
+import {computeSequencePropsSubscriptionFromContent} from '../sequence-props';
+
+// https://github.com/remotion-dev/remotion/issues/10717
+// Props passed via a JSX spread are invisible to the parser. Reporting them as
+// static(undefined) made the Studio delete the runtime values of `from` /
+// `durationInFrames`, mounting every <Sequence> at every frame.
+test('treats all props as computed if a spread attribute is present', () => {
+	const input = `import {Sequence} from 'remotion';
+
+export const Example = ({timing}: {timing: {from: number; durationInFrames: number}}) => {
+	return (
+		<Sequence {...timing} name="Scene" style={{opacity: 0.5}}>
+			<div />
+		</Sequence>
+	);
+};
+`;
+	const result = computeSequencePropsSubscriptionFromContent({
+		fileContents: input,
+		absolutePath: '/project/src/Example.tsx',
+		line: 5,
+		preferredNodePath: null,
+		componentIdentity: 'dev.remotion.remotion.Sequence',
+		keys: ['from', 'durationInFrames', 'name', 'style.opacity'],
+		effects: [],
+		videoConfigValues: {
+			durationInFrames: 120,
+			fps: 30,
+			height: 1080,
+			width: 1920,
+		},
+	});
+
+	expect(result.success).toBe(true);
+	if (!result.success) {
+		throw new Error('Expected the subscription to succeed');
+	}
+
+	expect(result.status.canUpdate).toBe(true);
+	if (!result.status.canUpdate) {
+		throw new Error('Expected canUpdate to be true');
+	}
+
+	expect(result.status.props).toEqual({
+		from: {status: 'computed'},
+		durationInFrames: {status: 'computed'},
+		name: {status: 'computed'},
+		'style.opacity': {status: 'computed'},
+	});
+});

--- a/packages/studio-codemods/src/test/sequence-props-spread.test.ts
+++ b/packages/studio-codemods/src/test/sequence-props-spread.test.ts
@@ -1,51 +1,73 @@
 import {expect, test} from 'bun:test';
 import {computeSequencePropsSubscriptionFromContent} from '../sequence-props';
 
+const videoConfigValues = {
+	durationInFrames: 120,
+	fps: 30,
+	height: 1080,
+	width: 1920,
+};
+
+const subscribe = (input: string, line: number, keys: string[]) => {
+	const result = computeSequencePropsSubscriptionFromContent({
+		fileContents: input,
+		absolutePath: '/project/src/Example.tsx',
+		line,
+		preferredNodePath: null,
+		componentIdentity: 'dev.remotion.remotion.Sequence',
+		keys,
+		effects: [],
+		videoConfigValues,
+	});
+
+	if (!result.success || !result.status.canUpdate) {
+		throw new Error('Expected the subscription to succeed');
+	}
+
+	return result.status.props;
+};
+
 // https://github.com/remotion-dev/remotion/issues/10717
 // Props passed via a JSX spread are invisible to the parser. Reporting them as
 // static(undefined) made the Studio delete the runtime values of `from` /
 // `durationInFrames`, mounting every <Sequence> at every frame.
-test('treats all props as computed if a spread attribute is present', () => {
+test('treats props that a spread attribute may override as computed', () => {
 	const input = `import {Sequence} from 'remotion';
 
 export const Example = ({timing}: {timing: {from: number; durationInFrames: number}}) => {
 	return (
-		<Sequence {...timing} name="Scene" style={{opacity: 0.5}}>
-			<div />
-		</Sequence>
+		<>
+			<Sequence from={10} {...timing} name="Scene" style={{opacity: 0.5}}>
+				<div />
+			</Sequence>
+			<Sequence {...timing} />
+		</>
 	);
 };
 `;
-	const result = computeSequencePropsSubscriptionFromContent({
-		fileContents: input,
-		absolutePath: '/project/src/Example.tsx',
-		line: 5,
-		preferredNodePath: null,
-		componentIdentity: 'dev.remotion.remotion.Sequence',
-		keys: ['from', 'durationInFrames', 'name', 'style.opacity'],
-		effects: [],
-		videoConfigValues: {
-			durationInFrames: 120,
-			fps: 30,
-			height: 1080,
-			width: 1920,
+	expect(
+		subscribe(input, 6, ['from', 'durationInFrames', 'name', 'style.opacity']),
+	).toEqual({
+		// Written before the spread, so the spread may override it
+		from: {status: 'computed'},
+		// Only provided by the spread
+		durationInFrames: {status: 'computed'},
+		// Written after the spread, so they win at runtime and stay editable
+		name: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 'Scene',
+		},
+		'style.opacity': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0.5,
 		},
 	});
 
-	expect(result.success).toBe(true);
-	if (!result.success) {
-		throw new Error('Expected the subscription to succeed');
-	}
-
-	expect(result.status.canUpdate).toBe(true);
-	if (!result.status.canUpdate) {
-		throw new Error('Expected canUpdate to be true');
-	}
-
-	expect(result.status.props).toEqual({
+	// With an empty element body, the spread may provide both props
+	expect(subscribe(input, 9, ['from', 'children'])).toEqual({
 		from: {status: 'computed'},
-		durationInFrames: {status: 'computed'},
-		name: {status: 'computed'},
-		'style.opacity': {status: 'computed'},
+		children: {status: 'computed'},
 	});
 });

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -1112,6 +1112,11 @@ const getPropsStatus = (
 
 	for (const attr of jsxElement.attributes) {
 		if (attr.type === 'JSXSpreadAttribute') {
+			// The spread may override every prop written before it
+			for (const key of Object.keys(props)) {
+				props[key] = computedStatus();
+			}
+
 			continue;
 		}
 
@@ -1600,6 +1605,7 @@ const getNestedPropStatus = ({
 	childKey,
 	videoConfigValues,
 	allowSpecialValues,
+	lastSpreadIndex,
 }: {
 	jsxElement: JSXOpeningElement;
 	ast: File;
@@ -1607,16 +1613,35 @@ const getNestedPropStatus = ({
 	childKey: string;
 	videoConfigValues: VideoConfigIdentifierValues;
 	allowSpecialValues: boolean;
+	lastSpreadIndex: number;
 }): CanUpdatePropStatus => {
-	const attr = jsxElement.attributes.find(
+	const attrIndex = jsxElement.attributes.findIndex(
 		(a) =>
 			a.type !== 'JSXSpreadAttribute' &&
 			a.name.type !== 'JSXNamespacedName' &&
 			a.name.name === parentKey,
-	) as JSXAttribute | undefined;
+	);
+	const attr =
+		attrIndex === -1
+			? undefined
+			: (jsxElement.attributes[attrIndex] as JSXAttribute);
 
-	if (!attr || !attr.value) {
+	if (attrIndex !== -1 && attrIndex < lastSpreadIndex) {
+		// A later spread may replace the whole parent object
+		return computedStatus();
+	}
+
+	if (!attr) {
+		if (lastSpreadIndex !== -1) {
+			// The spread may provide the parent object
+			return computedStatus();
+		}
+
 		// Parent attribute doesn't exist, nested prop can be added
+		return staticStatus(undefined, null);
+	}
+
+	if (!attr.value) {
 		return staticStatus(undefined, null);
 	}
 
@@ -1759,21 +1784,17 @@ const computeSequenceOnlyPropsRecord = ({
 	assetKeys: string[];
 	videoConfigValues: VideoConfigIdentifierValues;
 }): Record<string, CanUpdatePropStatus> => {
-	// Props may arrive through a JSX spread attribute ({...props}), which the
-	// parser cannot resolve. Since the spread may set or override any prop,
-	// treat all of them as computed so the runtime values pass through
-	// untouched and Visual Mode does not offer to edit them.
-	if (
-		jsxElement.attributes.some((attr) => attr.type === 'JSXSpreadAttribute')
-	) {
-		const computedProps: Record<string, CanUpdatePropStatus> = {};
-		for (const key of keys) {
-			computedProps[key] = computedStatus();
-		}
-
-		return computedProps;
-	}
-
+	// A JSX spread attribute ({...props}) is invisible to the parser and may
+	// set or override every prop that is not explicitly written after it.
+	// Affected props are treated as computed so the runtime values pass
+	// through untouched and Visual Mode does not offer to edit them.
+	// Attributes written after the last spread win at runtime and can be
+	// parsed as usual.
+	const lastSpreadIndex = jsxElement.attributes.reduce(
+		(highest, attr, index) =>
+			attr.type === 'JSXSpreadAttribute' ? index : highest,
+		-1,
+	);
 	const allProps = getPropsStatus(
 		jsxElement,
 		ast,
@@ -1793,6 +1814,18 @@ const computeSequenceOnlyPropsRecord = ({
 		}
 
 		if (key === 'children') {
+			const childrenAttrIndex = jsxElement.attributes.findIndex(
+				(attr) =>
+					attr.type === 'JSXAttribute' &&
+					attr.name.type === 'JSXIdentifier' &&
+					attr.name.name === 'children',
+			);
+			if (childrenAttrIndex !== -1 && childrenAttrIndex < lastSpreadIndex) {
+				// A later spread may override the children attribute
+				filteredProps[key] = computedStatus();
+				continue;
+			}
+
 			const staticChildrenAttribute = getStaticJsxChildrenAttribute(jsxElement);
 			if (staticChildrenAttribute) {
 				filteredProps[key] = staticStatus(staticChildrenAttribute.value, null);
@@ -1800,6 +1833,18 @@ const computeSequenceOnlyPropsRecord = ({
 			}
 
 			if (hasJsxChildrenAttribute(jsxElement)) {
+				filteredProps[key] = computedStatus();
+				continue;
+			}
+
+			// JSX element children are compiled after any spread and win over
+			// it. Only if the element body is empty may the spread provide the
+			// children.
+			const hasMeaningfulJsxChildren = jsxElementNode.children.some(
+				(candidate) =>
+					!(candidate.type === 'JSXText' && candidate.value.trim() === ''),
+			);
+			if (!hasMeaningfulJsxChildren && lastSpreadIndex !== -1) {
 				filteredProps[key] = computedStatus();
 				continue;
 			}
@@ -1820,9 +1865,13 @@ const computeSequenceOnlyPropsRecord = ({
 				childKey: key.slice(dotIndex + 1),
 				videoConfigValues,
 				allowSpecialValues: assetKeys.includes(key),
+				lastSpreadIndex,
 			});
 		} else if (key in allProps) {
 			filteredProps[key] = allProps[key];
+		} else if (lastSpreadIndex !== -1) {
+			// The spread may provide this prop
+			filteredProps[key] = computedStatus();
 		} else {
 			filteredProps[key] = staticStatus(undefined, null);
 		}

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -1759,6 +1759,21 @@ const computeSequenceOnlyPropsRecord = ({
 	assetKeys: string[];
 	videoConfigValues: VideoConfigIdentifierValues;
 }): Record<string, CanUpdatePropStatus> => {
+	// Props may arrive through a JSX spread attribute ({...props}), which the
+	// parser cannot resolve. Since the spread may set or override any prop,
+	// treat all of them as computed so the runtime values pass through
+	// untouched and Visual Mode does not offer to edit them.
+	if (
+		jsxElement.attributes.some((attr) => attr.type === 'JSXSpreadAttribute')
+	) {
+		const computedProps: Record<string, CanUpdatePropStatus> = {};
+		for (const key of keys) {
+			computedProps[key] = computedStatus();
+		}
+
+		return computedProps;
+	}
+
 	const allProps = getPropsStatus(
 		jsxElement,
 		ast,

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -218,6 +218,38 @@ export const Example = () => {
 	});
 });
 
+// https://github.com/remotion-dev/remotion/issues/10717
+// Props passed via a JSX spread are invisible to the parser. Reporting them as
+// static(undefined) made the Studio delete the runtime values of `from` /
+// `durationInFrames`, mounting every <Sequence> at every frame.
+test('computeSequencePropsStatus should treat all props as computed if a spread attribute is present', () => {
+	const input = `import {Sequence} from 'remotion';
+
+export const Example = ({timing}: {timing: {from: number; durationInFrames: number}}) => {
+	return (
+		<Sequence {...timing} name="Scene" style={{opacity: 0.5}}>
+			<div />
+		</Sequence>
+	);
+};
+`;
+	const result = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 5),
+		componentIdentity: null,
+		keys: ['from', 'durationInFrames', 'name', 'style.opacity'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	expect(result.props).toEqual({
+		from: {status: 'computed'},
+		durationInFrames: {status: 'computed'},
+		name: {status: 'computed'},
+		'style.opacity': {status: 'computed'},
+	});
+});
+
 test('computeSequencePropsStatus should parse video config numeric expressions', () => {
 	const input = `import React from 'react';
 import {Sequence, interpolate, useCurrentFrame, useVideoConfig} from 'remotion';

--- a/packages/studio-server/src/test/compute-sequence-props-status.test.ts
+++ b/packages/studio-server/src/test/compute-sequence-props-status.test.ts
@@ -222,31 +222,60 @@ export const Example = () => {
 // Props passed via a JSX spread are invisible to the parser. Reporting them as
 // static(undefined) made the Studio delete the runtime values of `from` /
 // `durationInFrames`, mounting every <Sequence> at every frame.
-test('computeSequencePropsStatus should treat all props as computed if a spread attribute is present', () => {
+test('computeSequencePropsStatus should treat props that a spread attribute may override as computed', () => {
 	const input = `import {Sequence} from 'remotion';
 
 export const Example = ({timing}: {timing: {from: number; durationInFrames: number}}) => {
 	return (
-		<Sequence {...timing} name="Scene" style={{opacity: 0.5}}>
-			<div />
-		</Sequence>
+		<>
+			<Sequence from={10} {...timing} name="Scene" style={{opacity: 0.5}}>
+				<div />
+			</Sequence>
+			<Sequence {...timing} />
+		</>
 	);
 };
 `;
-	const result = computeSequencePropsStatusFromContent({
+	const spreadMayOverride = computeSequencePropsStatusFromContent({
 		fileContents: input,
-		nodePath: getNodePathFromContent(input, 5),
+		nodePath: getNodePathFromContent(input, 6),
 		componentIdentity: null,
 		keys: ['from', 'durationInFrames', 'name', 'style.opacity'],
 		effects: [],
 		videoConfigValues: null,
 	});
 
-	expect(result.props).toEqual({
+	expect(spreadMayOverride.props).toEqual({
+		// Written before the spread, so the spread may override it
 		from: {status: 'computed'},
+		// Only provided by the spread
 		durationInFrames: {status: 'computed'},
-		name: {status: 'computed'},
-		'style.opacity': {status: 'computed'},
+		// Written after the spread, so they win at runtime and stay editable
+		name: {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 'Scene',
+		},
+		'style.opacity': {
+			status: 'static',
+			keyframeDisplayOffsetAdjustment: null,
+			codeValue: 0.5,
+		},
+	});
+
+	const spreadMayProvide = computeSequencePropsStatusFromContent({
+		fileContents: input,
+		nodePath: getNodePathFromContent(input, 9),
+		componentIdentity: null,
+		keys: ['from', 'children'],
+		effects: [],
+		videoConfigValues: null,
+	});
+
+	// With an empty element body, the spread may provide both props
+	expect(spreadMayProvide.props).toEqual({
+		from: {status: 'computed'},
+		children: {status: 'computed'},
 	});
 });
 


### PR DESCRIPTION
Closes #10717

## Problem

When `from` / `durationInFrames` were passed to `<Sequence>` via a JSX spread (`<Sequence {...timing}>`), every Sequence stayed mounted at every frame in the Studio. Rendering was unaffected, so the composition looked fine until the Studio was opened.

Root cause: the Studio determines each prop's "status" by parsing the source file. The parser skips `JSXSpreadAttribute`s, so any schema key not found as an explicit attribute was reported as `static` with `codeValue: undefined` — the encoding for "not set in code". `computeEffectiveSchemaValuesDotNotation` then trusted that status over the actual runtime props and deleted `from` / `durationInFrames` before they reached the `Sequence` implementation, which fell back to `from = 0`, `durationInFrames = Infinity`.

The same applied to every `withInteractivitySchema`-wrapped component (e.g. spreading `src` into `<Img>`).

## Fix

JSX attribute merging is positional, so only props that a spread can actually reach are demoted to `computed` (runtime values pass through untouched, Visual Mode does not offer to edit them):

- Explicit attributes written **before** the last spread — the spread may override them.
- Keys **not explicitly written** on the element — the spread may provide them. This includes nested props whose parent attribute (e.g. `style`) is missing or written before a spread.
- The `children` key when the element body is empty and no `children` attribute follows the spread.

Attributes written **after** the last spread win at runtime, so they are parsed and stay editable as before. JSX element children also stay editable, since the JSX transform emits them after any spread.

Applied to both copies of the parser:

- `packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts` (local Studio)
- `packages/studio-codemods/src/sequence-props.ts` (Browser Studio)

## Tests

One regression test per implementation, covering: a prop before the spread (computed), a prop only provided by the spread (computed), props after the spread (still static/editable), a nested `style.opacity` after the spread (still static), and `children` with an empty element body (computed). Both fail with the old `static(undefined)` statuses when the fix is reverted.
