### PR TITLE
`@remotion/studio`: Allow Canvas Capture drops anywhere

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {expect, test, type Page} from '@playwright/test';
+import {expect, test, type Locator, type Page} from '@playwright/test';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
 import {
 	STUDIO_URL,
@@ -69,6 +69,46 @@ const dropAssetOnCanvas = async ({
 			}),
 		);
 	}, dragData);
+};
+
+const dropFile = async ({
+	base64,
+	fileName,
+	mimeType,
+	target,
+}: {
+	base64: string;
+	fileName: string;
+	mimeType: string;
+	target: Locator;
+}) => {
+	return target.evaluate(
+		(element, file) => {
+			const bytes = Uint8Array.from(atob(file.base64), (character) =>
+				character.charCodeAt(0),
+			);
+			const dataTransfer = new DataTransfer();
+			dataTransfer.items.add(
+				new File([bytes], file.fileName, {type: file.mimeType}),
+			);
+			const dragOver = new DragEvent('dragover', {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer,
+			});
+			element.dispatchEvent(dragOver);
+			element.dispatchEvent(
+				new DragEvent('drop', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer,
+				}),
+			);
+
+			return dragOver.defaultPrevented;
+		},
+		{base64, fileName, mimeType},
+	);
 };
 
 const getVideoTag = (source: string, assetPath: string) => {
@@ -142,6 +182,58 @@ test.describe('visual mode', () => {
 		await expect(
 			page.getByText('Composition with ID does-not-exist not found.'),
 		).toBeVisible();
+	});
+
+	test('should route Canvas Capture drops by Studio target', async ({page}) => {
+		test.setTimeout(90_000);
+		const canvasCapture = fs.readFileSync(
+			path.join(
+				exampleDir,
+				'../brand/public/remotion-capture-editor-starter.mp4',
+			),
+		);
+		const publicFileName = 'canvas-capture-drop-e2e.mp4';
+		const publicAsset = path.join(exampleDir, 'public', publicFileName);
+		fs.rmSync(publicAsset, {force: true});
+		const file = {
+			base64: canvasCapture.toString('base64'),
+			fileName: publicFileName,
+			mimeType: 'video/mp4',
+		};
+		const modalTitle = page.getByText('Import Canvas Capture', {exact: true});
+
+		try {
+			await page.goto(`${STUDIO_URL}/does-not-exist`);
+			const missingComposition = page.getByText(
+				'Composition with ID does-not-exist not found.',
+			);
+			await expect(missingComposition).toBeVisible();
+			expect(await dropFile({...file, target: missingComposition})).toBe(true);
+			await expect(modalTitle).toBeVisible();
+			await page.keyboard.press('Escape');
+
+			await page.getByText('Assets', {exact: true}).click();
+			const assetSelector = page.locator('[data-asset-selector]');
+			await expect(assetSelector).toBeVisible();
+			expect(await dropFile({...file, target: assetSelector})).toBe(true);
+			await expect
+				.poll(
+					() =>
+						fs.existsSync(publicAsset) &&
+						fs.readFileSync(publicAsset).equals(canvasCapture),
+				)
+				.toBe(true);
+			await expect(page.getByText(publicFileName, {exact: true})).toBeVisible();
+			await expect(modalTitle).toBeHidden();
+
+			await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+			const timeline = page.locator('[data-timeline-scrollable]');
+			await expect(timeline).toBeVisible();
+			expect(await dropFile({...file, target: timeline})).toBe(true);
+			await expect(modalTitle).toBeVisible();
+		} finally {
+			fs.rmSync(publicAsset, {force: true});
+		}
 	});
 
 	test('should virtualize a large timeline without hiding tracks', async ({

--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -132,7 +132,7 @@ export const AssetSelector: React.FC<{
 					return;
 				}
 
-				const {files} = e.dataTransfer;
+				const files = Array.from(e.dataTransfer.files);
 				if (files.length === 0) {
 					setDropLocation(null);
 					return;

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -24,7 +24,6 @@ import {
 } from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import {getAssetMetadata} from '../helpers/get-asset-metadata';
-import {getCanvasCaptureImport} from '../helpers/get-canvas-capture-import';
 import {
 	applyZoomAroundFocalPoint,
 	getCenterPointWhileScrolling,
@@ -50,6 +49,7 @@ import {EditorSnappingContext} from '../state/editor-snapping';
 import {EditorZoomGesturesContext} from '../state/editor-zoom-gestures';
 import {SetSelectedModalContext} from '../state/modals';
 import {callApi} from './call-api';
+import {handleCanvasCaptureDrop} from './canvas-capture-drop';
 import {
 	getCompositionDropPreviewBox,
 	snapCompositionDropPosition,
@@ -1147,15 +1147,12 @@ export const Canvas: React.FC<{
 				if (localFiles.length === 1) {
 					setIsAddingAsset(true);
 					try {
-						const canvasCapture = await getCanvasCaptureImport(localFiles[0]);
-						if (canvasCapture !== null) {
-							setSelectedModal({
-								type: 'new-comp',
-								canvasCapture,
-								folderName: null,
-								parentName: null,
-								stack: null,
-							});
+						if (
+							await handleCanvasCaptureDrop({
+								files: localFiles,
+								setSelectedModal,
+							})
+						) {
 							return;
 						}
 					} finally {

--- a/packages/studio/src/components/CanvasCaptureDropHandler.tsx
+++ b/packages/studio/src/components/CanvasCaptureDropHandler.tsx
@@ -1,0 +1,53 @@
+import {useCallback, useContext, useEffect, type FC} from 'react';
+import {SetSelectedModalContext} from '../state/modals';
+import {handleCanvasCaptureDrop} from './canvas-capture-drop';
+import {isFileDragEvent} from './drop-handler-data';
+
+export const CanvasCaptureDropHandler: FC<{
+	readonly readOnlyStudio: boolean;
+}> = ({readOnlyStudio}) => {
+	const {setSelectedModal} = useContext(SetSelectedModalContext);
+
+	const onDragOver = useCallback(
+		(event: DragEvent) => {
+			if (readOnlyStudio || !isFileDragEvent(event)) {
+				return;
+			}
+
+			event.preventDefault();
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = 'copy';
+			}
+		},
+		[readOnlyStudio],
+	);
+
+	const onDrop = useCallback(
+		async (event: DragEvent) => {
+			if (readOnlyStudio || !isFileDragEvent(event)) {
+				return;
+			}
+
+			const files = Array.from(event.dataTransfer?.files ?? []);
+			if (files.length === 0) {
+				return;
+			}
+
+			event.preventDefault();
+			await handleCanvasCaptureDrop({files, setSelectedModal});
+		},
+		[readOnlyStudio, setSelectedModal],
+	);
+
+	useEffect(() => {
+		document.addEventListener('dragover', onDragOver);
+		document.addEventListener('drop', onDrop);
+
+		return () => {
+			document.removeEventListener('dragover', onDragOver);
+			document.removeEventListener('drop', onDrop);
+		};
+	}, [onDragOver, onDrop]);
+
+	return null;
+};

--- a/packages/studio/src/components/Editor.tsx
+++ b/packages/studio/src/components/Editor.tsx
@@ -11,6 +11,7 @@ import {compositionListRenderedRef} from '../state/composition-list';
 import {ScaleLockProvider} from '../state/scale-lock';
 import {TimelineZoomContext} from '../state/timeline-zoom';
 import {HigherZIndex} from '../state/z-index';
+import {CanvasCaptureDropHandler} from './CanvasCaptureDropHandler';
 import {EditorContent} from './EditorContent';
 import {ForceSpecificCursor} from './ForceSpecificCursor';
 import {Modals} from './Modals';
@@ -109,6 +110,7 @@ export const Editor: React.FC<{
 				<SequencePropsSubscriptionProvider>
 					<Internals.CurrentScaleContext.Provider value={value}>
 						<ForceSpecificCursor />
+						<CanvasCaptureDropHandler readOnlyStudio={readOnlyStudio} />
 						<ScaleLockProvider>
 							<div style={background}>
 								<Internals.CompositionRenderErrorContext.Provider

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -3,7 +3,9 @@ import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {useCachedCompositionComponentInfo} from '../../helpers/open-in-editor';
-import {isSupportedDropEvent} from '../drop-handler-data';
+import {SetSelectedModalContext} from '../../state/modals';
+import {handleCanvasCaptureDrop} from '../canvas-capture-drop';
+import {isFileDragEvent, isSupportedDropEvent} from '../drop-handler-data';
 import {getEffectDragData} from '../effect-drag-and-drop';
 import {handleDrop} from '../handle-drop';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -33,6 +35,7 @@ export const useTimelineAssetDrop = () => {
 	);
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const chooseSvgImportMode = useSvgImportDialog();
+	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const [assetDropFrame, setAssetDropFrame] = useState<number | null>(null);
@@ -127,6 +130,27 @@ export const useTimelineAssetDrop = () => {
 				return;
 			}
 
+			const localFiles = isFileDragEvent(event)
+				? Array.from(dataTransfer.files)
+				: null;
+			if (localFiles !== null && !window.remotion_isReadOnlyStudio) {
+				event.preventDefault();
+				event.stopPropagation();
+				setIsAddingAsset(true);
+				try {
+					if (
+						await handleCanvasCaptureDrop({
+							files: localFiles,
+							setSelectedModal,
+						})
+					) {
+						return;
+					}
+				} finally {
+					setIsAddingAsset(false);
+				}
+			}
+
 			if (getEffectDragData(dataTransfer) !== null) {
 				event.preventDefault();
 				return;
@@ -172,7 +196,7 @@ export const useTimelineAssetDrop = () => {
 					event,
 					fps: videoConfig.fps,
 					from: frame,
-					localFiles: null,
+					localFiles,
 					preferCompositionStart: false,
 				});
 			} finally {
@@ -186,6 +210,7 @@ export const useTimelineAssetDrop = () => {
 			compositionFile,
 			currentCompositionId,
 			getDropFrame,
+			setSelectedModal,
 			videoConfig,
 		],
 	);

--- a/packages/studio/src/components/canvas-capture-drop.ts
+++ b/packages/studio/src/components/canvas-capture-drop.ts
@@ -1,0 +1,28 @@
+import {getCanvasCaptureImport} from '../helpers/get-canvas-capture-import';
+import type {SetSelectedModalContextType} from '../state/modals';
+
+export const handleCanvasCaptureDrop = async ({
+	files,
+	setSelectedModal,
+}: {
+	readonly files: readonly File[];
+	readonly setSelectedModal: SetSelectedModalContextType['setSelectedModal'];
+}): Promise<boolean> => {
+	if (files.length !== 1) {
+		return false;
+	}
+
+	const canvasCapture = await getCanvasCaptureImport(files[0]);
+	if (canvasCapture === null) {
+		return false;
+	}
+
+	setSelectedModal({
+		type: 'new-comp',
+		canvasCapture,
+		folderName: null,
+		parentName: null,
+		stack: null,
+	});
+	return true;
+};


### PR DESCRIPTION
## Summary

- allow Canvas Capture files to be dropped anywhere in Remotion Studio
- let explicit drop targets keep their own behavior, including uploading captures to `public/` from the Assets panel
- share Canvas Capture detection between the canvas, timeline, and global fallback handler
- add an end-to-end test for generic, Assets panel, and timeline drops

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should route Canvas Capture drops by Studio target"`

Closes #10384
