### PR TITLE
`@remotion/renderer`: Preserve hardware acceleration fallback warning

### DIFF
--- a/packages/renderer/src/ffmpeg-args.ts
+++ b/packages/renderer/src/ffmpeg-args.ts
@@ -106,6 +106,7 @@ export const generateFfmpegArgs = ({
 		hardwareAcceleration,
 		indent,
 		logLevel,
+		onLog: null,
 	});
 
 	if (encoderSettings === null) {

--- a/packages/renderer/src/get-codec-name.ts
+++ b/packages/renderer/src/get-codec-name.ts
@@ -1,3 +1,4 @@
+import type {OnLog} from './browser/BrowserPage';
 import type {Codec} from './codec';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
@@ -40,6 +41,7 @@ export const getCodecName = ({
 	hardwareAcceleration,
 	logLevel,
 	indent,
+	onLog,
 }: {
 	codec: Codec;
 	hardwareAcceleration: HardwareAccelerationOption;
@@ -48,6 +50,7 @@ export const getCodecName = ({
 	crf: unknown;
 	logLevel: LogLevel;
 	indent: boolean;
+	onLog: OnLog | null;
 }): CodecSettings | null => {
 	const preferredHwAcceleration =
 		hardwareAcceleration === 'required' ||
@@ -68,10 +71,17 @@ export const getCodecName = ({
 
 	const warnAboutDisabledHardwareAcceleration = () => {
 		if (hardwareAcceleration === 'if-possible' && unsupportedQualityOption) {
-			Log.warn(
-				{indent, logLevel},
-				`${indent ? '' : '\n'}Hardware accelerated encoding disabled - "${unsupportedQualityOption}" option is not supported with hardware acceleration`,
-			);
+			const message = `Hardware accelerated encoding disabled - "${unsupportedQualityOption}" option is not supported with hardware acceleration`;
+			if (onLog !== null) {
+				onLog({
+					logLevel: 'warn',
+					previewString: message,
+					tag: '',
+				});
+				return;
+			}
+
+			Log.warn({indent, logLevel}, `${indent ? '' : '\n'}${message}`);
 		}
 	};
 

--- a/packages/renderer/src/prespawn-ffmpeg.ts
+++ b/packages/renderer/src/prespawn-ffmpeg.ts
@@ -1,4 +1,5 @@
 import type {_InternalTypes} from 'remotion';
+import type {OnLog} from './browser/BrowserPage';
 import {callFf} from './call-ffmpeg';
 import type {HardwareAccelerationOption} from './client';
 import type {Codec} from './codec';
@@ -60,6 +61,7 @@ type PreStitcherOptions = {
 	colorSpace: ColorSpace | null;
 	binariesDirectory: string | null;
 	hardwareAcceleration: HardwareAccelerationOption;
+	onLog: OnLog;
 };
 
 export const prespawnFfmpeg = (options: PreStitcherOptions) => {
@@ -99,6 +101,7 @@ export const prespawnFfmpeg = (options: PreStitcherOptions) => {
 		crf: options.crf,
 		encodingMaxRate: options.encodingMaxRate,
 		encodingBufferSize: options.encodingBufferSize,
+		onLog: options.onLog,
 	});
 
 	const ffmpegArgs = [

--- a/packages/renderer/src/probe-encoder.ts
+++ b/packages/renderer/src/probe-encoder.ts
@@ -1,10 +1,14 @@
 import {execFileSync} from 'node:child_process';
 import path from 'path';
+import type {OnLog} from './browser/BrowserPage';
 import type {Codec} from './codec';
 import {getExecutablePath} from './compositor/get-executable-path';
 import {getExplicitEnv} from './compositor/get-explicit-env';
 import {makeFileExecutableIfItIsNot} from './compositor/make-file-executable';
-import {getCodecName} from './get-codec-name';
+import {
+	getCodecName,
+	hasSpecifiedUnsupportedHardwareQualifySettings,
+} from './get-codec-name';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {HardwareAccelerationOption} from './options/hardware-acceleration';
@@ -78,6 +82,7 @@ export const resolveHardwareAcceleration = ({
 	crf,
 	encodingMaxRate,
 	encodingBufferSize,
+	onLog,
 }: {
 	codec: Codec;
 	hardwareAcceleration: HardwareAccelerationOption;
@@ -87,6 +92,7 @@ export const resolveHardwareAcceleration = ({
 	crf: unknown;
 	encodingMaxRate: string | null;
 	encodingBufferSize: string | null;
+	onLog: OnLog | null;
 }): HardwareAccelerationOption => {
 	if (hardwareAcceleration === 'disable') {
 		return 'disable';
@@ -100,6 +106,7 @@ export const resolveHardwareAcceleration = ({
 		encodingBufferSize,
 		logLevel,
 		indent,
+		onLog,
 	});
 
 	// Audio codecs return null, no probing needed
@@ -109,6 +116,17 @@ export const resolveHardwareAcceleration = ({
 
 	// Only probe if getCodecName selected a hardware-accelerated encoder
 	if (!preferred.hardwareAccelerated) {
+		if (
+			hardwareAcceleration === 'if-possible' &&
+			hasSpecifiedUnsupportedHardwareQualifySettings({
+				crf,
+				encodingMaxRate,
+				encodingBufferSize,
+			})
+		) {
+			return 'disable';
+		}
+
 		return hardwareAcceleration;
 	}
 

--- a/packages/renderer/src/render-media.ts
+++ b/packages/renderer/src/render-media.ts
@@ -567,6 +567,7 @@ const internalRenderMediaRaw = ({
 				colorSpace,
 				binariesDirectory,
 				hardwareAcceleration,
+				onLog,
 			});
 			stitcherFfmpeg = preStitcher.task;
 		}
@@ -837,6 +838,7 @@ const internalRenderMediaRaw = ({
 					separateAudioTo,
 					metadata,
 					hardwareAcceleration,
+					onLog,
 					sampleRate,
 				});
 			})

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -4,6 +4,7 @@ import type {_InternalTypes} from 'remotion';
 import type {RenderMediaOnDownload} from './assets/download-and-map-assets-to-file';
 import type {RenderAssetInfo} from './assets/download-map';
 import {cleanDownloadMap} from './assets/download-map';
+import type {OnLog} from './browser/BrowserPage';
 import {callFfNative} from './call-ffmpeg';
 import type {Codec} from './codec';
 import {DEFAULT_CODEC} from './codec';
@@ -11,6 +12,7 @@ import {codecSupportsMedia} from './codec-supports-media';
 import {convertNumberOfGifLoopsToFfmpegSyntax} from './convert-number-of-gif-loops-to-ffmpeg';
 import {createAudio} from './create-audio';
 import {validateQualitySettings} from './crf';
+import {defaultOnLog} from './default-on-log';
 import {deleteDirectory} from './delete-directory';
 import {generateFfmpegArgs} from './ffmpeg-args';
 import type {FfmpegOverrideFn} from './ffmpeg-override';
@@ -76,6 +78,7 @@ type InternalStitchFramesToVideoOptions = {
 	binariesDirectory: string | null;
 	metadata: Record<string, string> | null;
 	sampleRate: number;
+	onLog: OnLog;
 } & ToOptions<typeof optionsMap.stitchFramesToVideo>;
 
 export type StitchFramesToVideoOptions = {
@@ -166,6 +169,7 @@ const innerStitchFramesToVideo = async (
 		metadata,
 		hardwareAcceleration,
 		sampleRate,
+		onLog,
 	}: InternalStitchFramesToVideoOptions,
 	remotionRoot: string,
 ): Promise<ReturnType> => {
@@ -382,16 +386,20 @@ const innerStitchFramesToVideo = async (
 		return Promise.resolve(file);
 	}
 
-	const resolvedHardwareAcceleration = resolveHardwareAcceleration({
-		codec,
-		hardwareAcceleration,
-		binariesDirectory,
-		indent: indent ?? false,
-		logLevel,
-		crf,
-		encodingMaxRate: maxRate,
-		encodingBufferSize: bufferSize,
-	});
+	// Parallel encoding already resolved the encoder in the pre-stitcher.
+	const resolvedHardwareAcceleration = preEncodedFileLocation
+		? 'disable'
+		: resolveHardwareAcceleration({
+				codec,
+				hardwareAcceleration,
+				binariesDirectory,
+				indent: indent ?? false,
+				logLevel,
+				crf,
+				encodingMaxRate: maxRate,
+				encodingBufferSize: bufferSize,
+				onLog,
+			});
 
 	const ffmpegArgs = [
 		...(preEncodedFileLocation
@@ -635,5 +643,6 @@ export const stitchFramesToVideo = ({
 		separateAudioTo: separateAudioTo ?? null,
 		hardwareAcceleration: hardwareAcceleration ?? 'disable',
 		sampleRate: sampleRate ?? 48000,
+		onLog: defaultOnLog,
 	});
 };

--- a/packages/renderer/src/test/get-codec-name.test.ts
+++ b/packages/renderer/src/test/get-codec-name.test.ts
@@ -40,6 +40,7 @@ const callGetCodecName = ({
 		encodingBufferSize,
 		logLevel: 'warn',
 		indent: false,
+		onLog: null,
 	});
 
 describe('getCodecName - macOS VideoToolbox (existing behavior)', () => {

--- a/packages/renderer/src/test/probe-encoder.test.ts
+++ b/packages/renderer/src/test/probe-encoder.test.ts
@@ -38,6 +38,7 @@ describe('resolveHardwareAcceleration', () => {
 				crf: null,
 				encodingMaxRate: null,
 				encodingBufferSize: null,
+				onLog: null,
 			}),
 		).toBe('disable');
 	});
@@ -53,6 +54,7 @@ describe('resolveHardwareAcceleration', () => {
 				crf: null,
 				encodingMaxRate: null,
 				encodingBufferSize: null,
+				onLog: null,
 			}),
 		).toBe('if-possible');
 	});
@@ -68,6 +70,7 @@ describe('resolveHardwareAcceleration', () => {
 				crf: null,
 				encodingMaxRate: null,
 				encodingBufferSize: null,
+				onLog: null,
 			}),
 		).toBe('required');
 	});
@@ -83,6 +86,7 @@ describe('resolveHardwareAcceleration', () => {
 				crf: null,
 				encodingMaxRate: null,
 				encodingBufferSize: null,
+				onLog: null,
 			}),
 		).toBe('if-possible');
 	});
@@ -90,8 +94,9 @@ describe('resolveHardwareAcceleration', () => {
 	describe('software encoder passthrough', () => {
 		afterEach(restorePlatform);
 
-		test('returns original value when getCodecName returns software (CRF set on linux)', () => {
-			setPlatform('linux');
+		test('reports why CRF disables hardware acceleration on Windows', () => {
+			setPlatform('win32');
+			const onLog = mock(() => undefined);
 			expect(
 				resolveHardwareAcceleration({
 					codec: 'h264',
@@ -102,8 +107,16 @@ describe('resolveHardwareAcceleration', () => {
 					crf: 20,
 					encodingMaxRate: null,
 					encodingBufferSize: null,
+					onLog,
 				}),
-			).toBe('if-possible');
+			).toBe('disable');
+			expect(onLog).toHaveBeenCalledTimes(1);
+			expect(onLog).toHaveBeenCalledWith({
+				logLevel: 'warn',
+				previewString:
+					'Hardware accelerated encoding disabled - "crf" option is not supported with hardware acceleration',
+				tag: '',
+			});
 		});
 
 		test('returns original value when codec has no hw encoder (vp8)', () => {
@@ -118,6 +131,7 @@ describe('resolveHardwareAcceleration', () => {
 					crf: null,
 					encodingMaxRate: null,
 					encodingBufferSize: null,
+					onLog: null,
 				}),
 			).toBe('if-possible');
 		});
@@ -134,6 +148,7 @@ describe('resolveHardwareAcceleration', () => {
 					crf: null,
 					encodingMaxRate: null,
 					encodingBufferSize: null,
+					onLog: null,
 				}),
 			).toBe('if-possible');
 		});
@@ -150,6 +165,7 @@ describe('resolveHardwareAcceleration', () => {
 					crf: null,
 					encodingMaxRate: null,
 					encodingBufferSize: null,
+					onLog: null,
 				}),
 			).toBe('disable');
 		});


### PR DESCRIPTION
## Summary

- route hardware acceleration fallback warnings through the renderer log callback so CLI progress rendering keeps them visible
- resolve incompatible quality options to software once and avoid duplicate encoder resolution during parallel encoding
- add a Windows regression test for the CRF fallback warning

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/renderer/src/test/probe-encoder.test.ts packages/renderer/src/test/get-codec-name.test.ts packages/renderer/src/test/ffmpeg-args.test.ts`

Closes #10767
