### PR TITLE
`@remotion/web-renderer`: Allow setting metadata

### DIFF
--- a/packages/docs/docs/metadata.mdx
+++ b/packages/docs/docs/metadata.mdx
@@ -39,6 +39,7 @@ You can set metadata when rendering videos with Remotion using
 - [`--metadata`](/docs/lambda/cli/render#--metadata) in `npx remotion lambda render`
 - [`--metadata`](/docs/cloudrun/cli/render#--metadata) in `npx remotion cloudrun render`
 - [`metadata`](/docs/renderer/render-media#metadata) in `renderMedia()`
+- [`metadata`](/docs/web-renderer/render-media-on-web#metadata) in [`renderMediaOnWeb()`](/docs/web-renderer/render-media-on-web) <AvailableFrom v="4.0.517" inline />
 - [`metadata`](/docs/lambda/rendermediaonlambda) in `renderMediaOnLambda()`
 - [`metadata`](/docs/cloudrun/rendermediaoncloudrun) in `renderMediaOnCloudrun()`
 

--- a/packages/docs/docs/web-renderer/render-media-on-web.mdx
+++ b/packages/docs/docs/web-renderer/render-media-on-web.mdx
@@ -209,6 +209,37 @@ _number_
 The [audio sample rate](/docs/sample-rate) in Hz.  
 Default is `48000`.
 
+### `metadata?`<AvailableFrom v="4.0.517" />
+
+_object_ <TsType type="MetadataTags" source="mediabunny" href="https://mediabunny.dev/api/MetadataTags" />
+
+Metadata to embed in the output media. See [Mediabunny's metadata documentation](https://mediabunny.dev/guide/reading-media-files#reading-metadata-tags) for the available fields.
+
+```tsx twoslash title="Set output metadata"
+const Component: React.FC = () => null;
+
+// ---cut---
+import {renderMediaOnWeb} from '@remotion/web-renderer';
+
+await renderMediaOnWeb({
+  composition: {
+    component: Component,
+    durationInFrames: 100,
+    fps: 30,
+    width: 1920,
+    height: 1080,
+    id: 'my-composition',
+  },
+  metadata: {
+    title: 'My video',
+    artist: 'Remotion user',
+    comment: 'My comment',
+  },
+});
+```
+
+Remotion adds `Made with Remotion <version>` to the comment. If you pass a comment, it is appended after this text.
+
 ### `delayRenderTimeoutInMilliseconds?`
 
 _number_

--- a/packages/web-renderer/src/render-media-on-web.tsx
+++ b/packages/web-renderer/src/render-media-on-web.tsx
@@ -1,4 +1,9 @@
-import {BufferTarget, StreamTarget, type StreamTargetChunk} from 'mediabunny';
+import {
+	BufferTarget,
+	StreamTarget,
+	type MetadataTags,
+	type StreamTargetChunk,
+} from 'mediabunny';
 import type {CalculateMetadataFunction} from 'remotion';
 import {Internals, type LogLevel} from 'remotion';
 import {VERSION} from 'remotion/version';
@@ -140,6 +145,7 @@ type OptionalRenderMediaOnWebOptions<Schema extends $ZodObject> = {
 	scale: number;
 	sampleRate: number;
 	allowHtmlInCanvas: boolean;
+	metadata: MetadataTags | null;
 };
 
 export type RenderMediaOnWebOptions<
@@ -191,6 +197,7 @@ const internalRenderMediaOnWeb = async <
 	isProduction,
 	sampleRate,
 	allowHtmlInCanvas,
+	metadata,
 }: InternalRenderMediaOnWebOptions<
 	Schema,
 	Props
@@ -423,8 +430,13 @@ const internalRenderMediaOnWeb = async <
 		target,
 	});
 
+	const defaultComment = `Made with Remotion ${VERSION}`;
 	outputWithCleanup.output.setMetadataTags({
-		comment: `Made with Remotion ${VERSION}`,
+		...(metadata ?? {}),
+		comment:
+			metadata?.comment === undefined
+				? defaultComment
+				: `${defaultComment}; ${metadata.comment}`,
 	});
 
 	using throttledProgress = createThrottledProgressCallback(onProgress);
@@ -799,6 +811,7 @@ export const renderMediaOnWeb = <
 				isProduction: options.isProduction ?? true,
 				allowHtmlInCanvas: options.allowHtmlInCanvas ?? false,
 				sampleRate: options.sampleRate ?? 48000,
+				metadata: options.metadata ?? null,
 			}),
 		);
 

--- a/packages/web-renderer/src/test/render-media.test.tsx
+++ b/packages/web-renderer/src/test/render-media.test.tsx
@@ -322,7 +322,7 @@ test(
 	},
 );
 
-test('should include "Made with Remotion" metadata', async (t) => {
+test('should include custom metadata and "Made with Remotion"', async (t) => {
 	if (t.task.file.projectName === 'webkit') {
 		t.skip();
 		return;
@@ -340,6 +340,11 @@ test('should include "Made with Remotion" metadata', async (t) => {
 			durationInFrames: 5,
 		},
 		inputProps: {},
+		metadata: {
+			title: 'My video',
+			artist: 'Remotion user',
+			comment: 'My comment',
+		},
 	});
 
 	const blob = await result.getBlob();
@@ -350,7 +355,9 @@ test('should include "Made with Remotion" metadata', async (t) => {
 	});
 
 	const tags = await input.getMetadataTags();
-	expect(tags.comment).toBe(`Made with Remotion ${VERSION}`);
+	expect(tags.title).toBe('My video');
+	expect(tags.artist).toBe('Remotion user');
+	expect(tags.comment).toBe(`Made with Remotion ${VERSION}; My comment`);
 });
 
 test('should not fire stale progress callbacks after render completes', async (t) => {


### PR DESCRIPTION
## Summary

- add a `metadata` option to `renderMediaOnWeb()` using Mediabunny's `MetadataTags`
- preserve the mandatory `Made with Remotion` comment while appending a custom comment
- verify embedded metadata from the rendered output and document the new option

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx vitest src/test/render-media.test.tsx --run -t 'custom metadata'`
- `TWOSLASH_WORKER_COUNT=1 bun prewarm-twoslash.ts`

Closes #10727

## Preview

- [`renderMediaOnWeb()` documentation](https://remotion-git-codex-render-media-on-web-metadata-remotion.vercel.app/docs/web-renderer/render-media-on-web)
- [Setting video metadata](https://remotion-git-codex-render-media-on-web-metadata-remotion.vercel.app/docs/metadata#adding-metadata)
