### PR TITLE
`@remotion/studio`: Remove redundant success notifications

### DIFF
--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -125,12 +125,10 @@ export const AssetSelector: React.FC<{
 						outputPath: renderOutput.outputPath,
 						assetPath: destination,
 					});
-					showNotification(
-						result.created
-							? `Created ${destination}`
-							: `${destination} already exists`,
-						3000,
-					);
+					if (!result.created) {
+						showNotification(`${destination} already exists`, 3000);
+					}
+
 					return;
 				}
 
@@ -168,12 +166,6 @@ export const AssetSelector: React.FC<{
 						contents: body,
 						filePath: makePath(file),
 					});
-				}
-
-				if (files.length === 1) {
-					showNotification(`Created ${makePath(files[0])}`, 3000);
-				} else {
-					showNotification(`Added ${files.length} files to ${assetPath}`, 3000);
 				}
 			} catch (error) {
 				showNotification(`Error during upload: ${error}`, 3000);

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -331,12 +331,11 @@ export const CompositionSelector: React.FC = () => {
 						compositionDragDataToSymbolicatedStack(compositionDragData),
 				});
 
-				notification.replaceContent(
-					result.success
-						? `Moved ${compositionDragData.compositionId} outside of folder`
-						: result.reason,
-					result.success ? 2000 : 4000,
-				);
+				if (result.success) {
+					notification.dismiss();
+				} else {
+					notification.replaceContent(result.reason, 4000);
+				}
 			} catch (err) {
 				notification.replaceContent(
 					err instanceof Error ? err.message : String(err),

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -19,7 +19,6 @@ import {
 	WHITE_ALPHA_06,
 	WHITE_ALPHA_12,
 } from '../helpers/colors';
-import {getFolderId} from '../helpers/get-folder-id';
 import {noop} from '../helpers/noop';
 import {
 	markCompositionSidebarScrollFromRowClick,
@@ -331,10 +330,6 @@ export const CompositionSelectorItem: React.FC<{
 				return;
 			}
 
-			const folderId = getFolderId({
-				folderName: item.folderName,
-				parentName: item.parentName,
-			});
 			const notification = showNotification(
 				`Moving ${compositionDragData.compositionId}...`,
 				null,
@@ -355,12 +350,12 @@ export const CompositionSelectorItem: React.FC<{
 						compositionDragDataToSymbolicatedStack(compositionDragData),
 				});
 
-				notification.replaceContent(
-					result.success
-						? `Moved ${compositionDragData.compositionId} to ${folderId}`
-						: result.reason,
-					result.success ? 2000 : 4000,
-				);
+				if (result.success) {
+					notification.dismiss();
+				} else {
+					notification.replaceContent(result.reason, 4000);
+				}
+
 				if (result.success && !item.expanded) {
 					toggleFolder(item.folderName, item.parentName);
 				}

--- a/packages/studio/src/components/InlineCompositionName.tsx
+++ b/packages/studio/src/components/InlineCompositionName.tsx
@@ -62,7 +62,7 @@ export const InlineCompositionName: React.FC<{
 						return;
 					}
 
-					notification.replaceContent(`Renamed to ${newId}`, 2000);
+					notification.dismiss();
 				})
 				.catch((err) => {
 					notification.replaceContent(

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -187,9 +187,7 @@ const SequenceSourceQuickActions: React.FC<{
 			nodePath: nodePath.nodePath,
 		})
 			.then((result) => {
-				if (result.success) {
-					showNotification('Split video from audio', 2000);
-				} else {
+				if (!result.success) {
 					showNotification(result.reason, 4000);
 				}
 			})

--- a/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
+++ b/packages/studio/src/components/InspectorPanel/use-composition-actions.ts
@@ -106,7 +106,6 @@ export const useCompositionActions = () => {
 				: await callApi('/api/insert-jsx-element', request);
 
 			if (result.success) {
-				showNotification('Added <Solid> to source file', 2000);
 				return;
 			}
 

--- a/packages/studio/src/components/NewComposition/CodemodFooter.tsx
+++ b/packages/studio/src/components/NewComposition/CodemodFooter.tsx
@@ -65,7 +65,6 @@ export const CodemodFooter: React.FC<{
 	readonly codemod: RecastCodemod;
 	readonly stack: string | null;
 	readonly loadingNotification: React.ReactNode | null;
-	readonly successNotification: React.ReactNode;
 	readonly errorNotification: string;
 	readonly genericSubmitLabel: string;
 	readonly submitLabel: (options: {relativeRootPath: string}) => string;
@@ -78,7 +77,6 @@ export const CodemodFooter: React.FC<{
 	stack,
 	valid,
 	loadingNotification,
-	successNotification,
 	errorNotification,
 	genericSubmitLabel,
 	submitLabel,
@@ -125,11 +123,7 @@ export const CodemodFooter: React.FC<{
 					return;
 				}
 
-				if (notification) {
-					notification.replaceContent(successNotification, 2000);
-				} else {
-					showNotification(successNotification, 2000);
-				}
+				notification?.dismiss();
 
 				onSuccess?.();
 			})
@@ -147,7 +141,6 @@ export const CodemodFooter: React.FC<{
 		loadingNotification,
 		onSuccess,
 		setSelectedModal,
-		successNotification,
 		symbolicatedStack,
 	]);
 

--- a/packages/studio/src/components/NewComposition/DeleteComposition.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteComposition.tsx
@@ -60,7 +60,6 @@ const DeleteCompositionLoaded: React.FC<{
 					<CodemodFooter
 						errorNotification={`Could not delete composition`}
 						loadingNotification={'Deleting'}
-						successNotification={`Deleted ${unresolved.id}`}
 						genericSubmitLabel={`Delete`}
 						submitLabel={({relativeRootPath}) =>
 							`Delete from ${relativeRootPath}`

--- a/packages/studio/src/components/NewComposition/DeleteFolder.tsx
+++ b/packages/studio/src/components/NewComposition/DeleteFolder.tsx
@@ -50,7 +50,6 @@ export const DeleteFolder: React.FC<{
 					<CodemodFooter
 						errorNotification={`Could not delete folder`}
 						loadingNotification={'Deleting folder'}
-						successNotification={`Deleted folder ${folderId}`}
 						genericSubmitLabel={`Delete`}
 						submitLabel={({relativeRootPath}) =>
 							`Delete from ${relativeRootPath}`

--- a/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
+++ b/packages/studio/src/components/NewComposition/DuplicateComposition.tsx
@@ -370,7 +370,6 @@ const DuplicateCompositionLoaded: React.FC<{
 					<CodemodFooter
 						loadingNotification={'Duplicating...'}
 						errorNotification={'Could not duplicate composition'}
-						successNotification={`Duplicated ${unresolved.id} as ${newId}`}
 						genericSubmitLabel={'Duplicate'}
 						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
 						codemod={codemod}

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -331,7 +331,6 @@ const NewCompositionLoaded: React.FC<{
 					<CodemodFooter
 						loadingNotification={null}
 						errorNotification="Could not create composition"
-						successNotification={`Created ${newId}`}
 						genericSubmitLabel="Add to root file"
 						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
 						codemod={codemod}

--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -9,7 +9,6 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, type _InternalTypes} from 'remotion';
-import {getFolderId} from '../../helpers/get-folder-id';
 import {validateNewFolderName} from '../../helpers/validate-new-folder-name';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -92,8 +91,6 @@ export const NewFolder: React.FC<{
 		e.preventDefault();
 	}, []);
 
-	const folderId = getFolderId({folderName: newName, parentName});
-
 	return (
 		<DismissableModal>
 			<ModalHeader title="New folder" />
@@ -137,7 +134,6 @@ export const NewFolder: React.FC<{
 					<CodemodFooter
 						loadingNotification={'Creating folder...'}
 						errorNotification={'Could not create folder'}
-						successNotification={`Created folder ${folderId}`}
 						genericSubmitLabel={'Add to root file'}
 						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
 						codemod={codemod}

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -110,7 +110,6 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 					<CodemodFooter
 						loadingNotification={'Renaming...'}
 						errorNotification={'Could not rename composition'}
-						successNotification={`Renamed to ${newId}`}
 						genericSubmitLabel={'Rename'}
 						submitLabel={({relativeRootPath}) => `Modify ${relativeRootPath}`}
 						codemod={codemod}

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -113,7 +113,6 @@ export const RenameFolder: React.FC<{
 					<CodemodFooter
 						loadingNotification={'Renaming folder...'}
 						errorNotification={'Could not rename folder'}
-						successNotification={`Renamed folder to ${newName}`}
 						genericSubmitLabel={'Rename'}
 						submitLabel={({relativeRootPath}) => `Modify ${relativeRootPath}`}
 						codemod={codemod}

--- a/packages/studio/src/components/NewComposition/use-rename-static-file.ts
+++ b/packages/studio/src/components/NewComposition/use-rename-static-file.ts
@@ -119,7 +119,7 @@ export const useRenameStaticFile = ({
 					replaceUrl(`/assets/${newRelativePath}`);
 				}
 
-				notification.replaceContent(`Renamed to ${newRelativePath}`, 2000);
+				notification.dismiss();
 				return true;
 			} catch (err) {
 				notification.replaceContent(

--- a/packages/studio/src/components/Notifications/NotificationCenter.tsx
+++ b/packages/studio/src/components/Notifications/NotificationCenter.tsx
@@ -30,6 +30,7 @@ type TNotification = {
 };
 
 type CreatedNotification = {
+	dismiss: () => void;
 	replaceContent: (
 		newContent: React.ReactNode,
 		durationInMs: number | null,
@@ -71,6 +72,14 @@ export const NotificationCenter: React.FC = () => {
 			});
 
 			return {
+				dismiss: () => {
+					setNotifications((oldNotifications) => {
+						return oldNotifications.filter(
+							(notificationToFilter) =>
+								notificationToFilter.id !== notification.id,
+						);
+					});
+				},
 				replaceContent: (
 					newContent: React.ReactNode,
 					durationInMs: number | null,

--- a/packages/studio/src/components/RenderModal/RenderStatusModal.tsx
+++ b/packages/studio/src/components/RenderModal/RenderStatusModal.tsx
@@ -87,7 +87,6 @@ export const RenderStatusModal: React.FC<{readonly jobId: string}> = ({
 		setSelectedModal(null);
 		if (isClientJob) {
 			removeClientJob(job.id);
-			showNotification('Removed render', 2000);
 		} else {
 			removeRenderJob(job).catch((err) => {
 				showNotification(`Could not remove job: ${err.message}`, 2000);

--- a/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
@@ -33,17 +33,12 @@ export const RenderQueueRemoveItem: React.FC<{
 
 				removeClientJob(job.id);
 				unregisterClientRender(job.id).catch(() => {});
-				showNotification('Removed job', 2000);
 				return;
 			}
 
-			removeRenderJob(job)
-				.then(() => {
-					showNotification('Removed job', 2000);
-				})
-				.catch((err) => {
-					showNotification(`Could not remove item: ${err.message}`, 2000);
-				});
+			removeRenderJob(job).catch((err) => {
+				showNotification(`Could not remove item: ${err.message}`, 2000);
+			});
 		},
 		[job, isClientJob, removeClientJob, canvasContent, setCanvasContent],
 	);

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -164,7 +164,6 @@ const TimelineContextMenuArea: React.FC<{
 				: await callApi('/api/insert-jsx-element', request);
 
 			if (result.success) {
-				showNotification('Added <Solid> to source file', 2000);
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -1255,12 +1255,12 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 									? 'Reapply property paste onto selected sequences'
 									: 'Reapply property paste',
 						}).then(() => {
-							showNotification(
-								sequencePropTarget.targets.length > 1
-									? 'Pasted property onto selected sequences'
-									: 'Pasted property',
-								2000,
-							);
+							if (sequencePropTarget.targets.length > 1) {
+								showNotification(
+									'Pasted property onto selected sequences',
+									2000,
+								);
+							}
 						});
 					}
 
@@ -1351,12 +1351,12 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 									? 'Reapply effect prop paste onto selected effects'
 									: 'Reapply effect prop paste',
 						}).then(() => {
-							showNotification(
-								effectPropTarget.targets.length > 1
-									? 'Pasted effect prop onto selected effects'
-									: 'Pasted effect prop',
-								2000,
-							);
+							if (effectPropTarget.targets.length > 1) {
+								showNotification(
+									'Pasted effect prop onto selected effects',
+									2000,
+								);
+							}
 						});
 					}
 
@@ -1416,9 +1416,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 						clientId,
 						insertAtIndices,
 					}).then((pasteResult) => {
-						if (pasteResult.success) {
-							showNotification('Pasted effects', 2000);
-						} else {
+						if (!pasteResult.success) {
 							showNotification(pasteResult.reason, 4000);
 						}
 					});

--- a/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineEffectItem.tsx
@@ -461,9 +461,7 @@ export const TimelineEffectItem: React.FC<{
 					clientId: previewServerState.clientId,
 				});
 
-				if (result.success) {
-					showNotification('Reordered effect', 2000);
-				} else {
+				if (!result.success) {
 					showNotification(result.reason, 4000);
 				}
 			} catch (err) {

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -640,9 +640,7 @@ const TimelineSequenceItemInner: React.FC<{
 					clientId: previewServerState.clientId,
 				});
 
-				if (result.success) {
-					showNotification('Reordered sequence', 2000);
-				} else {
+				if (!result.success) {
 					showNotification(result.reason, 4000);
 				}
 			} catch (err) {

--- a/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/duplicate-selected-timeline-item.ts
@@ -72,15 +72,7 @@ export const duplicateSequencesFromSource = (
 				const failedResult = results.find((result) => !result.success);
 				if (failedResult && !failedResult.success) {
 					showNotification(failedResult.reason, 4000);
-					return;
 				}
-
-				showNotification(
-					toDuplicate.length === 1
-						? 'Duplicated sequence in source file'
-						: 'Duplicated sequences in source files',
-					2000,
-				);
 			})
 			.catch((err) => {
 				showNotification((err as Error).message, 4000);
@@ -115,14 +107,7 @@ const duplicateEffectsFromSource = (
 		}),
 	)
 		.then((result) => {
-			if (result.success) {
-				showNotification(
-					effects.length === 1
-						? 'Duplicated effect in source file'
-						: 'Duplicated effects in source files',
-					2000,
-				);
-			} else {
+			if (!result.success) {
 				showNotification(result.reason, 4000);
 			}
 		})

--- a/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
@@ -161,7 +161,6 @@ export const splitTimelineSequenceFromSource = ({
 	})
 		.then((result) => {
 			if (result.success) {
-				showNotification('Split sequence', 2000);
 				return true;
 			}
 

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -76,9 +76,7 @@ export const addEffectToSequence = async ({
 			clientId,
 		});
 
-		if (result.success) {
-			showNotification(`Added ${effect.name}()`, 2000);
-		} else {
+		if (!result.success) {
 			showNotification(result.reason, 4000);
 		}
 	} catch (err) {

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -258,38 +258,6 @@ const isSvgFile = (file: File) => file.name.toLowerCase().endsWith('.svg');
 
 export const hasSvgFile = (files: File[]) => files.some(isSvgFile);
 
-const getAssetLabel = (element: InsertableCompositionElement) => {
-	if (element.type !== 'asset') {
-		throw new Error('Expected asset element');
-	}
-
-	if (element.assetType === 'image') {
-		return '<CanvasImage>';
-	}
-
-	if (element.assetType === 'video') {
-		return '<Video>';
-	}
-
-	if (element.assetType === 'gif') {
-		return '<Gif>';
-	}
-
-	if (element.assetType === 'animated-image') {
-		return '<AnimatedImage>';
-	}
-
-	if (element.assetType === 'audio') {
-		return '<Audio>';
-	}
-
-	throw new Error('Unsupported asset type');
-};
-
-const getComponentLabel = (component: ComponentDragData['component']) => {
-	return `<${component.componentName}>`;
-};
-
 const getCenteredPosition = ({
 	dimensions,
 	dropPosition,
@@ -684,17 +652,6 @@ export const pickFilesToImport = ({
 	});
 };
 
-const notifyInsertedAssets = (insertedLabels: string[]) => {
-	if (insertedLabels.length === 1) {
-		showNotification(`Added ${insertedLabels[0]} to source file`, 2000);
-	} else if (insertedLabels.length > 1) {
-		showNotification(
-			`Added ${insertedLabels.length} assets to source file`,
-			2000,
-		);
-	}
-};
-
 const notifyUnsupportedFiles = (unsupportedFiles: string[]) => {
 	if (unsupportedFiles.length === 1) {
 		showNotification(
@@ -804,7 +761,6 @@ export const importAssets = async ({
 		return;
 	}
 
-	const insertedLabels: string[] = [];
 	const addedStaticFiles: string[] = [];
 	const unsupportedFiles: string[] = [];
 	const notifyAddedStaticFiles = () => {
@@ -851,7 +807,6 @@ export const importAssets = async ({
 					return;
 				}
 
-				insertedLabels.push('<Interactive.Svg>');
 				continue;
 			}
 
@@ -912,12 +867,9 @@ export const importAssets = async ({
 				notifyAddedStaticFiles();
 				return;
 			}
-
-			insertedLabels.push(getAssetLabel(element));
 		}
 
 		notifyAddedStaticFiles();
-		notifyInsertedAssets(insertedLabels);
 		notifyUnsupportedFiles(unsupportedFiles);
 	} catch (error) {
 		showNotification(
@@ -1008,7 +960,7 @@ export const insertSvgMarkup = async ({
 			dimensions = null;
 		}
 
-		const inserted = await insertCompositionElement({
+		await insertCompositionElement({
 			compositionFile,
 			compositionId,
 			from: null,
@@ -1022,10 +974,6 @@ export const insertSvgMarkup = async ({
 				}),
 			},
 		});
-
-		if (inserted) {
-			notifyInsertedAssets(['<Interactive.Svg>']);
-		}
 	} catch (error) {
 		showNotification(
 			`Could not add SVG: ${
@@ -1079,7 +1027,7 @@ export const importRemoteAsset = async ({
 					fps,
 				})
 			: null;
-		const inserted = await insertCompositionElement({
+		await insertCompositionElement({
 			compositionFile,
 			compositionId,
 			from: getFromForDrop({
@@ -1098,12 +1046,6 @@ export const importRemoteAsset = async ({
 				}),
 			},
 		});
-
-		if (!inserted) {
-			return;
-		}
-
-		notifyInsertedAssets([getAssetLabel(element)]);
 	} catch (error) {
 		showNotification(
 			`Could not add remote asset: ${
@@ -1149,7 +1091,7 @@ export const insertRemoteAudio = async ({
 			position: null,
 		};
 
-		const inserted = await insertCompositionElement({
+		await insertCompositionElement({
 			compositionFile,
 			compositionId,
 			element,
@@ -1159,12 +1101,6 @@ export const insertRemoteAudio = async ({
 				preferCompositionStart,
 			}),
 		});
-
-		if (!inserted) {
-			return;
-		}
-
-		notifyInsertedAssets([getAssetLabel(element)]);
 	} catch (error) {
 		showNotification(
 			`Could not add sound effect: ${
@@ -1198,7 +1134,6 @@ export const insertExistingAssets = async ({
 		return;
 	}
 
-	const insertedLabels: string[] = [];
 	const unsupportedFiles: string[] = [];
 
 	try {
@@ -1244,11 +1179,8 @@ export const insertExistingAssets = async ({
 			if (!inserted) {
 				return;
 			}
-
-			insertedLabels.push(getAssetLabel(element));
 		}
 
-		notifyInsertedAssets(insertedLabels);
 		notifyUnsupportedFiles(unsupportedFiles);
 	} catch (error) {
 		showNotification(
@@ -1276,7 +1208,7 @@ export const insertComponent = async ({
 	preferCompositionStart: boolean | null;
 }) => {
 	try {
-		const inserted = await insertCompositionElement({
+		await insertCompositionElement({
 			compositionFile,
 			compositionId,
 			from: getFromForDrop({
@@ -1296,15 +1228,6 @@ export const insertComponent = async ({
 				}),
 			},
 		});
-
-		if (!inserted) {
-			return;
-		}
-
-		showNotification(
-			`Added ${getComponentLabel(component)} to source file`,
-			2000,
-		);
 	} catch (error) {
 		showNotification(
 			`Could not add component: ${
@@ -1363,7 +1286,7 @@ export const insertComposition = async ({
 			width: calculated.width,
 			height: calculated.height,
 		};
-		const inserted = await insertCompositionElement({
+		await insertCompositionElement({
 			compositionFile,
 			compositionId,
 			from: getFromForDrop({
@@ -1386,15 +1309,6 @@ export const insertComposition = async ({
 				}),
 			},
 		});
-
-		if (!inserted) {
-			return;
-		}
-
-		showNotification(
-			`Added ${composition.compositionId} to ${compositionId}`,
-			2000,
-		);
 	} catch (error) {
 		showNotification(
 			`Could not add composition: ${
@@ -1443,10 +1357,7 @@ export const insertElement = async ({
 					? response.reason
 					: `Element file changed: ${response.conflict.filePath}`;
 			showNotification(`Could not add Element: ${reason}`, 4000);
-			return;
 		}
-
-		showNotification(`Added ${element.displayName} to source file`, 2000);
 	} catch (error) {
 		showNotification(
 			`Could not add Element: ${

--- a/packages/studio/src/components/use-delete-asset.tsx
+++ b/packages/studio/src/components/use-delete-asset.tsx
@@ -35,7 +35,7 @@ export const useDeleteAsset = (relativePath: string | null) => {
 
 				deleteStaticFile(relativePath)
 					.then(() => {
-						notification.replaceContent(`Deleted ${relativePath}`, 2000);
+						notification.dismiss();
 					})
 					.catch((err) => {
 						notification.replaceContent(


### PR DESCRIPTION
## Summary

- remove success notifications for Studio changes that are already visible on the canvas, timeline, or sidebar
- retain failure messages, clipboard confirmations, filesystem side-effect messages, and multi-target paste feedback
- dismiss progress notifications silently when asynchronous operations succeed

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun --cwd packages/studio test`
