### PR TITLE
`@remotion/studio`: Auto-scroll timeline while reordering layers

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -40,6 +40,10 @@ import {shouldSubscribeToSequenceProps} from './should-subscribe-to-sequence-pro
 import {SubscribeToNodePaths} from './SubscribeToNodePaths';
 import {TimelineAssetDropFrameContext} from './timeline-asset-drop-context';
 import {timelineVerticalScroll} from './timeline-refs';
+import {
+	EDGE_SCROLL_VERTICAL_INCREMENT,
+	startTimelineEdgeAutoScroll,
+} from './timeline-scroll-logic';
 import {TimelineDragHandler} from './TimelineDragHandler';
 import {TimelineHeightContainer} from './TimelineHeightContainer';
 import {TimelineInOutDragHandler} from './TimelineInOutDragHandler';
@@ -54,8 +58,10 @@ import {
 	TimelineSelectAllKeybindings,
 	useTimelineSelection,
 } from './TimelineSelection';
+import {SEQUENCE_REORDER_MIME_TYPE} from './TimelineSequenceItem';
 import {TimelineSlider} from './TimelineSlider';
 import {
+	TIMELINE_TIME_INDICATOR_HEIGHT,
 	TimelineTimeIndicators,
 	TimelineTimePlaceholders,
 } from './TimelineTimeIndicators';
@@ -86,6 +92,7 @@ const TimelineContextMenuArea: React.FC<{
 		Internals.CompositionManager,
 	);
 	const videoConfig = Internals.useUnsafeVideoConfig();
