### PR TITLE
Elements: Reorder background elements

### DIFF
--- a/packages/docs/src/components/Elements/element-library-data.ts
+++ b/packages/docs/src/components/Elements/element-library-data.ts
@@ -30,6 +30,13 @@ const elementCategories = Array.from(
 	new Set(Object.values(elementDefinitions).map(({category}) => category)),
 ).sort(compareStrings) as ElementCategory[];
 
+const backgroundOrder: Record<string, number> = {
+	'backgrounds/notebook-paper': 0,
+	'backgrounds/paper-texture': 1,
+	'backgrounds/rotating-starburst': 2,
+	'backgrounds/liquid-contours': 3,
+};
+
 export const getElementCategoryLabel = (category: ElementCategory) => {
 	if (category === 'youtube') {
 		return 'YouTube';
@@ -57,7 +64,18 @@ export const getElementLibrarySections = (
 		category: currentCategory,
 		definitions: definitions
 			.filter((definition) => definition.category === currentCategory)
-			.sort((a, b) => compareStrings(a.displayName, b.displayName)),
+			.sort((a, b) => {
+				if (currentCategory === 'backgrounds') {
+					const orderDifference =
+						(backgroundOrder[a.slug] ?? Number.MAX_SAFE_INTEGER) -
+						(backgroundOrder[b.slug] ?? Number.MAX_SAFE_INTEGER);
+					if (orderDifference !== 0) {
+						return orderDifference;
+					}
+				}
+
+				return compareStrings(a.displayName, b.displayName);
+			}),
 		label: getElementCategoryLabel(currentCategory),
 	}));
 };

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -352,6 +352,20 @@ describe('Element library', () => {
 				`<ElementLibrary category="${section.category}" />`,
 			);
 
+			if (section.category === 'backgrounds') {
+				const backgroundNames = [
+					'Notebook Paper',
+					'Paper Texture',
+					'Rotating Starburst',
+					'Liquid Contours',
+				];
+				for (let index = 1; index < backgroundNames.length; index++) {
+					expect(
+						categoryMarkup.indexOf(backgroundNames[index - 1]),
+					).toBeLessThan(categoryMarkup.indexOf(backgroundNames[index]));
+				}
+			}
+
 			for (const definition of elementDefinitionList) {
 				if (definition.category === section.category) {
 					expect(categoryMarkup).toContain(definition.displayName);


### PR DESCRIPTION
## Summary

- prioritize neutral background Elements in the library
- move the more colorful background treatments to the end
- cover the rendered card order with a regression test

## Verification

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`
