### PR TITLE
`@remotion/studio`: Hide scale controls for tiny outlines

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -134,20 +134,25 @@ test.describe('inspector section collapse', () => {
 		const tinyScaleEdges = page.locator(
 			'[data-remotion-studio-scale-edge-contains-selection="true"]',
 		);
+		const tinySelectedOutline = page.locator(
+			'polygon[data-remotion-directly-selected-outline="true"]',
+		);
 		const tinyTransform = page
 			.getByText('Tiny transform', {exact: true})
 			.first();
 		await expect(async () => {
 			await tinyTransform.click();
-			await expect(tinyScaleEdges).toHaveCount(2, {timeout: 1_000});
+			await expect(tinySelectedOutline).toHaveCount(1, {timeout: 1_000});
+			const dimensions = await tinySelectedOutline.evaluate((outline) => {
+				const rect = outline.getBoundingClientRect();
+				return {height: rect.height, width: rect.width};
+			});
+			expect(dimensions.width).toBeGreaterThan(0);
+			expect(dimensions.width).toBeLessThan(16);
+			expect(dimensions.height).toBeGreaterThan(0);
+			expect(dimensions.height).toBeLessThan(16);
+			await expect(tinyScaleEdges).toHaveCount(0, {timeout: 1_000});
 		}).toPass({timeout: 30_000});
-		expect(
-			await tinyScaleEdges.evaluateAll((edges) =>
-				edges.map((edge) =>
-					edge.getAttribute('data-remotion-studio-scale-edge'),
-				),
-			),
-		).toEqual(['right', 'bottom']);
 		await expect(
 			page.locator(
 				'[data-remotion-studio-rotation-corner-contains-selection="true"]',

--- a/packages/studio/src/components/selected-outline-control-layout.ts
+++ b/packages/studio/src/components/selected-outline-control-layout.ts
@@ -91,16 +91,11 @@ export const getSelectedOutlineControlLayout = (
 	const rotationHandleRadius = Math.max(targetHalfSizeX, targetHalfSizeY) * 1.5;
 	const scaleEdges = (['top', 'right', 'bottom', 'left'] as const).filter(
 		(edge) => {
-			// Preserve one scale control per axis when opposite edge targets would overlap.
-			if (edge === 'top') {
+			if (edge === 'top' || edge === 'bottom') {
 				return !isTinyY;
 			}
 
-			if (edge === 'left') {
-				return !isTinyX;
-			}
-
-			return true;
+			return !isTinyX;
 		},
 	);
 	const rotationCorners = (

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -7214,6 +7214,12 @@ test('Selected outline controls adapt to the screen-space outline size', () => {
 		{x: 8, y: 40},
 		{x: 0, y: 40},
 	]);
+	const flat = getSelectedOutlineControlLayout([
+		{x: 0, y: 0},
+		{x: 40, y: 0},
+		{x: 40, y: 8},
+		{x: 0, y: 8},
+	]);
 
 	expect(normal.scaleEdges).toEqual(['top', 'right', 'bottom', 'left']);
 	expect(normal.scaleHitWidth).toEqual({horizontal: 9, vertical: 9});
@@ -7224,11 +7230,14 @@ test('Selected outline controls adapt to the screen-space outline size', () => {
 	expect(small.scaleHitWidth).toEqual({horizontal: 4.5, vertical: 4.5});
 	expect(small.rotationHandleRadius).toBe(3.375);
 	expect(small.rotationCorners).toHaveLength(4);
-	expect(tiny.scaleEdges).toEqual(['right', 'bottom']);
+	expect(tiny.scaleEdges).toEqual([]);
 	expect(tiny.rotationCorners).toEqual([]);
-	expect(thin.scaleEdges).toEqual(['top', 'right', 'bottom']);
+	expect(thin.scaleEdges).toEqual(['top', 'bottom']);
 	expect(thin.scaleHitWidth).toEqual({horizontal: 9, vertical: 4.5});
 	expect(thin.rotationCorners).toEqual([]);
+	expect(flat.scaleEdges).toEqual(['right', 'left']);
+	expect(flat.scaleHitWidth).toEqual({horizontal: 4.5, vertical: 9});
+	expect(flat.rotationCorners).toEqual([]);
 });
 
 test('Selected outline rotation pivot follows transform origin', () => {


### PR DESCRIPTION
## Summary

- hide horizontal scale controls when an outline is narrower than 16 screen pixels
- hide vertical scale controls when an outline is shorter than 16 screen pixels
- cover tiny, thin, and flat outline layouts in the existing Studio geometry test

## Test plan

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`
- red/green verified against the previous scale-edge filtering behavior
