### PR TITLE
`@remotion/studio`: Add rulers and guides toolbar controls

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -22,6 +22,7 @@ import {PlaybackRateSelector} from './PlaybackRateSelector';
 import {PlayPause} from './PlayPause';
 import {PreviewToolbarOverflowButton} from './PreviewToolbarOverflowButton';
 import {RenderButton} from './RenderButton';
+import {RulersAndGuidesToggle} from './RulersAndGuidesToggle';
 import {SizeSelector} from './SizeSelector';
 import {SnappingToggle} from './SnappingToggle';
 import {TimelineInOutPointToggle} from './TimelineInOutToggle';
@@ -190,6 +191,14 @@ export const PreviewToolbar: React.FC<{
 							<OutlineToggle />
 						</PreviewToolbarControl>
 					)}
+					{isMobileLayout ? null : (
+						<>
+							<Spacing x={0.25} />
+							<PreviewToolbarControl>
+								<RulersAndGuidesToggle />
+							</PreviewToolbarControl>
+						</>
+					)}
 					{readOnlyStudio || isMobileLayout ? null : (
 						<>
 							<Spacing x={0.25} />
@@ -200,7 +209,7 @@ export const PreviewToolbar: React.FC<{
 					)}
 				</>
 			) : null}
-			<Spacing x={1} />
+			<Spacing x={2} />
 			{canvasContent && isFullscreenSupported ? (
 				<PreviewToolbarControl>
 					<FullScreenToggle hidden={isMobileLayout} />

--- a/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
+++ b/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
@@ -5,7 +5,9 @@ import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {Checkmark} from '../icons/Checkmark';
 import {EllipsisIcon} from '../icons/ellipsis';
 import {CheckerboardContext} from '../state/checkerboard';
+import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
+import {EditorShowRulersContext} from '../state/editor-rulers';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineDropdown} from './InlineDropdown';
 import {toggleLoop} from './LoopToggle';
@@ -40,6 +42,12 @@ export const PreviewToolbarOverflowButton: React.FC<{
 	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
 	const {editorShowOutlines, setEditorShowOutlines} = useContext(
 		EditorShowOutlinesContext,
+	);
+	const {editorShowGuides, setEditorShowGuides} = useContext(
+		EditorShowGuidesContext,
+	);
+	const {editorShowRulers, setEditorShowRulers} = useContext(
+		EditorShowRulersContext,
 	);
 	const {
 		items: previewSizeItems,
@@ -144,6 +152,28 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				subMenu: null,
 				quickSwitcherLabel: null,
 			});
+			items.push({
+				type: 'item',
+				id: 'rulers',
+				label: 'Rulers',
+				value: 'rulers',
+				onClick: () => setEditorShowRulers((current) => !current),
+				keyHint: null,
+				leftItem: editorShowRulers ? <Checkmark /> : null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
+			items.push({
+				type: 'item',
+				id: 'guides',
+				label: 'Guides',
+				value: 'guides',
+				onClick: () => setEditorShowGuides((current) => !current),
+				keyHint: null,
+				leftItem: editorShowGuides ? <Checkmark /> : null,
+				subMenu: null,
+				quickSwitcherLabel: null,
+			});
 		}
 
 		if (showFullscreen) {
@@ -172,9 +202,13 @@ export const PreviewToolbarOverflowButton: React.FC<{
 		showCompositionControls,
 		loop,
 		checkerboard,
+		editorShowGuides,
 		editorShowOutlines,
+		editorShowRulers,
 		setCheckerboard,
+		setEditorShowGuides,
 		setEditorShowOutlines,
+		setEditorShowRulers,
 		setLoop,
 		zoomable,
 		keyboardShortcutsDisabled,

--- a/packages/studio/src/components/RulersAndGuidesToggle.tsx
+++ b/packages/studio/src/components/RulersAndGuidesToggle.tsx
@@ -1,0 +1,48 @@
+import React, {useCallback, useContext} from 'react';
+import {BLUE} from '../helpers/colors';
+import {EditorShowGuidesContext} from '../state/editor-guides';
+import {EditorShowRulersContext} from '../state/editor-rulers';
+import {ControlButton} from './ControlButton';
+
+export const RulersAndGuidesToggle: React.FC = () => {
+	const {editorShowGuides, setEditorShowGuides} = useContext(
+		EditorShowGuidesContext,
+	);
+	const {editorShowRulers, setEditorShowRulers} = useContext(
+		EditorShowRulersContext,
+	);
+	const rulersOrGuidesAreVisible = editorShowRulers || editorShowGuides;
+
+	const onClick = useCallback(() => {
+		setEditorShowRulers(() => !rulersOrGuidesAreVisible);
+		setEditorShowGuides(() => !rulersOrGuidesAreVisible);
+	}, [rulersOrGuidesAreVisible, setEditorShowGuides, setEditorShowRulers]);
+
+	const accessibilityLabel = rulersOrGuidesAreVisible
+		? 'Hide rulers and guides'
+		: 'Show rulers and guides';
+
+	return (
+		<ControlButton
+			title={accessibilityLabel}
+			aria-label={accessibilityLabel}
+			aria-pressed={rulersOrGuidesAreVisible}
+			onClick={onClick}
+		>
+			{(color) => (
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 576 512"
+					style={{width: 18, height: 18}}
+					aria-hidden="true"
+					focusable="false"
+				>
+					<path
+						fill={rulersOrGuidesAreVisible ? BLUE : color}
+						d="M525.9 154.2L186.5 493.6c-6.2 6.2-16.4 6.2-22.6 0L50.7 380.5c-6.2-6.2-6.2-16.4 0-22.6l33.9-33.9 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 33.9-33.9c6.2-6.2 16.4-6.2 22.6 0L525.9 131.5c6.2 6.2 6.2 16.4 0 22.6zM73.3 289.9L28.1 335.2c-18.7 18.7-18.7 49.1 0 67.9L141.2 516.2c18.7 18.7 49.1 18.7 67.9 0L548.5 176.8c18.7-18.7 18.7-49.1 0-67.9L435.4-4.2C416.6-23 386.2-23 367.5-4.2 77.1 286.2 140.3 223 73.3 289.9z"
+					/>
+				</svg>
+			)}
+		</ControlButton>
+	);
+};

--- a/packages/studio/src/components/TimelineInOutToggle.tsx
+++ b/packages/studio/src/components/TimelineInOutToggle.tsx
@@ -37,6 +37,10 @@ const style: React.CSSProperties = {
 	height: 17,
 };
 
+const buttonStyle: React.CSSProperties = {
+	width: 18,
+};
+
 export const inOutHandles = createRef<{
 	inMarkClick: (e: KeyboardEvent | null) => void;
 	outMarkClick: (e: KeyboardEvent | null) => void;
@@ -303,6 +307,7 @@ export const TimelineInOutPointToggle: React.FC = () => {
 			<ControlButton
 				title={getTooltipText('In', 'I')}
 				aria-label={getTooltipText('In', 'I')}
+				style={buttonStyle}
 				onClick={onInMark}
 				onContextMenu={clearInMark}
 				disabled={!videoConfig || isFirstFrame}
@@ -317,6 +322,7 @@ export const TimelineInOutPointToggle: React.FC = () => {
 			<ControlButton
 				title={getTooltipText('Out', 'O')}
 				aria-label={getTooltipText('Out', 'O')}
+				style={buttonStyle}
 				onClick={onOutMark}
 				onContextMenu={clearOutMark}
 				disabled={!videoConfig || isLastFrame}


### PR DESCRIPTION
## Summary

- add a combined rulers and guides toggle to the Studio preview toolbar
- expose separate Rulers and Guides options in the small-viewport overflow menu
- refine preview-toolbar spacing and compact the in/out point controls

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
