### PR TITLE
`@remotion/studio`: Align canvas rulers with timeline ticks

### DIFF
--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -7,7 +7,7 @@ import React, {
 	useRef,
 } from 'react';
 import {Internals} from 'remotion';
-import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
+import {BACKGROUND, SHADOW_BLACK} from '../../helpers/colors';
 import {getRulerGuideHighlight} from '../../helpers/editor-guide-selection';
 import {drawMarkingOnRulerCanvas} from '../../helpers/editor-ruler';
 import {getRulerCanvasSize} from '../../helpers/ruler-canvas-size';
@@ -119,8 +119,7 @@ const Ruler: React.FC<RulerProps> = ({
 			height: rulerHeight,
 			left: isVerticalRuler ? 0 : 'unset',
 			top: isVerticalRuler ? 'unset' : 0,
-			borderBottom: isVerticalRuler ? undefined : '1px solid ' + RULER_COLOR,
-			borderRight: isVerticalRuler ? '1px solid ' + RULER_COLOR : undefined,
+			boxShadow: SHADOW_BLACK,
 			cursor,
 		}),
 		[rulerWidth, rulerHeight, cursor, isVerticalRuler],

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -6,7 +6,7 @@ import React, {
 	useMemo,
 	useRef,
 } from 'react';
-import {BACKGROUND, RULER_COLOR} from '../../helpers/colors';
+import {BACKGROUND, WHITE_ALPHA_15} from '../../helpers/colors';
 import {getRulerPoints, getRulerScaleRange} from '../../helpers/editor-ruler';
 import type {AssetMetadata} from '../../helpers/get-asset-metadata';
 import type {Dimensions} from '../../helpers/is-current-selected-still';
@@ -33,8 +33,7 @@ const originBlockStyles: React.CSSProperties = {
 	position: 'absolute',
 	top: 0,
 	left: 0,
-	borderBottom: '1px solid ' + RULER_COLOR,
-	borderRight: '1px solid ' + RULER_COLOR,
+	boxShadow: `inset -1px -1px 0 ${WHITE_ALPHA_15}`,
 	width: `${RULER_WIDTH}px`,
 	height: `${RULER_WIDTH}px`,
 	background: BACKGROUND,
@@ -272,7 +271,6 @@ export const EditorRulers: React.FC<{
 
 	return (
 		<>
-			<div style={originBlockStyles} />
 			<Ruler
 				orientation="horizontal"
 				scale={scale}
@@ -293,6 +291,7 @@ export const EditorRulers: React.FC<{
 				size={canvasSize}
 				onPointerSessionStart={onPointerSessionStart}
 			/>
+			<div style={originBlockStyles} />
 		</>
 	);
 };

--- a/packages/studio/src/helpers/editor-ruler.ts
+++ b/packages/studio/src/helpers/editor-ruler.ts
@@ -1,6 +1,11 @@
 import type {Size} from '@remotion/player';
 import {MINIMUM_VISIBLE_CANVAS_SIZE} from '../state/editor-rulers';
-import {BACKGROUND, BACKGROUND__TRANSPARENT, RULER_COLOR} from './colors';
+import {
+	BACKGROUND,
+	BACKGROUND__TRANSPARENT,
+	LIGHT_TEXT,
+	WHITE_ALPHA_15,
+} from './colors';
 import type {RulerGuideHighlight} from './editor-guide-selection';
 
 type Orientation = 'horizontal' | 'vertical';
@@ -85,7 +90,8 @@ const drawGuide = ({
 			scale,
 		}) +
 		originOffset -
-		startMarking * scale;
+		startMarking * scale +
+		0.5;
 	drawGradient({
 		canvasHeight,
 		context,
@@ -165,11 +171,11 @@ export const drawMarkingOnRulerCanvas = ({
 
 	context.clearRect(0, 0, canvasWidth, canvasHeight);
 
-	context.strokeStyle = RULER_COLOR;
+	context.strokeStyle = WHITE_ALPHA_15;
 	context.lineWidth = 1;
 	context.beginPath();
 	points.forEach((point) => {
-		context.strokeStyle = RULER_COLOR;
+		context.strokeStyle = WHITE_ALPHA_15;
 		context.lineWidth = 1;
 		const originDistance = point.position + originOffset - startMarking * scale;
 		context.beginPath();
@@ -196,14 +202,14 @@ export const drawMarkingOnRulerCanvas = ({
 		context.stroke();
 		context.font = '10px Arial, Helvetica, sans-serif';
 		context.textAlign = 'left';
-		context.fillStyle = RULER_COLOR;
+		context.fillStyle = LIGHT_TEXT;
 
 		drawLabel({
 			orientation,
 			context,
 			label: point.value.toString(),
 			originDistance,
-			color: RULER_COLOR,
+			color: LIGHT_TEXT,
 		});
 	});
 


### PR DESCRIPTION
## Summary

- align canvas ruler tick and label colors with the timeline
- replace hard ruler borders with subtle shadows and keep the corner treatment clean
- align highlighted canvas guide strokes with their CSS guide lines

## Verification

- `bunx oxfmt packages/studio/src/components/EditorRuler/Ruler.tsx packages/studio/src/components/EditorRuler/index.tsx packages/studio/src/helpers/editor-ruler.ts --write`
- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/canvas-rulers.test.ts packages/studio/src/test/editor-guides.test.ts`
- visually verified in the example Studio
