### PR TITLE
`@remotion/studio`: Optimize timeline hover outlines

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -158,6 +158,7 @@ test.describe('inspector section collapse', () => {
 		await expect(
 			page.getByRole('button', {name: 'Show 3D transform controls'}),
 		).toBeVisible();
+		await page.locator('.remotion-studio-composition-container').hover();
 		await page
 			.locator('polygon[pointer-events="all"]')
 			.nth(1)

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -674,6 +674,8 @@ type ActiveSelectedOutlineOverlayProps = Omit<
 	readonly getSelectableOutlines: (
 		timelinePosition: number,
 	) => ReturnType<typeof getSequencesWithSelectableOutlines>;
+	readonly hoveredTimelineNodePathKey: string | null;
+	readonly measureAllOutlines: boolean;
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onSelect: (
@@ -696,6 +698,8 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 	draggingOutline,
 	getLatestOutlineTargetByKey,
 	getSelectableOutlines,
+	hoveredTimelineNodePathKey,
+	measureAllOutlines,
 	onDraggingChange,
 	onContextMenuOpenChange,
 	onSelect,
@@ -711,8 +715,42 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 	const selectableOutlines = useMemo(() => {
 		return getSelectableOutlines(timelinePosition);
 	}, [getSelectableOutlines, timelinePosition]);
+	const selectableOutlinesForLayout = useMemo(() => {
+		if (measureAllOutlines) {
+			return selectableOutlines;
+		}
+
+		// A timeline item can represent multiple connected canvas instances.
+		// Keep every instance of an active source node without calculating targets
+		// for unrelated timeline items while the canvas itself is inactive.
+		const activeNodePathKeys = new Set<string>();
+		for (const {key, nodePathInfo} of selectableOutlines) {
+			const nodePathKey = timelineSequenceNodePathToKey(
+				nodePathInfo.sequenceSubscriptionKey,
+			);
+			if (
+				selectedSequenceKeys.has(key) ||
+				sequenceKeysContainingSelection.has(key) ||
+				nodePathKey === hoveredTimelineNodePathKey
+			) {
+				activeNodePathKeys.add(nodePathKey);
+			}
+		}
+
+		return selectableOutlines.filter(({nodePathInfo}) =>
+			activeNodePathKeys.has(
+				timelineSequenceNodePathToKey(nodePathInfo.sequenceSubscriptionKey),
+			),
+		);
+	}, [
+		hoveredTimelineNodePathKey,
+		measureAllOutlines,
+		selectableOutlines,
+		selectedSequenceKeys,
+		sequenceKeysContainingSelection,
+	]);
 	const outlineRuntimeControls = useMemo(() => {
-		return selectableOutlines.flatMap(({key, sequence}) => {
+		return selectableOutlinesForLayout.flatMap(({key, sequence}) => {
 			if (
 				!selectedSequenceKeys.has(key) &&
 				!sequenceKeysContainingSelection.has(key)
@@ -723,7 +761,7 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 			return sequence.controls ? [sequence.controls] : [];
 		});
 	}, [
-		selectableOutlines,
+		selectableOutlinesForLayout,
 		selectedSequenceKeys,
 		sequenceKeysContainingSelection,
 	]);
@@ -746,14 +784,14 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 			calculateOutlineTargetsForCurrentState({
 				mode: 'layout',
 				runtimeValuesByStore: outlineRuntimeValuesByStore,
-				selectableOutlines,
+				selectableOutlines: selectableOutlinesForLayout,
 				targetKey: null,
 				targetTimelinePosition: timelinePosition,
 			}),
 		[
 			calculateOutlineTargetsForCurrentState,
 			outlineRuntimeValuesByStore,
-			selectableOutlines,
+			selectableOutlinesForLayout,
 			timelinePosition,
 		],
 	);
@@ -989,6 +1027,10 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		canvasContextMenuOpen ||
 		sequenceKeysContainingSelection.size > 0 ||
 		hoveredSequence?.source === 'timeline';
+	const measureAllOutlines =
+		canvasHovered || draggingOutline || canvasContextMenuOpen;
+	const hoveredTimelineNodePathKey =
+		hoveredSequence?.source === 'timeline' ? hoveredSequence.nodePathKey : null;
 	useLayoutEffect(() => {
 		if (measurementActive) {
 			return;
@@ -1015,6 +1057,8 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 					draggingOutline={draggingOutline}
 					getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
 					getSelectableOutlines={getSelectableOutlines}
+					hoveredTimelineNodePathKey={hoveredTimelineNodePathKey}
+					measureAllOutlines={measureAllOutlines}
 					onDraggingChange={onDraggingChange}
 					onContextMenuOpenChange={setCanvasContextMenuOpen}
 					onSelect={selectOutlineItem}


### PR DESCRIPTION
## Summary

- Limit inactive-canvas outline layout work to selected and newly hovered timeline nodes
- Preserve all connected canvas instances for the active source node
- Continue measuring every outline during canvas hover, outline dragging, and canvas context menus

## Performance

- Reduced first timeline-hover geometry reads in the 1,000-item stress test from 5,367 to 9
- Reduced the peak profiled interaction commit from 117.6ms to 38.8ms

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter=@remotion/studio`
- Targeted Studio Playwright tests for canvas context menus and outline dragging
- Browser geometry-read probe on `InteractiveDivStressTest`
