### PR TITLE
`@remotion/renderer`: Finalize Fast Start before publishing output

### DIFF
--- a/packages/renderer/src/finalize-fast-start.ts
+++ b/packages/renderer/src/finalize-fast-start.ts
@@ -1,0 +1,96 @@
+import {randomUUID} from 'node:crypto';
+import {promises} from 'node:fs';
+import path from 'node:path';
+import {callFf} from './call-ffmpeg';
+import type {LogLevel} from './log-level';
+import {Log} from './logger';
+import type {CancelSignal} from './make-cancel-signal';
+
+export type FastStartMuxer = 'mov' | 'mp4';
+
+export const finalizeFastStart = async ({
+	input,
+	output,
+	muxer,
+	force,
+	indent,
+	logLevel,
+	binariesDirectory,
+	cancelSignal,
+}: {
+	input: string;
+	output: string;
+	muxer: FastStartMuxer;
+	force: boolean;
+	indent: boolean;
+	logLevel: LogLevel;
+	binariesDirectory: string | null;
+	cancelSignal: CancelSignal | null;
+}) => {
+	let fastStartFile: string | null = null;
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const candidate = path.join(
+			path.dirname(output),
+			`${path.basename(output)}.${randomUUID()}.remotion-in-progress`,
+		);
+		const task = callFf({
+			bin: 'ffmpeg',
+			args: [
+				'-hide_banner',
+				'-i',
+				input,
+				'-c',
+				'copy',
+				'-movflags',
+				'faststart',
+				'-y',
+				'-f',
+				muxer,
+				candidate,
+			],
+			indent,
+			logLevel,
+			binariesDirectory,
+			cancelSignal: cancelSignal ?? undefined,
+		});
+		let stderr = '';
+		task.stderr?.on('data', (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		try {
+			await task;
+			fastStartFile = candidate;
+			break;
+		} catch (error) {
+			await promises.rm(candidate, {force: true}).catch(() => undefined);
+			const isReopenFailure =
+				stderr.includes('Unable to re-open') &&
+				stderr.includes('output file for shifting data');
+			if (!isReopenFailure || attempt === 2) {
+				throw error;
+			}
+
+			Log.verbose(
+				{indent, logLevel, tag: 'stitchFramesToVideo()'},
+				`Retrying Fast Start finalization (attempt ${attempt + 2} of 3)`,
+			);
+		}
+	}
+
+	if (fastStartFile === null) {
+		throw new Error('Fast Start finalization did not produce an output file');
+	}
+
+	if (force) {
+		await promises.rename(fastStartFile, output);
+		return;
+	}
+
+	try {
+		await promises.link(fastStartFile, output);
+	} finally {
+		await promises.rm(fastStartFile, {force: true});
+	}
+};

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -1,11 +1,10 @@
-import {randomUUID} from 'node:crypto';
 import {cpSync, promises, rmSync} from 'node:fs';
 import path from 'node:path';
 import type {_InternalTypes} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
 import type {RenderAssetInfo} from './assets/download-map';
 import {cleanDownloadMap} from './assets/download-map';
-import {callFf, callFfNative} from './call-ffmpeg';
+import {callFfNative} from './call-ffmpeg';
 import type {Codec} from './codec';
 import {DEFAULT_CODEC} from './codec';
 import {codecSupportsMedia} from './codec-supports-media';
@@ -15,6 +14,7 @@ import {validateQualitySettings} from './crf';
 import {deleteDirectory} from './delete-directory';
 import {generateFfmpegArgs} from './ffmpeg-args';
 import type {FfmpegOverrideFn} from './ffmpeg-override';
+import {finalizeFastStart, type FastStartMuxer} from './finalize-fast-start';
 import {findRemotionRoot} from './find-closest-package-json';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
 import {getExtensionOfFilename} from './get-extension-of-filename';
@@ -111,6 +111,24 @@ export type StitchFramesToVideoOptions = {
 } & Partial<ToOptions<typeof optionsMap.stitchFramesToVideo>>;
 
 type ReturnType = Promise<Buffer | null>;
+
+const getFastStartMuxer = ({
+	codec,
+	outputExtension,
+}: {
+	codec: Codec;
+	outputExtension: string;
+}): FastStartMuxer | null => {
+	if (codec !== 'h264') {
+		return null;
+	}
+
+	if (outputExtension === 'mp4' || outputExtension === 'mov') {
+		return outputExtension;
+	}
+
+	return null;
+};
 
 const innerStitchFramesToVideo = async (
 	{
@@ -218,12 +236,7 @@ const innerStitchFramesToVideo = async (
 		getExtensionOfFilename(outputLocation) ??
 		getFileExtensionFromCodec(codec, resolvedAudioCodec)
 	).toLowerCase();
-	const fastStartMuxer =
-		codec === 'h264' && outputExtension === 'mp4'
-			? 'mp4'
-			: codec === 'h264' && outputExtension === 'mov'
-				? 'mov'
-				: null;
+	const fastStartMuxer = getFastStartMuxer({codec, outputExtension});
 	// Fast Start reopens its output for an in-place second pass. Keep that work
 	// away from the public output path so Windows file observers cannot lock it.
 	const fastStartIntermediate =
@@ -509,78 +522,22 @@ const innerStitchFramesToVideo = async (
 		});
 	});
 
