### PR TITLE
`@remotion/studio`: Unify segmented button controls

### DIFF
--- a/packages/studio/src/components/FixComputedValueModal.tsx
+++ b/packages/studio/src/components/FixComputedValueModal.tsx
@@ -75,7 +75,7 @@ const mainSegmentStyle: React.CSSProperties = {
 
 const dropdownSegmentStyle: React.CSSProperties = {
 	padding: 0,
-	width: 24,
+	width: 20,
 };
 
 const menuLabel: React.CSSProperties = {
@@ -194,9 +194,7 @@ export const FixComputedValueModal: React.FC<{
 							idleColor: LIGHT_TEXT,
 							leaveLeftSpace: true,
 							onOpenChange: null,
-							renderContent: (color: string) => (
-								<CaretDown color={color} small />
-							),
+							renderContent: (color: string) => <CaretDown color={color} />,
 							segmentId: 'another-coding-agent',
 							selectedId: null,
 							style: dropdownSegmentStyle,

--- a/packages/studio/src/components/FixComputedValueModal.tsx
+++ b/packages/studio/src/components/FixComputedValueModal.tsx
@@ -1,27 +1,20 @@
 import type {DefaultCodingAgent} from '@remotion/renderer';
 import React, {useCallback} from 'react';
-import {
-	LIGHT_TEXT,
-	SELECTED_BACKGROUND,
-	TRANSPARENT,
-	WHITE,
-	getBackgroundFromHoverState,
-} from '../helpers/colors';
+import {LIGHT_TEXT, SELECTED_BACKGROUND, WHITE} from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
 import {openInCodingAgent} from '../helpers/open-in-editor';
 import {CaretDown} from '../icons/caret';
 import {ClipboardIcon} from '../icons/clipboard';
 import type {ModalState} from '../state/modals';
-import {useZIndex} from '../state/z-index';
 import {CodingAgentIcon} from './CodingAgentIcon';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
-import {InlineDropdown} from './InlineDropdown';
 import {ModalFooterContainer} from './ModalFooter';
 import {ModalHeader} from './ModalHeader';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {DismissableModal} from './NewComposition/DismissableModal';
 import {showNotification} from './Notifications/NotificationCenter';
+import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
 import {useSettings} from './SettingsContext';
 
 const panelStyle: React.CSSProperties = {
@@ -75,38 +68,13 @@ const footer: React.CSSProperties = {
 	justifyContent: 'flex-end',
 };
 
-const splitButton: React.CSSProperties = {
-	alignItems: 'center',
-	borderRadius: 4,
-	display: 'inline-flex',
-	flexDirection: 'row',
-	gap: 1,
-	height: 24,
-	overflow: 'hidden',
-};
-
-const mainButtonBase: React.CSSProperties = {
-	alignItems: 'center',
-	background: TRANSPARENT,
-	border: 'none',
-	borderRadius: '4px 0 0 4px',
-	color: LIGHT_TEXT,
-	display: 'inline-flex',
-	fontFamily: 'sans-serif',
-	fontSize: 12,
+const mainSegmentStyle: React.CSSProperties = {
 	gap: 6,
-	height: 24,
 	padding: '0 9px',
-	whiteSpace: 'nowrap',
 };
 
-const singleButton: React.CSSProperties = {
-	borderRadius: 4,
-};
-
-const dropdownButton: React.CSSProperties = {
-	borderRadius: '0 4px 4px 0',
-	height: 24,
+const dropdownSegmentStyle: React.CSSProperties = {
+	padding: 0,
 	width: 24,
 };
 
@@ -126,8 +94,6 @@ export const FixComputedValueModal: React.FC<{
 	readonly state: FixComputedValueModalState;
 }> = ({state}) => {
 	const {codingAgentInfo} = useSettings();
-	const {tabIndex} = useZIndex();
-	const [hovered, setHovered] = React.useState(false);
 	const prompt = `/remotion-interactivity ${state.context} make "${state.prop}" interactive`;
 	const installCommand = 'npx remotion skills add';
 	const installedCodingAgents = codingAgentInfo?.installedCodingAgents ?? [];
@@ -190,21 +156,63 @@ export const FixComputedValueModal: React.FC<{
 		}));
 	}, [alternativeCodingAgents, openWithCodingAgent]);
 
-	const renderDropdownAction: RenderInlineAction = useCallback((color) => {
-		return <CaretDown color={color} small />;
-	}, []);
+	const segments = React.useMemo((): SegmentedButtonSegment[] => {
+		if (!defaultCodingAgent) {
+			return [];
+		}
 
-	const mainButtonStyle = React.useMemo((): React.CSSProperties => {
-		return {
-			...mainButtonBase,
-			...(alternativeCodingAgents.length === 0 ? singleButton : null),
-			background: getBackgroundFromHoverState({
-				hovered,
-				selected: false,
-			}),
-			color: hovered ? WHITE : LIGHT_TEXT,
-		};
-	}, [alternativeCodingAgents.length, hovered]);
+		return [
+			{
+				ariaLabel: `Open in ${defaultCodingAgent.nameWithType}`,
+				buttonId: null,
+				disabled: false,
+				idleColor: LIGHT_TEXT,
+				onClick: () => {
+					openWithCodingAgent(
+						defaultCodingAgent.id,
+						defaultCodingAgent.nameWithType,
+					).catch(() => undefined);
+				},
+				onPointerDown: null,
+				renderContent: () => (
+					<>
+						<CodingAgentIcon codingAgentId={defaultCodingAgent.id} size={18} />
+						Open in {defaultCodingAgent.name}
+					</>
+				),
+				segmentId: 'default-coding-agent',
+				style: mainSegmentStyle,
+				title: `Open in ${defaultCodingAgent.nameWithType}`,
+				type: 'action',
+			},
+			...(alternativeCodingAgents.length > 0
+				? [
+						{
+							ariaLabel: 'Open in another coding agent',
+							buttonId: null,
+							disabled: false,
+							idleColor: LIGHT_TEXT,
+							leaveLeftSpace: true,
+							onOpenChange: null,
+							renderContent: (color: string) => (
+								<CaretDown color={color} small />
+							),
+							segmentId: 'another-coding-agent',
+							selectedId: null,
+							style: dropdownSegmentStyle,
+							title: 'Open in another coding agent',
+							type: 'menu' as const,
+							values: agentMenuItems,
+						},
+					]
+				: []),
+		];
+	}, [
+		agentMenuItems,
+		alternativeCodingAgents.length,
+		defaultCodingAgent,
+		openWithCodingAgent,
+	]);
 
 	return (
 		<DismissableModal panelStyle={panelStyle}>
@@ -246,40 +254,7 @@ export const FixComputedValueModal: React.FC<{
 			</div>
 			{defaultCodingAgent ? (
 				<ModalFooterContainer style={footer}>
-					<div
-						style={splitButton}
-						onPointerEnter={() => setHovered(true)}
-						onPointerLeave={() => setHovered(false)}
-					>
-						<button
-							aria-label={`Open in ${defaultCodingAgent.nameWithType}`}
-							onClick={() => {
-								openWithCodingAgent(
-									defaultCodingAgent.id,
-									defaultCodingAgent.nameWithType,
-								).catch(() => undefined);
-							}}
-							style={mainButtonStyle}
-							tabIndex={tabIndex}
-							title={`Open in ${defaultCodingAgent.nameWithType}`}
-							type="button"
-						>
-							<CodingAgentIcon
-								codingAgentId={defaultCodingAgent.id}
-								size={18}
-							/>
-							Open in {defaultCodingAgent.name}
-						</button>
-						{alternativeCodingAgents.length > 0 ? (
-							<InlineDropdown
-								renderAction={renderDropdownAction}
-								style={dropdownButton}
-								title="Open in another coding agent"
-								values={agentMenuItems}
-								variant={null}
-							/>
-						) : null}
-					</div>
+					<SegmentedButton segments={segments} style={null} title={null} />
 				</ModalFooterContainer>
 			) : null}
 		</DismissableModal>

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -1,15 +1,10 @@
 import type {DefaultCodingAgent} from '@remotion/renderer';
 import type {EditorPickerId} from '@remotion/studio-shared';
-import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {
-	LIGHT_TEXT,
-	TRANSPARENT,
-	WHITE,
-	getBackgroundFromHoverState,
-} from '../helpers/colors';
+import {LIGHT_TEXT} from '../helpers/colors';
 import {
 	openInCodingAgent,
 	openInGitClient,
@@ -19,43 +14,26 @@ import {
 import {CaretDown} from '../icons/caret';
 import {EditorIcon} from '../icons/editor';
 import {SetSelectedModalContext} from '../state/modals';
-import {useZIndex} from '../state/z-index';
 import {getOpenInMenuItems} from './get-open-in-menu-items';
-import type {RenderInlineAction} from './InlineAction';
-import {InlineDropdown} from './InlineDropdown';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {openInFileExplorer} from './RenderQueue/actions';
+import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
 import {
 	useDefaultCodingAgentInfo,
 	useEditorOpening,
 } from './use-default-editor-info';
 
-const splitButton: React.CSSProperties = {
-	alignItems: 'center',
-	borderRadius: 3,
-	display: 'inline-flex',
-	flexDirection: 'row',
-	flexShrink: 0,
-	gap: 1,
-	height: 24,
-	overflow: 'hidden',
+const mainSegmentStyle: React.CSSProperties = {
+	columnGap: 4,
+	fontSize: 11,
+	lineHeight: '14px',
+	padding: '0 2px 0 4px',
 };
 
-const mainButtonBase: React.CSSProperties = {
-	alignItems: 'center',
-	background: TRANSPARENT,
-	border: 'none',
-	borderRadius: '3px 0 0 3px',
-	color: LIGHT_TEXT,
-	columnGap: 4,
-	display: 'inline-flex',
-	fontFamily: 'sans-serif',
-	fontSize: 11,
-	height: 24,
-	lineHeight: '14px',
-	padding: '0 6px',
-	whiteSpace: 'nowrap',
+const dropdownSegmentStyle: React.CSSProperties = {
+	padding: 0,
+	width: 20,
 };
 
 const editorButtonIconSize = 18;
@@ -68,10 +46,6 @@ export const InspectorOpenInEditor: React.FC<{
 }> = ({contextForAgents = null, label, location, locationType}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
-	const {tabIndex} = useZIndex();
-	const [hovered, setHovered] = useState(false);
-	const [dropdownOpened, setDropdownOpened] = useState(false);
-	const ignorePointerEnter = useRef(false);
 	const {
 		canConfigureApps,
 		canOpenInEditor,
@@ -123,41 +97,6 @@ export const InspectorOpenInEditor: React.FC<{
 		},
 		[defaultEditorId, openWithEditor],
 	);
-	const onDropdownOpenChange = useCallback((open: boolean) => {
-		setDropdownOpened(open);
-		if (!open) {
-			ignorePointerEnter.current = true;
-			setHovered(false);
-		}
-	}, []);
-	const mainHovered = hovered && !dropdownOpened;
-	const mainButtonStyle = useMemo((): React.CSSProperties => {
-		return {
-			...mainButtonBase,
-			background: getBackgroundFromHoverState({
-				hovered: mainHovered,
-				selected: false,
-			}),
-			color: mainHovered ? WHITE : LIGHT_TEXT,
-			opacity: canOpenDefault ? 1 : 0.5,
-			pointerEvents: canOpenDefault ? 'auto' : 'none',
-		};
-	}, [canOpenDefault, mainHovered]);
-	const dropdownForegroundColor =
-		hovered || dropdownOpened ? WHITE : LIGHT_TEXT;
-	const dropdownStyle = useMemo((): React.CSSProperties => {
-		return {
-			background: getBackgroundFromHoverState({
-				hovered,
-				selected: dropdownOpened,
-			}),
-			borderRadius: '0 3px 3px 0',
-			color: dropdownForegroundColor,
-		};
-	}, [dropdownForegroundColor, dropdownOpened, hovered]);
-	const renderDropdownAction: RenderInlineAction = useCallback((color) => {
-		return <CaretDown color={color} small />;
-	}, []);
 	const menuItems = useMemo((): ComboboxValue[] => {
 		return getOpenInMenuItems({
 			codingAgentInfo,
@@ -239,6 +178,53 @@ export const InspectorOpenInEditor: React.FC<{
 		openWithEditor,
 		setSelectedModal,
 	]);
+	const segments = useMemo((): SegmentedButtonSegment[] => {
+		return [
+			{
+				ariaLabel: `Open in ${editorName}`,
+				buttonId: null,
+				disabled: !canOpenDefault,
+				idleColor: LIGHT_TEXT,
+				onClick: onOpenDefault,
+				onPointerDown: null,
+				renderContent: () => (
+					<>
+						{label}
+						<EditorIcon
+							editorId={defaultEditorId}
+							size={editorButtonIconSize}
+						/>
+					</>
+				),
+				segmentId: 'default-editor',
+				style: mainSegmentStyle,
+				title: `Open in ${editorName}`,
+				type: 'action',
+			},
+			{
+				ariaLabel: 'Open in another app',
+				buttonId: null,
+				disabled: false,
+				idleColor: LIGHT_TEXT,
+				leaveLeftSpace: true,
+				onOpenChange: null,
+				renderContent: (color) => <CaretDown color={color} />,
+				segmentId: 'another-app',
+				selectedId: null,
+				style: dropdownSegmentStyle,
+				title: 'Open in another app',
+				type: 'menu',
+				values: menuItems,
+			},
+		];
+	}, [
+		canOpenDefault,
+		defaultEditorId,
+		editorName,
+		label,
+		menuItems,
+		onOpenDefault,
+	]);
 
 	if (
 		previewServerState.type !== 'connected' ||
@@ -247,40 +233,5 @@ export const InspectorOpenInEditor: React.FC<{
 		return null;
 	}
 
-	return (
-		<div
-			style={splitButton}
-			onPointerEnter={() => {
-				if (!ignorePointerEnter.current) {
-					setHovered(true);
-				}
-			}}
-			onPointerLeave={() => {
-				ignorePointerEnter.current = false;
-				setHovered(false);
-			}}
-		>
-			<button
-				aria-label={`Open in ${editorName}`}
-				disabled={!canOpenDefault}
-				onClick={onOpenDefault}
-				style={mainButtonStyle}
-				tabIndex={tabIndex}
-				title={`Open in ${editorName}`}
-				type="button"
-			>
-				{label}
-				<EditorIcon editorId={defaultEditorId} size={editorButtonIconSize} />
-			</button>
-			<InlineDropdown
-				onOpenChange={onDropdownOpenChange}
-				renderAction={renderDropdownAction}
-				style={dropdownStyle}
-				title="Open in another app"
-				unhoveredColor={dropdownForegroundColor}
-				values={menuItems}
-				variant="compact"
-			/>
-		</div>
-	);
+	return <SegmentedButton segments={segments} style={null} title={null} />;
 };

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -6,12 +6,7 @@ import {
 	WHITE,
 	getBackgroundFromHoverState,
 } from '../../helpers/colors';
-import {
-	HOVERABLE_CLASS_NAME,
-	HOVER_GROUP_CLASS_NAME,
-	HOVER_GROUP_REVEAL_CLASS_NAME,
-	hoverableStyle,
-} from '../../helpers/hoverable';
+import {HOVERABLE_CLASS_NAME, hoverableStyle} from '../../helpers/hoverable';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {COMPACT_CONTROL_ROW_HEIGHT, COMPACT_INLINE_ROW_HEIGHT} from '../layout';
 import {ValidationMessage} from '../NewComposition/ValidationMessage';
@@ -174,41 +169,6 @@ const inlineLabelIcon: React.CSSProperties = {
 	width: 18,
 };
 
-const segmentedInlineAction: React.CSSProperties = {
-	display: 'flex',
-	gap: 1,
-	margin: `0 ${INLINE_LABEL_BUTTON_MARGIN}px`,
-	width: `calc(100% - ${INLINE_LABEL_BUTTON_MARGIN * 2}px)`,
-};
-
-const segmentedMainAction: React.CSSProperties = {
-	borderRadius: '4px 0 0 4px',
-	flex: 1,
-	margin: 0,
-	minWidth: 0,
-	width: 'auto',
-};
-
-const segmentedTrailingAction: React.CSSProperties = {
-	alignItems: 'center',
-	appearance: 'none',
-	border: 'none',
-	borderRadius: '0 4px 4px 0',
-	display: 'flex',
-	flex: '0 0 28px',
-	justifyContent: 'center',
-	margin: 0,
-	padding: 0,
-	width: 28,
-};
-
-export type InspectorQuickActionSegment = {
-	readonly disabled: boolean;
-	readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
-	readonly renderIcon: (color: string) => React.ReactNode;
-	readonly title?: string;
-};
-
 export type InspectorQuickActionProps = {
 	readonly children: React.ReactNode;
 	readonly disabled: boolean;
@@ -218,12 +178,6 @@ export type InspectorQuickActionProps = {
 	readonly size?: 'default' | 'compact';
 	readonly style?: React.CSSProperties;
 	readonly title?: string;
-	readonly variant?:
-		| {readonly type: 'single'}
-		| {
-				readonly type: 'segmented';
-				readonly trailing: InspectorQuickActionSegment;
-		  };
 };
 
 export const InspectorQuickAction: React.FC<InspectorQuickActionProps> = ({
@@ -235,13 +189,8 @@ export const InspectorQuickAction: React.FC<InspectorQuickActionProps> = ({
 	size = 'default',
 	style,
 	title,
-	variant = {type: 'single'},
 }) => {
-	const isSegmented = variant.type === 'segmented';
-	// A non-clickable single action (onClick === null) never shows a hover
-	// effect. In the segmented variant, the main segment highlights whenever
-	// the group is hovered, even if it is not clickable itself.
-	const showsHover = !disabled && (onClick !== null || isSegmented);
+	const showsHover = !disabled && onClick !== null;
 	const buttonStyle = React.useMemo(
 		(): React.CSSProperties => ({
 			...(disabled ? inlineLabelButtonDisabled : inlineLabelButton),
@@ -254,10 +203,9 @@ export const InspectorQuickAction: React.FC<InspectorQuickActionProps> = ({
 				hoverColor: showsHover ? WHITE : LIGHT_TEXT,
 			}),
 			...(size === 'compact' ? compactInlineLabelButton : null),
-			...(isSegmented ? segmentedMainAction : null),
 			...style,
 		}),
-		[disabled, showsHover, isSegmented, size, style],
+		[disabled, showsHover, size, style],
 	);
 
 	const mainContent = (
@@ -286,46 +234,6 @@ export const InspectorQuickAction: React.FC<InspectorQuickActionProps> = ({
 			{mainContent}
 		</div>
 	);
-
-	if (variant.type === 'segmented') {
-		const trailingStyle: React.CSSProperties = {
-			...segmentedTrailingAction,
-			...hoverableStyle({
-				idleBackground: TRANSPARENT,
-				hoverBackground: variant.trailing.disabled
-					? TRANSPARENT
-					: getBackgroundFromHoverState({hovered: true, selected: false}),
-				idleColor: LIGHT_TEXT,
-				hoverColor: variant.trailing.disabled ? LIGHT_TEXT : WHITE,
-			}),
-			height:
-				size === 'compact'
-					? COMPACT_INLINE_ROW_HEIGHT
-					: COMPACT_CONTROL_ROW_HEIGHT,
-			opacity: variant.trailing.disabled ? 0.35 : 1,
-		};
-
-		return (
-			<div className={HOVER_GROUP_CLASS_NAME} style={segmentedInlineAction}>
-				{mainAction}
-				<button
-					type="button"
-					className={HOVERABLE_CLASS_NAME}
-					disabled={variant.trailing.disabled}
-					style={trailingStyle}
-					title={variant.trailing.title}
-					onClick={variant.trailing.onClick}
-				>
-					<span
-						className={HOVER_GROUP_REVEAL_CLASS_NAME}
-						style={inlineLabelIcon}
-					>
-						{variant.trailing.renderIcon(CURRENT_COLOR)}
-					</span>
-				</button>
-			</div>
-		);
-	}
 
 	return mainAction;
 };

--- a/packages/studio/src/components/MenuBuildIndicator.tsx
+++ b/packages/studio/src/components/MenuBuildIndicator.tsx
@@ -59,6 +59,7 @@ export const MenuBuildIndicator: React.FC<{
 			<Spacing x={mobileLayout ? 0.5 : 2} />
 			{window.remotion_projectName}
 			<MenuCompositionName />
+			<Spacing x={1} />
 			<InspectorOpenInEditor location={folderLocation} locationType="folder" />
 			{mobileLayout ? null : <Spacing x={0.5} />}
 			{mobileLayout ? (

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -9,74 +9,23 @@ import type {
 } from '@remotion/renderer';
 import type {RenderStillOnWebImageFormat} from '@remotion/web-renderer';
 import type {SVGProps} from 'react';
-import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
-import ReactDOM from 'react-dom';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {
-	TRANSPARENT,
-	WHITE,
-	WHITE_ALPHA_80,
-	getBackgroundFromHoverState,
-} from '../helpers/colors';
+import {WHITE_ALPHA_80} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {CaretDown} from '../icons/caret';
 import {ThinRenderIcon} from '../icons/render';
 import {useTimelineInOutFramePosition} from '../state/in-out';
 import {SetSelectedModalContext} from '../state/modals';
-import {HigherZIndex, useZIndex} from '../state/z-index';
 import {Row, Spacing} from './layout';
-import {MENU_INITIATOR_CLASSNAME, isMenuItem} from './Menu/is-menu-item';
-import {getPortal} from './Menu/portals';
-import {
-	fullScreenOverlay,
-	menuContainerTowardsBottom,
-	menuContainerTowardsTop,
-	outerPortal,
-} from './Menu/styles';
 import type {ComboboxValue} from './NewComposition/ComboBox';
-import {MenuContent} from './NewComposition/MenuContent';
+import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
 
-const splitButtonContainer: React.CSSProperties = {
-	display: 'inline-flex',
-	flexDirection: 'row',
-	alignItems: 'center',
-	borderRadius: 3,
-	gap: 1,
-	overflow: 'hidden',
-};
-
-const mainButtonStyle: React.CSSProperties = {
-	paddingLeft: 7,
-	paddingRight: 7,
-	paddingTop: 7,
-	paddingBottom: 7,
-	background: TRANSPARENT,
-	border: 'none',
-	borderRadius: '3px 0 0 3px',
-	color: WHITE,
-	cursor: 'default',
-	display: 'flex',
-	alignItems: 'center',
-	fontSize: 14,
-	fontFamily: 'inherit',
-};
-
-const dropdownTriggerStyle: React.CSSProperties = {
-	paddingLeft: 6,
-	paddingRight: 6,
-	paddingTop: 7,
-	paddingBottom: 7,
-	background: TRANSPARENT,
-	border: 'none',
-	borderRadius: '0 3px 3px 0',
-	color: WHITE,
-	cursor: 'default',
-	display: 'flex',
-	alignItems: 'center',
-	justifyContent: 'center',
+const segmentedButtonStyle: React.CSSProperties = {
+	height: 28,
 };
 
 const mainButtonContent: React.CSSProperties = {
@@ -98,22 +47,23 @@ const label: React.CSSProperties = {
 	whiteSpace: 'nowrap',
 };
 
-const compactSplitButtonSegmentHeight = 24;
-
-const compactMainButtonStyle: React.CSSProperties = {
-	...mainButtonStyle,
-	boxSizing: 'border-box',
-	height: compactSplitButtonSegmentHeight,
-	padding: '0 4px',
-	fontSize: 12,
+const compactMainSegmentStyle: React.CSSProperties = {
+	padding: '0 6px',
 };
 
-const compactDropdownTriggerStyle: React.CSSProperties = {
-	...dropdownTriggerStyle,
-	boxSizing: 'border-box',
-	height: compactSplitButtonSegmentHeight,
+const defaultMainSegmentStyle: React.CSSProperties = {
+	fontFamily: 'inherit',
+	fontSize: 14,
+	padding: '0 7px',
+};
+
+const compactDropdownSegmentStyle: React.CSSProperties = {
 	padding: 0,
 	width: 20,
+};
+
+const defaultDropdownSegmentStyle: React.CSSProperties = {
+	padding: '0 6px',
 };
 
 const compactMainButtonContent: React.CSSProperties = {
@@ -158,72 +108,6 @@ const RenderButtonInner: React.FC<{
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const [preferredRenderType, setPreferredRenderType] = useState<RenderType>(
 		() => getInitialRenderType(readOnlyStudio),
-	);
-	const [dropdownOpened, setDropdownOpened] = useState(false);
-	const [hovered, setHovered] = useState(false);
-	const dropdownRef = useRef<HTMLButtonElement>(null);
-	const containerRef = useRef<HTMLDivElement>(null);
-	const {currentZIndex} = useZIndex();
-
-	const size = PlayerInternals.useElementSize(dropdownRef, {
-		triggerOnWindowResize: true,
-		shouldApplyCssTransforms: true,
-	});
-
-	const refresh = size?.refresh;
-
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLButtonElement>) => {
-			// Prevent deselection of currently selected items
-			e.stopPropagation();
-			setDropdownOpened((o) => {
-				if (!o) {
-					refresh?.();
-				}
-
-				return !o;
-			});
-		},
-		[refresh],
-	);
-
-	const onMenuPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			// Prevent deselection of currently selected items
-			e.stopPropagation();
-		},
-		[],
-	);
-
-	const onClickDropdown = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation();
-			const isKeyboardInitiated = e.detail === 0;
-			if (!isKeyboardInitiated) {
-				return;
-			}
-
-			setDropdownOpened((o) => {
-				if (!o) {
-					refresh?.();
-
-					window.addEventListener(
-						'pointerup',
-						(evt) => {
-							if (!isMenuItem(evt.target as HTMLElement)) {
-								setDropdownOpened(false);
-							}
-						},
-						{
-							once: true,
-						},
-					);
-				}
-
-				return !o;
-			});
-		},
-		[refresh],
 	);
 
 	const connectionStatus = useContext(StudioServerConnectionCtx)
@@ -393,10 +277,6 @@ const RenderButtonInner: React.FC<{
 		}
 	}, [renderType, openServerRenderModal, openClientRenderModal]);
 
-	const onHideDropdown = useCallback(() => {
-		setDropdownOpened(false);
-	}, []);
-
 	const handleRenderTypeChange = useCallback(
 		(newType: RenderType) => {
 			setPreferredRenderType(newType);
@@ -405,8 +285,6 @@ const RenderButtonInner: React.FC<{
 			} catch {
 				// localStorage might not be available
 			}
-
-			setDropdownOpened(false);
 
 			if (newType === 'server-render') {
 				openServerRenderModal(false);
@@ -476,57 +354,6 @@ const RenderButtonInner: React.FC<{
 		];
 	}, [canServerRender, handleRenderTypeChange, readOnlyStudio]);
 
-	const spaceToBottom = useMemo(() => {
-		const margin = 10;
-		if (size && dropdownOpened) {
-			return size.windowSize.height - (size.top + size.height) - margin;
-		}
-
-		return 0;
-	}, [dropdownOpened, size]);
-
-	const spaceToTop = useMemo(() => {
-		const margin = 10;
-		if (size && dropdownOpened) {
-			return size.top - margin;
-		}
-
-		return 0;
-	}, [dropdownOpened, size]);
-
-	const derivedMaxHeight = useMemo(() => {
-		return spaceToTop > spaceToBottom ? spaceToTop : spaceToBottom;
-	}, [spaceToBottom, spaceToTop]);
-
-	const portalStyle = useMemo((): React.CSSProperties | null => {
-		if (!dropdownOpened || !size) {
-			return null;
-		}
-
-		const verticalLayout = spaceToTop > spaceToBottom ? 'bottom' : 'top';
-		return {
-			...(verticalLayout === 'top'
-				? {
-						...menuContainerTowardsBottom,
-						top: size.top + size.height,
-					}
-				: {
-						...menuContainerTowardsTop,
-						bottom: size.windowSize.height - size.top,
-					}),
-			right: size.windowSize.width - size.left - size.width,
-		};
-	}, [dropdownOpened, size, spaceToBottom, spaceToTop]);
-
-	const containerStyle = useMemo((): React.CSSProperties => {
-		return {
-			...splitButtonContainer,
-			borderRadius: controlSize === 'compact' ? 3 : 4,
-			opacity: 1,
-			cursor: 'default',
-		};
-	}, [controlSize]);
-
 	const renderLabel =
 		renderType === 'server-render'
 			? 'Render'
@@ -534,18 +361,72 @@ const RenderButtonInner: React.FC<{
 				? 'Render via CLI'
 				: 'Render on web';
 	const showRenderLabel = !narrow || renderType !== 'server-render';
-	const mainHovered = hovered && !dropdownOpened;
-	const mainForegroundColor = mainHovered ? WHITE : WHITE_ALPHA_80;
-	const dropdownForegroundColor =
-		hovered || dropdownOpened ? WHITE : WHITE_ALPHA_80;
-	const mainSegmentBackground = getBackgroundFromHoverState({
-		hovered: mainHovered,
-		selected: false,
-	});
-	const dropdownSegmentBackground = getBackgroundFromHoverState({
-		hovered,
-		selected: dropdownOpened,
-	});
+	const segments = useMemo((): SegmentedButtonSegment[] => {
+		return [
+			{
+				ariaLabel: renderLabel,
+				buttonId: 'render-modal-button',
+				disabled: false,
+				idleColor: WHITE_ALPHA_80,
+				onClick,
+				onPointerDown: null,
+				renderContent: (color) => (
+					<Row
+						align="center"
+						style={
+							controlSize === 'compact'
+								? compactMainButtonContent
+								: mainButtonContent
+						}
+					>
+						<ThinRenderIcon fill={color} svgProps={iconStyle} />
+						{showRenderLabel ? (
+							<>
+								<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
+								<span style={controlSize === 'compact' ? compactLabel : label}>
+									{renderLabel}
+								</span>
+							</>
+						) : null}
+					</Row>
+				),
+				segmentId: 'render',
+				style:
+					controlSize === 'compact'
+						? compactMainSegmentStyle
+						: defaultMainSegmentStyle,
+				title: tooltip,
+				type: 'action',
+			},
+			{
+				ariaLabel: 'Select render type',
+				buttonId: null,
+				disabled: false,
+				idleColor: WHITE_ALPHA_80,
+				leaveLeftSpace: false,
+				onOpenChange: null,
+				renderContent: (color) => <CaretDown color={color} />,
+				segmentId: 'render-type',
+				selectedId: renderType,
+				style:
+					controlSize === 'compact'
+						? compactDropdownSegmentStyle
+						: defaultDropdownSegmentStyle,
+				title: 'Select render type',
+				type: 'menu',
+				values: dropdownValues,
+			},
+		];
+	}, [
+		controlSize,
+		dropdownValues,
+		iconStyle,
+		onClick,
+		renderLabel,
+		renderType,
+		showRenderLabel,
+		tooltip,
+	]);
 
 	if (!video) {
 		return null;
@@ -572,95 +453,11 @@ const RenderButtonInner: React.FC<{
 				onClick={() => openServerRenderModal(true)}
 				type="button"
 			/>
-			<div
-				ref={containerRef}
-				style={containerStyle}
+			<SegmentedButton
+				segments={segments}
+				style={segmentedButtonStyle}
 				title={tooltip}
-				onPointerEnter={() => setHovered(true)}
-				onPointerLeave={() => setHovered(false)}
-			>
-				<button
-					type="button"
-					aria-label={renderLabel}
-					style={{
-						...(controlSize === 'compact'
-							? compactMainButtonStyle
-							: mainButtonStyle),
-						backgroundColor: mainSegmentBackground,
-						color: mainForegroundColor,
-					}}
-					onClick={onClick}
-					id="render-modal-button"
-				>
-					<Row
-						align="center"
-						style={
-							controlSize === 'compact'
-								? compactMainButtonContent
-								: mainButtonContent
-						}
-					>
-						<ThinRenderIcon fill={mainForegroundColor} svgProps={iconStyle} />
-						{showRenderLabel ? (
-							<>
-								<Spacing x={controlSize === 'compact' ? 0.75 : 1} />
-								<span
-									style={{
-										...(controlSize === 'compact' ? compactLabel : label),
-										color: mainForegroundColor,
-									}}
-								>
-									{renderLabel}
-								</span>
-							</>
-						) : null}
-					</Row>
-				</button>
-				<button
-					ref={dropdownRef}
-					type="button"
-					style={{
-						...(controlSize === 'compact'
-							? compactDropdownTriggerStyle
-							: dropdownTriggerStyle),
-						backgroundColor: dropdownSegmentBackground,
-						color: dropdownForegroundColor,
-					}}
-					className={MENU_INITIATOR_CLASSNAME}
-					onPointerDown={onPointerDown}
-					onClick={onClickDropdown}
-				>
-					<CaretDown color={dropdownForegroundColor} />
-				</button>
-			</div>
-			{portalStyle
-				? ReactDOM.createPortal(
-						<div style={fullScreenOverlay}>
-							<div style={outerPortal} className="css-reset">
-								<HigherZIndex
-									onOutsideClick={onHideDropdown}
-									onEscape={onHideDropdown}
-								>
-									<div style={portalStyle} onPointerDown={onMenuPointerDown}>
-										<MenuContent
-											onNextMenu={() => {}}
-											onPreviousMenu={() => {}}
-											values={dropdownValues}
-											onHide={onHideDropdown}
-											leaveLeftSpace={false}
-											preselectIndex={dropdownValues.findIndex(
-												(v) => v.id === renderType,
-											)}
-											topItemCanBeUnselected={false}
-											fixedHeight={derivedMaxHeight}
-										/>
-									</div>
-								</HigherZIndex>
-							</div>
-						</div>,
-						getPortal(currentZIndex),
-					)
-				: null}
+			/>
 		</>
 	);
 };

--- a/packages/studio/src/components/SegmentedButton.tsx
+++ b/packages/studio/src/components/SegmentedButton.tsx
@@ -1,0 +1,394 @@
+import {PlayerInternals} from '@remotion/player';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
+import {
+	CURRENT_COLOR,
+	TRANSPARENT,
+	WHITE,
+	getBackgroundFromHoverState,
+} from '../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../helpers/hoverable';
+import {useMobileLayout} from '../helpers/mobile-layout';
+import {noop} from '../helpers/noop';
+import {HigherZIndex, useZIndex} from '../state/z-index';
+import {MENU_INITIATOR_CLASSNAME} from './Menu/is-menu-item';
+import {getPortal} from './Menu/portals';
+import {
+	MAX_MENU_WIDTH,
+	MAX_MOBILE_MENU_WIDTH,
+	fullScreenOverlay,
+	menuContainerTowardsBottom,
+	menuContainerTowardsTop,
+	outerPortal,
+} from './Menu/styles';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+import {MenuContent} from './NewComposition/MenuContent';
+
+type SegmentedButtonSegmentCommon = {
+	readonly ariaLabel: string;
+	readonly buttonId: string | null;
+	readonly disabled: boolean;
+	readonly idleColor: string;
+	readonly renderContent: (color: string) => React.ReactNode;
+	readonly segmentId: string;
+	readonly style: React.CSSProperties | null;
+	readonly title: string | null;
+};
+
+export type SegmentedButtonSegment = SegmentedButtonSegmentCommon &
+	(
+		| {
+				readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
+				readonly onPointerDown: React.PointerEventHandler<HTMLButtonElement> | null;
+				readonly type: 'action';
+		  }
+		| {
+				readonly leaveLeftSpace: boolean;
+				readonly onOpenChange: ((open: boolean) => void) | null;
+				readonly selectedId: string | number | null;
+				readonly type: 'menu';
+				readonly values: ComboboxValue[];
+		  }
+	);
+
+const SEGMENTED_BUTTON_BORDER_RADIUS = 6;
+
+const containerStyle: React.CSSProperties = {
+	alignItems: 'center',
+	borderRadius: SEGMENTED_BUTTON_BORDER_RADIUS,
+	boxSizing: 'border-box',
+	display: 'inline-flex',
+	flexDirection: 'row',
+	flexShrink: 0,
+	gap: 1,
+	height: 24,
+	overflow: 'hidden',
+};
+
+const segmentStyle: React.CSSProperties = {
+	alignItems: 'center',
+	appearance: 'none',
+	border: 'none',
+	boxSizing: 'border-box',
+	cursor: 'default',
+	display: 'inline-flex',
+	fontFamily: 'sans-serif',
+	fontSize: 12,
+	height: '100%',
+	justifyContent: 'center',
+	lineHeight: '16px',
+	margin: 0,
+	minWidth: 0,
+	padding: '0 6px',
+	whiteSpace: 'nowrap',
+};
+
+const getSegmentBorderRadius = ({
+	index,
+	segmentCount,
+}: {
+	readonly index: number;
+	readonly segmentCount: number;
+}) => {
+	if (segmentCount === 1) {
+		return SEGMENTED_BUTTON_BORDER_RADIUS;
+	}
+
+	if (index === 0) {
+		return `${SEGMENTED_BUTTON_BORDER_RADIUS}px 0 0 ${SEGMENTED_BUTTON_BORDER_RADIUS}px`;
+	}
+
+	if (index === segmentCount - 1) {
+		return `0 ${SEGMENTED_BUTTON_BORDER_RADIUS}px ${SEGMENTED_BUTTON_BORDER_RADIUS}px 0`;
+	}
+
+	return 0;
+};
+
+const preventPointerFocus = (event: React.PointerEvent<HTMLButtonElement>) => {
+	if (event.button !== 0) {
+		return;
+	}
+
+	if (document.activeElement instanceof HTMLElement) {
+		document.activeElement.blur();
+	}
+
+	event.preventDefault();
+};
+
+const preventMouseFocus = (event: React.MouseEvent<HTMLButtonElement>) => {
+	event.stopPropagation();
+	if (event.button !== 0) {
+		return;
+	}
+
+	if (document.activeElement instanceof HTMLElement) {
+		document.activeElement.blur();
+	}
+
+	event.preventDefault();
+};
+
+const SegmentedButtonAction: React.FC<{
+	readonly index: number;
+	readonly segment: Extract<SegmentedButtonSegment, {type: 'action'}>;
+	readonly segmentCount: number;
+}> = ({index, segment, segmentCount}) => {
+	const {tabIndex} = useZIndex();
+	const style = useMemo((): React.CSSProperties => {
+		return {
+			...segmentStyle,
+			borderRadius: getSegmentBorderRadius({index, segmentCount}),
+			opacity: segment.disabled ? 0.5 : 1,
+			...hoverableStyle({
+				idleBackground: TRANSPARENT,
+				hoverBackground: segment.disabled
+					? TRANSPARENT
+					: getBackgroundFromHoverState({hovered: true, selected: false}),
+				idleColor: segment.idleColor,
+				hoverColor: segment.disabled ? segment.idleColor : WHITE,
+			}),
+			...segment.style,
+		};
+	}, [index, segment, segmentCount]);
+
+	const onClick = useCallback(
+		(event: React.MouseEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+			segment.onClick(event);
+		},
+		[segment],
+	);
+
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+			segment.onPointerDown?.(event);
+			preventPointerFocus(event);
+		},
+		[segment],
+	);
+
+	return (
+		<button
+			aria-label={segment.ariaLabel}
+			className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+			disabled={segment.disabled}
+			id={segment.buttonId ?? undefined}
+			onClick={onClick}
+			onMouseDown={preventMouseFocus}
+			onPointerDown={onPointerDown}
+			style={style}
+			tabIndex={tabIndex}
+			title={segment.title ?? undefined}
+			type="button"
+		>
+			{segment.renderContent(CURRENT_COLOR)}
+		</button>
+	);
+};
+
+const SegmentedButtonMenu: React.FC<{
+	readonly index: number;
+	readonly segment: Extract<SegmentedButtonSegment, {type: 'menu'}>;
+	readonly segmentCount: number;
+}> = ({index, segment, segmentCount}) => {
+	const [opened, setOpened] = useState(false);
+	const ref = useRef<HTMLButtonElement>(null);
+	const {currentZIndex, tabIndex} = useZIndex();
+	const isMobileLayout = useMobileLayout();
+	const size = PlayerInternals.useElementSize(ref, {
+		triggerOnWindowResize: true,
+		shouldApplyCssTransforms: true,
+	});
+	const refresh = size?.refresh;
+
+	const onHide = useCallback(() => {
+		setOpened(false);
+		segment.onOpenChange?.(false);
+	}, [segment]);
+
+	const onClick = useCallback(
+		(event: React.MouseEvent<HTMLButtonElement>) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (segment.values.length === 0) {
+				return;
+			}
+
+			refresh?.();
+			setOpened((currentlyOpened) => {
+				const next = !currentlyOpened;
+				segment.onOpenChange?.(next);
+				return next;
+			});
+		},
+		[refresh, segment],
+	);
+	const onPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+			preventPointerFocus(event);
+		},
+		[],
+	);
+
+	const spaceToBottom = useMemo(() => {
+		if (!size || !opened) {
+			return 0;
+		}
+
+		return size.windowSize.height - (size.top + size.height) - 10;
+	}, [opened, size]);
+
+	const spaceToTop = useMemo(() => {
+		if (!size || !opened) {
+			return 0;
+		}
+
+		return size.top - 10;
+	}, [opened, size]);
+
+	const portalStyle = useMemo((): React.CSSProperties | null => {
+		if (!opened || !size) {
+			return null;
+		}
+
+		const minSpaceRequired = isMobileLayout
+			? MAX_MOBILE_MENU_WIDTH
+			: MAX_MENU_WIDTH;
+		const spaceToRight = size.windowSize.width - size.left;
+		const spaceToLeft = size.left + size.width;
+		const canOpenOnLeft = spaceToLeft >= minSpaceRequired;
+		const canOpenOnRight = spaceToRight >= minSpaceRequired;
+		const openTowardsTop = spaceToTop > spaceToBottom;
+
+		return {
+			...(openTowardsTop
+				? {
+						...menuContainerTowardsTop,
+						bottom: size.windowSize.height - size.top,
+					}
+				: {
+						...menuContainerTowardsBottom,
+						top: size.top + size.height,
+					}),
+			...(canOpenOnRight
+				? {left: size.left}
+				: canOpenOnLeft
+					? {right: size.windowSize.width - size.left - size.width}
+					: {left: 0}),
+		};
+	}, [isMobileLayout, opened, size, spaceToBottom, spaceToTop]);
+
+	const style = useMemo((): React.CSSProperties => {
+		return {
+			...segmentStyle,
+			borderRadius: getSegmentBorderRadius({index, segmentCount}),
+			opacity: segment.disabled ? 0.5 : 1,
+			...hoverableStyle({
+				idleBackground: opened
+					? getBackgroundFromHoverState({hovered: false, selected: true})
+					: TRANSPARENT,
+				hoverBackground: segment.disabled
+					? TRANSPARENT
+					: getBackgroundFromHoverState({hovered: true, selected: opened}),
+				idleColor: opened ? WHITE : segment.idleColor,
+				hoverColor: segment.disabled ? segment.idleColor : WHITE,
+			}),
+			...segment.style,
+		};
+	}, [index, opened, segment, segmentCount]);
+
+	return (
+		<>
+			<button
+				ref={ref}
+				aria-expanded={opened}
+				aria-haspopup="menu"
+				aria-label={segment.ariaLabel}
+				className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME} ${MENU_INITIATOR_CLASSNAME}`}
+				disabled={segment.disabled}
+				id={segment.buttonId ?? undefined}
+				onClick={onClick}
+				onMouseDown={preventMouseFocus}
+				onPointerDown={onPointerDown}
+				style={style}
+				tabIndex={tabIndex}
+				title={segment.title ?? undefined}
+				type="button"
+			>
+				{segment.renderContent(CURRENT_COLOR)}
+			</button>
+			{portalStyle
+				? ReactDOM.createPortal(
+						<div
+							style={fullScreenOverlay}
+							onPointerDown={(event) => event.stopPropagation()}
+						>
+							<div style={outerPortal} className="css-reset">
+								<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
+									<div style={portalStyle}>
+										<MenuContent
+											fixedHeight={Math.max(spaceToBottom, spaceToTop)}
+											leaveLeftSpace={segment.leaveLeftSpace}
+											onHide={onHide}
+											onNextMenu={noop}
+											onPreviousMenu={noop}
+											preselectIndex={
+												segment.selectedId === null
+													? false
+													: segment.values.findIndex(
+															(value) => value.id === segment.selectedId,
+														)
+											}
+											topItemCanBeUnselected={false}
+											values={segment.values}
+										/>
+									</div>
+								</HigherZIndex>
+							</div>
+						</div>,
+						getPortal(currentZIndex),
+					)
+				: null}
+		</>
+	);
+};
+
+export const SegmentedButton: React.FC<{
+	readonly segments: SegmentedButtonSegment[];
+	readonly style: React.CSSProperties | null;
+	readonly title: string | null;
+}> = ({segments, style, title}) => {
+	return (
+		<div style={{...containerStyle, ...style}} title={title ?? undefined}>
+			{segments.map((segment, index) => {
+				if (segment.type === 'action') {
+					return (
+						<SegmentedButtonAction
+							key={segment.segmentId}
+							index={index}
+							segment={segment}
+							segmentCount={segments.length}
+						/>
+					);
+				}
+
+				return (
+					<SegmentedButtonMenu
+						key={segment.segmentId}
+						index={index}
+						segment={segment}
+						segmentCount={segments.length}
+					/>
+				);
+			})}
+		</div>
+	);
+};

--- a/packages/studio/src/components/SegmentedButton.tsx
+++ b/packages/studio/src/components/SegmentedButton.tsx
@@ -212,6 +212,16 @@ const SegmentedButtonMenu: React.FC<{
 		setOpened(false);
 		segment.onOpenChange?.(false);
 	}, [segment]);
+	const onOutsideClick = useCallback(
+		(target: Node) => {
+			if (ref.current?.contains(target)) {
+				return;
+			}
+
+			onHide();
+		},
+		[onHide],
+	);
 
 	const onClick = useCallback(
 		(event: React.MouseEvent<HTMLButtonElement>) => {
@@ -332,7 +342,7 @@ const SegmentedButtonMenu: React.FC<{
 							onPointerDown={(event) => event.stopPropagation()}
 						>
 							<div style={outerPortal} className="css-reset">
-								<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
+								<HigherZIndex onOutsideClick={onOutsideClick} onEscape={onHide}>
 									<div style={portalStyle}>
 										<MenuContent
 											fixedHeight={Math.max(spaceToBottom, spaceToTop)}

--- a/packages/studio/src/components/SettingsModalFooter.tsx
+++ b/packages/studio/src/components/SettingsModalFooter.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import {BLUE, LIGHT_TEXT} from '../helpers/colors';
 import {InspectorOpenInEditor} from './InspectorOpenInEditor';
+import {Spacing} from './layout';
 import {ModalFooterContainer} from './ModalFooter';
 
 const footer: React.CSSProperties = {
@@ -44,6 +45,7 @@ export const SettingsModalFooter: React.FC = () => {
 			<div style={footerRow}>
 				<div style={configFileHint}>
 					Changes save to
+					<Spacing x={0.5} />
 					<InspectorOpenInEditor
 						locationType={null}
 						location={configFileLocation}

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -24,7 +24,22 @@ const penIcon: React.CSSProperties = {
 	width: 14,
 };
 
-export type InspectorSourceAction = Omit<InspectorQuickActionProps, 'variant'>;
+const sourceActions: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flex: 1,
+	gap: 4,
+	minWidth: 0,
+};
+
+const standaloneSourceActionStyle: React.CSSProperties = {
+	flex: 1,
+	margin: 0,
+	minWidth: 0,
+	width: 'auto',
+};
+
+export type InspectorSourceAction = InspectorQuickActionProps;
 
 type AssetSelectionContextValue = {
 	readonly initialQuery: string;
@@ -166,18 +181,13 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 	}
 
 	return (
-		<InspectorQuickAction
-			{...inlineSourceAction}
-			size="compact"
-			variant={{
-				type: 'segmented',
-				trailing: {
-					disabled: window.remotion_isReadOnlyStudio,
-					onClick: openAssetSelection,
-					renderIcon: (color) => <PenIcon color={color} style={penIcon} />,
-					title: 'Change source',
-				},
-			}}
-		/>
+		<div style={sourceActions}>
+			<InspectorQuickAction
+				{...inlineSourceAction}
+				size="compact"
+				style={standaloneSourceActionStyle}
+			/>
+			{action}
+		</div>
 	);
 };

--- a/packages/studio/src/components/TimelineCombobox.tsx
+++ b/packages/studio/src/components/TimelineCombobox.tsx
@@ -1,51 +1,24 @@
-import {PlayerInternals} from '@remotion/player';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import ReactDOM from 'react-dom';
-import {
-	LIGHT_TEXT,
-	WHITE,
-	WHITE_ALPHA_80,
-	getBackgroundFromHoverState,
-} from '../helpers/colors';
-import {useMobileLayout} from '../helpers/mobile-layout';
-import {noop} from '../helpers/noop';
+import React from 'react';
+import {LIGHT_TEXT} from '../helpers/colors';
 import {CaretDown} from '../icons/caret';
-import {HigherZIndex, useZIndex} from '../state/z-index';
 import type {RenderInlineAction} from './InlineAction';
 import {Spacing} from './layout';
-import {MENU_INITIATOR_CLASSNAME, isMenuItem} from './Menu/is-menu-item';
-import {getPortal} from './Menu/portals';
-import {
-	MAX_MENU_WIDTH,
-	MAX_MOBILE_MENU_WIDTH,
-	fullScreenOverlay,
-	menuContainerTowardsBottom,
-	menuContainerTowardsTop,
-	outerPortal,
-} from './Menu/styles';
 import type {ComboboxValue} from './NewComposition/ComboBox';
-import {MenuContent} from './NewComposition/MenuContent';
+import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
 
-const container: React.CSSProperties = {
-	boxSizing: 'border-box',
-	border: 'none',
-	borderRadius: 3,
-	height: 24,
-	padding: '0 4px',
-	fontFamily: 'inherit',
-	maxWidth: '100%',
+const segmentedButtonStyle: React.CSSProperties = {
+	height: 28,
 };
 
 const label: React.CSSProperties = {
 	flex: 'none',
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
 	fontFamily: 'inherit',
 	fontSize: 12,
 	lineHeight: '16px',
-	color: WHITE_ALPHA_80,
 	minWidth: 0,
+	overflow: 'hidden',
 	textAlign: 'left',
+	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',
 };
 
@@ -66,226 +39,53 @@ export const TimelineCombobox: React.FC<{
 	renderLeftItem,
 	unhoveredIconColor = LIGHT_TEXT,
 }) => {
-	const [hovered, setIsHovered] = useState(false);
-	const [opened, setOpened] = useState(false);
-	const ref = useRef<HTMLButtonElement>(null);
-	const {tabIndex, currentZIndex} = useZIndex();
-	const size = PlayerInternals.useElementSize(ref, {
-		triggerOnWindowResize: true,
-		shouldApplyCssTransforms: true,
-	});
-
-	const refresh = size?.refresh;
-
-	const onHide = useCallback(() => {
-		setOpened(false);
-	}, []);
-
-	const onOverlayPointerDown = useCallback(
-		(e: React.PointerEvent<HTMLDivElement>) => {
-			e.stopPropagation();
-		},
-		[],
-	);
-
-	useEffect(() => {
-		const {current} = ref;
-		if (!current) {
-			return;
-		}
-
-		const onMouseEnter = () => setIsHovered(true);
-		const onMouseLeave = () => setIsHovered(false);
-		const onPointerDown = (e: PointerEvent) => {
-			e.stopPropagation();
-
-			return setOpened((isOpened) => {
-				if (!isOpened) {
-					refresh?.();
-				}
-
-				return !isOpened;
-			});
-		};
-
-		const onClick = (e: MouseEvent | PointerEvent) => {
-			e.stopPropagation();
-			const isKeyboardInitiated = e.detail === 0;
-			if (!isKeyboardInitiated) {
-				return;
-			}
-
-			return setOpened((isOpened) => {
-				if (!isOpened) {
-					refresh?.();
-
-					window.addEventListener(
-						'pointerup',
-						(evt) => {
-							if (!isMenuItem(evt.target as HTMLElement)) {
-								setOpened(false);
-							}
-						},
-						{once: true},
-					);
-				}
-
-				return !isOpened;
-			});
-		};
-
-		current.addEventListener('mouseenter', onMouseEnter);
-		current.addEventListener('mouseleave', onMouseLeave);
-		current.addEventListener('pointerdown', onPointerDown);
-		current.addEventListener('click', onClick);
-
-		return () => {
-			current.removeEventListener('mouseenter', onMouseEnter);
-			current.removeEventListener('mouseleave', onMouseLeave);
-			current.removeEventListener('pointerdown', onPointerDown);
-			current.removeEventListener('click', onClick);
-		};
-	}, [refresh]);
-
-	const spaceToBottom = useMemo(() => {
-		const margin = 10;
-		if (size && opened) {
-			return size.windowSize.height - (size.top + size.height) - margin;
-		}
-
-		return 0;
-	}, [opened, size]);
-
-	const spaceToTop = useMemo(() => {
-		const margin = 10;
-		if (size && opened) {
-			return size.top - margin;
-		}
-
-		return 0;
-	}, [opened, size]);
-
-	const derivedMaxHeight = useMemo(() => {
-		return spaceToTop > spaceToBottom ? spaceToTop : spaceToBottom;
-	}, [spaceToBottom, spaceToTop]);
-
-	const isMobileLayout = useMobileLayout();
-
-	const portalStyle = useMemo((): React.CSSProperties | null => {
-		if (!opened || !size) {
-			return null;
-		}
-
-		const spaceToRight = size.windowSize.width - size.left;
-		const spaceToLeft = size.left + size.width;
-		const minSpaceRequired = isMobileLayout
-			? MAX_MOBILE_MENU_WIDTH
-			: MAX_MENU_WIDTH;
-		const verticalLayout = spaceToTop > spaceToBottom ? 'bottom' : 'top';
-		const canOpenOnLeft = spaceToLeft >= minSpaceRequired;
-		const canOpenOnRight = spaceToRight >= minSpaceRequired;
-		const horizontalLayout = canOpenOnRight ? 'left' : 'right';
-
-		return {
-			...(verticalLayout === 'top'
-				? {
-						...menuContainerTowardsBottom,
-						top: size.top + size.height,
-					}
-				: {
-						...menuContainerTowardsTop,
-						bottom: size.windowSize.height - size.top,
-					}),
-			...(horizontalLayout === 'left'
-				? {left: size.left}
-				: canOpenOnLeft
-					? {right: size.windowSize.width - size.left - size.width}
-					: {left: 0}),
-		};
-	}, [isMobileLayout, opened, size, spaceToBottom, spaceToTop]);
-
 	const selected = values.find((value) => value.id === selectedId) as
 		| SelectionItem
 		| undefined;
-
-	const style = useMemo((): React.CSSProperties => {
-		return {
-			...container,
-			userSelect: 'none',
-			WebkitUserSelect: 'none',
-			display: 'inline-flex',
-			flexDirection: 'row',
-			alignItems: 'center',
-			backgroundColor: getBackgroundFromHoverState({
-				hovered,
-				selected: opened,
-			}),
-		};
-	}, [hovered, opened]);
-	const foregroundColor = hovered || opened ? WHITE : WHITE_ALPHA_80;
-	const labelStyle = useMemo((): React.CSSProperties => {
-		return {
-			...label,
-			width: labelWidth,
-			color: foregroundColor,
-		};
-	}, [foregroundColor, labelWidth]);
+	const segments: SegmentedButtonSegment[] = [
+		{
+			ariaLabel: title,
+			buttonId: null,
+			disabled: false,
+			idleColor: unhoveredIconColor,
+			leaveLeftSpace: true,
+			onOpenChange: null,
+			renderContent: (color) => (
+				<>
+					{renderLeftItem ? (
+						<>
+							{renderLeftItem(color)}
+							<Spacing x={0.5} />
+						</>
+					) : null}
+					{selected ? (
+						<div
+							title={
+								typeof selected.label === 'string' ? selected.label : undefined
+							}
+							style={{...label, width: labelWidth}}
+						>
+							{selected.label}
+						</div>
+					) : null}
+					<Spacing x={0.5} />
+					<CaretDown color={color} />
+				</>
+			),
+			segmentId: 'selector',
+			selectedId,
+			style: {fontFamily: 'inherit', padding: '0 4px'},
+			title,
+			type: 'menu',
+			values,
+		},
+	];
 
 	return (
-		<>
-			<button
-				ref={ref}
-				title={title}
-				aria-label={title}
-				tabIndex={tabIndex}
-				type="button"
-				style={style}
-				className={MENU_INITIATOR_CLASSNAME}
-			>
-				{renderLeftItem ? (
-					<>
-						{renderLeftItem(foregroundColor)}
-						<Spacing x={0.5} />
-					</>
-				) : null}
-				{selected ? (
-					<div
-						title={
-							typeof selected.label === 'string' ? selected.label : undefined
-						}
-						style={labelStyle}
-					>
-						{selected.label}
-					</div>
-				) : null}
-				<Spacing x={0.5} />
-				<CaretDown color={hovered || opened ? WHITE : unhoveredIconColor} />
-			</button>
-			{portalStyle
-				? ReactDOM.createPortal(
-						<div style={fullScreenOverlay} onPointerDown={onOverlayPointerDown}>
-							<div style={outerPortal} className="css-reset">
-								<HigherZIndex onOutsideClick={onHide} onEscape={onHide}>
-									<div style={portalStyle}>
-										<MenuContent
-											onNextMenu={noop}
-											onPreviousMenu={noop}
-											values={values}
-											onHide={onHide}
-											leaveLeftSpace
-											preselectIndex={values.findIndex(
-												(value) => selected && value.id === selected.id,
-											)}
-											topItemCanBeUnselected={false}
-											fixedHeight={derivedMaxHeight}
-										/>
-									</div>
-								</HigherZIndex>
-							</div>
-						</div>,
-						getPortal(currentZIndex),
-					)
-				: null}
-		</>
+		<SegmentedButton
+			segments={segments}
+			style={segmentedButtonStyle}
+			title={null}
+		/>
 	);
 };


### PR DESCRIPTION
## Summary

- add one shared segmented button component for action and menu segments
- migrate Render, Open in Editor, coding-agent, Zoom, and Playback Rate controls
- keep Change source standalone and align the migrated controls' sizing and spacing

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio'`
- verified the controls and menus in Remotion Studio
