### PR TITLE
`@remotion/studio`: Refine navbar menu styling

### DIFF
--- a/packages/studio/src/components/Menu/MenuItem.tsx
+++ b/packages/studio/src/components/Menu/MenuItem.tsx
@@ -10,22 +10,32 @@ import {
 import {HOVERABLE_CLASS_NAME, hoverableStyle} from '../../helpers/hoverable';
 import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {HigherZIndex, useZIndex} from '../../state/z-index';
+import {MENU_TOOLBAR_HEIGHT} from '../menu-toolbar-height';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {MenuContent} from '../NewComposition/MenuContent';
 import {MENU_INITIATOR_CLASSNAME, isMenuItem} from './is-menu-item';
 import {getPortal} from './portals';
 import {menuContainerTowardsBottom, outerPortal} from './styles';
 
+const MENU_ITEM_HEIGHT = 24;
+const MENU_ITEM_VERTICAL_MARGIN = (MENU_TOOLBAR_HEIGHT - MENU_ITEM_HEIGHT) / 2;
+
 const container: React.CSSProperties = {
+	alignItems: 'center',
+	boxSizing: 'border-box',
+	display: 'inline-flex',
 	fontSize: 13,
-	paddingLeft: 10,
-	paddingRight: 10,
+	height: MENU_ITEM_HEIGHT,
+	justifyContent: 'center',
+	paddingLeft: 8,
+	paddingRight: 8,
 	cursor: 'default',
-	paddingTop: 6,
-	paddingBottom: 6,
+	paddingTop: 0,
+	paddingBottom: 0,
 	userSelect: 'none',
 	WebkitUserSelect: 'none',
 	border: 'none',
+	borderRadius: 3,
 };
 
 export type MenuId =
@@ -98,7 +108,7 @@ export const MenuItem: React.FC<{
 		return {
 			...menuContainerTowardsBottom,
 			left: size.left,
-			top: size.top + size.height,
+			top: size.top + size.height + MENU_ITEM_VERTICAL_MARGIN,
 		};
 	}, [selected, size]);
 
@@ -168,7 +178,7 @@ export const MenuItem: React.FC<{
 	const outerStyle = useMemo(() => {
 		return {
 			...outerPortal,
-			top: (size?.top ?? 0) + (size?.height ?? 0),
+			top: (size?.top ?? 0) + (size?.height ?? 0) + MENU_ITEM_VERTICAL_MARGIN,
 		};
 	}, [size]);
 

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -38,6 +38,11 @@ const flex: React.CSSProperties = {
 	flex: 1,
 };
 
+const menuItems: React.CSSProperties = {
+	display: 'inline-flex',
+	height: 24,
+};
+
 export const MenuToolbar: React.FC<{
 	readonly readOnlyStudio: boolean;
 }> = ({readOnlyStudio}) => {
@@ -173,23 +178,25 @@ export const MenuToolbar: React.FC<{
 				) : (
 					<SidebarCollapserControl side="left" />
 				)}
-				{structure.map((s) => {
-					return (
-						<MenuItem
-							key={s.id}
-							selected={selected === s.id}
-							onItemSelected={itemClicked}
-							onItemHovered={itemHovered}
-							id={s.id}
-							label={s.label}
-							onItemQuit={onItemQuit}
-							menu={s}
-							onPreviousMenu={onPreviousMenu}
-							onNextMenu={onNextMenu}
-							leaveLeftPadding={s.leaveLeftPadding}
-						/>
-					);
-				})}
+				<div style={menuItems}>
+					{structure.map((s) => {
+						return (
+							<MenuItem
+								key={s.id}
+								selected={selected === s.id}
+								onItemSelected={itemClicked}
+								onItemHovered={itemHovered}
+								id={s.id}
+								label={s.label}
+								onItemQuit={onItemQuit}
+								menu={s}
+								onPreviousMenu={onPreviousMenu}
+								onNextMenu={onNextMenu}
+								leaveLeftPadding={s.leaveLeftPadding}
+							/>
+						);
+					})}
+				</div>
 				{readOnlyStudio || browserStudioOperations ? null : <UpdateCheck />}
 			</div>
 			{mobileLayout ? null : <div style={flex} />}

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -199,6 +199,7 @@ export const SidebarCollapserControl: React.FC<{
 				variant={null}
 				onClick={toggleLeft}
 				renderAction={toggleLeftAction}
+				style={{marginRight: 4}}
 				unhoveredColor={WHITE_ALPHA_80}
 			/>
 		);


### PR DESCRIPTION
## Summary

- match navbar menu items to the compact inline toolbar controls
- use rounded, lighter hover backgrounds with balanced horizontal padding
- keep dropdowns aligned to the bottom of the navbar and balance spacing after the left sidebar toggle

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter=@remotion/studio`
- verified in the example Studio at `http://localhost:3011`
