### PR TITLE
`@remotion/renderer`: Select Fast Start based on output container

### DIFF
--- a/packages/renderer/src/combine-chunks.ts
+++ b/packages/renderer/src/combine-chunks.ts
@@ -66,21 +66,6 @@ type AllCombineChunksOptions = MandatoryCombineChunksOptions &
 export type CombineChunksOptions = MandatoryCombineChunksOptions &
 	Partial<OptionalCombineChunksOptions>;
 
-const codecSupportsFastStart: {[key in Codec]: boolean} = {
-	'h264-mkv': false,
-	'h264-ts': false,
-	h264: true,
-	h265: true,
-	av1: true,
-	aac: false,
-	gif: false,
-	mp3: false,
-	prores: false,
-	vp8: false,
-	vp9: false,
-	wav: false,
-};
-
 const REMOTION_FILELIST_TOKEN = 'remotion-filelist';
 
 export const internalCombineChunks = async ({
@@ -250,7 +235,6 @@ export const internalCombineChunks = async ({
 			binariesDirectory,
 			fps,
 			cancelSignal,
-			addFaststart: codecSupportsFastStart[codec],
 			metadata,
 			numberOfGifLoops,
 		});

--- a/packages/renderer/src/finalize-fast-start.ts
+++ b/packages/renderer/src/finalize-fast-start.ts
@@ -2,11 +2,10 @@ import {randomUUID} from 'node:crypto';
 import {promises} from 'node:fs';
 import path from 'node:path';
 import {callFf} from './call-ffmpeg';
+import type {FastStartMuxer} from './get-fast-start-muxer';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
-
-export type FastStartMuxer = 'mov' | 'mp4';
 
 export const finalizeFastStart = async ({
 	input,

--- a/packages/renderer/src/get-fast-start-muxer.ts
+++ b/packages/renderer/src/get-fast-start-muxer.ts
@@ -1,0 +1,13 @@
+export type FastStartMuxer = 'mov' | 'mp4';
+
+export const getFastStartMuxer = (
+	outputExtension: string,
+): FastStartMuxer | null => {
+	const normalizedExtension = outputExtension.toLowerCase();
+
+	if (normalizedExtension === 'mp4' || normalizedExtension === 'mov') {
+		return normalizedExtension;
+	}
+
+	return null;
+};

--- a/packages/renderer/src/mux-video-and-audio.ts
+++ b/packages/renderer/src/mux-video-and-audio.ts
@@ -1,5 +1,7 @@
 import {callFf} from './call-ffmpeg';
 import {convertNumberOfGifLoopsToFfmpegSyntax} from './convert-number-of-gif-loops-to-ffmpeg';
+import {getExtensionOfFilename} from './get-extension-of-filename';
+import {getFastStartMuxer} from './get-fast-start-muxer';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
 import type {CancelSignal} from './make-cancel-signal';
@@ -17,7 +19,6 @@ export const muxVideoAndAudio = async ({
 	binariesDirectory,
 	fps,
 	cancelSignal,
-	addFaststart,
 	metadata,
 	numberOfGifLoops,
 }: {
@@ -30,12 +31,15 @@ export const muxVideoAndAudio = async ({
 	fps: number;
 	onProgress: (p: number) => void;
 	cancelSignal: CancelSignal | undefined;
-	addFaststart: boolean;
 	metadata?: Record<string, string> | null;
 	numberOfGifLoops: number | null;
 }) => {
 	const startTime = Date.now();
 	Log.verbose({indent, logLevel}, 'Muxing video and audio together');
+	const outputExtension = getExtensionOfFilename(output);
+	const fastStartMuxer = outputExtension
+		? getFastStartMuxer(outputExtension)
+		: null;
 
 	const command = [
 		'-hide_banner',
@@ -56,8 +60,8 @@ export const muxVideoAndAudio = async ({
 		numberOfGifLoops === null
 			? null
 			: convertNumberOfGifLoopsToFfmpegSyntax(numberOfGifLoops),
-		addFaststart ? '-movflags' : null,
-		addFaststart ? 'faststart' : null,
+		fastStartMuxer ? '-movflags' : null,
+		fastStartMuxer ? 'faststart' : null,
 		...makeMetadataArgs(metadata ?? {}),
 		'-y',
 		output,

--- a/packages/renderer/src/stitch-frames-to-video.ts
+++ b/packages/renderer/src/stitch-frames-to-video.ts
@@ -16,10 +16,11 @@ import {defaultOnLog} from './default-on-log';
 import {deleteDirectory} from './delete-directory';
 import {generateFfmpegArgs} from './ffmpeg-args';
 import type {FfmpegOverrideFn} from './ffmpeg-override';
-import {finalizeFastStart, type FastStartMuxer} from './finalize-fast-start';
+import {finalizeFastStart} from './finalize-fast-start';
 import {findRemotionRoot} from './find-closest-package-json';
 import {getFileExtensionFromCodec} from './get-extension-from-codec';
 import {getExtensionOfFilename} from './get-extension-of-filename';
+import {getFastStartMuxer} from './get-fast-start-muxer';
 import {getProResProfileName} from './get-prores-profile-name';
 import type {LogLevel} from './log-level';
 import {Log} from './logger';
@@ -114,24 +115,6 @@ export type StitchFramesToVideoOptions = {
 } & Partial<ToOptions<typeof optionsMap.stitchFramesToVideo>>;
 
 type ReturnType = Promise<Buffer | null>;
-
-const getFastStartMuxer = ({
-	codec,
-	outputExtension,
-}: {
-	codec: Codec;
-	outputExtension: string;
-}): FastStartMuxer | null => {
-	if (codec !== 'h264') {
-		return null;
-	}
-
-	if (outputExtension === 'mp4' || outputExtension === 'mov') {
-		return outputExtension;
-	}
-
-	return null;
-};
 
 const innerStitchFramesToVideo = async (
 	{
@@ -240,7 +223,7 @@ const innerStitchFramesToVideo = async (
 		getExtensionOfFilename(outputLocation) ??
 		getFileExtensionFromCodec(codec, resolvedAudioCodec)
 	).toLowerCase();
-	const fastStartMuxer = getFastStartMuxer({codec, outputExtension});
+	const fastStartMuxer = getFastStartMuxer(outputExtension);
 	// Fast Start reopens its output for an in-place second pass. Keep that work
 	// away from the public output path so Windows file observers cannot lock it.
 	const fastStartIntermediate =
@@ -434,9 +417,6 @@ const innerStitchFramesToVideo = async (
 			indent,
 			logLevel,
 		}),
-		codec === 'h264' && fastStartMuxer === null
-			? ['-movflags', 'faststart']
-			: null,
 		// Ignore metadata that may come from remote media
 		['-map_metadata', '-1'],
 		...makeMetadataArgs(metadata ?? {}),

--- a/packages/renderer/src/test/stitch-frames-to-video.test.ts
+++ b/packages/renderer/src/test/stitch-frames-to-video.test.ts
@@ -197,80 +197,87 @@ test('Fast Start finalization stays off the public output path', async () => {
 	}
 });
 
-test('Fast Start is selected from the output container', async () => {
-	const testDirectory = await fs.promises.mkdtemp(
-		path.join(os.tmpdir(), 'remotion-faststart-container-test-'),
-	);
-	await fs.promises.copyFile(
-		path.join(
-			__dirname,
-			'..',
-			'..',
-			'..',
-			'example',
-			'public',
-			'stuttgart-pin.png',
-		),
-		path.join(testDirectory, 'frame-0.png'),
-	);
+test(
+	'Fast Start is selected from the output container',
+	async () => {
+		const testDirectory = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), 'remotion-faststart-container-test-'),
+		);
+		await fs.promises.copyFile(
+			path.join(
+				__dirname,
+				'..',
+				'..',
+				'..',
+				'example',
+				'public',
+				'stuttgart-pin.png',
+			),
+			path.join(testDirectory, 'frame-0.png'),
+		);
 
-	try {
-		const h264Mp4 = await stitchVideo({
-			codec: 'h264',
-			extension: 'mp4',
-			testDirectory,
-		});
-		const h264Mkv = await stitchVideo({
-			codec: 'h264',
-			extension: 'mkv',
-			testDirectory,
-		});
-		const h265Mp4 = await stitchVideo({
-			codec: 'h265',
-			extension: 'mp4',
-			testDirectory,
-		});
-		const av1Mp4 = await stitchVideo({
-			codec: 'av1',
-			extension: 'mp4',
-			testDirectory,
-		});
-		const proResMov = await stitchVideo({
-			codec: 'prores',
-			extension: 'mov',
-			testDirectory,
-		});
-
-		await expectContainer(h264Mp4, 'mp4');
-		await expectContainer(h264Mkv, 'mkv');
-		await expectContainer(h265Mp4, 'mp4');
-		await expectContainer(av1Mp4, 'mp4');
-		await expectContainer(proResMov, 'mov');
-
-		for (const {codec, container, extension, source} of [
-			{codec: 'h264', container: 'mp4', extension: 'mp4', source: h264Mp4},
-			{codec: 'h264', container: 'mov', extension: 'mov', source: h264Mp4},
-			{codec: 'h264', container: 'mkv', extension: 'mkv', source: h264Mp4},
-			{codec: 'h264', container: 'mpegts', extension: 'ts', source: h264Mp4},
-			{codec: 'h265', container: 'mkv', extension: 'mkv', source: h265Mp4},
-			{codec: 'h265', container: 'hevc', extension: 'hevc', source: h265Mp4},
-			{codec: 'av1', container: 'mkv', extension: 'mkv', source: av1Mp4},
-			{codec: 'av1', container: 'webm', extension: 'webm', source: av1Mp4},
-		] as const) {
-			const output = path.join(testDirectory, `combined-${codec}.${extension}`);
-			await combineChunks({
-				audioFiles: [],
-				codec,
-				compositionDurationInFrames: 1,
-				fps: 1,
-				framesPerChunk: 1,
-				outputLocation: output,
-				preferLossless: false,
-				videoFiles: [source],
+		try {
+			const h264Mp4 = await stitchVideo({
+				codec: 'h264',
+				extension: 'mp4',
+				testDirectory,
 			});
-			await expectContainer(output, container);
+			const h264Mkv = await stitchVideo({
+				codec: 'h264',
+				extension: 'mkv',
+				testDirectory,
+			});
+			const h265Mp4 = await stitchVideo({
+				codec: 'h265',
+				extension: 'mp4',
+				testDirectory,
+			});
+			const av1Mp4 = await stitchVideo({
+				codec: 'av1',
+				extension: 'mp4',
+				testDirectory,
+			});
+			const proResMov = await stitchVideo({
+				codec: 'prores',
+				extension: 'mov',
+				testDirectory,
+			});
+
+			await expectContainer(h264Mp4, 'mp4');
+			await expectContainer(h264Mkv, 'mkv');
+			await expectContainer(h265Mp4, 'mp4');
+			await expectContainer(av1Mp4, 'mp4');
+			await expectContainer(proResMov, 'mov');
+
+			for (const {codec, container, extension, source} of [
+				{codec: 'h264', container: 'mp4', extension: 'mp4', source: h264Mp4},
+				{codec: 'h264', container: 'mov', extension: 'mov', source: h264Mp4},
+				{codec: 'h264', container: 'mkv', extension: 'mkv', source: h264Mp4},
+				{codec: 'h264', container: 'mpegts', extension: 'ts', source: h264Mp4},
+				{codec: 'h265', container: 'mkv', extension: 'mkv', source: h265Mp4},
+				{codec: 'h265', container: 'hevc', extension: 'hevc', source: h265Mp4},
+				{codec: 'av1', container: 'mkv', extension: 'mkv', source: av1Mp4},
+				{codec: 'av1', container: 'webm', extension: 'webm', source: av1Mp4},
+			] as const) {
+				const output = path.join(
+					testDirectory,
+					`combined-${codec}.${extension}`,
+				);
+				await combineChunks({
+					audioFiles: [],
+					codec,
+					compositionDurationInFrames: 1,
+					fps: 1,
+					framesPerChunk: 1,
+					outputLocation: output,
+					preferLossless: false,
+					videoFiles: [source],
+				});
+				await expectContainer(output, container);
+			}
+		} finally {
+			await fs.promises.rm(testDirectory, {force: true, recursive: true});
 		}
-	} finally {
-		await fs.promises.rm(testDirectory, {force: true, recursive: true});
-	}
-});
+	},
+	{timeout: 15_000},
+);

--- a/packages/renderer/src/test/stitch-frames-to-video.test.ts
+++ b/packages/renderer/src/test/stitch-frames-to-video.test.ts
@@ -3,7 +3,111 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {cleanDownloadMap, makeDownloadMap} from '../assets/download-map';
+import {callFf} from '../call-ffmpeg';
+import type {Codec} from '../codec';
+import {combineChunks} from '../combine-chunks';
+import {getFastStartMuxer} from '../get-fast-start-muxer';
 import {stitchFramesToVideo} from '../stitch-frames-to-video';
+
+type Container = 'hevc' | 'mkv' | 'mov' | 'mp4' | 'mpegts' | 'webm';
+
+const expectContainer = async (file: string, container: Container) => {
+	const probe = await callFf({
+		bin: 'ffprobe',
+		args: [
+			'-v',
+			'error',
+			'-show_entries',
+			'format=format_name:format_tags=major_brand',
+			'-of',
+			'json',
+			file,
+		],
+		indent: false,
+		logLevel: 'error',
+		binariesDirectory: null,
+		cancelSignal: undefined,
+	});
+	const parsed = JSON.parse(probe.stdout) as {
+		format: {format_name: string; tags?: {major_brand?: string}};
+	};
+	const output = await fs.promises.readFile(file);
+
+	if (container === 'mp4' || container === 'mov') {
+		expect(parsed.format.format_name).toBe('mov,mp4,m4a,3gp,3g2,mj2');
+		expect(parsed.format.tags?.major_brand).toBe(
+			container === 'mov' ? 'qt  ' : 'isom',
+		);
+		expect(output.indexOf('moov')).toBeGreaterThan(-1);
+		expect(output.indexOf('moov')).toBeLessThan(output.indexOf('mdat'));
+		return;
+	}
+
+	if (container === 'mkv' || container === 'webm') {
+		expect(parsed.format.format_name).toBe('matroska,webm');
+		expect(
+			output.includes(Buffer.from(container === 'mkv' ? 'matroska' : 'webm')),
+		).toBe(true);
+		return;
+	}
+
+	expect(parsed.format.format_name).toBe(container);
+};
+
+const stitchVideo = async ({
+	codec,
+	extension,
+	testDirectory,
+}: {
+	codec: Codec;
+	extension: string;
+	testDirectory: string;
+}) => {
+	const downloadMap = makeDownloadMap(48000);
+	const output = path.join(testDirectory, `stitched-${codec}.${extension}`);
+	try {
+		await stitchFramesToVideo({
+			assetsInfo: {
+				assets: [
+					{
+						frame: 0,
+						audioAndVideoAssets: [],
+						artifactAssets: [],
+						inlineAudioAssets: [],
+					},
+				],
+				chunkLengthInSeconds: 1,
+				downloadMap,
+				firstFrameIndex: 0,
+				forSeamlessAacConcatenation: false,
+				imageSequenceName: path.join(testDirectory, 'frame-%d.png'),
+				trimLeftOffset: 0,
+				trimRightOffset: 0,
+			},
+			codec,
+			force: true,
+			fps: 1,
+			height: 128,
+			muted: true,
+			outputLocation: output,
+			pixelFormat: codec === 'prores' ? 'yuv422p10le' : undefined,
+			width: 128,
+		});
+	} finally {
+		downloadMap.allowCleanup();
+		cleanDownloadMap(downloadMap);
+	}
+
+	return output;
+};
+
+test('Fast Start muxers are selected from the container extension', () => {
+	expect(
+		['mp4', 'MP4', 'mov', 'MOV', 'mkv', 'ts', 'hevc', 'webm'].map(
+			getFastStartMuxer,
+		),
+	).toEqual(['mp4', 'mp4', 'mov', 'mov', null, null, null, null]);
+});
 
 test('Fast Start finalization stays off the public output path', async () => {
 	const testDirectory = await fs.promises.mkdtemp(
@@ -89,6 +193,84 @@ test('Fast Start finalization stays off the public output path', async () => {
 	} finally {
 		downloadMap.allowCleanup();
 		cleanDownloadMap(downloadMap);
+		await fs.promises.rm(testDirectory, {force: true, recursive: true});
+	}
+});
+
+test('Fast Start is selected from the output container', async () => {
+	const testDirectory = await fs.promises.mkdtemp(
+		path.join(os.tmpdir(), 'remotion-faststart-container-test-'),
+	);
+	await fs.promises.copyFile(
+		path.join(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'example',
+			'public',
+			'stuttgart-pin.png',
+		),
+		path.join(testDirectory, 'frame-0.png'),
+	);
+
+	try {
+		const h264Mp4 = await stitchVideo({
+			codec: 'h264',
+			extension: 'mp4',
+			testDirectory,
+		});
+		const h264Mkv = await stitchVideo({
+			codec: 'h264',
+			extension: 'mkv',
+			testDirectory,
+		});
+		const h265Mp4 = await stitchVideo({
+			codec: 'h265',
+			extension: 'mp4',
+			testDirectory,
+		});
+		const av1Mp4 = await stitchVideo({
+			codec: 'av1',
+			extension: 'mp4',
+			testDirectory,
+		});
+		const proResMov = await stitchVideo({
+			codec: 'prores',
+			extension: 'mov',
+			testDirectory,
+		});
+
+		await expectContainer(h264Mp4, 'mp4');
+		await expectContainer(h264Mkv, 'mkv');
+		await expectContainer(h265Mp4, 'mp4');
+		await expectContainer(av1Mp4, 'mp4');
+		await expectContainer(proResMov, 'mov');
+
+		for (const {codec, container, extension, source} of [
+			{codec: 'h264', container: 'mp4', extension: 'mp4', source: h264Mp4},
+			{codec: 'h264', container: 'mov', extension: 'mov', source: h264Mp4},
+			{codec: 'h264', container: 'mkv', extension: 'mkv', source: h264Mp4},
+			{codec: 'h264', container: 'mpegts', extension: 'ts', source: h264Mp4},
+			{codec: 'h265', container: 'mkv', extension: 'mkv', source: h265Mp4},
+			{codec: 'h265', container: 'hevc', extension: 'hevc', source: h265Mp4},
+			{codec: 'av1', container: 'mkv', extension: 'mkv', source: av1Mp4},
+			{codec: 'av1', container: 'webm', extension: 'webm', source: av1Mp4},
+		] as const) {
+			const output = path.join(testDirectory, `combined-${codec}.${extension}`);
+			await combineChunks({
+				audioFiles: [],
+				codec,
+				compositionDurationInFrames: 1,
+				fps: 1,
+				framesPerChunk: 1,
+				outputLocation: output,
+				preferLossless: false,
+				videoFiles: [source],
+			});
+			await expectContainer(output, container);
+		}
+	} finally {
 		await fs.promises.rm(testDirectory, {force: true, recursive: true});
 	}
 });


### PR DESCRIPTION
## Summary

- select Fast Start from the resolved MP4 or MOV output container instead of the video codec
- share the same container decision between frame stitching and final chunk muxing
- cover MP4, MOV, MKV, MPEG-TS, raw HEVC, and WebM with real FFmpeg artifacts

## Testing

- `bun test src/test/stitch-frames-to-video.test.ts` in `packages/renderer`
- `bun run build`
- `bun run stylecheck`

Red/green verified for both frame stitching and final audio/video muxing.

Closes #10753