-	if (fastStartIntermediate) {
+	if (fastStartIntermediate && fastStartMuxer) {
 		const destination = outputLocation ?? tempFile;
 		if (destination === null) {
 			throw new Error('Expected a Fast Start output destination');
 		}
 
-		const finalDestination = path.resolve(remotionRoot, destination);
-		let fastStartFile: string | null = null;
-
-		for (let attempt = 0; attempt < 3; attempt++) {
-			const candidate = path.join(
-				path.dirname(finalDestination),
-				`${path.basename(finalDestination)}.${randomUUID()}.remotion-in-progress`,
-			);
-			const fastStartTask = callFf({
-				bin: 'ffmpeg',
-				args: [
-					'-hide_banner',
-					'-i',
-					fastStartIntermediate,
-					'-c',
-					'copy',
-					'-movflags',
-					'faststart',
-					'-y',
-					'-f',
-					fastStartMuxer,
-					candidate,
-				],
-				indent,
-				logLevel,
-				binariesDirectory,
-				cancelSignal: cancelSignal ?? undefined,
-			});
-			let fastStartStderr = '';
-			fastStartTask.stderr?.on('data', (data: Buffer) => {
-				fastStartStderr += data.toString();
-			});
-
-			try {
-				await fastStartTask;
-				fastStartFile = candidate;
-				break;
-			} catch (error) {
-				await promises.rm(candidate, {force: true}).catch(() => undefined);
-				const isReopenFailure =
-					fastStartStderr.includes('Unable to re-open') &&
-					fastStartStderr.includes('output file for shifting data');
-				if (!isReopenFailure || attempt === 2) {
-					throw error;
-				}
-
-				Log.verbose(
-					{indent, logLevel, tag: 'stitchFramesToVideo()'},
-					`Retrying Fast Start finalization (attempt ${attempt + 2} of 3)`,
-				);
-			}
-		}
-
-		if (fastStartFile === null) {
-			throw new Error('Fast Start finalization did not produce an output file');
-		}
-
-		if (force) {
-			await promises.rename(fastStartFile, finalDestination);
-		} else {
-			try {
-				await promises.link(fastStartFile, finalDestination);
-			} finally {
-				await promises.rm(fastStartFile, {force: true});
-			}
-		}
+		await finalizeFastStart({
+			input: fastStartIntermediate,
+			output: path.resolve(remotionRoot, destination),
+			muxer: fastStartMuxer,
+			force,
+			indent,
+			logLevel,
+			binariesDirectory,
+			cancelSignal,
+		});
 	}
 
 	const result = tempFile === null ? null : await promises.readFile(tempFile);

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -1,10 +1,11 @@
+import {randomUUID} from 'node:crypto';
 import {cpSync, promises, rmSync} from 'node:fs';
 import path from 'node:path';
 import type {_InternalTypes} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
 import type {RenderAssetInfo} from './assets/download-map';
 import {cleanDownloadMap} from './assets/download-map';
-import {callFfNative} from './call-ffmpeg';
+import {callFf, callFfNative} from './call-ffmpeg';
 import type {Codec} from './codec';
 import {DEFAULT_CODEC} from './codec';
 import {codecSupportsMedia} from './codec-supports-media';
@@ -16,6 +17,7 @@ import {generateFfmpegArgs} from './ffmpeg-args';
 import type {FfmpegOverrideFn} from './ffmpeg-override';
 import {findRemotionRoot} from './find-closest-package-json';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
+import {getExtensionOfFilename} from './get-extension-of-filename';
 import {getProResProfileName} from './get-prores-profile-name';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
@@ -212,6 +214,25 @@ const innerStitchFramesToVideo = async (
 				assetsInfo.downloadMap.stitchFrames,
 				`out.${getFileExtensionFromCodec(codec, resolvedAudioCodec)}`,
 			);
+	const outputExtension = (
+		getExtensionOfFilename(outputLocation) ??
+		getFileExtensionFromCodec(codec, resolvedAudioCodec)
+	).toLowerCase();
+	const fastStartMuxer =
+		codec === 'h264' && outputExtension === 'mp4'
+			? 'mp4'
+			: codec === 'h264' && outputExtension === 'mov'
+				? 'mov'
+				: null;
+	// Fast Start reopens its output for an in-place second pass. Keep that work
+	// away from the public output path so Windows file observers cannot lock it.
+	const fastStartIntermediate =
+		fastStartMuxer === null
+			? null
+			: path.join(
+					assetsInfo.downloadMap.stitchFrames,
+					'fast-start-intermediate.remotion-in-progress',
+				);
 
 	Log.verbose(
 		{
@@ -392,12 +413,15 @@ const innerStitchFramesToVideo = async (
 			indent,
 			logLevel,
 		}),
-		codec === 'h264' ? ['-movflags', 'faststart'] : null,
+		codec === 'h264' && fastStartMuxer === null
+			? ['-movflags', 'faststart']
+			: null,
 		// Ignore metadata that may come from remote media
 		['-map_metadata', '-1'],
 		...makeMetadataArgs(metadata ?? {}),
-		force ? '-y' : null,
-		outputLocation ?? tempFile,
+		force || fastStartIntermediate ? '-y' : null,
+		fastStartIntermediate ? ['-f', fastStartMuxer] : null,
+		fastStartIntermediate ?? outputLocation ?? tempFile,
 	];
 
 	const ffmpegString = ffmpegArgs.flat(2).filter(Boolean) as string[];
@@ -469,25 +493,10 @@ const innerStitchFramesToVideo = async (
 		rmSync(audio);
 	}
 
-	const result = await new Promise<Buffer | null>((resolve, reject) => {
+	await new Promise<void>((resolve, reject) => {
 		task.once('close', (code, signal) => {
 			if (code === 0) {
-				if (tempFile === null) {
-					cleanDownloadMap(assetsInfo.downloadMap);
-					return resolve(null);
-				}
-
-				promises
-					.readFile(tempFile)
-					.then((f) => {
-						resolve(f);
-					})
-					.catch((e) => {
-						reject(e);
-					})
-					.finally(() => {
-						cleanDownloadMap(assetsInfo.downloadMap);
-					});
+				resolve();
 			} else {
 				reject(
 					new Error(
@@ -499,6 +508,83 @@ const innerStitchFramesToVideo = async (
 			}
 		});
 	});
+
+	if (fastStartIntermediate) {
+		const destination = outputLocation ?? tempFile;
+		if (destination === null) {
+			throw new Error('Expected a Fast Start output destination');
+		}
+
+		const finalDestination = path.resolve(remotionRoot, destination);
+		let fastStartFile: string | null = null;
+
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const candidate = path.join(
+				path.dirname(finalDestination),
+				`${path.basename(finalDestination)}.${randomUUID()}.remotion-in-progress`,
+			);
+			const fastStartTask = callFf({
+				bin: 'ffmpeg',
+				args: [
+					'-hide_banner',
+					'-i',
+					fastStartIntermediate,
+					'-c',
+					'copy',
+					'-movflags',
+					'faststart',
+					'-y',
+					'-f',
+					fastStartMuxer,
+					candidate,
+				],
+				indent,
+				logLevel,
+				binariesDirectory,
+				cancelSignal: cancelSignal ?? undefined,
+			});
+			let fastStartStderr = '';
+			fastStartTask.stderr?.on('data', (data: Buffer) => {
+				fastStartStderr += data.toString();
+			});
+
+			try {
+				await fastStartTask;
+				fastStartFile = candidate;
+				break;
+			} catch (error) {
+				await promises.rm(candidate, {force: true}).catch(() => undefined);
+				const isReopenFailure =
+					fastStartStderr.includes('Unable to re-open') &&
+					fastStartStderr.includes('output file for shifting data');
+				if (!isReopenFailure || attempt === 2) {
+					throw error;
+				}
+
+				Log.verbose(
+					{indent, logLevel, tag: 'stitchFramesToVideo()'},
+					`Retrying Fast Start finalization (attempt ${attempt + 2} of 3)`,
+				);
+			}
+		}
+
+		if (fastStartFile === null) {
+			throw new Error('Fast Start finalization did not produce an output file');
+		}
+
+		if (force) {
+			await promises.rename(fastStartFile, finalDestination);
+		} else {
+			try {
+				await promises.link(fastStartFile, finalDestination);
+			} finally {
+				await promises.rm(fastStartFile, {force: true});
+			}
+		}
+	}
+
+	const result = tempFile === null ? null : await promises.readFile(tempFile);
+	cleanDownloadMap(assetsInfo.downloadMap);
 	assetsInfo.downloadMap.allowCleanup();
 
 	return result;

--- a/packages/renderer/src/test/stitch-frames-to-video.test.ts
+++ b/packages/renderer/src/test/stitch-frames-to-video.test.ts
@@ -1,0 +1,94 @@
+import {expect, test} from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {cleanDownloadMap, makeDownloadMap} from '../assets/download-map';
+import {stitchFramesToVideo} from '../stitch-frames-to-video';
+
+test('Fast Start finalization stays off the public output path', async () => {
+	const testDirectory = await fs.promises.mkdtemp(
+		path.join(os.tmpdir(), 'remotion-faststart-test-'),
+	);
+	const downloadMap = makeDownloadMap(48000);
+	const frame = path.join(testDirectory, 'frame-0.png');
+	await fs.promises.copyFile(
+		path.join(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'example',
+			'public',
+			'stuttgart-pin.png',
+		),
+		frame,
+	);
+	const assetsInfo = {
+		assets: [
+			{
+				frame: 0,
+				audioAndVideoAssets: [],
+				artifactAssets: [],
+				inlineAudioAssets: [],
+			},
+		],
+		chunkLengthInSeconds: 1,
+		downloadMap,
+		firstFrameIndex: 0,
+		forSeamlessAacConcatenation: false,
+		imageSequenceName: path.join(testDirectory, 'frame-%d.png'),
+		trimLeftOffset: 0,
+		trimRightOffset: 0,
+	};
+
+	try {
+		const outputPath = path.join(testDirectory, 'output.mp4');
+		const observedFiles = new Set<string>();
+		const watcher = fs.watch(testDirectory, (_event, filename) => {
+			if (filename) {
+				observedFiles.add(filename);
+			}
+		});
+		let progressUpdates = 0;
+		try {
+			await stitchFramesToVideo({
+				assetsInfo,
+				codec: 'h264',
+				force: false,
+				fps: 1,
+				height: 512,
+				muted: true,
+				onProgress: () => {
+					progressUpdates++;
+					expect(fs.existsSync(outputPath)).toBe(false);
+				},
+				outputLocation: outputPath,
+				width: 512,
+			});
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		} finally {
+			watcher.close();
+		}
+
+		expect(progressUpdates).toBeGreaterThan(0);
+		expect(
+			[...observedFiles].some(
+				(filename) =>
+					filename.startsWith('output.mp4.') &&
+					filename.endsWith('.remotion-in-progress'),
+			),
+		).toBe(true);
+		expect(
+			(await fs.promises.readdir(testDirectory)).some((filename) =>
+				filename.endsWith('.remotion-in-progress'),
+			),
+		).toBe(false);
+		const output = await fs.promises.readFile(outputPath);
+		expect(output.indexOf('moov')).toBeGreaterThan(-1);
+		expect(output.indexOf('moov')).toBeLessThan(output.indexOf('mdat'));
+	} finally {
+		downloadMap.allowCleanup();
+		cleanDownloadMap(downloadMap);
+		await fs.promises.rm(testDirectory, {force: true, recursive: true});
+	}
+});


### PR DESCRIPTION
## Summary

- Encode H.264 MP4/MOV output to a valid private intermediate before Fast Start finalization.
- Stream-copy Fast Start output to a unique `.<uuid>.remotion-in-progress` file and publish it only after FFmpeg has closed it.
- Retry the specific FFmpeg reopen-denied failure with a fresh in-progress path without repeating frame encoding.
- Keep the existing codec-based Fast Start policy unchanged; container-policy cleanup remains tracked in #10753.

## Verification

- Added a real FFmpeg/filesystem integration test proving the public MP4 does not appear during encoding, the in-progress suffix is used and cleaned up, and `moov` precedes `mdat` in the final artifact.
- Red/green verified by disconnecting the private finalization route and observing the test fail because the public MP4 appeared during progress.
- `bun test packages/renderer/src/test/stitch-frames-to-video.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #10747
