### PR TITLE
`remotion`: Keep Suspense loading indicator at UI scale

### DIFF
--- a/packages/core/src/loading-indicator.tsx
+++ b/packages/core/src/loading-indicator.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import {AbsoluteFillElement} from './AbsoluteFillElement.js';
+import {useCurrentScale} from './use-current-scale.js';
 
 const rotate: React.CSSProperties = {
 	transform: `rotate(90deg)`,
 };
 const ICON_SIZE = 40;
+const LABEL_SIZE = 14;
 
 const label: React.CSSProperties = {
-	color: 'white',
-	fontSize: 14,
+	color: 'rgba(255, 255, 255, 0.8)',
 	fontFamily: 'sans-serif',
 };
 
@@ -27,6 +28,8 @@ const content: React.CSSProperties = {
 };
 
 export const Loading: React.FC = () => {
+	const scale = useCurrentScale({dontThrowIfOutsideOfRemotion: true});
+
 	return (
 		<AbsoluteFillElement style={container} id="remotion-comp-loading">
 			<style type="text/css">{`
@@ -41,8 +44,8 @@ export const Loading: React.FC = () => {
 			`}</style>
 			<div id="remotion-comp-loading-content" style={content}>
 				<svg
-					width={ICON_SIZE}
-					height={ICON_SIZE}
+					width={ICON_SIZE / scale}
+					height={ICON_SIZE / scale}
 					viewBox="-100 -100 400 400"
 					style={rotate}
 				>
@@ -54,7 +57,9 @@ export const Loading: React.FC = () => {
 						d="M 2 172 a 196 100 0 0 0 195 5 A 196 240 0 0 0 100 2.259 A 196 240 0 0 0 2 172 z"
 					/>
 				</svg>
-				<p style={label}>Resolving {'<Suspense>'}...</p>
+				<p style={{...label, fontSize: LABEL_SIZE / scale}}>
+					Resolving {'<Suspense>'}...
+				</p>
 			</div>
 		</AbsoluteFillElement>
 	);

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -1486,6 +1486,9 @@ test('Loading indicator does not register an interactive sequence', () => {
 	);
 
 	expect(getByText('Resolving <Suspense>...')).toBeTruthy();
+	expect(getByText('Resolving <Suspense>...').style.color).toBe(
+		'rgba(255, 255, 255, 0.8)',
+	);
 	const loadingIndicator = container.querySelector<HTMLDivElement>(
 		'#remotion-comp-loading',
 	);
@@ -1497,6 +1500,26 @@ test('Loading indicator does not register an interactive sequence', () => {
 	);
 	expect(loadingContent?.style.animation).toBe('anim 2s');
 	expect(registeredSequences).toHaveLength(0);
+});
+
+test('Loading indicator compensates for the canvas scale', () => {
+	const {container} = render(
+		<SequenceTestWrapper onRegisterSequence={() => undefined}>
+			<Internals.CurrentScaleContext.Provider value={{type: 'scale', scale: 2}}>
+				<Loading />
+			</Internals.CurrentScaleContext.Provider>
+		</SequenceTestWrapper>,
+	);
+
+	const loadingLabel = container.querySelector<HTMLParagraphElement>(
+		'#remotion-comp-loading-content p',
+	);
+	const loadingIcon = container.querySelector<SVGElement>(
+		'#remotion-comp-loading-content svg',
+	);
+	expect(loadingLabel?.style.fontSize).toBe('7px');
+	expect(loadingIcon?.getAttribute('width')).toBe('20');
+	expect(loadingIcon?.getAttribute('height')).toBe('20');
 });
 
 test('Interactive elements inherit trimBefore from Sequence', () => {

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -771,6 +771,19 @@ export const Index: React.FC = () => {
 			</Folder>
 			<Folder name="regression-testing">
 				<Composition
+					id="suspense-loading-indicator-test"
+					lazyComponent={async () => {
+						await new Promise<void>((resolve) => {
+							setTimeout(resolve, 10_000);
+						});
+						return import('./SuspenseLoadingIndicatorTest');
+					}}
+					width={100}
+					height={100}
+					fps={30}
+					durationInFrames={30}
+				/>
+				<Composition
 					id="simple-img"
 					component={SimpleImg}
 					width={1080}

--- a/packages/example/src/SuspenseLoadingIndicatorTest.tsx
+++ b/packages/example/src/SuspenseLoadingIndicatorTest.tsx
@@ -1,0 +1,20 @@
+import {AbsoluteFill} from 'remotion';
+
+const SuspenseLoadingIndicatorTest: React.FC = () => {
+	return (
+		<AbsoluteFill
+			style={{
+				alignItems: 'center',
+				backgroundColor: '#1f2428',
+				color: 'white',
+				fontFamily: 'sans-serif',
+				fontSize: 14,
+				justifyContent: 'center',
+			}}
+		>
+			Loaded
+		</AbsoluteFill>
+	);
+};
+
+export default SuspenseLoadingIndicatorTest;


### PR DESCRIPTION
## Summary

- counter-scale the Suspense loading label and icon with the current canvas scale
- match the loading label color to the Studio play button
- add regression coverage and a delayed 100x100 testbed composition

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/sequence-register-once.test.tsx` in `packages/core`
- `bunx turbo run lint test --filter='@remotion/studio'`
- verified the label and play icon both compute to `rgba(255, 255, 255, 0.8)` in Studio
