### PR TITLE
`@remotion/studio-server`: Upgrade Recast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1759,7 +1759,7 @@
         "@babel/types": "7.24.0",
         "@remotion/studio-shared": "workspace:*",
         "ast-types": "0.16.1",
-        "recast": "0.23.11",
+        "recast": "0.23.21",
         "remotion": "workspace:*",
       },
       "devDependencies": {
@@ -1794,7 +1794,7 @@
         "memfs": "3.4.3",
         "open": "8.4.2",
         "prettier": "catalog:",
-        "recast": "0.23.11",
+        "recast": "0.23.21",
         "remotion": "workspace:*",
         "semver": "7.5.3",
         "zod": "catalog:",
@@ -7943,7 +7943,7 @@
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
-    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "0.16.1", "esprima": "4.0.1", "source-map": "0.6.1", "tiny-invariant": "1.3.3", "tslib": "2.8.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+    "recast": ["recast@0.23.21", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw=="],
 
     "rechoir": ["rechoir@0.8.0", "", { "dependencies": { "resolve": "^1.20.0" } }, "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ=="],
 

--- a/packages/studio-codemods/package.json
+++ b/packages/studio-codemods/package.json
@@ -28,7 +28,7 @@
 		"@babel/types": "7.24.0",
 		"@remotion/studio-shared": "workspace:*",
 		"ast-types": "0.16.1",
-		"recast": "0.23.11",
+		"recast": "0.23.21",
 		"remotion": "workspace:*"
 	},
 	"exports": {

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -33,7 +33,7 @@
 		"zod": "catalog:",
 		"prettier": "catalog:",
 		"remotion": "workspace:*",
-		"recast": "0.23.11",
+		"recast": "0.23.21",
 		"@remotion/bundler": "workspace:*",
 		"@remotion/renderer": "workspace:*",
 		"@remotion/studio-codemods": "workspace:*",


### PR DESCRIPTION
## Summary

- Upgrade Recast from 0.23.11 to 0.23.21 in `@remotion/studio-codemods` and `@remotion/studio-server`
- Refresh the Bun lockfile
- Keep compatibility with Remotion's Node 16 baseline; Recast 0.24.0 requires Node 22 and contains no runtime changes over 0.23.21

## Verification

- `bun run build`
- `bun run stylecheck`
