### PR TITLE
`@remotion/studio`: Fix Browser Studio asset previews

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -671,6 +671,8 @@ test('drops a local file into the virtual Assets folder', async ({page}) => {
 	});
 
 	await expect(studio.getByText('logo.png', {exact: true})).toBeVisible();
+	await assetSelector.getByText('logo.png', {exact: true}).click();
+	await expect(studio.locator('img[src^="blob:"]')).toBeVisible();
 	await expect
 		.poll(() =>
 			page.evaluate(() => {

--- a/packages/studio/src/components/StaticFilePreview.tsx
+++ b/packages/studio/src/components/StaticFilePreview.tsx
@@ -1,5 +1,6 @@
 import {useContext} from 'react';
 import {staticFile} from 'remotion';
+import {addAssetCacheBust} from '../helpers/add-asset-cache-bust';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT, WHITE} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
@@ -52,7 +53,13 @@ export const StaticFilePreview: React.FC<{
 		<FilePreview
 			currentAsset={currentAsset}
 			fileType={fileType}
-			src={`${staticFileSrc}?date=${assetMetadata && assetMetadata.type === 'found' ? assetMetadata.fetchedAt : 0}`}
+			src={addAssetCacheBust({
+				fetchedAt:
+					assetMetadata && assetMetadata.type === 'found'
+						? assetMetadata.fetchedAt
+						: 0,
+				src: staticFileSrc,
+			})}
 			assetMetadata={assetMetadata}
 		/>
 	);

--- a/packages/studio/src/helpers/add-asset-cache-bust.ts
+++ b/packages/studio/src/helpers/add-asset-cache-bust.ts
@@ -1,0 +1,13 @@
+export const addAssetCacheBust = ({
+	fetchedAt,
+	src,
+}: {
+	fetchedAt: number;
+	src: string;
+}) => {
+	if (src.startsWith('blob:')) {
+		return src;
+	}
+
+	return `${src}${src.includes('?') ? '&' : '?'}date=${fetchedAt}`;
+};

--- a/packages/studio/src/helpers/get-asset-metadata.ts
+++ b/packages/studio/src/helpers/get-asset-metadata.ts
@@ -1,6 +1,7 @@
 import {getVideoMetadata} from '@remotion/media-utils';
 import type {CanvasContent} from 'remotion';
 import {staticFile} from 'remotion';
+import {addAssetCacheBust} from './add-asset-cache-bust';
 import {getPreviewFileType} from './get-preview-file-type';
 import type {Dimensions} from './is-current-selected-still';
 
@@ -53,29 +54,40 @@ export const getAssetMetadata = async (
 
 	try {
 		const src = getSrcFromCanvasContent(canvasContent);
+		const listedStaticFile =
+			canvasContent.type === 'asset'
+				? window.remotion_staticFiles.find(
+						(file) => file.name === canvasContent.asset && file.src === src,
+					)
+				: null;
+		let size = listedStaticFile?.sizeInBytes ?? null;
 
-		const file = await fetch(src, {
-			method: 'HEAD',
-		});
+		if (size === null) {
+			const file = await fetch(src, {
+				method: 'HEAD',
+			});
 
-		if (file.status === 404) {
-			return {type: 'not-found'};
-		}
+			if (file.status === 404) {
+				return {type: 'not-found'};
+			}
 
-		if (file.status !== 200) {
-			throw new Error(
-				`Expected status code 200 or 404 for file, got ${file.status}`,
-			);
-		}
+			if (file.status !== 200) {
+				throw new Error(
+					`Expected status code 200 or 404 for file, got ${file.status}`,
+				);
+			}
 
-		const size = file.headers.get('content-length');
+			const contentLength = file.headers.get('content-length');
 
-		if (!size) {
-			throw new Error('Unexpected error: content-length is null');
+			if (!contentLength) {
+				throw new Error('Unexpected error: content-length is null');
+			}
+
+			size = Number(contentLength);
 		}
 
 		const fetchedAt = Date.now();
-		const srcWithTime = addTime ? `${src}?date=${fetchedAt}` : src;
+		const srcWithTime = addTime ? addAssetCacheBust({fetchedAt, src}) : src;
 
 		const fileType = getPreviewFileType(src);
 
@@ -83,7 +95,7 @@ export const getAssetMetadata = async (
 			const resolution = await getVideoMetadata(srcWithTime);
 			return {
 				type: 'found',
-				size: Number(size),
+				size,
 				dimensions: {width: resolution.width, height: resolution.height},
 				fetchedAt,
 			};
@@ -95,7 +107,7 @@ export const getAssetMetadata = async (
 				img.onload = () => {
 					resolve({
 						type: 'found',
-						size: Number(size),
+						size,
 						dimensions: {width: img.width, height: img.height},
 						fetchedAt,
 					});
@@ -113,7 +125,7 @@ export const getAssetMetadata = async (
 		return {
 			type: 'found',
 			dimensions: 'none',
-			size: Number(size),
+			size,
 			fetchedAt,
 		};
 	} catch (err) {

--- a/packages/studio/src/test/current-asset.test.ts
+++ b/packages/studio/src/test/current-asset.test.ts
@@ -9,6 +9,7 @@ import {
 	getStaticFileRenameSelection,
 	validateStaticFileRename,
 } from '../components/NewComposition/use-rename-static-file';
+import {addAssetCacheBust} from '../helpers/add-asset-cache-bust';
 
 test('requests image metadata for image assets', () => {
 	expect(getCurrentAssetImageMetadataSource('1.jpg')).toBe('/1.jpg');
@@ -25,6 +26,21 @@ test('does not request media metadata for image assets', () => {
 	expect(getCurrentAssetMetadataSource('1.jpg')).toBe(null);
 	expect(getCurrentAssetMetadataSource('nested/file.png')).toBe(null);
 	expect(getCurrentAssetMetadataSource('animation.gif')).toBe(null);
+});
+
+test('does not append cache-busting parameters to blob asset URLs', () => {
+	expect(
+		addAssetCacheBust({
+			fetchedAt: 123,
+			src: 'blob:https://www.remotion.dev/asset-id',
+		}),
+	).toBe('blob:https://www.remotion.dev/asset-id');
+	expect(addAssetCacheBust({fetchedAt: 123, src: '/asset.png'})).toBe(
+		'/asset.png?date=123',
+	);
+	expect(addAssetCacheBust({fetchedAt: 123, src: '/asset.png?v=1'})).toBe(
+		'/asset.png?v=1&date=123',
+	);
 });
 
 test('requests media metadata for audio and video assets', () => {


### PR DESCRIPTION
## Summary

- preserve Browser Studio `blob:` asset URLs instead of appending cache-busting query parameters
- reuse the static file list's size metadata so asset previews do not issue unsupported `HEAD` requests for blob URLs
- cover uploaded asset previews with unit and Browser Studio end-to-end regression tests

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/current-asset.test.ts`
- `bun test packages/browser-studio/src/test`
- `bunx playwright test --project=chromium --grep "drops a local file into the virtual Assets folder"`
