### PR TITLE
`@remotion/browser-studio`: Support Safari

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -73,6 +73,15 @@ const waitForBrowserStudioOperations = async (studio: FrameLocator) => {
 		.toBe(true);
 };
 
+test('runs Browser Studio in Safari', async ({page}) => {
+	await page.goto('/');
+
+	expect(await page.evaluate(() => window.crossOriginIsolated)).toBe(true);
+	await expect(
+		page.frameLocator('iframe').getByTitle('/project').getByText('MyComp'),
+	).toBeVisible();
+});
+
 test('loads Browser Studio, opens external links, and can add, delete, and duplicate', async ({
 	page,
 }) => {

--- a/packages/browser-studio/e2e/server.ts
+++ b/packages/browser-studio/e2e/server.ts
@@ -77,7 +77,7 @@ Bun.serve({
 	async fetch(request) {
 		const url = new URL(request.url);
 		const headers = {
-			'Cross-Origin-Embedder-Policy': 'credentialless',
+			'Cross-Origin-Embedder-Policy': 'require-corp',
 			'Cross-Origin-Opener-Policy': 'same-origin',
 		};
 

--- a/packages/browser-studio/playwright.config.ts
+++ b/packages/browser-studio/playwright.config.ts
@@ -19,7 +19,13 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'chromium',
+			grepInvert: /runs Browser Studio in Safari/,
 			use: {...devices['Desktop Chrome']},
+		},
+		{
+			name: 'webkit',
+			grep: /runs Browser Studio in Safari/,
+			use: {...devices['Desktop Safari']},
 		},
 	],
 	webServer: {

--- a/packages/browser-studio/src/dev/server.ts
+++ b/packages/browser-studio/src/dev/server.ts
@@ -15,7 +15,7 @@ const workspacePackagesDir = path.join(repoDir, 'packages');
 const workspacePackagePath = '/__remotion_browser_studio_workspace__/';
 
 const headers = {
-	'Cross-Origin-Embedder-Policy': 'credentialless',
+	'Cross-Origin-Embedder-Policy': 'require-corp',
 	'Cross-Origin-Opener-Policy': 'same-origin',
 };
 

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -1,7 +1,7 @@
 import {routes, type VercelConfig} from '@vercel/config/v1';
 
 const browserStudioIsolationHeaders = [
-	{key: 'Cross-Origin-Embedder-Policy', value: 'credentialless'},
+	{key: 'Cross-Origin-Embedder-Policy', value: 'require-corp'},
 	{key: 'Cross-Origin-Opener-Policy', value: 'same-origin'},
 ];
 


### PR DESCRIPTION
## Summary

- serve Browser Studio with `Cross-Origin-Embedder-Policy: require-corp` so Safari enables the cross-origin isolation required by Rspack's threaded WebAssembly runtime
- cover Browser Studio startup in WebKit and verify that the page is isolated before asserting the compiled composition is visible

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testbrowserstudio`

Closes #10782