+	const isStill = useIsStill();
 	const [isAddingSolid, setIsAddingSolid] = useState(false);
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
@@ -93,6 +100,56 @@ const TimelineContextMenuArea: React.FC<{
 	const previewInteractive = previewConnected && isStudioInteractivityEnabled();
 	const browserStudioOperations = getBrowserStudioOperations();
 	const browserStudioCanInsertSolid = browserStudioOperations !== null;
+
+	useEffect(() => {
+		const verticalScroll = timelineVerticalScroll.current;
+		if (!verticalScroll) {
+			return;
+		}
+
+		const autoScroll = startTimelineEdgeAutoScroll({
+			includeHorizontal: false,
+			includeVertical: true,
+			verticalTopOffset: isStill ? 0 : TIMELINE_TIME_INDICATOR_HEIGHT,
+			onTick: (directions) => {
+				if (directions.y === null) {
+					return;
+				}
+
+				verticalScroll.scrollTop +=
+					directions.y === 'up'
+						? -EDGE_SCROLL_VERTICAL_INCREMENT
+						: EDGE_SCROLL_VERTICAL_INCREMENT;
+			},
+		});
+
+		const onDragOver = (event: DragEvent) => {
+			if (
+				!event.dataTransfer ||
+				!Array.from(event.dataTransfer.types).includes(
+					SEQUENCE_REORDER_MIME_TYPE,
+				)
+			) {
+				autoScroll.stop();
+				return;
+			}
+
+			autoScroll.update(event);
+		};
+
+		const stopAutoScroll = () => autoScroll.stop();
+
+		verticalScroll.addEventListener('dragover', onDragOver, true);
+		document.addEventListener('dragend', stopAutoScroll, true);
+		document.addEventListener('drop', stopAutoScroll, true);
+
+		return () => {
+			autoScroll.stop();
+			verticalScroll.removeEventListener('dragover', onDragOver, true);
+			document.removeEventListener('dragend', stopAutoScroll, true);
+			document.removeEventListener('drop', stopAutoScroll, true);
+		};
+	}, [isStill]);
 
 	const currentCompositionId =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -300,7 +300,9 @@ const TimelineDragHandlerInner: React.FC = () => {
 		}
 
 		const scroller = startTimelineEdgeAutoScroll({
+			includeHorizontal: true,
 			includeVertical: false,
+			verticalTopOffset: 0,
 			onTick: onEdgeScrollTick,
 		});
 		autoScroller.current = scroller;

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -1648,7 +1648,9 @@ export const useTimelineMarqueeSelection = () => {
 			};
 
 			const autoScroll = startTimelineEdgeAutoScroll({
+				includeHorizontal: true,
 				includeVertical: true,
+				verticalTopOffset: 0,
 				onTick: (directions) => {
 					if (scrollable && directions.x !== null) {
 						scrollable.scrollLeft +=

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -112,7 +112,8 @@ const effectDropHighlight: React.CSSProperties = {
 	outlineOffset: -1,
 };
 
-const SEQUENCE_REORDER_MIME_TYPE = 'application/remotion-sequence-reorder';
+export const SEQUENCE_REORDER_MIME_TYPE =
+	'application/remotion-sequence-reorder';
 
 type SequenceReorderDragData = {
 	readonly nodePath: SequencePropsSubscriptionKey;

--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -58,17 +58,21 @@ const canScrollTimelineVerticallyIntoDirection = () => {
 const getEdgeScrollDirections = ({
 	clientX,
 	clientY,
+	includeHorizontal,
 	includeVertical,
+	verticalTopOffset,
 	active,
 }: {
 	clientX: number;
 	clientY: number;
+	includeHorizontal: boolean;
 	includeVertical: boolean;
+	verticalTopOffset: number;
 	active: TimelineEdgeScrollDirections;
 }): TimelineEdgeScrollDirections => {
 	let x: TimelineEdgeScrollDirections['x'] = null;
 	const scrollable = scrollableRef.current;
-	if (scrollable) {
+	if (includeHorizontal && scrollable) {
 		const rect = scrollable.getBoundingClientRect();
 		const leftThreshold =
 			rect.left + (active.x === 'left' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
@@ -91,6 +95,7 @@ const getEdgeScrollDirections = ({
 		const rect = vertical.getBoundingClientRect();
 		const topThreshold =
 			rect.top +
+			verticalTopOffset +
 			EDGE_SCROLL_VERTICAL_INSET +
 			(active.y === 'up' ? EDGE_SCROLL_EXIT_HYSTERESIS : 0);
 		const bottomThreshold =
@@ -111,16 +116,20 @@ const getEdgeScrollDirections = ({
 
 /**
  * Shared edge auto-scroll loop for drag gestures on the timeline (playhead
- * scrubbing, marquee selection). Detects when the pointer is in an edge zone
- * and repeatedly invokes `onTick` while it stays there. The consumer performs
- * the actual scrolling (and any dependent updates) inside `onTick`, so it can
- * read a settled scroll position afterwards.
+ * scrubbing, marquee selection, sequence reordering). Detects when the pointer
+ * is in an edge zone and repeatedly invokes `onTick` while it stays there. The
+ * consumer performs the actual scrolling (and any dependent updates) inside
+ * `onTick`, so it can read a settled scroll position afterwards.
  */
 export const startTimelineEdgeAutoScroll = ({
+	includeHorizontal,
 	includeVertical,
+	verticalTopOffset,
 	onTick,
 }: {
+	includeHorizontal: boolean;
 	includeVertical: boolean;
+	verticalTopOffset: number;
 	onTick: (directions: TimelineEdgeScrollDirections) => void;
 }): TimelineEdgeAutoScroller => {
 	let active: TimelineEdgeScrollDirections = {x: null, y: null};
@@ -142,7 +151,9 @@ export const startTimelineEdgeAutoScroll = ({
 		active = getEdgeScrollDirections({
 			clientX: lastPointer.clientX,
 			clientY: lastPointer.clientY,
+			includeHorizontal,
 			includeVertical,
+			verticalTopOffset,
 			active,
 		});
 		if (active.x === null && active.y === null) {
@@ -158,7 +169,9 @@ export const startTimelineEdgeAutoScroll = ({
 		active = getEdgeScrollDirections({
 			clientX: e.clientX,
 			clientY: e.clientY,
+			includeHorizontal,
 			includeVertical,
+			verticalTopOffset,
 			active,
 		});
 

--- a/packages/studio/src/test/timeline-scroll-logic.test.ts
+++ b/packages/studio/src/test/timeline-scroll-logic.test.ts
@@ -1,11 +1,37 @@
 import {expect, test} from 'bun:test';
+import {timelineVerticalScroll} from '../components/Timeline/timeline-refs';
 import {
 	getFrameFromX,
 	getFrameFromTimelineDrop,
 	getFrameIncrementFromWidth,
 	getScrollLeftToKeepCursorInPlace,
+	startTimelineEdgeAutoScroll,
 } from '../components/Timeline/timeline-scroll-logic';
 import {TIMELINE_PADDING} from '../helpers/timeline-layout';
+
+test('vertical top offset accounts for the covered timeline header', () => {
+	timelineVerticalScroll.current = {
+		clientHeight: 500,
+		getBoundingClientRect: () => ({bottom: 600, top: 100}),
+		scrollHeight: 1000,
+		scrollTop: 100,
+	} as HTMLDivElement;
+	const directions: Array<'up' | 'down' | null> = [];
+	const autoScroll = startTimelineEdgeAutoScroll({
+		includeHorizontal: false,
+		includeVertical: true,
+		verticalTopOffset: 39,
+		onTick: (nextDirections) => {
+			directions.push(nextDirections.y);
+		},
+	});
+
+	autoScroll.update({clientX: 200, clientY: 145});
+	autoScroll.stop();
+	timelineVerticalScroll.current = null;
+
+	expect(directions).toEqual(['up']);
+});
 
 test('getFrameFromX handles collapsed timeline widths', () => {
 	expect(


### PR DESCRIPTION
## Summary

- auto-scroll the timeline vertically while reordering sequence layers
- trigger upward scrolling before the pointer enters the area covered by the sticky timeline header
- keep horizontal scrolling disabled for layer reordering and clean up the scroll loop on drag end or drop

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/timeline-scroll-logic.test.ts`
