### PR TITLE
`@remotion/media`: Fix 5.1 audio downmixing

### DIFF
--- a/packages/media/src/convert-audiodata/resample-audiodata.ts
+++ b/packages/media/src/convert-audiodata/resample-audiodata.ts
@@ -21,6 +21,10 @@ const fixFloatingPoint = (value: number) => {
 	return value;
 };
 
+const clampToS16 = (value: number) => {
+	return Math.max(-32768, Math.min(32767, value));
+};
+
 export const resampleAudioData = ({
 	srcNumberOfChannels,
 	sourceChannels,
@@ -122,15 +126,16 @@ export const resampleAudioData = ({
 			const l = getSourceValues(start, end, 0);
 			const r = getSourceValues(start, end, 1);
 			const c = getSourceValues(start, end, 2);
-			const sl = getSourceValues(start, end, 3);
-			const sr = getSourceValues(start, end, 4);
+			const sl = getSourceValues(start, end, 4);
+			const sr = getSourceValues(start, end, 5);
 
 			const sq = Math.sqrt(1 / 2);
-			const l2 = l + sq * (c + sl);
-			const r2 = r + sq * (c + sr);
+			const norm = 1 / (1 + sq + sq);
+			const l2 = (l + sq * (c + sl)) * norm;
+			const r2 = (r + sq * (c + sr)) * norm;
 
-			destination[newFrameIndex * 2 + 0] = l2;
-			destination[newFrameIndex * 2 + 1] = r2;
+			destination[newFrameIndex * 2 + 0] = clampToS16(l2);
+			destination[newFrameIndex * 2 + 1] = clampToS16(r2);
 		}
 
 		// Discrete fallback: direct mapping with zero-fill or drop

--- a/packages/media/src/test/extract-audio-resampling.test.ts
+++ b/packages/media/src/test/extract-audio-resampling.test.ts
@@ -61,3 +61,20 @@ test('resamples Mediabunny AudioSamples as one continuous frame', async () => {
 
 	expect(maximumError).toBeLessThanOrEqual(2);
 });
+
+test('downmixes 5.1 audio without overflowing and excludes the LFE channel', () => {
+	const sourceChannels = new Int16Array([
+		32767, 32767, 32767, -32768, 32767, 32767, 0, 0, 0, 32767, 32767, -32768,
+	]);
+	const destination = new Int16Array(4);
+
+	resampleAudioData({
+		srcNumberOfChannels: 6,
+		sourceChannels,
+		destination,
+		targetFrames: 2,
+		chunkSize: 1,
+	});
+
+	expect(Array.from(destination)).toEqual([32767, 32767, 9597, -9597]);
+});


### PR DESCRIPTION
## Summary

- normalize 5.1-to-stereo downmixing to prevent signed 16-bit overflow
- use the correct surround-left and surround-right channel indexes while excluding LFE
- add a regression test covering overflow and channel ordering

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx vitest src/test/extract-audio-resampling.test.ts --browser --run`

Closes #10731
