### PR TITLE
Docs: Fix transparent light background in iframes

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -112,6 +112,7 @@ h6 {
 
 [data-theme='light'] {
 	--background: #fff;
+	--ifm-background-color: #fff;
 	--footer-background: #fcfcfc;
 	--footer-border: #eaeaea;
 	--text-color: #000;


### PR DESCRIPTION
## Summary

- set Infima's light document background to white so the Remotion website stays readable inside a credentialless Studio iframe
- keep the document canvas independent of `--background`, which homepage styles override to the blue-ish `#f8fafc`
- leave dark mode and the Studio and Element iframe implementations unchanged

The previous implementation in #10700 tied the document canvas to `--background`, changing standalone page colors, and was reverted in #10757. This replacement fixes the iframe bleed-through while preserving the existing standalone appearance.

Related to #10688 and #10696.

## Verification

- `bunx oxfmt packages/docs/src/css/custom.css --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun run formatting`
- `cd packages/docs && bun run lint`
- `cd packages/docs && bun run test`
- `REMOTION_DOCS_LOW_MEMORY_BUILD=1 bunx turbo run build-docs --filter=docs --no-update-notifier`
- pixel-compared the homepage, `/docs`, and `/elements` at 1440×900 before and after the change: 0 changed pixels
- verified `/elements` in a credentialless iframe over a dark host: transparent before, opaque white after
- verified dark mode keeps Infima's existing `#1b1b1d` document background
