### PR TITLE
`@remotion/studio-server`: Ignore missing skills in update checks

### DIFF
--- a/packages/cli/src/test/detect-outdated-remotion-skills.test.ts
+++ b/packages/cli/src/test/detect-outdated-remotion-skills.test.ts
@@ -94,10 +94,9 @@ test('detects project and global Remotion skill versions without a lockfile', ()
 				homeDirectory,
 			}).project,
 		).toEqual({
-			type: 'outdated',
+			type: 'up-to-date',
 			scope: 'project',
 			skillsDirectory: projectSkillsDirectory,
-			outdatedSkillNames: remotionSkillNames.slice(1),
 		});
 
 		for (const skillName of remotionSkillNames) {

--- a/packages/studio-server/src/detect-outdated-remotion-skills.ts
+++ b/packages/studio-server/src/detect-outdated-remotion-skills.ts
@@ -85,10 +85,10 @@ const getStatusForSkillsDirectory = ({
 	const outdatedSkillNames = remotionSkillNames.filter((skillName) => {
 		const skill = installedSkills.get(skillName);
 		return (
-			!skill?.installed ||
-			skill.version === null ||
-			semver.valid(skill.version) === null ||
-			semver.lt(skill.version, currentVersion)
+			skill?.installed &&
+			(skill.version === null ||
+				semver.valid(skill.version) === null ||
+				semver.lt(skill.version, currentVersion))
 		);
 	});
 

--- a/packages/studio-server/src/test/update-available.test.ts
+++ b/packages/studio-server/src/test/update-available.test.ts
@@ -4,7 +4,7 @@ import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {isUpdateAvailable} from '../preview-server/update-available';
 
-test('reports outdated project skills when Remotion itself is up to date', async () => {
+test('only reports installed outdated project skills', async () => {
 	const remotionRoot = mkdtempSync(
 		path.join(tmpdir(), 'remotion-studio-skills-update-'),
 	);
@@ -19,17 +19,37 @@ test('reports outdated project skills when Remotion itself is up to date', async
 		mkdirSync(skillDirectory, {recursive: true});
 		writeFileSync(
 			path.join(skillDirectory, 'SKILL.md'),
-			'---\nname: remotion-best-practices\nversion: 4.0.501\n---\n',
+			'---\nname: remotion-best-practices\nversion: 4.0.502\n---\n',
 		);
 
-		const result = await isUpdateAvailable({
+		const currentResult = await isUpdateAvailable({
 			remotionRoot,
 			currentVersion: '4.0.502',
 			logLevel: 'error',
 			getLatestVersion: () => Promise.resolve('4.0.502'),
 		});
 
-		expect(result).toMatchObject({
+		expect(currentResult).toMatchObject({
+			currentVersion: '4.0.502',
+			latestVersion: '4.0.502',
+			updateAvailable: false,
+			skillsUpdateAvailable: false,
+			timedOut: false,
+		});
+
+		writeFileSync(
+			path.join(skillDirectory, 'SKILL.md'),
+			'---\nname: remotion-best-practices\nversion: 4.0.501\n---\n',
+		);
+
+		const outdatedResult = await isUpdateAvailable({
+			remotionRoot,
+			currentVersion: '4.0.502',
+			logLevel: 'error',
+			getLatestVersion: () => Promise.resolve('4.0.502'),
+		});
+
+		expect(outdatedResult).toMatchObject({
 			currentVersion: '4.0.502',
 			latestVersion: '4.0.502',
 			updateAvailable: false,


### PR DESCRIPTION
## Summary

- Ignore Remotion skills that are not installed when checking for updates
- Continue reporting installed skills with missing, invalid, or older versions
- Cover the detector and Studio update-panel behavior with regression tests

## Testing

- `bun test packages/cli/src/test/detect-outdated-remotion-skills.test.ts packages/studio-server/src/test/update-available.test.ts`
- `bun run build`
- `bun run stylecheck`
