### PR TITLE
`@remotion/studio`: Fix checkerboard bleeding at canvas edges

### DIFF
--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -66,6 +66,9 @@ const containerStyle = (options: {
 }): React.CSSProperties => {
 	return {
 		transform: `scale(${options.scale})`,
+		// Avoid the background bleeding through opaque compositions at fractional
+		// scales due to Chromium compositing the child and background together.
+		willChange: 'transform',
 		marginLeft: options.xCorrection,
 		marginTop: options.yCorrection,
 		width: options.width,


### PR DESCRIPTION
## Summary

- promote the scaled Studio composition canvas to its own compositor layer
- prevent the checkerboard background from bleeding through opaque composition edges at fractional scales
- preserve the existing canvas geometry and coordinate system

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make lint test --filter=@remotion/studio`
- reproduced the artifact with a high-contrast opaque composition and verified zero leaked edge pixels across multiple Chromium viewport sizes and device pixel ratios
