### PR TITLE
`@remotion/studio`: Align effect inspector controls

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineBooleanField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineBooleanField.tsx
@@ -6,10 +6,6 @@ import type {
 } from '../../helpers/timeline-layout';
 import {Checkbox} from '../Checkbox';
 
-const checkboxContainer: React.CSSProperties = {
-	marginLeft: 8,
-};
-
 export const TimelineBooleanField: React.FC<{
 	readonly field: SchemaFieldInfo;
 	readonly propStatus: CanUpdateSequencePropStatusStatic;
@@ -26,14 +22,12 @@ export const TimelineBooleanField: React.FC<{
 	}, [propStatus, onSave, checked]);
 
 	return (
-		<div style={checkboxContainer}>
-			<Checkbox
-				checked={checked}
-				onChange={onChange}
-				name={field.key}
-				disabled={false}
-				variant="small"
-			/>
-		</div>
+		<Checkbox
+			checked={checked}
+			onChange={onChange}
+			name={field.key}
+			disabled={false}
+			variant="small"
+		/>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -125,6 +125,7 @@ export const TimelineEffectItem: React.FC<{
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly validatedLocation: CodePosition;
 	readonly rowDepth: number;
+	readonly labelNextToToggle: boolean;
 	readonly getIsExpanded: GetIsExpanded;
 	readonly toggleTrack: (nodePathInfo: SequenceNodePathInfo) => void;
 }> = ({
@@ -136,6 +137,7 @@ export const TimelineEffectItem: React.FC<{
 	nodePath,
 	validatedLocation,
 	rowDepth,
+	labelNextToToggle,
 	getIsExpanded,
 	toggleTrack,
 }) => {
@@ -502,7 +504,7 @@ export const TimelineEffectItem: React.FC<{
 					<TimelineLayerEyeSpacer />
 				)
 			}
-			arrow={<TimelineExpandArrowSpacer />}
+			arrow={labelNextToToggle ? null : <TimelineExpandArrowSpacer />}
 			style={rowStyle}
 			selected={selection.selected}
 			selectable={selection.selectable}

--- a/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedRow.tsx
@@ -62,6 +62,7 @@ const TimelineExpandedRowInner: React.FC<TimelineExpandedRowProps> = ({
 }) => {
 	const rowDepth =
 		(rowDepthBase ?? getExpandedRowDepth({nestedDepth, treeDepth: 0})) + depth;
+	const isInspector = keyframeControlsMode === 'inspector';
 	const selection = useTimelineRowSelection(node.nodePathInfo);
 	const labelStyle = React.useMemo(
 		(): React.CSSProperties => ({
@@ -91,6 +92,7 @@ const TimelineExpandedRowInner: React.FC<TimelineExpandedRowProps> = ({
 					nodePath={nodePath}
 					validatedLocation={validatedLocation}
 					rowDepth={rowDepth}
+					labelNextToToggle={isInspector}
 					getIsExpanded={getIsExpanded}
 					toggleTrack={toggleTrack}
 				/>
@@ -132,7 +134,7 @@ const TimelineExpandedRowInner: React.FC<TimelineExpandedRowProps> = ({
 				<TimelineEffectPropItem
 					field={node.field}
 					validatedLocation={validatedLocation}
-					rowDepth={rowDepth}
+					rowDepth={isInspector ? rowDepth - 1 : rowDepth}
 					nodePath={nodePath}
 					nodePathInfo={node.nodePathInfo}
 					keyframeDisplayOffset={keyframeDisplayOffset}


### PR DESCRIPTION
## Summary

- align effect property labels with sequence property labels in the Studio inspector
- place effect names directly beside the `fx` toggle in the inspector
- left-align boolean controls with number and enum controls

## Testing

- `bun run build`
- `bun run stylecheck`
- verified the inspector alignment in the `img-effects` composition
