### PR TITLE
`@remotion/renderer`: Use clip-relative WAV files for inline audio

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -162,7 +162,7 @@ export type InlineAudioAsset = {
 	id: string;
 	audio: Int16Array | number[];
 	frame: number;
-	startInVideo?: number;
+	startInVideo: number | null;
 	timestamp: number;
 	duration: number;
 	toneFrequency: number;

--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -162,6 +162,7 @@ export type InlineAudioAsset = {
 	id: string;
 	audio: Int16Array | number[];
 	frame: number;
+	startInVideo?: number;
 	timestamp: number;
 	duration: number;
 	toneFrequency: number;

--- a/packages/example/src/AudioTesting/InlineAudioStress.tsx
+++ b/packages/example/src/AudioTesting/InlineAudioStress.tsx
@@ -1,0 +1,91 @@
+import {Audio} from '@remotion/media';
+import {Sequence, useCurrentFrame} from 'remotion';
+
+export type InlineAudioStressClip = {
+	readonly outerFrom: number;
+	readonly middleFrom: number;
+	readonly innerFrom: number;
+	readonly durationInFrames: number;
+};
+
+export type InlineAudioStressRange = {
+	readonly from: number;
+	readonly durationInFrames: number;
+};
+
+export type InlineAudioStressProps = {
+	readonly src: string;
+	readonly clips: InlineAudioStressClip[];
+	readonly intermittentOuterFrom: number;
+	readonly intermittentInnerFrom: number;
+	readonly intermittentDurationInFrames: number;
+	readonly intermittentRanges: InlineAudioStressRange[];
+};
+
+const IntermittentAudio: React.FC<{
+	readonly src: string;
+	readonly ranges: InlineAudioStressRange[];
+}> = ({src, ranges}) => {
+	const frame = useCurrentFrame();
+	const isMounted = ranges.some(
+		(range) =>
+			frame >= range.from && frame < range.from + range.durationInFrames,
+	);
+
+	return isMounted ? <Audio src={src} loop volume={0.125} /> : null;
+};
+
+export const InlineAudioStress: React.FC<InlineAudioStressProps> = ({
+	src,
+	clips,
+	intermittentOuterFrom,
+	intermittentInnerFrom,
+	intermittentDurationInFrames,
+	intermittentRanges,
+}) => {
+	return (
+		<>
+			{clips.map((clip, index) => (
+				<Sequence
+					key={index}
+					from={clip.outerFrom}
+					durationInFrames={
+						clip.middleFrom + clip.innerFrom + clip.durationInFrames
+					}
+				>
+					<Sequence
+						from={clip.middleFrom}
+						durationInFrames={clip.innerFrom + clip.durationInFrames}
+					>
+						<Sequence
+							from={clip.innerFrom}
+							durationInFrames={clip.durationInFrames}
+						>
+							<Audio src={src} loop volume={0.25} />
+						</Sequence>
+					</Sequence>
+				</Sequence>
+			))}
+			<Sequence
+				from={intermittentOuterFrom}
+				durationInFrames={intermittentInnerFrom + intermittentDurationInFrames}
+			>
+				<Sequence
+					from={intermittentInnerFrom}
+					durationInFrames={intermittentDurationInFrames}
+				>
+					<IntermittentAudio src={src} ranges={intermittentRanges} />
+				</Sequence>
+			</Sequence>
+		</>
+	);
+};
+
+export const inlineAudioStressDefaultProps: InlineAudioStressProps = {
+	src: '',
+	clips: [],
+	intermittentOuterFrom: 0,
+	intermittentInnerFrom: 0,
+	intermittentDurationInFrames: 1,
+	intermittentRanges: [],
+};

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -213,6 +213,10 @@ import {AudioSmoothnessSlicedVideoComp} from './AudioSmoothness/SlicedVideo';
 import {AudioSmoothnessTrimAfterLoopComp} from './AudioSmoothness/TrimAfterLoop';
 import {AudioSmoothnessTrimButtonComp} from './AudioSmoothness/TrimButton';
 import Amplify from './AudioTesting/Amplify';
+import {
+	InlineAudioStress,
+	inlineAudioStressDefaultProps,
+} from './AudioTesting/InlineAudioStress';
 import {Issue7568} from './AudioTesting/Issue7568';
 import {
 	Issue10468,
@@ -1804,6 +1808,15 @@ export const Index: React.FC = () => {
 					fps={24.87}
 					durationInFrames={120}
 					defaultProps={issue5758DefaultProps}
+				/>
+				<Composition
+					id="inline-audio-stress"
+					component={InlineAudioStress}
+					width={16}
+					height={16}
+					fps={30}
+					durationInFrames={620}
+					defaultProps={inlineAudioStressDefaultProps}
 				/>
 				<Composition
 					id="audio-issue-7568"

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -10,6 +10,7 @@ import {
 import os from 'os';
 import path from 'path';
 import {
+	combineChunks,
 	renderMedia,
 	RenderInternals,
 	selectComposition,
@@ -113,6 +114,25 @@ const getSampleRateFromFile = async (filePath: string): Promise<number> => {
 	}
 
 	return parseInt(match[1], 10);
+};
+
+const decodeAudioToPcmWav = async ({
+	input,
+	output,
+}: {
+	input: string;
+	output: string;
+}) => {
+	await RenderInternals.callFf({
+		bin: 'ffmpeg',
+		args: ['-y', '-i', input, '-map', '0:a:0', '-c:a', 'pcm_s16le', output],
+		indent: false,
+		logLevel: 'error',
+		binariesDirectory: null,
+		cancelSignal: undefined,
+	});
+
+	return readPcmWav(output);
 };
 
 const issue10468Source = readFileSync(
@@ -463,6 +483,109 @@ test(
 				process.env.TMPDIR = previousTmpDir;
 			}
 
+			rmSync(tmpDir, {recursive: true, force: true});
+		}
+	},
+	{timeout: 300000},
+);
+
+test(
+	'@remotion/media keeps seamless AAC chunks sample-identical with 423 nested clips',
+	async () => {
+		const tmpDir = mkdtempSync(
+			path.join(os.tmpdir(), 'inline-audio-seamless-aac-'),
+		);
+		try {
+			const composition = await selectComposition({
+				id: 'inline-audio-stress',
+				serveUrl: exampleBuild,
+				inputProps: inlineAudioStressInputProps,
+			});
+			const singleAac = path.join(tmpDir, 'single.aac');
+			await renderMedia({
+				outputLocation: singleAac,
+				codec: 'aac',
+				serveUrl: exampleBuild,
+				composition,
+				inputProps: inlineAudioStressInputProps,
+				sampleRate: STRESS_SAMPLE_RATE,
+				concurrency: 4,
+				logLevel: 'error',
+			});
+
+			const framesPerChunk = 200;
+			const audioFiles: string[] = [];
+			for (
+				let chunkStart = 0;
+				chunkStart < STRESS_DURATION_IN_FRAMES;
+				chunkStart += framesPerChunk
+			) {
+				const chunk = path.join(tmpDir, `chunk-${chunkStart}.aac`);
+				audioFiles.push(chunk);
+				await renderMedia({
+					outputLocation: chunk,
+					codec: 'aac',
+					serveUrl: exampleBuild,
+					composition,
+					inputProps: inlineAudioStressInputProps,
+					frameRange: [
+						chunkStart,
+						Math.min(
+							chunkStart + framesPerChunk - 1,
+							STRESS_DURATION_IN_FRAMES - 1,
+						),
+					],
+					compositionStart: 0,
+					forSeamlessAacConcatenation: true,
+					sampleRate: STRESS_SAMPLE_RATE,
+					concurrency: 4,
+					logLevel: 'error',
+				});
+			}
+
+			const combinedAac = path.join(tmpDir, 'combined.aac');
+			await combineChunks({
+				outputLocation: combinedAac,
+				audioFiles,
+				videoFiles: [],
+				codec: 'aac',
+				audioCodec: 'aac',
+				fps: STRESS_FPS,
+				framesPerChunk,
+				preferLossless: false,
+				compositionDurationInFrames: STRESS_DURATION_IN_FRAMES,
+				sampleRate: STRESS_SAMPLE_RATE,
+				logLevel: 'error',
+			});
+
+			const single = await decodeAudioToPcmWav({
+				input: singleAac,
+				output: path.join(tmpDir, 'single.wav'),
+			});
+			const combined = await decodeAudioToPcmWav({
+				input: combinedAac,
+				output: path.join(tmpDir, 'combined.wav'),
+			});
+			expect(combined.sampleRate).toBe(single.sampleRate);
+			expect(combined.channels).toBe(single.channels);
+			expect(combined.samples.length).toBeGreaterThanOrEqual(
+				single.samples.length,
+			);
+
+			let firstDifferentSample = -1;
+			for (let index = 0; index < single.samples.length; index++) {
+				if (single.samples[index] !== combined.samples[index]) {
+					firstDifferentSample = index;
+					break;
+				}
+			}
+
+			expect(firstDifferentSample).toBe(-1);
+			// AAC concatenation may retain up to two encoder frames of tail padding.
+			expect(
+				combined.samples.length - single.samples.length,
+			).toBeLessThanOrEqual(2 * 1024 * single.channels);
+		} finally {
 			rmSync(tmpDir, {recursive: true, force: true});
 		}
 	},

--- a/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
+++ b/packages/it-tests/src/ssr/render-media-sample-rate.test.ts
@@ -1,5 +1,12 @@
 import {expect, test} from 'bun:test';
-import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+} from 'node:fs';
 import os from 'os';
 import path from 'path';
 import {
@@ -131,6 +138,120 @@ const issue5758InputProps = {
 	src: `data:audio/wav;base64,${issue5758Source.toString('base64')}`,
 };
 
+const STRESS_FPS = 30;
+const STRESS_SAMPLE_RATE = 48_000;
+const STRESS_DURATION_IN_FRAMES = 620;
+const STRESS_CLIP_COUNT = 423;
+const STRESS_SOURCE_AMPLITUDE = 8000;
+const STRESS_INTERMITTENT_START = 28;
+const stressIntermittentRanges = [
+	{from: 0, durationInFrames: 37},
+	{from: 52, durationInFrames: 39},
+	{from: 143, durationInFrames: 37},
+	{from: 260, durationInFrames: 70},
+	{from: 411, durationInFrames: 89},
+];
+
+let nextStressClipStart = 20;
+const stressClips = new Array(STRESS_CLIP_COUNT).fill(null).map((_, index) => {
+	if (index % 17 === 0) {
+		nextStressClipStart += 4;
+	} else if (index % 7 === 0) {
+		nextStressClipStart++;
+	}
+
+	const middleFrom = (index * 7) % 8;
+	const innerFrom = (index * 11) % 9;
+	const clip = {
+		outerFrom: nextStressClipStart - middleFrom - innerFrom,
+		middleFrom,
+		innerFrom,
+		durationInFrames: 1,
+	};
+	nextStressClipStart++;
+	return clip;
+});
+
+const stressClipStarts = new Set(
+	stressClips.map((clip) => clip.outerFrom + clip.middleFrom + clip.innerFrom),
+);
+
+const makeConstantPcmWavDataUrl = () => {
+	const channels = 2;
+	const sourceDurationInFrames = 30;
+	const samplesPerChannel =
+		(STRESS_SAMPLE_RATE / STRESS_FPS) * sourceDurationInFrames;
+	const dataSize = samplesPerChannel * channels * 2;
+	const wav = Buffer.alloc(44 + dataSize);
+	wav.write('RIFF', 0);
+	wav.writeUInt32LE(36 + dataSize, 4);
+	wav.write('WAVE', 8);
+	wav.write('fmt ', 12);
+	wav.writeUInt32LE(16, 16);
+	wav.writeUInt16LE(1, 20);
+	wav.writeUInt16LE(channels, 22);
+	wav.writeUInt32LE(STRESS_SAMPLE_RATE, 24);
+	wav.writeUInt32LE(STRESS_SAMPLE_RATE * channels * 2, 28);
+	wav.writeUInt16LE(channels * 2, 32);
+	wav.writeUInt16LE(16, 34);
+	wav.write('data', 36);
+	wav.writeUInt32LE(dataSize, 40);
+	for (let offset = 44; offset < wav.length; offset += 2) {
+		wav.writeInt16LE(STRESS_SOURCE_AMPLITUDE, offset);
+	}
+
+	return `data:audio/wav;base64,${wav.toString('base64')}`;
+};
+
+const inlineAudioStressInputProps = {
+	src: makeConstantPcmWavDataUrl(),
+	clips: stressClips,
+	intermittentOuterFrom: 11,
+	intermittentInnerFrom: 17,
+	intermittentDurationInFrames: 560,
+	intermittentRanges: stressIntermittentRanges,
+};
+
+const getInlineAudioTempSize = (
+	directory: string,
+	insideInlineAudioDirectory: boolean,
+): number => {
+	if (!existsSync(directory)) {
+		return 0;
+	}
+
+	try {
+		return readdirSync(directory, {withFileTypes: true}).reduce(
+			(total, entry) => {
+				const entryPath = path.join(directory, entry.name);
+				if (entry.isFile()) {
+					return insideInlineAudioDirectory
+						? total + statSync(entryPath).size
+						: total;
+				}
+
+				if (!entry.isDirectory()) {
+					return total;
+				}
+
+				return (
+					total +
+					getInlineAudioTempSize(
+						entryPath,
+						insideInlineAudioDirectory ||
+							entry.name === 'remotion-inline-audio-mixing',
+					)
+				);
+			},
+			0,
+		);
+	} catch {
+		// The renderer can delete a temporary file between readdirSync() and
+		// statSync() while the size monitor is running.
+		return 0;
+	}
+};
+
 const renderIssue10468Wav = async ({
 	tmpDir,
 	name,
@@ -256,6 +377,96 @@ test(
 		}
 	},
 	{timeout: 180000},
+);
+
+test(
+	'@remotion/media keeps 423 nested and intermittently mounted audio clips sample-aligned',
+	async () => {
+		const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'inline-audio-stress-'));
+		const previousTmpDir = process.env.TMPDIR;
+		process.env.TMPDIR = tmpDir;
+		let peakInlineAudioTempSize = 0;
+		const tempSizeMonitor = setInterval(() => {
+			peakInlineAudioTempSize = Math.max(
+				peakInlineAudioTempSize,
+				getInlineAudioTempSize(tmpDir, false),
+			);
+		}, 5);
+		try {
+			const outputLocation = path.join(tmpDir, 'stress.wav');
+			const composition = await selectComposition({
+				id: 'inline-audio-stress',
+				serveUrl: exampleBuild,
+				inputProps: inlineAudioStressInputProps,
+			});
+			await renderMedia({
+				outputLocation,
+				codec: 'wav',
+				serveUrl: exampleBuild,
+				composition,
+				inputProps: inlineAudioStressInputProps,
+				sampleRate: STRESS_SAMPLE_RATE,
+				concurrency: 4,
+				logLevel: 'error',
+			});
+
+			const rendered = readPcmWav(outputLocation);
+			expect(rendered.sampleRate).toBe(STRESS_SAMPLE_RATE);
+			expect(rendered.channels).toBe(2);
+			const samplesPerFrame = STRESS_SAMPLE_RATE / STRESS_FPS;
+			const expectedSampleCount =
+				STRESS_DURATION_IN_FRAMES * samplesPerFrame * rendered.channels;
+			expect(rendered.samples.length).toBe(expectedSampleCount);
+
+			const observedLevels = new Set<number>();
+			let maximumMeanError = 0;
+			for (let frame = 0; frame < STRESS_DURATION_IN_FRAMES; frame++) {
+				const intermittentFrame = frame - STRESS_INTERMITTENT_START;
+				const intermittentIsMounted = stressIntermittentRanges.some(
+					(range) =>
+						intermittentFrame >= range.from &&
+						intermittentFrame < range.from + range.durationInFrames,
+				);
+				const expectedAmplitude =
+					(stressClipStarts.has(frame) ? 2000 : 0) +
+					(intermittentIsMounted ? 1000 : 0);
+				observedLevels.add(expectedAmplitude);
+
+				// Ignore a few samples at frame boundaries so this assertion is about
+				// timeline placement rather than decoder edge interpolation.
+				const firstSample = (frame * samplesPerFrame + 64) * rendered.channels;
+				const lastSample =
+					((frame + 1) * samplesPerFrame - 64) * rendered.channels;
+				let sum = 0;
+				for (let sample = firstSample; sample < lastSample; sample++) {
+					sum += Math.abs(rendered.samples[sample]);
+				}
+
+				const mean = sum / (lastSample - firstSample);
+				maximumMeanError = Math.max(
+					maximumMeanError,
+					Math.abs(mean - expectedAmplitude),
+				);
+			}
+
+			expect([...observedLevels].sort((a, b) => a - b)).toEqual([
+				0, 1000, 2000, 3000,
+			]);
+			expect(maximumMeanError).toBeLessThanOrEqual(20);
+			expect(peakInlineAudioTempSize).toBeGreaterThan(2_000_000);
+			expect(peakInlineAudioTempSize).toBeLessThan(10_000_000);
+		} finally {
+			clearInterval(tempSizeMonitor);
+			if (previousTmpDir === undefined) {
+				delete process.env.TMPDIR;
+			} else {
+				process.env.TMPDIR = previousTmpDir;
+			}
+
+			rmSync(tmpDir, {recursive: true, force: true});
+		}
+	},
+	{timeout: 300000},
 );
 
 test(

--- a/packages/media/src/audio/audio-for-rendering.tsx
+++ b/packages/media/src/audio/audio-for-rendering.tsx
@@ -68,6 +68,9 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 	const [initialRequestInit] = useState(requestInit);
 
 	const sequenceContext = useContext(Internals.SequenceContext);
+	const startInVideo = sequenceContext
+		? sequenceContext.cumulatedFrom + sequenceContext.relativeFrom
+		: 0;
 
 	// Generate a string that's as unique as possible for this asset
 	// but at the same time the same on all threads
@@ -238,6 +241,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 							? audio.data
 							: Array.from(audio.data),
 						frame: absoluteFrame,
+						startInVideo,
 						timestamp: audio.timestamp,
 						duration:
 							(audio.numberOfFrames / getTargetSampleRate()) * 1_000_000,
@@ -277,6 +281,7 @@ export const AudioForRendering: React.FC<AudioProps> = ({
 		playbackRate,
 		registerRenderAsset,
 		src,
+		startInVideo,
 		startsAt,
 		unregisterRenderAsset,
 		volumeProp,

--- a/packages/media/src/video/video-for-rendering.tsx
+++ b/packages/media/src/video/video-for-rendering.tsx
@@ -109,6 +109,9 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 	);
 	const startsAt = Internals.useMediaStartsAt();
 	const sequenceContext = useContext(Internals.SequenceContext);
+	const startInVideo = sequenceContext
+		? sequenceContext.cumulatedFrom + sequenceContext.relativeFrom
+		: 0;
 
 	// Generate a string that's as unique as possible for this asset
 	// but at the same time the same on all threads
@@ -393,6 +396,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 							? audio.data
 							: Array.from(audio.data),
 						frame: absoluteFrame,
+						startInVideo,
 						timestamp: audio.timestamp,
 						duration:
 							(audio.numberOfFrames / getTargetSampleRate()) * 1_000_000,
@@ -432,6 +436,7 @@ export const VideoForRendering: React.FC<InnerVideoProps> = ({
 		playbackRate,
 		registerRenderAsset,
 		src,
+		startInVideo,
 		startsAt,
 		unregisterRenderAsset,
 		volumeProp,

--- a/packages/renderer/src/assets/inline-audio-mixing.ts
+++ b/packages/renderer/src/assets/inline-audio-mixing.ts
@@ -42,8 +42,8 @@ const WAV_HEADER_SIZE = 44;
 
 export type InlineAudioTrack = {
 	outName: string;
-	startInSeconds: number;
-	durationInSeconds: number;
+	startInSamples: number;
+	durationInSamples: number;
 };
 
 export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
@@ -51,7 +51,7 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 	const openFiles: Record<string, number> = {};
 	const writtenHeaders: Record<string, boolean> = {};
 	const toneFrequencies: Record<string, number> = {};
-	const startTimesInSeconds: Record<string, number> = {};
+	const startTimesInSamples: Record<string, number> = {};
 	const writtenDataSizes: Record<string, number> = {};
 
 	const cleanup = () => {
@@ -69,12 +69,11 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		return Object.keys(writtenHeaders)
 			.map((outName) => ({
 				outName,
-				startInSeconds: startTimesInSeconds[outName],
-				durationInSeconds:
-					writtenDataSizes[outName] /
-					(NUMBER_OF_CHANNELS * sampleRate * BYTES_PER_SAMPLE),
+				startInSamples: startTimesInSamples[outName],
+				durationInSamples:
+					writtenDataSizes[outName] / (NUMBER_OF_CHANNELS * BYTES_PER_SAMPLE),
 			}))
-			.sort((a, b) => a.startInSeconds - b.startInSeconds);
+			.sort((a, b) => a.startInSamples - b.startInSamples);
 	};
 
 	const getFilePath = (asset: InlineAudioAsset) => {
@@ -198,21 +197,25 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 
 		const assetStartInVideo = asset.startInVideo ?? firstFrame;
 		const firstFrameForAsset = Math.max(assetStartInVideo, firstFrame);
-		const startsAtRenderStart = firstFrameForAsset === firstFrame;
-		const startInSeconds = Math.max(
+		const startInSamples = Math.max(
 			0,
-			(firstFrameForAsset - firstFrame) / fps - trimLeftOffset,
+			Math.floor(
+				correctFloatingPointError(
+					((firstFrameForAsset - firstFrame) / fps - trimLeftOffset) *
+						sampleRate,
+				),
+			),
 		);
 		if (
-			startTimesInSeconds[filePath] !== undefined &&
-			Math.abs(startTimesInSeconds[filePath] - startInSeconds) > 0.00001
+			startTimesInSamples[filePath] !== undefined &&
+			startTimesInSamples[filePath] !== startInSamples
 		) {
 			throw new Error(
-				`The start time for inline audio asset ${asset.id} changed from ${startTimesInSeconds[filePath]} to ${startInSeconds}`,
+				`The start time for inline audio asset ${asset.id} changed from ${startTimesInSamples[filePath]} to ${startInSamples} samples`,
 			);
 		}
 
-		startTimesInSeconds[filePath] = startInSeconds;
+		startTimesInSamples[filePath] = startInSamples;
 
 		let arr = new Int16Array(asset.audio);
 		const isFirst = asset.frame === firstFrame;
@@ -240,16 +243,18 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 			);
 		}
 
-		const positionInSeconds =
-			(asset.frame - firstFrameForAsset) / fps -
-			(isFirst || !startsAtRenderStart ? 0 : trimLeftOffset);
+		const positionInRenderInSeconds =
+			(asset.frame - firstFrame) / fps - (isFirst ? 0 : trimLeftOffset);
 
 		// Always rounding down to ensure there are no gaps when the samples don't align
 		// In @remotion/media, we also round down the sample start timestamp and round up the end timestamp
 		// This might lead to overlapping, hopefully aligning perfectly!
 		// Test case: https://github.com/remotion-dev/remotion/issues/5758
 		const position =
-			Math.floor(correctFloatingPointError(positionInSeconds * sampleRate)) *
+			(Math.floor(
+				correctFloatingPointError(positionInRenderInSeconds * sampleRate),
+			) -
+				startInSamples) *
 			NUMBER_OF_CHANNELS *
 			BYTES_PER_SAMPLE;
 

--- a/packages/renderer/src/assets/inline-audio-mixing.ts
+++ b/packages/renderer/src/assets/inline-audio-mixing.ts
@@ -38,13 +38,21 @@ const correctFloatingPointError = (value: number): number => {
 const BIT_DEPTH = 16;
 const BYTES_PER_SAMPLE = BIT_DEPTH / 8;
 const NUMBER_OF_CHANNELS = 2;
+const WAV_HEADER_SIZE = 44;
+
+export type InlineAudioTrack = {
+	outName: string;
+	startInSeconds: number;
+	durationInSeconds: number;
+};
 
 export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 	const folderToAdd = makeAndReturn(dir, 'remotion-inline-audio-mixing');
-	// asset id -> file descriptor
 	const openFiles: Record<string, number> = {};
 	const writtenHeaders: Record<string, boolean> = {};
 	const toneFrequencies: Record<string, number> = {};
+	const startTimesInSeconds: Record<string, number> = {};
+	const writtenDataSizes: Record<string, number> = {};
 
 	const cleanup = () => {
 		for (const fileName of Object.keys(openFiles)) {
@@ -57,29 +65,25 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		deleteDirectory(folderToAdd);
 	};
 
-	const getListOfAssets = () => {
-		return Object.keys(openFiles);
+	const getListOfAssets = (): InlineAudioTrack[] => {
+		return Object.keys(writtenHeaders)
+			.map((outName) => ({
+				outName,
+				startInSeconds: startTimesInSeconds[outName],
+				durationInSeconds:
+					writtenDataSizes[outName] /
+					(NUMBER_OF_CHANNELS * sampleRate * BYTES_PER_SAMPLE),
+			}))
+			.sort((a, b) => a.startInSeconds - b.startInSeconds);
 	};
 
 	const getFilePath = (asset: InlineAudioAsset) => {
 		return path.join(folderToAdd, `${asset.id}.wav`);
 	};
 
-	const ensureAsset = ({
-		asset,
-		fps,
-		totalNumberOfFrames,
-		trimLeftOffset,
-		trimRightOffset,
-	}: {
-		asset: InlineAudioAsset;
-		fps: number;
-		totalNumberOfFrames: number;
-		trimLeftOffset: number;
-		trimRightOffset: number;
-	}) => {
+	const ensureAsset = (asset: InlineAudioAsset) => {
 		const filePath = getFilePath(asset);
-		if (!openFiles[filePath]) {
+		if (openFiles[filePath] === undefined) {
 			openFiles[filePath] = fs.openSync(filePath, 'w');
 		}
 
@@ -88,43 +92,21 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		}
 
 		writtenHeaders[filePath] = true;
-
-		const expectedDataSize = Math.round(
-			(totalNumberOfFrames / fps - trimLeftOffset + trimRightOffset) *
-				NUMBER_OF_CHANNELS *
-				sampleRate *
-				BYTES_PER_SAMPLE,
-		);
-
-		const expectedSize = 40 + expectedDataSize;
+		writtenDataSizes[filePath] = 0;
 
 		const fd = openFiles[filePath];
 		writeSync(fd, new Uint8Array([0x52, 0x49, 0x46, 0x46]), 0, 4, 0); // "RIFF"
-		writeSync(
-			fd,
-			new Uint8Array(numberTo32BiIntLittleEndian(expectedSize)),
-			0,
-			4,
-			4,
-		); // Remaining size
+		writeSync(fd, numberTo32BiIntLittleEndian(36), 0, 4, 4); // Remaining size
 		writeSync(fd, new Uint8Array([0x57, 0x41, 0x56, 0x45]), 0, 4, 8); // "WAVE"
 		writeSync(fd, new Uint8Array([0x66, 0x6d, 0x74, 0x20]), 0, 4, 12); // "fmt "
 		writeSync(fd, new Uint8Array([BIT_DEPTH, 0x00, 0x00, 0x00]), 0, 4, 16); // fmt chunk size = 16
 		writeSync(fd, new Uint8Array([0x01, 0x00]), 0, 2, 20); // Audio format (PCM) = 1, set 3 if float32 would be true
 		writeSync(fd, new Uint8Array([NUMBER_OF_CHANNELS, 0x00]), 0, 2, 22); // Number of channels
+		writeSync(fd, numberTo32BiIntLittleEndian(sampleRate), 0, 4, 24); // Sample rate
 		writeSync(
 			fd,
-			new Uint8Array(numberTo32BiIntLittleEndian(sampleRate)),
-			0,
-			4,
-			24,
-		); // Sample rate
-		writeSync(
-			fd,
-			new Uint8Array(
-				numberTo32BiIntLittleEndian(
-					sampleRate * NUMBER_OF_CHANNELS * BYTES_PER_SAMPLE,
-				),
+			numberTo32BiIntLittleEndian(
+				sampleRate * NUMBER_OF_CHANNELS * BYTES_PER_SAMPLE,
 			),
 			0,
 			4,
@@ -132,22 +114,14 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		); // Byte rate
 		writeSync(
 			fd,
-			new Uint8Array(
-				numberTo16BitLittleEndian(NUMBER_OF_CHANNELS * BYTES_PER_SAMPLE),
-			),
+			numberTo16BitLittleEndian(NUMBER_OF_CHANNELS * BYTES_PER_SAMPLE),
 			0,
 			2,
 			32,
 		); // Block align
 		writeSync(fd, numberTo16BitLittleEndian(BIT_DEPTH), 0, 2, 34); // Bits per sample
 		writeSync(fd, new Uint8Array([0x64, 0x61, 0x74, 0x61]), 0, 4, 36); // "data"
-		writeSync(
-			fd,
-			new Uint8Array(numberTo32BiIntLittleEndian(expectedDataSize)),
-			0,
-			4,
-			40,
-		); // Remaining size
+		writeSync(fd, numberTo32BiIntLittleEndian(0), 0, 4, 40); // Data size
 	};
 
 	const finish = async ({
@@ -163,7 +137,15 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		cancelSignal: CancelSignal | undefined;
 		sampleRate: number;
 	}) => {
-		for (const fileName of Object.keys(openFiles)) {
+		for (const fileName of Object.keys(writtenHeaders)) {
+			const fd = openFiles[fileName];
+			const dataSize = Math.max(0, fs.fstatSync(fd).size - WAV_HEADER_SIZE);
+			writtenDataSizes[fileName] = dataSize;
+			writeSync(fd, numberTo32BiIntLittleEndian(36 + dataSize), 0, 4, 4);
+			writeSync(fd, numberTo32BiIntLittleEndian(dataSize), 0, 4, 40);
+			fs.closeSync(fd);
+			delete openFiles[fileName];
+
 			const frequency = toneFrequencies[fileName];
 			if (frequency === 1) {
 				continue;
@@ -180,10 +162,6 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 				cancelSignal,
 				sampleRate: finishSampleRate,
 			});
-			try {
-				fs.closeSync(openFiles[fileName]);
-			} catch {}
-
 			fs.renameSync(tmpFile, fileName);
 		}
 	};
@@ -203,16 +181,9 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		trimLeftOffset: number;
 		trimRightOffset: number;
 	}) => {
-		ensureAsset({
-			asset,
-			fps,
-			totalNumberOfFrames,
-			trimLeftOffset,
-			trimRightOffset,
-		});
+		ensureAsset(asset);
 
 		const filePath = getFilePath(asset);
-
 		if (
 			toneFrequencies[filePath] !== undefined &&
 			toneFrequencies[filePath] !== asset.toneFrequency
@@ -224,6 +195,24 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 
 		const fileDescriptor = openFiles[filePath];
 		toneFrequencies[filePath] = asset.toneFrequency;
+
+		const assetStartInVideo = asset.startInVideo ?? firstFrame;
+		const firstFrameForAsset = Math.max(assetStartInVideo, firstFrame);
+		const startsAtRenderStart = firstFrameForAsset === firstFrame;
+		const startInSeconds = Math.max(
+			0,
+			(firstFrameForAsset - firstFrame) / fps - trimLeftOffset,
+		);
+		if (
+			startTimesInSeconds[filePath] !== undefined &&
+			Math.abs(startTimesInSeconds[filePath] - startInSeconds) > 0.00001
+		) {
+			throw new Error(
+				`The start time for inline audio asset ${asset.id} changed from ${startTimesInSeconds[filePath]} to ${startInSeconds}`,
+			);
+		}
+
+		startTimesInSeconds[filePath] = startInSeconds;
 
 		let arr = new Int16Array(asset.audio);
 		const isFirst = asset.frame === firstFrame;
@@ -252,7 +241,8 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 		}
 
 		const positionInSeconds =
-			(asset.frame - firstFrame) / fps - (isFirst ? 0 : trimLeftOffset);
+			(asset.frame - firstFrameForAsset) / fps -
+			(isFirst || !startsAtRenderStart ? 0 : trimLeftOffset);
 
 		// Always rounding down to ensure there are no gaps when the samples don't align
 		// In @remotion/media, we also round down the sample start timestamp and round up the end timestamp
@@ -264,16 +254,15 @@ export const makeInlineAudioMixing = (dir: string, sampleRate: number) => {
 			BYTES_PER_SAMPLE;
 
 		writeSync(
-			// fs
 			fileDescriptor,
-			// data
 			arr,
-			// offset of data
 			0,
-			// length
 			arr.byteLength,
-			// position
-			44 + position,
+			WAV_HEADER_SIZE + position,
+		);
+		writtenDataSizes[filePath] = Math.max(
+			writtenDataSizes[filePath],
+			position + arr.byteLength,
 		);
 	};
 

--- a/packages/renderer/src/create-audio.ts
+++ b/packages/renderer/src/create-audio.ts
@@ -161,9 +161,10 @@ export const createAudio = async ({
 			? [
 					inlineAudioTrackToPreprocessedAudioTrack({
 						track: mergedInlineAudio,
-						relativeToInSeconds: 0,
-						padToDurationInSeconds: chunkLengthInSeconds,
-						sampleRate,
+						relativeToInSamples: 0,
+						padToDurationInSamples: Math.round(
+							chunkLengthInSeconds * sampleRate,
+						),
 					}),
 				]
 			: []),

--- a/packages/renderer/src/create-audio.ts
+++ b/packages/renderer/src/create-audio.ts
@@ -11,6 +11,10 @@ import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
 import {mergeAudioTrack} from './merge-audio-track';
+import {
+	inlineAudioTrackToPreprocessedAudioTrack,
+	mergeInlineAudioTracks,
+} from './merge-inline-audio-tracks';
 import type {AudioCodec} from './options/audio-codec';
 import {getExtensionFromAudioCodec} from './options/audio-codec';
 import type {PreprocessedAudioTrack} from './preprocess-audio-track';
@@ -138,17 +142,31 @@ export const createAudio = async ({
 	});
 
 	const inlinedAudio = downloadMap.inlineAudioMixing.getListOfAssets();
+	const mergedInlineAudio = await mergeInlineAudioTracks({
+		tracks: inlinedAudio,
+		downloadMap,
+		remotionRoot,
+		indent,
+		logLevel,
+		binariesDirectory,
+		cancelSignal,
+		fps,
+		chunkLengthInSeconds,
+		sampleRate,
+	});
 
 	const preprocessed: PreprocessedAudioTrack[] = [
 		...audioTracks.filter(truthy),
-		...inlinedAudio.map((asset) => ({
-			outName: asset,
-			filter: {
-				filter: null,
-				pad_start: null,
-				pad_end: null,
-			},
-		})),
+		...(mergedInlineAudio
+			? [
+					inlineAudioTrackToPreprocessedAudioTrack({
+						track: mergedInlineAudio,
+						relativeToInSeconds: 0,
+						padToDurationInSeconds: chunkLengthInSeconds,
+						sampleRate,
+					}),
+				]
+			: []),
 	];
 	const merged = path.join(downloadMap.audioPreprocessing, 'merged.wav');
 	const extension = getExtensionFromAudioCodec(audioCodec);

--- a/packages/renderer/src/merge-inline-audio-tracks.ts
+++ b/packages/renderer/src/merge-inline-audio-tracks.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+import type {DownloadMap} from './assets/download-map';
+import type {InlineAudioTrack} from './assets/inline-audio-mixing';
+import {chunk} from './chunk';
+import {deleteDirectory} from './delete-directory';
+import type {LogLevel} from './log-level';
+import type {CancelSignal} from './make-cancel-signal';
+import {mergeAudioTrack} from './merge-audio-track';
+import type {PreprocessedAudioTrack} from './preprocess-audio-track';
+
+const MAX_INLINE_AUDIO_INPUTS = 10;
+
+export const inlineAudioTrackToPreprocessedAudioTrack = ({
+	track,
+	relativeToInSeconds,
+	padToDurationInSeconds,
+	sampleRate,
+}: {
+	track: InlineAudioTrack;
+	relativeToInSeconds: number;
+	padToDurationInSeconds: number | null;
+	sampleRate: number;
+}): PreprocessedAudioTrack => {
+	const delayInSamples = Math.max(
+		0,
+		Math.round((track.startInSeconds - relativeToInSeconds) * sampleRate),
+	);
+	const padAtEndInSamples =
+		padToDurationInSeconds === null
+			? 0
+			: Math.max(
+					0,
+					Math.round(padToDurationInSeconds * sampleRate) -
+						delayInSamples -
+						Math.round(track.durationInSeconds * sampleRate),
+				);
+
+	return {
+		outName: track.outName,
+		filter: {
+			pad_start:
+				delayInSamples === 0
+					? null
+					: `adelay=${new Array(3).fill(`${delayInSamples}S`).join('|')}`,
+			pad_end:
+				padAtEndInSamples === 0 ? null : `apad=pad_len=${padAtEndInSamples}`,
+		},
+	};
+};
+
+export const mergeInlineAudioTracks = async ({
+	tracks,
+	downloadMap,
+	remotionRoot,
+	indent,
+	logLevel,
+	binariesDirectory,
+	cancelSignal,
+	fps,
+	chunkLengthInSeconds,
+	sampleRate,
+}: {
+	tracks: InlineAudioTrack[];
+	downloadMap: DownloadMap;
+	remotionRoot: string;
+	indent: boolean;
+	logLevel: LogLevel;
+	binariesDirectory: string | null;
+	cancelSignal: CancelSignal | undefined;
+	fps: number;
+	chunkLengthInSeconds: number;
+	sampleRate: number;
+}): Promise<InlineAudioTrack | null> => {
+	let currentTracks = tracks.sort(
+		(a, b) => a.startInSeconds - b.startInSeconds,
+	);
+	let level = 0;
+
+	while (currentTracks.length > 1) {
+		const groups = chunk(currentTracks, MAX_INLINE_AUDIO_INPUTS);
+		currentTracks = await Promise.all(
+			groups.map(async (group, index): Promise<InlineAudioTrack> => {
+				if (group.length === 1) {
+					return group[0];
+				}
+
+				const [{startInSeconds}] = group;
+				const durationInSamples = Math.max(
+					...group.map((track) => {
+						return (
+							Math.round((track.startInSeconds - startInSeconds) * sampleRate) +
+							Math.round(track.durationInSeconds * sampleRate)
+						);
+					}),
+				);
+				const outName = path.join(
+					downloadMap.audioMixing,
+					`inline-${level}-${index}.wav`,
+				);
+
+				await mergeAudioTrack({
+					files: group.map((track) =>
+						inlineAudioTrackToPreprocessedAudioTrack({
+							track,
+							relativeToInSeconds: startInSeconds,
+							padToDurationInSeconds: null,
+							sampleRate,
+						}),
+					),
+					outName,
+					downloadMap,
+					remotionRoot,
+					indent,
+					logLevel,
+					binariesDirectory,
+					cancelSignal,
+					onProgress: () => undefined,
+					fps,
+					chunkLengthInSeconds,
+					sampleRate,
+				});
+
+				for (const track of group) {
+					deleteDirectory(track.outName);
+				}
+
+				return {
+					outName,
+					startInSeconds,
+					durationInSeconds: durationInSamples / sampleRate,
+				};
+			}),
+		);
+		level++;
+	}
+
+	return currentTracks[0] ?? null;
+};

--- a/packages/renderer/src/merge-inline-audio-tracks.ts
+++ b/packages/renderer/src/merge-inline-audio-tracks.ts
@@ -12,27 +12,23 @@ const MAX_INLINE_AUDIO_INPUTS = 10;
 
 export const inlineAudioTrackToPreprocessedAudioTrack = ({
 	track,
-	relativeToInSeconds,
-	padToDurationInSeconds,
-	sampleRate,
+	relativeToInSamples,
+	padToDurationInSamples,
 }: {
 	track: InlineAudioTrack;
-	relativeToInSeconds: number;
-	padToDurationInSeconds: number | null;
-	sampleRate: number;
+	relativeToInSamples: number;
+	padToDurationInSamples: number | null;
 }): PreprocessedAudioTrack => {
 	const delayInSamples = Math.max(
 		0,
-		Math.round((track.startInSeconds - relativeToInSeconds) * sampleRate),
+		track.startInSamples - relativeToInSamples,
 	);
 	const padAtEndInSamples =
-		padToDurationInSeconds === null
+		padToDurationInSamples === null
 			? 0
 			: Math.max(
 					0,
-					Math.round(padToDurationInSeconds * sampleRate) -
-						delayInSamples -
-						Math.round(track.durationInSeconds * sampleRate),
+					padToDurationInSamples - delayInSamples - track.durationInSamples,
 				);
 
 	return {
@@ -72,7 +68,7 @@ export const mergeInlineAudioTracks = async ({
 	sampleRate: number;
 }): Promise<InlineAudioTrack | null> => {
 	let currentTracks = tracks.sort(
-		(a, b) => a.startInSeconds - b.startInSeconds,
+		(a, b) => a.startInSamples - b.startInSamples,
 	);
 	let level = 0;
 
@@ -84,12 +80,11 @@ export const mergeInlineAudioTracks = async ({
 					return group[0];
 				}
 
-				const [{startInSeconds}] = group;
+				const [{startInSamples}] = group;
 				const durationInSamples = Math.max(
 					...group.map((track) => {
 						return (
-							Math.round((track.startInSeconds - startInSeconds) * sampleRate) +
-							Math.round(track.durationInSeconds * sampleRate)
+							track.startInSamples - startInSamples + track.durationInSamples
 						);
 					}),
 				);
@@ -102,9 +97,8 @@ export const mergeInlineAudioTracks = async ({
 					files: group.map((track) =>
 						inlineAudioTrackToPreprocessedAudioTrack({
 							track,
-							relativeToInSeconds: startInSeconds,
-							padToDurationInSeconds: null,
-							sampleRate,
+							relativeToInSamples: startInSamples,
+							padToDurationInSamples: null,
 						}),
 					),
 					outName,
@@ -126,8 +120,8 @@ export const mergeInlineAudioTracks = async ({
 
 				return {
 					outName,
-					startInSeconds,
-					durationInSeconds: durationInSamples / sampleRate,
+					startInSamples,
+					durationInSamples,
 				};
 			}),
 		);

--- a/packages/renderer/src/test/inline-audio-mixing.test.ts
+++ b/packages/renderer/src/test/inline-audio-mixing.test.ts
@@ -1,0 +1,149 @@
+import {expect, test} from 'bun:test';
+import {mkdtempSync, readFileSync, rmSync, statSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type {InlineAudioAsset} from 'remotion/no-react';
+import {cleanDownloadMap, makeDownloadMap} from '../assets/download-map';
+import {makeInlineAudioMixing} from '../assets/inline-audio-mixing';
+import {mergeInlineAudioTracks} from '../merge-inline-audio-tracks';
+
+const SAMPLE_RATE = 48_000;
+const FPS = 30;
+const SAMPLES_PER_FRAME = SAMPLE_RATE / FPS;
+
+const makeAsset = ({
+	id,
+	frame,
+	startInVideo,
+}: {
+	id: string;
+	frame: number;
+	startInVideo: number | undefined;
+}): InlineAudioAsset => ({
+	type: 'inline-audio',
+	id,
+	audio: new Int16Array(SAMPLES_PER_FRAME * 2).fill(1000),
+	frame,
+	startInVideo,
+	timestamp: 0,
+	duration: 1_000_000 / FPS,
+	toneFrequency: 1,
+});
+
+const finish = (mixing: ReturnType<typeof makeInlineAudioMixing>) => {
+	return mixing.finish({
+		indent: false,
+		logLevel: 'error',
+		binariesDirectory: null,
+		cancelSignal: undefined,
+		sampleRate: SAMPLE_RATE,
+	});
+};
+
+test('writes late inline audio relative to its clip origin', async () => {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'inline-audio-relative-'));
+	const mixing = makeInlineAudioMixing(dir, SAMPLE_RATE);
+
+	try {
+		// Deliberately write the second frame first to ensure the origin does not
+		// depend on renderer concurrency or completion order.
+		mixing.addAsset({
+			asset: makeAsset({id: 'late', frame: 301, startInVideo: 300}),
+			fps: FPS,
+			totalNumberOfFrames: 330,
+			firstFrame: 0,
+			trimLeftOffset: 0,
+			trimRightOffset: 0,
+		});
+		mixing.addAsset({
+			asset: makeAsset({id: 'late', frame: 300, startInVideo: 300}),
+			fps: FPS,
+			totalNumberOfFrames: 330,
+			firstFrame: 0,
+			trimLeftOffset: 0,
+			trimRightOffset: 0,
+		});
+		await finish(mixing);
+
+		const [track] = mixing.getListOfAssets();
+		const wav = readFileSync(track.outName);
+		expect(track.startInSeconds).toBe(10);
+		expect(track.durationInSeconds).toBeCloseTo(2 / FPS, 8);
+		expect(wav.length).toBe(44 + SAMPLES_PER_FRAME * 2 * 2 * 2);
+		expect(wav.readUInt32LE(4)).toBe(wav.length - 8);
+		expect(wav.readUInt32LE(40)).toBe(wav.length - 44);
+	} finally {
+		mixing.cleanup();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test('keeps a composition-relative fallback for an unknown clip origin', async () => {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'inline-audio-fallback-'));
+	const mixing = makeInlineAudioMixing(dir, SAMPLE_RATE);
+
+	try {
+		mixing.addAsset({
+			asset: makeAsset({id: 'unknown', frame: 3, startInVideo: undefined}),
+			fps: FPS,
+			totalNumberOfFrames: 4,
+			firstFrame: 0,
+			trimLeftOffset: 0,
+			trimRightOffset: 0,
+		});
+		await finish(mixing);
+
+		const [track] = mixing.getListOfAssets();
+		expect(track.startInSeconds).toBe(0);
+		expect(track.durationInSeconds).toBeCloseTo(4 / FPS, 8);
+	} finally {
+		mixing.cleanup();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test(
+	'pre-merges many sequential clips without materializing their timeline offsets',
+	async () => {
+		const downloadMap = makeDownloadMap(SAMPLE_RATE);
+
+		try {
+			for (let index = 0; index < 12; index++) {
+				downloadMap.inlineAudioMixing.addAsset({
+					asset: makeAsset({
+						id: `clip-${index}`,
+						frame: 300 + index,
+						startInVideo: 300 + index,
+					}),
+					fps: FPS,
+					totalNumberOfFrames: 360,
+					firstFrame: 0,
+					trimLeftOffset: 0,
+					trimRightOffset: 0,
+				});
+			}
+
+			await finish(downloadMap.inlineAudioMixing);
+			const merged = await mergeInlineAudioTracks({
+				tracks: downloadMap.inlineAudioMixing.getListOfAssets(),
+				downloadMap,
+				remotionRoot: process.cwd(),
+				indent: false,
+				logLevel: 'error',
+				binariesDirectory: null,
+				cancelSignal: undefined,
+				fps: FPS,
+				chunkLengthInSeconds: 12,
+				sampleRate: SAMPLE_RATE,
+			});
+
+			expect(merged).not.toBeNull();
+			expect(merged?.startInSeconds).toBe(10);
+			expect(merged?.durationInSeconds).toBeCloseTo(12 / FPS, 8);
+			expect(statSync(merged!.outName).size).toBeLessThan(100_000);
+		} finally {
+			cleanDownloadMap(downloadMap);
+		}
+	},
+	{timeout: 30_000},
+);

--- a/packages/renderer/src/test/inline-audio-mixing.test.ts
+++ b/packages/renderer/src/test/inline-audio-mixing.test.ts
@@ -103,24 +103,34 @@ test('keeps a composition-relative fallback for an unknown clip origin', async (
 });
 
 test(
-	'pre-merges many sequential clips without materializing their timeline offsets',
+	'pre-merges 423 offset clips without materializing their timeline offsets',
 	async () => {
 		const downloadMap = makeDownloadMap(SAMPLE_RATE);
 
 		try {
-			for (let index = 0; index < 12; index++) {
+			let nextFrame = 300;
+			const startFrames: number[] = [];
+			for (let index = 0; index < 423; index++) {
+				if (index % 17 === 0) {
+					nextFrame += 4;
+				} else if (index % 7 === 0) {
+					nextFrame++;
+				}
+
+				startFrames.push(nextFrame);
 				downloadMap.inlineAudioMixing.addAsset({
 					asset: makeAsset({
 						id: `clip-${index}`,
-						frame: 300 + index,
-						startInVideo: 300 + index,
+						frame: nextFrame,
+						startInVideo: nextFrame,
 					}),
 					fps: FPS,
-					totalNumberOfFrames: 360,
+					totalNumberOfFrames: 1000,
 					firstFrame: 0,
 					trimLeftOffset: 0,
 					trimRightOffset: 0,
 				});
+				nextFrame++;
 			}
 
 			await finish(downloadMap.inlineAudioMixing);
@@ -138,12 +148,15 @@ test(
 			});
 
 			expect(merged).not.toBeNull();
-			expect(merged?.startInSeconds).toBe(10);
-			expect(merged?.durationInSeconds).toBeCloseTo(12 / FPS, 8);
-			expect(statSync(merged!.outName).size).toBeLessThan(100_000);
+			expect(merged?.startInSeconds).toBe(startFrames[0] / FPS);
+			expect(merged?.durationInSeconds).toBeCloseTo(
+				(startFrames.at(-1)! - startFrames[0] + 1) / FPS,
+				8,
+			);
+			expect(statSync(merged!.outName).size).toBeLessThan(4_000_000);
 		} finally {
 			cleanDownloadMap(downloadMap);
 		}
 	},
-	{timeout: 30_000},
+	{timeout: 120_000},
 );

--- a/packages/renderer/src/test/inline-audio-mixing.test.ts
+++ b/packages/renderer/src/test/inline-audio-mixing.test.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 import type {InlineAudioAsset} from 'remotion/no-react';
 import {cleanDownloadMap, makeDownloadMap} from '../assets/download-map';
 import {makeInlineAudioMixing} from '../assets/inline-audio-mixing';
-import {mergeInlineAudioTracks} from '../merge-inline-audio-tracks';
+import {
+	inlineAudioTrackToPreprocessedAudioTrack,
+	mergeInlineAudioTracks,
+} from '../merge-inline-audio-tracks';
 
 const SAMPLE_RATE = 48_000;
 const FPS = 30;
@@ -67,8 +70,8 @@ test('writes late inline audio relative to its clip origin', async () => {
 
 		const [track] = mixing.getListOfAssets();
 		const wav = readFileSync(track.outName);
-		expect(track.startInSeconds).toBe(10);
-		expect(track.durationInSeconds).toBeCloseTo(2 / FPS, 8);
+		expect(track.startInSamples).toBe(10 * SAMPLE_RATE);
+		expect(track.durationInSamples).toBe(2 * SAMPLES_PER_FRAME);
 		expect(wav.length).toBe(44 + SAMPLES_PER_FRAME * 2 * 2 * 2);
 		expect(wav.readUInt32LE(4)).toBe(wav.length - 8);
 		expect(wav.readUInt32LE(40)).toBe(wav.length - 44);
@@ -94,8 +97,50 @@ test('keeps a composition-relative fallback for an unknown clip origin', async (
 		await finish(mixing);
 
 		const [track] = mixing.getListOfAssets();
-		expect(track.startInSeconds).toBe(0);
-		expect(track.durationInSeconds).toBeCloseTo(4 / FPS, 8);
+		expect(track.startInSamples).toBe(0);
+		expect(track.durationInSamples).toBe(4 * SAMPLES_PER_FRAME);
+	} finally {
+		mixing.cleanup();
+		rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+test('preserves legacy sample placement at fractional frame rates', async () => {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'inline-audio-fractional-'));
+	const mixing = makeInlineAudioMixing(dir, SAMPLE_RATE);
+
+	try {
+		// Write out of order to also exercise sparse compact-file placement.
+		mixing.addAsset({
+			asset: makeAsset({id: 'fractional', frame: 83, startInVideo: 81}),
+			fps: 24.87,
+			totalNumberOfFrames: 41,
+			firstFrame: 79,
+			trimLeftOffset: 0.0021487736228385534,
+			trimRightOffset: 0,
+		});
+		mixing.addAsset({
+			asset: makeAsset({id: 'fractional', frame: 81, startInVideo: 81}),
+			fps: 24.87,
+			totalNumberOfFrames: 41,
+			firstFrame: 79,
+			trimLeftOffset: 0.0021487736228385534,
+			trimRightOffset: 0,
+		});
+		await finish(mixing);
+
+		const [track] = mixing.getListOfAssets();
+		const wav = readFileSync(track.outName);
+		const preprocessed = inlineAudioTrackToPreprocessedAudioTrack({
+			track,
+			relativeToInSamples: 0,
+			padToDurationInSamples: null,
+		});
+		expect(preprocessed.filter.pad_start).toBe('adelay=3756S|3756S|3756S');
+		// Legacy absolute placement for frame 83 is sample 7617. Relative to the
+		// compact track's sample 3756 origin, its first sample must be at 3861.
+		expect(wav.readInt16LE(44 + 3860 * 2 * 2)).toBe(0);
+		expect(wav.readInt16LE(44 + 3861 * 2 * 2)).toBe(1000);
 	} finally {
 		mixing.cleanup();
 		rmSync(dir, {recursive: true, force: true});
@@ -148,10 +193,9 @@ test(
 			});
 
 			expect(merged).not.toBeNull();
-			expect(merged?.startInSeconds).toBe(startFrames[0] / FPS);
-			expect(merged?.durationInSeconds).toBeCloseTo(
-				(startFrames.at(-1)! - startFrames[0] + 1) / FPS,
-				8,
+			expect(merged?.startInSamples).toBe((startFrames[0] * SAMPLE_RATE) / FPS);
+			expect(merged?.durationInSamples).toBe(
+				((startFrames.at(-1)! - startFrames[0] + 1) * SAMPLE_RATE) / FPS,
 			);
 			expect(statSync(merged!.outName).size).toBeLessThan(4_000_000);
 		} finally {

--- a/packages/renderer/src/test/inline-audio-mixing.test.ts
+++ b/packages/renderer/src/test/inline-audio-mixing.test.ts
@@ -18,7 +18,7 @@ const makeAsset = ({
 }: {
 	id: string;
 	frame: number;
-	startInVideo: number | undefined;
+	startInVideo: number | null;
 }): InlineAudioAsset => ({
 	type: 'inline-audio',
 	id,
@@ -84,7 +84,7 @@ test('keeps a composition-relative fallback for an unknown clip origin', async (
 
 	try {
 		mixing.addAsset({
-			asset: makeAsset({id: 'unknown', frame: 3, startInVideo: undefined}),
+			asset: makeAsset({id: 'unknown', frame: 3, startInVideo: null}),
 			fps: FPS,
 			totalNumberOfFrames: 4,
 			firstFrame: 0,


### PR DESCRIPTION
## Summary

- write inline audio WAV files relative to each media clip instead of the composition timeline
- keep clip starts, frame placement, merge delays, durations, and padding in integer PCM sample coordinates
- preserve the legacy floor-and-floating-point-correction semantics at fractional frame rates
- retain the previous composition-relative behavior for custom asset producers without start metadata
- bound temporary storage with hierarchical merging while preserving seamless AAC concatenation
- stress-test 423 clips with three nested sequence levels, irregular offsets, and repeated audio unmount gaps

## Testing

- `bun run build`
- `bun run stylecheck`
- renderer inline-audio unit suite
- 24.87 FPS regression proving the legacy 3,756-sample clip offset and later frame placement
- 620-frame WAV validation covering silence, clip-only audio, intermittently mounted audio, and overlap
- live inline-audio temp usage observed above 2 MB and below 10 MB during the 423-clip render
- four Lambda-style AAC chunks decoded sample-identically to a single render across all 1,988,608 reference samples
- red/green verified for the fractional-FPS rounding regression
