### PR TITLE
`@remotion/media`: Apply initial preview volume before playback

### DIFF
--- a/packages/media/src/audio-iterator-manager.ts
+++ b/packages/media/src/audio-iterator-manager.ts
@@ -77,6 +77,7 @@ export const audioIteratorManager = ({
 	getMediaEndTimestamp,
 	getStartTime,
 	initialMuted,
+	initialVolume,
 	drawDebugOverlay,
 }: {
 	audioTrack: InputAudioTrack;
@@ -87,10 +88,11 @@ export const audioIteratorManager = ({
 	getMediaEndTimestamp: () => number;
 	getStartTime: () => number;
 	initialMuted: boolean;
+	initialVolume: number;
 	drawDebugOverlay: () => void;
 }) => {
 	let muted = initialMuted;
-	let currentVolume = 1;
+	let currentVolume = Math.max(0, initialVolume);
 	let currentSeek: {
 		time: number;
 		playbackRate: number;
@@ -103,6 +105,7 @@ export const audioIteratorManager = ({
 	} | null = null;
 
 	const gainNode = sharedAudioContext.audioContext.createGain();
+	gainNode.gain.value = muted ? 0 : currentVolume;
 	gainNode.connect(sharedAudioContext.gainNode);
 
 	const audioSink = new AudioBufferSink(audioTrack);

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -142,6 +142,7 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
 	const initialMuted = useRef(effectiveMuted);
+	const initialVolume = useRef(userPreferredVolume);
 	const initialDurationInFrames = useRef(videoConfig.durationInFrames);
 	const initialSequenceOffset = useRef(sequenceOffset);
 
@@ -222,7 +223,11 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 			mediaPlayerRef.current = player;
 
 			player
-				.initialize(currentTimeRef.current, initialMuted.current)
+				.initialize(
+					currentTimeRef.current,
+					initialMuted.current,
+					initialVolume.current,
+				)
 				.then((result) => {
 					if (result.type === 'disposed') {
 						return;

--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -211,8 +211,13 @@ export class MediaPlayer {
 	public initialize(
 		startTimeUnresolved: number,
 		initialMuted: boolean,
+		initialVolume: number,
 	): Promise<MediaPlayerInitResult> {
-		const promise = this._initialize(startTimeUnresolved, initialMuted);
+		const promise = this._initialize(
+			startTimeUnresolved,
+			initialMuted,
+			initialVolume,
+		);
 		this.initializationPromise = promise;
 		this.seekPromiseChain = promise;
 		return promise;
@@ -255,6 +260,7 @@ export class MediaPlayer {
 	private async _initialize(
 		startTimeUnresolved: number,
 		initialMuted: boolean,
+		initialVolume: number,
 	): Promise<MediaPlayerInitResult> {
 		using _ = this.delayPlaybackHandleIfNotPremounting();
 		try {
@@ -391,6 +397,7 @@ export class MediaPlayer {
 					getSequenceEndTimestamp: () => this.getSequenceEndTimestamp(),
 					getStartTime: () => this.getStartTime(),
 					initialMuted,
+					initialVolume,
 					drawDebugOverlay: this.drawDebugOverlay,
 					getSequenceDurationInSeconds: () =>
 						this.getSequenceDurationInSeconds(),

--- a/packages/media/src/test/audio-iterator.test.ts
+++ b/packages/media/src/test/audio-iterator.test.ts
@@ -76,6 +76,7 @@ const prepare = async (options?: {
 		getSequenceDurationInSeconds: () => sequenceDurationInSeconds,
 		getStartTime: () => startTime,
 		initialMuted: false,
+		initialVolume: 1,
 		drawDebugOverlay: () => {},
 	});
 

--- a/packages/media/src/test/media-player.test.ts
+++ b/packages/media/src/test/media-player.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {MediaPlayer} from '../media-player';
 import type {SharedAudioContextForMediaPlayer} from '../shared-audio-context-for-media-player';
 
@@ -33,12 +33,14 @@ const makeSharedAudioContext = (): SharedAudioContextForMediaPlayer => {
 	};
 };
 
-test('audio-only file should initialize without `audioStreamIndex` (regression for #7210)', async () => {
-	const player = new MediaPlayer({
+const makeAudioPlayer = (
+	sharedAudioContext: SharedAudioContextForMediaPlayer,
+) => {
+	return new MediaPlayer({
 		canvas: null,
 		src: '/voice-note.m4a',
 		logLevel: 'error',
-		sharedAudioContext: makeSharedAudioContext(),
+		sharedAudioContext,
 		loop: false,
 		trimBefore: undefined,
 		trimAfter: undefined,
@@ -60,12 +62,48 @@ test('audio-only file should initialize without `audioStreamIndex` (regression f
 		getEffects: () => [],
 		getEffectChainState: () => null,
 	});
+};
 
-	const result = await player.initialize(0, false);
+test('audio-only file should initialize without `audioStreamIndex` (regression for #7210)', async () => {
+	const player = makeAudioPlayer(makeSharedAudioContext());
+
+	const result = await player.initialize(0, false, 1);
 
 	expect(result.type).toBe('success');
 
 	await player.dispose();
+});
+
+test('uses the initial volume before audio playback is ready', async () => {
+	const sharedAudioContext = makeSharedAudioContext();
+	const mediaGainNodes: GainNode[] = [];
+	const createGain = sharedAudioContext.audioContext.createGain.bind(
+		sharedAudioContext.audioContext,
+	);
+	const createGainSpy = vi
+		.spyOn(sharedAudioContext.audioContext, 'createGain')
+		.mockImplementation(() => {
+			const gainNode = createGain();
+			mediaGainNodes.push(gainNode);
+			return gainNode;
+		});
+	const player = makeAudioPlayer(sharedAudioContext);
+
+	try {
+		const result = await player.initialize(0, false, 0.25);
+
+		expect(result.type).toBe('success');
+		expect(mediaGainNodes).toHaveLength(1);
+		expect(mediaGainNodes[0].gain.value).toBe(0.25);
+
+		player.setMuted(true);
+		expect(mediaGainNodes[0].gain.value).toBe(0);
+		player.setMuted(false);
+		expect(mediaGainNodes[0].gain.value).toBe(0.25);
+	} finally {
+		createGainSpy.mockRestore();
+		await player.dispose();
+	}
 });
 
 test('dispose should immediately unblock playback delays', async () => {
@@ -127,7 +165,7 @@ test('dispose should immediately unblock playback delays', async () => {
 		getEffectChainState: () => null,
 	});
 
-	await player.initialize(0, false);
+	await player.initialize(0, false, 1);
 
 	const seekDelayPromise = new Promise<void>((resolve) => {
 		delayPlaybackCalled = resolve;

--- a/packages/media/src/test/trim-change-seek.test.ts
+++ b/packages/media/src/test/trim-change-seek.test.ts
@@ -29,7 +29,7 @@ test('setTrimBefore and setTrimAfter should update frame when paused', async () 
 		getEffectChainState: () => null,
 	});
 
-	await player.initialize(0, false);
+	await player.initialize(0, false, 1);
 
 	const initialFrames = player.videoIteratorManager!.getFramesRendered();
 	await player.setTrimBefore(30, 0);

--- a/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
+++ b/packages/media/src/test/video-with-no-frames-in-beginning.test.ts
@@ -125,6 +125,7 @@ test('same goes for audio', async () => {
 		getSequenceDurationInSeconds: () => 10,
 		getStartTime: () => 0,
 		initialMuted: false,
+		initialVolume: 1,
 		drawDebugOverlay: () => {},
 	});
 

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -205,6 +205,7 @@ const VideoForPreviewAssertedShowing: React.FC<
 	const initialGlobalPlaybackRate = useRef(globalPlaybackRate);
 	const initialPlaybackRate = useRef(playbackRate);
 	const initialMuted = useRef(effectiveMuted);
+	const initialVolume = useRef(userPreferredVolume);
 	const initialSequenceDuration = useRef(videoConfig.durationInFrames);
 	const initialSequenceOffset = useRef(sequenceOffset);
 	const hasDrawnRealFrameRef = useRef(false);
@@ -301,7 +302,11 @@ const VideoForPreviewAssertedShowing: React.FC<
 
 			mediaPlayerRef.current = player;
 			player
-				.initialize(currentTimeRef.current, initialMuted.current)
+				.initialize(
+					currentTimeRef.current,
+					initialMuted.current,
+					initialVolume.current,
+				)
 				.then((result) => {
 					if (result.type === 'disposed') {
 						return;


### PR DESCRIPTION
## Summary

- pass the evaluated initial volume from `<Audio>` and `<Video>` previews into `MediaPlayer`
- initialize the per-media Web Audio gain before connecting or scheduling audio
- add browser integration coverage for initial gain and mute transitions

## Test plan

- `bunx vitest src/test/media-player.test.ts --browser --run`
- `bunx turbo run lint test --filter='@remotion/media'`
- `bun run build`
- `bun run stylecheck`
- red/green regression verification: test fails with gain `1` when the initialization assignment is removed and passes with the fix restored

Closes #10756
