### PR TITLE
`@remotion/studio`: Unify inspector row styling

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -19,10 +19,7 @@ import {ExpandedFolderIcon} from '../icons/folder';
 import {RemotionConvertIcon} from '../icons/remotion-convert';
 import {TrashIcon} from '../icons/trash';
 import {InlineEditableTitle} from './InlineEditableTitle';
-import {
-	InspectorInfoHeader,
-	InspectorInfoSubtitle,
-} from './InspectorInfoHeader';
+import {InspectorInfoHeader} from './InspectorInfoHeader';
 import {
 	InspectorDetailRow,
 	InspectorQuickActionsSection,
@@ -30,7 +27,7 @@ import {
 	InspectorSection,
 } from './InspectorPanel/common';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from './InspectorPanelLayout';
-import {COMPACT_INLINE_ROW_HEIGHT} from './layout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from './layout';
 import {
 	getStaticFileRenameSelection,
 	useRenameStaticFile,
@@ -40,7 +37,7 @@ import {openInFileExplorer} from './RenderQueue/actions';
 import {useDeleteAsset} from './use-delete-asset';
 import {useStaticFiles} from './use-static-files';
 
-export const CURRENT_ASSET_HEIGHT = COMPACT_INLINE_ROW_HEIGHT + 8;
+export const CURRENT_ASSET_HEIGHT = COMPACT_CONTROL_ROW_HEIGHT;
 
 const quickActionIconStyle: React.CSSProperties = {
 	display: 'block',
@@ -247,6 +244,13 @@ export const AssetInfo: React.FC<{
 
 	const fileName = assetName.split('/').pop() ?? assetName;
 	const fileDetails: CurrentAssetDetail[] = [];
+	if (imageMetadata !== null) {
+		fileDetails.push({
+			label: 'Dimensions',
+			value: `${imageMetadata.width} × ${imageMetadata.height}`,
+		});
+	}
+
 	const container = mediaMetadata?.format ?? imageMetadata?.format ?? null;
 	if (container !== null) {
 		fileDetails.push({label: 'Container', value: container});
@@ -291,11 +295,6 @@ export const AssetInfo: React.FC<{
 					size={contentSized ? 'default' : 'inspector'}
 					title={assetName}
 				/>
-				{imageMetadata ? (
-					<InspectorInfoSubtitle size={contentSized ? 'default' : 'inspector'}>
-						{imageMetadata.width} × {imageMetadata.height}
-					</InspectorInfoSubtitle>
-				) : null}
 			</InspectorInfoHeader>
 			{fileDetails.length > 0 ? (
 				<InspectorSection header="File">

--- a/packages/studio/src/components/InlineEditableTitle.tsx
+++ b/packages/studio/src/components/InlineEditableTitle.tsx
@@ -12,7 +12,7 @@ import {
 	getBackgroundFromHoverState,
 } from '../helpers/colors';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from './InspectorPanelLayout';
-import {COMPACT_INLINE_ROW_HEIGHT} from './layout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from './layout';
 
 const titleWrapper: React.CSSProperties = {
 	boxSizing: 'border-box',
@@ -71,7 +71,7 @@ const inspectorTitleWrapper: React.CSSProperties = {
 	...titleWrapper,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
-	height: COMPACT_INLINE_ROW_HEIGHT,
+	height: COMPACT_CONTROL_ROW_HEIGHT,
 	margin: '0 4px',
 	width: 'calc(100% - 8px)',
 };
@@ -81,7 +81,7 @@ const inspectorTitleInner: React.CSSProperties = {
 	alignItems: 'center',
 	fontFamily: 'sans-serif',
 	fontSize: 13,
-	height: COMPACT_INLINE_ROW_HEIGHT,
+	height: COMPACT_CONTROL_ROW_HEIGHT,
 	paddingBottom: 0,
 	paddingLeft: INSPECTOR_PANEL_HORIZONTAL_PADDING - 4,
 	paddingRight: INSPECTOR_PANEL_HORIZONTAL_PADDING - 4,

--- a/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
@@ -21,12 +21,12 @@ import {InlineCompositionName} from '../InlineCompositionName';
 import {InspectorInfoHeader} from '../InspectorInfoHeader';
 import {InspectorLocationCopy} from '../InspectorLocationCopy';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
-import {COMPACT_INLINE_ROW_HEIGHT} from '../layout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from '../layout';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
 import {useEditorOpening} from '../use-default-editor-info';
 
-const COMPOSITION_INSPECTOR_HEADER_HEIGHT = 66;
+const COMPOSITION_INSPECTOR_HEADER_HEIGHT = COMPACT_CONTROL_ROW_HEIGHT * 3;
 
 const sourceLocationIconStyle: CSSProperties = {
 	flexShrink: 0,
@@ -36,7 +36,7 @@ const sourceLocationIconStyle: CSSProperties = {
 
 const componentLocationPlaceholder: CSSProperties = {
 	flexShrink: 0,
-	height: COMPACT_INLINE_ROW_HEIGHT,
+	height: COMPACT_CONTROL_ROW_HEIGHT,
 };
 
 const renderReactIcon = (color: string) => {

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -158,7 +158,7 @@ const PresetDropdown: React.FC<{
 	const renderAction = useCallback((color: string) => {
 		return (
 			<span style={presetButtonIcon}>
-				<CaretDown color={color} small />
+				<CaretDown color={color} />
 			</span>
 		);
 	}, []);

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -52,26 +52,34 @@ const computedValueStyle: React.CSSProperties = {
 	lineHeight: '20px',
 };
 
+const metadataFormatterStyle: React.CSSProperties = {
+	fontSize: 13,
+};
+
 const metadataDraggerStyles: Record<
 	CompositionMetadataField,
 	React.CSSProperties
 > = {
 	durationInFrames: {
+		fontSize: 13,
 		padding: '2px 0 2px 6px',
 		textAlign: 'right',
-		width: 92,
+		width: 104,
 	},
 	fps: {
+		fontSize: 13,
 		padding: '2px 0 2px 6px',
 		textAlign: 'right',
 		width: 72,
 	},
 	height: {
+		fontSize: 13,
 		padding: '2px 0 2px 6px',
 		textAlign: 'right',
 		width: 52,
 	},
 	width: {
+		fontSize: 13,
 		padding: '2px 0 2px 6px',
 		textAlign: 'right',
 		width: 52,
@@ -213,12 +221,10 @@ const CompositionMetadataValue: React.FC<{
 		[field],
 	);
 
-	return computed ? (
+	return computed || disabled ? (
 		<span style={computedContainerStyle}>
 			<span style={computedValueStyle}>{formatValue(value)}</span>
 		</span>
-	) : disabled ? (
-		formatValue(value)
 	) : (
 		<InputDragger
 			aria-label={fieldLabels[field]}
@@ -234,6 +240,7 @@ const CompositionMetadataValue: React.FC<{
 			step={isFps ? 0.01 : 1}
 			dragDecimalPlaces={isFps ? 2 : 0}
 			formatter={formatValue}
+			formatterStyle={metadataFormatterStyle}
 			rightAlign
 			style={metadataDraggerStyles[field]}
 		/>
@@ -492,7 +499,6 @@ export const CompositionMetadata: React.FC<{
 						pendingValue={pendingValues.width ?? null}
 						value={video.width}
 					/>
-					{disabled ? '\u00A0' : null}
 					<CompositionMetadataValue
 						computed={heightIsComputed}
 						disabled={disabled}

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useContext, useMemo} from 'react';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {CURRENT_COLOR} from '../../helpers/colors';
 import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
 import {ReactIcon} from '../../icons/react';
 import {InlineEditableTitle} from '../InlineEditableTitle';
@@ -8,7 +9,7 @@ import {InspectorInfoHeader} from '../InspectorInfoHeader';
 import {InspectorLocationCopy} from '../InspectorLocationCopy';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
 import {InspectorSourceLocation} from '../InspectorSourceLocation';
-import {COMPACT_INLINE_ROW_HEIGHT} from '../layout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from '../layout';
 import {useOpenSequenceInApps} from '../Timeline/use-open-sequence-in-apps';
 import {useRenameSequence} from '../Timeline/use-rename-sequence';
 import {
@@ -37,7 +38,7 @@ const sequenceInspectorSubtitle: React.CSSProperties = {
 	alignItems: 'center',
 	boxSizing: 'border-box',
 	fontSize: 13,
-	height: COMPACT_INLINE_ROW_HEIGHT,
+	height: COMPACT_CONTROL_ROW_HEIGHT,
 	lineHeight: '18px',
 	margin: '0 4px',
 	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING - 4}px`,
@@ -46,6 +47,14 @@ const sequenceInspectorSubtitle: React.CSSProperties = {
 
 const defaultCursor: React.CSSProperties = {
 	cursor: 'default',
+};
+
+const externalTabIndicatorStyle: React.CSSProperties = {
+	display: 'inline-block',
+	height: 12,
+	marginLeft: 4,
+	verticalAlign: -2,
+	width: 12,
 };
 
 type SequenceInspectorSourceLocation = {
@@ -149,11 +158,24 @@ export const SequenceInspectorHeader: React.FC<{
 					<InspectorQuickAction
 						disabled={false}
 						style={defaultCursor}
-						size="compact"
 						title="Open component docs"
 						onClick={openDocumentationLink}
 					>
 						{componentName}
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 16 16"
+							style={externalTabIndicatorStyle}
+						>
+							<path
+								d="M4 12 12 4M6 4h6v6"
+								fill="none"
+								stroke={CURRENT_COLOR}
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth="1.5"
+							/>
+						</svg>
 					</InspectorQuickAction>
 				) : (
 					<div style={subtitleStyle}>{componentName}</div>

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -7,6 +7,7 @@ import {
 	WHITE,
 } from '../../helpers/colors';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from '../layout';
 
 export const container: React.CSSProperties = {
 	backgroundColor: BACKGROUND,
@@ -190,6 +191,7 @@ export const detailRow: React.CSSProperties = {
 	display: 'flex',
 	gap: 12,
 	justifyContent: 'space-between',
+	minHeight: COMPACT_CONTROL_ROW_HEIGHT,
 };
 
 export const detailLabel: React.CSSProperties = {

--- a/packages/studio/src/components/InspectorSourceLocation.tsx
+++ b/packages/studio/src/components/InspectorSourceLocation.tsx
@@ -104,7 +104,6 @@ export const InspectorSourceLocation: React.FC<{
 				disabled={!canOpen}
 				onClick={onClick}
 				renderIcon={(iconColor) => renderIcon?.(iconColor)}
-				size="compact"
 				title={fileLocation ?? undefined}
 			>
 				{label}


### PR DESCRIPTION
## Summary

- align composition, sequence, and asset inspector rows to the 28px quick-action height
- make read-only composition metadata match computed values and reduce interactive number sizing
- widen the duration control, move image dimensions into file details, and mark linked component names as external links

## Testing

- `bun run build`
- `bun run stylecheck`
- visually verified composition, sequence, and asset inspector states in Remotion Studio

Closes #10735
