### PR TITLE
`@remotion/bundler`: Reduce Studio Fast Refresh latency

### DIFF
--- a/packages/bundler/src/fast-refresh/zero-delay-rspack-refresh-loader.ts
+++ b/packages/bundler/src/fast-refresh/zero-delay-rspack-refresh-loader.ts
@@ -1,0 +1,22 @@
+import type {LoaderDefinition} from 'webpack';
+
+const rspackReactRefreshDelay = '      }, 30);';
+const zeroDelayReactRefresh = '      }, 0);';
+
+const removeRspackReactRefreshDelay = (source: string) => {
+	const occurrences = source.split(rspackReactRefreshDelay).length - 1;
+
+	if (occurrences !== 1) {
+		throw new Error(
+			`Expected one 30ms React Refresh debounce in @rspack/plugin-react-refresh, found ${occurrences}.`,
+		);
+	}
+
+	return source.replace(rspackReactRefreshDelay, zeroDelayReactRefresh);
+};
+
+const ZeroDelayRspackRefreshLoader: LoaderDefinition = function (source) {
+	return removeRspackReactRefreshDelay(source);
+};
+
+export default ZeroDelayRspackRefreshLoader;

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -124,6 +124,17 @@ export const rspackConfig = async ({
 		module: {
 			rules: [
 				...getSharedModuleRules(),
+				...(environment === 'development'
+					? [
+							{
+								test: /[\\/]@rspack[\\/]plugin-react-refresh[\\/]client[\\/]refreshUtils\.js$/,
+								enforce: 'pre' as const,
+								use: [
+									require.resolve('./fast-refresh/zero-delay-rspack-refresh-loader.js'),
+								],
+							},
+						]
+					: []),
 				{
 					// Emscripten's main.js spawns Workers of itself via
 					// new Worker(new URL('./main.js', import.meta.url)).

--- a/packages/bundler/src/test/zero-delay-rspack-refresh-loader.test.ts
+++ b/packages/bundler/src/test/zero-delay-rspack-refresh-loader.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {createRspackCompiler, rspackConfig} from '../rspack-config';
+
+test('emits a zero-delay Rspack React Refresh runtime', async () => {
+	const outputDirectory = mkdtempSync(
+		path.join(tmpdir(), 'remotion-rspack-refresh-'),
+	);
+	const [, config] = await rspackConfig({
+		entry: require.resolve('@remotion/studio/renderEntry'),
+		userDefinedComponent: require.resolve('@remotion/studio/renderEntry'),
+		outDir: outputDirectory,
+		environment: 'development',
+		bundlerOverride: (configuration) => configuration,
+		rspackOverride: (configuration) => configuration,
+		onProgress: () => undefined,
+		enableCaching: false,
+		remotionRoot: process.cwd(),
+		poll: null,
+		extraPlugins: [],
+	});
+	const compiler = createRspackCompiler(config);
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			compiler.run((error, stats) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+
+				if (stats?.hasErrors()) {
+					reject(new Error(stats.toString({errors: true})));
+					return;
+				}
+
+				resolve();
+			});
+		});
+
+		const bundle = readFileSync(
+			path.join(outputDirectory, 'bundle.js'),
+			'utf8',
+		);
+		const refreshRuntimeStart = bundle.indexOf(
+			'function createDebounceUpdate()',
+		);
+		const refreshRuntime = bundle.slice(
+			refreshRuntimeStart,
+			refreshRuntimeStart + 1500,
+		);
+
+		expect(refreshRuntimeStart).toBeGreaterThan(-1);
+		expect(refreshRuntime).toContain('}, 0);');
+		expect(refreshRuntime).not.toContain('}, 30);');
+	} finally {
+		await new Promise<void>((resolve) => compiler.close(() => resolve()));
+		rmSync(outputDirectory, {recursive: true, force: true});
+	}
+});

--- a/packages/studio-server/src/codemods/delete-jsx-node.ts
+++ b/packages/studio-server/src/codemods/delete-jsx-node.ts
@@ -17,20 +17,26 @@ export {
 export const deleteJsxNodes = ({
 	input,
 	nodePaths,
+	onFormatFile,
 	prettierConfigOverride,
 }: {
 	input: string;
 	nodePaths: SequenceNodePath[];
+	onFormatFile: ((stage: 'start' | 'complete') => void) | null;
 	prettierConfigOverride?: Record<string, unknown> | null;
 }) =>
 	deleteJsxNodesCodemod({
 		input,
 		nodePaths,
-		formatFile: ({contents, prettierConfigOverride: override}) =>
-			formatFileContent({
+		formatFile: async ({contents, prettierConfigOverride: override}) => {
+			onFormatFile?.('start');
+			const result = await formatFileContent({
 				input: contents,
 				prettierConfigOverride: override,
-			}),
+			});
+			onFormatFile?.('complete');
+			return result;
+		},
 		prettierConfigOverride,
 	});
 

--- a/packages/studio-server/src/preview-server/hmr-timing.ts
+++ b/packages/studio-server/src/preview-server/hmr-timing.ts
@@ -1,0 +1,18 @@
+import {RenderInternals, type LogLevel} from '@remotion/renderer';
+
+export const logHmrTiming = ({
+	detail,
+	logLevel,
+	stage,
+}: {
+	detail: string | null;
+	logLevel: LogLevel;
+	stage: string;
+}) => {
+	const detailSuffix = detail ? ` ${detail}` : '';
+
+	RenderInternals.Log.trace(
+		{indent: false, logLevel},
+		`[hmr-timing] epoch=${Date.now()} monotonic=${performance.now().toFixed(3)} stage=${stage}${detailSuffix}`,
+	);
+};

--- a/packages/studio-server/src/preview-server/hot-middleware/index.tsx
+++ b/packages/studio-server/src/preview-server/hot-middleware/index.tsx
@@ -8,6 +8,7 @@ import type {webpack} from '@remotion/bundler';
 import type {LogLevel} from '@remotion/renderer';
 import {RenderInternals} from '@remotion/renderer';
 import type {HotMiddlewareMessage, ModuleMap} from '@remotion/studio-shared';
+import {logHmrTiming} from '../hmr-timing';
 import type {LiveEventsServer} from '../live-events';
 import type {WebpackStats} from './types';
 
@@ -130,9 +131,17 @@ export const setupWebpackHmr = (
 	};
 
 	compiler.hooks.invalid.tap('remotion', onInvalid);
+	compiler.hooks.watchRun.tap('remotion-hmr-timing', () => {
+		logHmrTiming({detail: null, logLevel, stage: 'compiler-watch-run'});
+	});
 	compiler.hooks.done.tap('remotion', onDone);
 
-	function onInvalid() {
+	function onInvalid(fileName: string | null, changeTime: number) {
+		logHmrTiming({
+			detail: `file=${fileName ?? 'manual'} changeTime=${changeTime}`,
+			logLevel,
+			stage: 'compiler-invalid',
+		});
 		latestStats = null;
 		RenderInternals.Log.info({indent: false, logLevel}, 'Building...');
 		publishHmr({
@@ -141,9 +150,15 @@ export const setupWebpackHmr = (
 	}
 
 	function onDone(statsResult: webpack.Stats) {
+		logHmrTiming({
+			detail: `reportedBuildDuration=${statsResult.endTime - statsResult.startTime}ms`,
+			logLevel,
+			stage: 'compiler-done',
+		});
 		// Keep hold of latest stats so they can be propagated to new clients
 		latestStats = statsResult;
 		publishStats('built', latestStats, publishHmr);
+		logHmrTiming({detail: null, logLevel, stage: 'hmr-stats-published'});
 	}
 
 	liveEventsServer.addNewClientListener(() => {

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -9,6 +9,7 @@ import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
 import {formatLogFileLocation} from '../format-log-file-location';
+import {logHmrTiming} from '../hmr-timing';
 import {broadcastSequenceNodePathMutation} from '../sequence-node-path-mutation';
 import {
 	printUndoHint,
@@ -35,6 +36,12 @@ export const deleteJsxNodeHandler: ApiHandler<
 > = ({input: {nodes}, remotionRoot, logLevel}) => {
 	return withSourceFileWriteQueue(async () => {
 		try {
+			logHmrTiming({
+				detail: null,
+				logLevel,
+				stage: 'delete-jsx-node-request-start',
+			});
+
 			if (nodes.length === 0) {
 				throw new Error('No JSX nodes were specified for deletion');
 			}
@@ -65,6 +72,13 @@ export const deleteJsxNodeHandler: ApiHandler<
 						await deleteJsxNodes({
 							input: fileContents,
 							nodePaths: fileItems.map((item) => item.nodePath),
+							onFormatFile: (stage) => {
+								logHmrTiming({
+									detail: `file=${fileRelativeToRoot}`,
+									logLevel,
+									stage: `source-file-format-${stage}`,
+								});
+							},
 						});
 
 					return {
@@ -79,6 +93,11 @@ export const deleteJsxNodeHandler: ApiHandler<
 					};
 				}),
 			);
+			logHmrTiming({
+				detail: `files=${updates.length}`,
+				logLevel,
+				stage: 'delete-jsx-node-codemod-complete',
+			});
 			const nodePathMutation = broadcastSequenceNodePathMutation(
 				updates.map((update) => ({
 					absolutePath: update.absolutePath,
@@ -108,11 +127,21 @@ export const deleteJsxNodeHandler: ApiHandler<
 					nodePathRemappings: update.nodePathRemappings,
 				});
 				suppressUndoStackInvalidation(update.absolutePath);
+				logHmrTiming({
+					detail: `file=${update.fileRelativeToRoot}`,
+					logLevel,
+					stage: 'source-file-write-start',
+				});
 				writeFileAndNotifyFileWatchers({
 					file: update.absolutePath,
 					content: update.output,
 					originatorClientId: undefined,
 					metadata: {skipSequencePropsUpdate: true},
+				});
+				logHmrTiming({
+					detail: `file=${update.fileRelativeToRoot}`,
+					logLevel,
+					stage: 'source-file-write-complete',
 				});
 
 				const locationLabel = formatLogFileLocation({

--- a/packages/studio-server/src/test/delete-jsx-node.test.ts
+++ b/packages/studio-server/src/test/delete-jsx-node.test.ts
@@ -139,6 +139,7 @@ test('deleteJsxNodes removes multiple JSX children in one transform', async () =
 			lineColumnToNodePath(multipleSiblings, 7),
 			lineColumnToNodePath(multipleSiblings, 8),
 		],
+		onFormatFile: null,
 	});
 
 	expect(output).not.toContain('<div');


### PR DESCRIPTION
## Summary

- Remove the hard-coded 30ms React Refresh debounce from Rspack development bundles while preserving next-task batching.
- Add trace-level timing markers around Visual Mode deletion, source formatting and writes, Rspack invalidation/compilation, and HMR stats publication.
- Add an integration test that compiles a real Rspack development bundle and verifies the emitted React Refresh runtime.

## Context

Deleting a JSX node through Studio Visual Mode can take several hundred milliseconds before the canvas reflects the edit. An instrumented deletion of `Peak badge` from the `AnimatedBarChart` example took about 440ms from the Delete keypress until the badge disappeared.

The end-to-end trace showed several independent costs:

- whole-file Prettier formatting;
- filesystem watcher and Rspack compilation latency;
- HMR stats serialization/publication;
- client-side hot-update evaluation and React Refresh.

This PR addresses one deterministic part of the client-side phase and keeps the server-side trace markers that made the breakdown possible.

## Root cause

`@rspack/plugin-react-refresh@1.6.1` implements refresh batching in its private `client/refreshUtils.js` module with:

```js
setTimeout(() => {
  Refresh.performReactRefresh();
}, 30);
```

The delay is not configurable. In the browser trace, the final hot-update script finished loading approximately 31.5ms before the React Refresh task began. The delay therefore appeared directly on the edit-to-canvas critical path.

## Implementation

In development mode, the Rspack configuration applies a pre-loader only to the plugin's `refreshUtils.js` module. The loader changes the delay from 30ms to 0ms.

A zero-delay timer was chosen instead of calling `performReactRefresh()` synchronously:

- calls made while evaluating multiple updated modules still coalesce behind the plugin's existing `refreshTimeout` guard;
- the refresh remains in the next task, after the current HMR application stack unwinds;
- the artificial 30ms wait is removed.

The plugin is pinned to version 1.6.1. The loader expects exactly one copy of the known source fragment and throws during compilation if the upstream implementation changes. This prevents a future dependency update from silently disabling or misapplying the transformation.

## Measurements

Directional measurements from the same Visual Mode deletion workflow:

| Client phase | Before | After |
| --- | ---: | ---: |
| Final hot-update script to React task | 31.5ms | 1.1–2.7ms |
| React Refresh task | 61ms | 58ms |
| Final hot-update script to badge removal | 92.9ms | 60.9ms |
| Final hot-update script to first animation frame | 100.2ms | 66.4ms |

The scheduling gap falls by approximately 29–30ms. The React work itself remains in the same range, showing that the improvement comes from removing the fixed debounce rather than from measurement variance inside React.

## Instrumentation

At trace log level, the Studio server now emits epoch and monotonic timestamps for:

- delete request start;
- source formatting start and completion;
- codemod completion;
- source write start and completion;
- compiler invalidation and `watchRun`;
- compiler completion;
- HMR stats publication.

The formatting callback is nullable and has no effect outside callers that opt into timing. The logger uses the existing trace-level logging path, so normal Studio output is unchanged.

## Remaining work

This PR does not attempt to solve the other measured bottlenecks:

- whole-file formatting took about 83ms in the original run;
- HMR stats publication took about 61ms;
- React/Studio reconciliation still takes roughly 58–61ms;
- direct Rspack invalidation may save another 12–20ms.

Those phases can now be investigated independently using the timing markers added here.

## Verification

- `bun test packages/bundler/src/test/zero-delay-rspack-refresh-loader.test.ts packages/studio-server/src/test/delete-jsx-node.test.ts`
- `bun run build`
- `bun run stylecheck`
- Manual browser trace of two zero-delay Visual Mode deletion runs
- Red/green verification: the integration test fails when the emitted delay is restored to 30ms and passes with the production transformation enabled

The integration test uses the real Rspack configuration and compiler with caching disabled, then inspects the emitted development bundle. No internal collaborators are mocked.

Closes #10736
