### PR TITLE
`@remotion/studio`: Prevent outline when not using keyboard navigation

### DIFF
--- a/packages/studio/src/components/InlineAction.tsx
+++ b/packages/studio/src/components/InlineAction.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {
 	CURRENT_COLOR,
 	LIGHT_TEXT,
@@ -33,9 +33,25 @@ export const InlineAction = ({
 	variant,
 	style: customStyle,
 	className,
+	onPointerDown: onPointerDownProp,
 	...buttonProps
 }: InlineActionProps) => {
 	const {tabIndex} = useZIndex();
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLButtonElement>) => {
+			onPointerDownProp?.(event);
+			if (event.button !== 0) {
+				return;
+			}
+
+			if (document.activeElement instanceof HTMLElement) {
+				document.activeElement.blur();
+			}
+
+			event.preventDefault();
+		},
+		[onPointerDownProp],
+	);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {
@@ -72,6 +88,7 @@ export const InlineAction = ({
 			}
 			disabled={disabled}
 			onClick={onClick}
+			onPointerDown={onPointerDown}
 			style={style}
 			tabIndex={tabIndex}
 			title={title}


### PR DESCRIPTION
## Summary

- prevent inline action buttons from retaining focus after primary pointer input
- preserve keyboard focus indicators and consumer pointer-down handlers
- apply the behavior consistently to Preview Toolbar and sidebar icon actions

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run formatting lint test make --filter=@remotion/studio`
- verified pointer and keyboard focus behavior in Remotion Studio
