### PR TITLE
Docs: Correct Windows NVENC prerequisites

### DIFF
--- a/packages/docs/docs/hardware-acceleration.mdx
+++ b/packages/docs/docs/hardware-acceleration.mdx
@@ -88,12 +88,13 @@ To use hardware-accelerated encoding on Linux and Windows, you need:
 - NVIDIA drivers installed (version 525+ recommended)
 - FFmpeg compiled with `h264_nvenc` or `hevc_nvenc` encoder support
 
-The FFmpeg binaries bundled with Remotion include NVENC support on Linux x64 only. NVENC on Linux ARM64 is not supported. On Windows, point Remotion to an FFmpeg build that includes NVENC using [`--binaries-directory`](/docs/cli/render#--binaries-directory) or [`binariesDirectory`](/docs/renderer/render-media#binariesdirectory).
+The FFmpeg binaries bundled with Remotion include the `h264_nvenc` and `hevc_nvenc` encoders on Linux x64 and Windows x64. The bundled Linux ARM64 binaries do not include NVENC support.
+
+The presence of these encoders in FFmpeg does not guarantee hardware acceleration. A compatible NVIDIA GPU and driver are still required.
 
 Set `--hardware-acceleration if-possible` and Remotion will use NVENC if the configured FFmpeg build supports it.
 
 Note that NVENC encoding is only available for H.264 and H.265 codecs. Other codecs will fall back to software encoding.
-
 
 ## Controlling quality using `--video-bitrate`
 


### PR DESCRIPTION
## Summary

- document bundled NVENC encoder availability on Linux x64 and Windows x64
- clarify that the bundled Linux ARM64 binaries do not include NVENC
- distinguish FFmpeg encoder availability from the NVIDIA GPU and driver requirements

## Validation

- `bunx oxfmt packages/docs/docs/hardware-acceleration.mdx --write`
- `bun run build`
- `bun run stylecheck`
- `bun run build-docs` *(fails in the unrelated `@remotion/promo-pages` output because `./components/team` and `./index.css` cannot be resolved)*

Closes #10768

## Preview

- [Hardware accelerated encoding](https://remotion-git-codex-correct-windows-nvenc-docs-remotion.vercel.app/docs/hardware-acceleration)
