### PR TITLE
`@remotion/studio`: Add pixel grid to canvas

### DIFF
--- a/packages/studio/src/components/EditorContexts.tsx
+++ b/packages/studio/src/components/EditorContexts.tsx
@@ -18,6 +18,7 @@ import {SetTimelineInOutProvider} from './SetTimelineInOutProvider';
 import {SettingsProvider} from './SettingsContext';
 import {ShowGuidesProvider} from './ShowGuidesProvider';
 import {ShowOutlinesProvider} from './ShowOutlinesProvider';
+import {ShowPixelGridProvider} from './ShowPixelGridProvider';
 import {ShowRulersProvider} from './ShowRulersProvider';
 import {SnappingProvider} from './SnappingProvider';
 import {VisualControlsUndoSync} from './VisualControls/VisualControlsUndoSync';
@@ -37,35 +38,37 @@ export const EditorContexts: React.FC<{
 							<KeybindingContextProvider>
 								<CheckerboardProvider>
 									<ZoomGesturesProvider>
-										<ShowRulersProvider>
-											<ShowGuidesProvider>
-												<ShowOutlinesProvider>
-													<SnappingProvider>
-														<PreviewSizeProvider>
-															<ModalsProvider>
-																<MediaVolumeProvider>
-																	<PlayerInternals.PlayerEmitterProvider
-																		currentPlaybackRate={null}
-																	>
-																		<SidebarContextProvider>
-																			<FolderContextProvider>
-																				<HighestZIndexProvider>
-																					<SetTimelineInOutProvider>
-																						<ExpandedTracksProvider>
-																							{children}
-																						</ExpandedTracksProvider>
-																					</SetTimelineInOutProvider>
-																				</HighestZIndexProvider>
-																			</FolderContextProvider>
-																		</SidebarContextProvider>
-																	</PlayerInternals.PlayerEmitterProvider>
-																</MediaVolumeProvider>
-															</ModalsProvider>
-														</PreviewSizeProvider>
-													</SnappingProvider>
-												</ShowOutlinesProvider>
-											</ShowGuidesProvider>
-										</ShowRulersProvider>
+										<ShowPixelGridProvider>
+											<ShowRulersProvider>
+												<ShowGuidesProvider>
+													<ShowOutlinesProvider>
+														<SnappingProvider>
+															<PreviewSizeProvider>
+																<ModalsProvider>
+																	<MediaVolumeProvider>
+																		<PlayerInternals.PlayerEmitterProvider
+																			currentPlaybackRate={null}
+																		>
+																			<SidebarContextProvider>
+																				<FolderContextProvider>
+																					<HighestZIndexProvider>
+																						<SetTimelineInOutProvider>
+																							<ExpandedTracksProvider>
+																								{children}
+																							</ExpandedTracksProvider>
+																						</SetTimelineInOutProvider>
+																					</HighestZIndexProvider>
+																				</FolderContextProvider>
+																			</SidebarContextProvider>
+																		</PlayerInternals.PlayerEmitterProvider>
+																	</MediaVolumeProvider>
+																</ModalsProvider>
+															</PreviewSizeProvider>
+														</SnappingProvider>
+													</ShowOutlinesProvider>
+												</ShowGuidesProvider>
+											</ShowRulersProvider>
+										</ShowPixelGridProvider>
 									</ZoomGesturesProvider>
 								</CheckerboardProvider>
 							</KeybindingContextProvider>

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -18,12 +18,13 @@ import {
 	getCheckerboardBackgroundPos,
 	getCheckerboardBackgroundSize,
 } from '../helpers/checkerboard-background';
-import {LIGHT_TEXT} from '../helpers/colors';
+import {LIGHT_TEXT, RULER_COLOR} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import type {Dimensions} from '../helpers/is-current-selected-still';
 import {calculateStudioCanvasTransformation} from '../helpers/studio-fit-padding';
 import {CheckerboardContext} from '../state/checkerboard';
+import {EditorShowPixelGridContext} from '../state/editor-pixel-grid';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from './Menu/is-menu-item';
 import {RenderPreview} from './RenderPreview';
 import {SelectedOutlineOverlay} from './SelectedOutlineOverlay';
@@ -55,6 +56,7 @@ const assetMetadataErrorContainer: React.CSSProperties = {
 };
 
 const checkerboardSize = 49;
+const PIXEL_GRID_MIN_SCALE = 4;
 
 const containerStyle = (options: {
 	scale: number;
@@ -85,6 +87,32 @@ const containerStyle = (options: {
 				checkerboardSize,
 			) /* Must be half of one side of the square */,
 	};
+};
+
+const PixelGrid: React.FC<{
+	readonly scale: number;
+}> = ({scale}) => {
+	const {editorShowPixelGrid} = useContext(EditorShowPixelGridContext);
+
+	if (!editorShowPixelGrid || scale < PIXEL_GRID_MIN_SCALE) {
+		return null;
+	}
+
+	return (
+		<div
+			aria-hidden="true"
+			className="css-reset"
+			data-testid="pixel-grid"
+			style={{
+				position: 'absolute',
+				inset: 0,
+				pointerEvents: 'none',
+				opacity: 0.35,
+				backgroundImage: `linear-gradient(to right, ${RULER_COLOR} 1px, transparent 1px), linear-gradient(to bottom, ${RULER_COLOR} 1px, transparent 1px)`,
+				backgroundSize: `${scale}px ${scale}px`,
+			}}
+		/>
+	);
 };
 
 export const VideoPreview: React.FC<{
@@ -275,6 +303,7 @@ const CompWhenItHasDimensions: React.FC<{
 				xCorrection={xCorrection}
 				yCorrection={yCorrection}
 			/>
+			<PixelGrid scale={scale} />
 			<SelectedOutlineOverlay
 				canvasHovered={canvasHovered}
 				compositionHeight={(contentDimensions as Dimensions).height}

--- a/packages/studio/src/components/ShowPixelGridProvider.tsx
+++ b/packages/studio/src/components/ShowPixelGridProvider.tsx
@@ -1,0 +1,37 @@
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+	EditorShowPixelGridContext,
+	loadEditorShowPixelGridOption,
+	persistEditorShowPixelGridOption,
+} from '../state/editor-pixel-grid';
+
+export const ShowPixelGridProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const [editorShowPixelGrid, setEditorShowPixelGridState] = useState(() =>
+		loadEditorShowPixelGridOption(),
+	);
+	const setEditorShowPixelGrid = useCallback(
+		(newValue: (prevState: boolean) => boolean) => {
+			setEditorShowPixelGridState((prevState) => {
+				const newVal = newValue(prevState);
+				persistEditorShowPixelGridOption(newVal);
+				return newVal;
+			});
+		},
+		[],
+	);
+
+	const editorShowPixelGridCtx = useMemo(() => {
+		return {
+			editorShowPixelGrid,
+			setEditorShowPixelGrid,
+		};
+	}, [editorShowPixelGrid, setEditorShowPixelGrid]);
+
+	return (
+		<EditorShowPixelGridContext.Provider value={editorShowPixelGridCtx}>
+			{children}
+		</EditorShowPixelGridContext.Provider>
+	);
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -23,6 +23,7 @@ import {Checkmark} from '../icons/Checkmark';
 import {drawRef} from '../state/canvas-ref';
 import {CheckerboardContext} from '../state/checkerboard';
 import {EditorShowGuidesContext} from '../state/editor-guides';
+import {EditorShowPixelGridContext} from '../state/editor-pixel-grid';
 import {EditorShowRulersContext} from '../state/editor-rulers';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
@@ -295,6 +296,9 @@ export const useMenuStructure = (
 	const {editorZoomGestures, setEditorZoomGestures} = useContext(
 		EditorZoomGesturesContext,
 	);
+	const {editorShowPixelGrid, setEditorShowPixelGrid} = useContext(
+		EditorShowPixelGridContext,
+	);
 	const {editorShowRulers, setEditorShowRulers} = useContext(
 		EditorShowRulersContext,
 	);
@@ -531,6 +535,22 @@ export const useMenuStructure = (
 						quickSwitcherLabel: editorZoomGestures
 							? 'Disable Zoom and Pan Gestures'
 							: 'Enable Zoom and Pan Gestures',
+					},
+					{
+						id: 'pixel-grid',
+						keyHint: null,
+						label: 'Pixel Grid',
+						onClick: () => {
+							closeMenu();
+							setEditorShowPixelGrid((c) => !c);
+						},
+						type: 'item' as const,
+						value: 'pixel-grid',
+						leftItem: editorShowPixelGrid ? <Checkmark /> : null,
+						subMenu: null,
+						quickSwitcherLabel: editorShowPixelGrid
+							? 'Hide Pixel Grid'
+							: 'Show Pixel Grid',
 					},
 					{
 						id: 'show-rulers',
@@ -1110,6 +1130,7 @@ export const useMenuStructure = (
 		currentComposition,
 		resolvedCompositionLocation,
 		editorZoomGestures,
+		editorShowPixelGrid,
 		editorShowRulers,
 		editorShowGuides,
 		editorSnapping,
@@ -1127,6 +1148,7 @@ export const useMenuStructure = (
 		size.size,
 		setSize,
 		setEditorZoomGestures,
+		setEditorShowPixelGrid,
 		setEditorShowRulers,
 		setEditorShowGuides,
 		setEditorSnapping,

--- a/packages/studio/src/state/editor-pixel-grid.ts
+++ b/packages/studio/src/state/editor-pixel-grid.ts
@@ -1,0 +1,22 @@
+import {createContext} from 'react';
+
+type State = {
+	editorShowPixelGrid: boolean;
+	setEditorShowPixelGrid: (cb: (prevState: boolean) => boolean) => void;
+};
+
+const key = 'remotion.editorShowPixelGrid';
+
+export const persistEditorShowPixelGridOption = (option: boolean) => {
+	localStorage.setItem(key, String(option));
+};
+
+export const loadEditorShowPixelGridOption = (): boolean => {
+	const item = localStorage.getItem(key);
+	return item !== 'false';
+};
+
+export const EditorShowPixelGridContext = createContext<State>({
+	editorShowPixelGrid: true,
+	setEditorShowPixelGrid: () => undefined,
+});


### PR DESCRIPTION
## Summary

- add a CSS pixel grid inside the Studio composition canvas at 400% zoom and above
- add a persisted **View → Pixel Grid** preference that is enabled by default
- keep selection controls above the non-interactive grid overlay

## Testing

- `bun run build`
- `bun run stylecheck`
- manually verified the grid bounds, zoom threshold, menu toggle, and persisted preference in Remotion Studio
