### PR TITLE
Elements: Keep interactive nodes draggable

### DIFF
--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -37,6 +37,7 @@ type MovingPillCaptionsLayerProps = Omit<
 	MovingPillCaptionsProps,
 	'captions'
 > & {
+	readonly callerStyle: React.CSSProperties | null;
 	readonly captions: Caption[];
 };
 
@@ -78,6 +79,7 @@ const movingPillCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
+	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -392,6 +394,7 @@ const MovingPillCaptionsInner = forwardRef<
 >(
 	(
 		{
+			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -405,6 +408,16 @@ const MovingPillCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
+		const {
+			rotate: callerRotate,
+			scale: callerScale,
+			transform: callerTransform,
+			transformBox: callerTransformBox,
+			transformOrigin: callerTransformOrigin,
+			transformStyle: callerTransformStyle,
+			translate: callerTranslate,
+			...callerContentStyle
+		} = callerStyle ?? {};
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -429,19 +442,34 @@ const MovingPillCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
-					ref={outlineRef}
 					style={{
 						height: height ?? '100%',
+						rotate: callerRotate,
+						scale: callerScale,
+						transform: callerTransform,
+						transformBox: callerTransformBox,
+						transformOrigin: callerTransformOrigin,
+						transformStyle: callerTransformStyle,
+						translate: callerTranslate,
 						width: width ?? '100%',
-						...style,
 					}}
 				>
-					<MovingPillCaptionsContent
-						captionAreaWidth={width ?? null}
-						captions={captions}
-						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
-						fontLoaded={fontLoaded}
-					/>
+					<div
+						ref={outlineRef}
+						style={{
+							height: '100%',
+							width: '100%',
+							...style,
+							...callerContentStyle,
+						}}
+					>
+						<MovingPillCaptionsContent
+							captionAreaWidth={width ?? null}
+							captions={captions}
+							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
+							fontLoaded={fontLoaded}
+						/>
+					</div>
 				</div>
 			</Sequence>
 		);
@@ -458,10 +486,18 @@ const MovingPillCaptionsLayer = Interactive.withSchema({
 
 export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 	captions,
+	style,
 	...props
 }) => {
 	if (captions) {
-		return <MovingPillCaptionsLayer {...props} captions={captions} />;
+		return (
+			<MovingPillCaptionsLayer
+				{...props}
+				callerStyle={style ?? null}
+				captions={captions}
+				style={{translate: '0px 0px'}}
+			/>
+		);
 	}
 
 	return (
@@ -476,6 +512,7 @@ export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 		>
 			<MovingPillCaptionsLayer
 				{...props}
+				callerStyle={style ?? null}
 				captions={[
 					{
 						text: 'Captions',
@@ -529,6 +566,7 @@ export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 				]}
 				width={681}
 				height={252}
+				style={{translate: '0px 0px'}}
 			/>
 		</div>
 	);

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -36,6 +36,7 @@ type PoppingWordCaptionsLayerProps = Omit<
 	PoppingWordCaptionsProps,
 	'captions'
 > & {
+	readonly callerStyle: React.CSSProperties | null;
 	readonly captions: Caption[];
 };
 
@@ -74,6 +75,7 @@ const poppingWordCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
+	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -302,6 +304,7 @@ const PoppingWordCaptionsInner = forwardRef<
 >(
 	(
 		{
+			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -315,6 +318,16 @@ const PoppingWordCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
+		const {
+			rotate: callerRotate,
+			scale: callerScale,
+			transform: callerTransform,
+			transformBox: callerTransformBox,
+			transformOrigin: callerTransformOrigin,
+			transformStyle: callerTransformStyle,
+			translate: callerTranslate,
+			...callerContentStyle
+		} = callerStyle ?? {};
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -339,19 +352,34 @@ const PoppingWordCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
-					ref={outlineRef}
 					style={{
 						height: height ?? '100%',
+						rotate: callerRotate,
+						scale: callerScale,
+						transform: callerTransform,
+						transformBox: callerTransformBox,
+						transformOrigin: callerTransformOrigin,
+						transformStyle: callerTransformStyle,
+						translate: callerTranslate,
 						width: width ?? '100%',
-						...style,
 					}}
 				>
-					<PoppingWordCaptionsContent
-						captionAreaWidth={width ?? null}
-						captions={captions}
-						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
-						fontLoaded={fontLoaded}
-					/>
+					<div
+						ref={outlineRef}
+						style={{
+							height: '100%',
+							width: '100%',
+							...style,
+							...callerContentStyle,
+						}}
+					>
+						<PoppingWordCaptionsContent
+							captionAreaWidth={width ?? null}
+							captions={captions}
+							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
+							fontLoaded={fontLoaded}
+						/>
+					</div>
 				</div>
 			</Sequence>
 		);
@@ -368,10 +396,18 @@ const PoppingWordCaptionsLayer = Interactive.withSchema({
 
 export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 	captions,
+	style,
 	...props
 }) => {
 	if (captions) {
-		return <PoppingWordCaptionsLayer {...props} captions={captions} />;
+		return (
+			<PoppingWordCaptionsLayer
+				{...props}
+				callerStyle={style ?? null}
+				captions={captions}
+				style={{translate: '0px 0px'}}
+			/>
+		);
 	}
 
 	return (
@@ -386,6 +422,7 @@ export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 		>
 			<PoppingWordCaptionsLayer
 				{...props}
+				callerStyle={style ?? null}
 				captions={[
 					{
 						text: 'Captions',
@@ -439,6 +476,7 @@ export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 				]}
 				width={681}
 				height={252}
+				style={{translate: '0px 0px'}}
 			/>
 		</div>
 	);

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -34,6 +34,7 @@ type WordHighlightCaptionsLayerProps = Omit<
 	WordHighlightCaptionsProps,
 	'captions'
 > & {
+	readonly callerStyle: React.CSSProperties | null;
 	readonly captions: Caption[];
 };
 
@@ -71,6 +72,7 @@ const wordHighlightCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
+	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -260,6 +262,7 @@ const WordHighlightCaptionsInner = forwardRef<
 >(
 	(
 		{
+			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -273,6 +276,16 @@ const WordHighlightCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
+		const {
+			rotate: callerRotate,
+			scale: callerScale,
+			transform: callerTransform,
+			transformBox: callerTransformBox,
+			transformOrigin: callerTransformOrigin,
+			transformStyle: callerTransformStyle,
+			translate: callerTranslate,
+			...callerContentStyle
+		} = callerStyle ?? {};
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -297,19 +310,34 @@ const WordHighlightCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
-					ref={outlineRef}
 					style={{
 						height: height ?? '100%',
+						rotate: callerRotate,
+						scale: callerScale,
+						transform: callerTransform,
+						transformBox: callerTransformBox,
+						transformOrigin: callerTransformOrigin,
+						transformStyle: callerTransformStyle,
+						translate: callerTranslate,
 						width: width ?? '100%',
-						...style,
 					}}
 				>
-					<WordHighlightCaptionsContent
-						captionAreaWidth={width ?? null}
-						captions={captions}
-						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
-						fontLoaded={fontLoaded}
-					/>
+					<div
+						ref={outlineRef}
+						style={{
+							height: '100%',
+							width: '100%',
+							...style,
+							...callerContentStyle,
+						}}
+					>
+						<WordHighlightCaptionsContent
+							captionAreaWidth={width ?? null}
+							captions={captions}
+							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
+							fontLoaded={fontLoaded}
+						/>
+					</div>
 				</div>
 			</Sequence>
 		);
@@ -326,10 +354,18 @@ const WordHighlightCaptionsLayer = Interactive.withSchema({
 
 export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 	captions,
+	style,
 	...props
 }) => {
 	if (captions) {
-		return <WordHighlightCaptionsLayer {...props} captions={captions} />;
+		return (
+			<WordHighlightCaptionsLayer
+				{...props}
+				callerStyle={style ?? null}
+				captions={captions}
+				style={{translate: '0px 0px'}}
+			/>
+		);
 	}
 
 	return (
@@ -344,6 +380,7 @@ export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 		>
 			<WordHighlightCaptionsLayer
 				{...props}
+				callerStyle={style ?? null}
 				captions={[
 					{
 						text: 'Captions',
@@ -397,6 +434,7 @@ export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 				]}
 				width={681}
 				height={252}
+				style={{translate: '0px 0px'}}
 			/>
 		</div>
 	);

--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -9,6 +9,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 	type InteractiveBaseProps,
+	type InteractiveTransformProps,
 	type InteractivitySchema,
 	type SequenceControls,
 } from 'remotion';
@@ -18,16 +19,18 @@ loadFont('normal', {
 	weights: ['500', '600', '700'],
 });
 
-type ProductCardProps = InteractiveBaseProps & {
-	readonly count: number;
-	readonly discount: string;
-	readonly image: string;
-	readonly imageFit: 'contain' | 'cover';
-	readonly index: number;
-	readonly originalPrice: string;
-	readonly price: string;
-	readonly title: string;
-};
+type ProductCardProps = InteractiveBaseProps &
+	Omit<InteractiveTransformProps, 'style'> & {
+		readonly count: number;
+		readonly discount: string;
+		readonly image: string;
+		readonly imageFit: 'contain' | 'cover';
+		readonly index: number;
+		readonly originalPrice: string;
+		readonly price: string;
+		readonly style: React.CSSProperties | null;
+		readonly title: string;
+	};
 
 const productCardSchema = {
 	...Interactive.baseSchema,
@@ -68,6 +71,7 @@ const productCardSchema = {
 	},
 	count: {type: 'hidden'},
 	index: {type: 'hidden'},
+	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
 const ProductCardInner = forwardRef<
@@ -85,6 +89,7 @@ const ProductCardInner = forwardRef<
 			name,
 			originalPrice,
 			price,
+			style,
 			title,
 			...sequenceProps
 		},
@@ -169,7 +174,6 @@ const ProductCardInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
-					ref={outlineRef}
 					style={{
 						height: 560,
 						left: 300,
@@ -186,7 +190,9 @@ const ProductCardInner = forwardRef<
 					}}
 				>
 					<div
+						ref={outlineRef}
 						style={{
+							...style,
 							backgroundColor: '#ffffff',
 							boxSizing: 'border-box',
 							color: '#1d1d19',
@@ -425,6 +431,7 @@ export const ProductCollection = () => {
 				name="Cloudline Runner card"
 				originalPrice="$148"
 				price="$118"
+				style={{translate: '0px 0px'}}
 				title="Cloudline Runner"
 			/>
 			<ProductCard
@@ -436,6 +443,7 @@ export const ProductCollection = () => {
 				name="Minimal Steel Watch card"
 				originalPrice=""
 				price="$185"
+				style={{translate: '0px 0px'}}
 				title="Minimal Steel Watch"
 			/>
 			<ProductCard
@@ -447,6 +455,7 @@ export const ProductCollection = () => {
 				name="Studio Sunglasses card"
 				originalPrice="$125"
 				price="$94"
+				style={{translate: '0px 0px'}}
 				title="Studio Sunglasses"
 			/>
 			<ProductCard
@@ -458,6 +467,7 @@ export const ProductCollection = () => {
 				name="Studio Headset card"
 				originalPrice=""
 				price="$179"
+				style={{translate: '0px 0px'}}
 				title="Studio Headset"
 			/>
 			<ProductCard
@@ -469,6 +479,7 @@ export const ProductCollection = () => {
 				name="Sculptural Table Lamp card"
 				originalPrice=""
 				price="$149"
+				style={{translate: '0px 0px'}}
 				title="Sculptural Table Lamp"
 			/>
 		</Interactive.Div>

--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -349,7 +349,7 @@ const ProductCard = Interactive.withSchema({
 
 export const ProductCollection = () => {
 	const frame = useCurrentFrame();
-	const {durationInFrames} = useVideoConfig();
+	const {durationInFrames: collectionDurationInFrames} = useVideoConfig();
 
 	return (
 		<Interactive.Div
@@ -364,7 +364,12 @@ export const ProductCollection = () => {
 				left: 60,
 				opacity: interpolate(
 					frame,
-					[0, 10, durationInFrames - 8, durationInFrames - 1],
+					[
+						0,
+						10,
+						collectionDurationInFrames - 8,
+						collectionDurationInFrames - 1,
+					],
 					[0, 1, 1, 0],
 					{
 						easing: Easing.bezier(0.16, 1, 0.3, 1),
@@ -376,7 +381,12 @@ export const ProductCollection = () => {
 				position: 'absolute',
 				scale: interpolate(
 					frame,
-					[0, 16, durationInFrames - 8, durationInFrames - 1],
+					[
+						0,
+						16,
+						collectionDurationInFrames - 8,
+						collectionDurationInFrames - 1,
+					],
 					[0.97, 1, 1, 0.98],
 					{
 						easing: Easing.bezier(0.16, 1, 0.3, 1),
@@ -389,7 +399,12 @@ export const ProductCollection = () => {
 				transform: 'perspective(100px)',
 				translate: interpolate(
 					frame,
-					[0, 16, durationInFrames - 8, durationInFrames - 1],
+					[
+						0,
+						16,
+						collectionDurationInFrames - 8,
+						collectionDurationInFrames - 1,
+					],
 					['0px 30px', '0px 0px', '0px 0px', '0px -20px'],
 					{
 						easing: Easing.bezier(0.16, 1, 0.3, 1),

--- a/packages/docs/elements/data/line-chart/line-chart.tsx
+++ b/packages/docs/elements/data/line-chart/line-chart.tsx
@@ -98,7 +98,7 @@ export const LineChart: React.FC = () => {
 						letterSpacing: -3.8,
 						lineHeight: 0.95,
 						margin: 0,
-						translate: '0 -32px',
+						translate: '0px -32px',
 					}}
 				>
 					Monthly active users
@@ -132,7 +132,8 @@ export const LineChart: React.FC = () => {
 									right: 0,
 									textAlign: 'right',
 									top: `${((MAX_VALUE - value) / (MAX_VALUE - MIN_VALUE)) * 100}%`,
-									translate: '0 -50%',
+									transform: 'translateY(-50%)',
+									translate: '0px 0px',
 									whiteSpace: 'nowrap',
 									width: '100%',
 								}}
@@ -249,7 +250,8 @@ export const LineChart: React.FC = () => {
 										left: `${((CHART_SIDE_PADDING + (index / (data.length - 1)) * (CHART_WIDTH - CHART_SIDE_PADDING * 2)) / CHART_WIDTH) * 100}%`,
 										position: 'absolute',
 										top: 0,
-										translate: '-50% 0',
+										transform: 'translateX(-50%)',
+										translate: '0px 0px',
 									}}
 								>
 									{label}

--- a/packages/docs/elements/data/line-chart/line-chart.tsx
+++ b/packages/docs/elements/data/line-chart/line-chart.tsx
@@ -124,22 +124,28 @@ export const LineChart: React.FC = () => {
 						}}
 					>
 						{Y_AXIS_VALUES.map((value) => (
-							<Interactive.Div
+							<div
 								key={value}
-								name="Y-axis label"
 								style={{
 									position: 'absolute',
 									right: 0,
-									textAlign: 'right',
 									top: `${((MAX_VALUE - value) / (MAX_VALUE - MIN_VALUE)) * 100}%`,
 									transform: 'translateY(-50%)',
-									translate: '0px 0px',
-									whiteSpace: 'nowrap',
 									width: '100%',
 								}}
 							>
-								{value}K
-							</Interactive.Div>
+								<Interactive.Div
+									name="Y-axis label"
+									style={{
+										textAlign: 'right',
+										translate: '0px 0px',
+										whiteSpace: 'nowrap',
+										width: '100%',
+									}}
+								>
+									{value}K
+								</Interactive.Div>
+							</div>
 						))}
 					</div>
 					<svg
@@ -243,19 +249,22 @@ export const LineChart: React.FC = () => {
 					>
 						{data.map(({label}, index) =>
 							index % 2 === 0 ? (
-								<Interactive.Div
+								<div
 									key={label}
-									name="X-axis label"
 									style={{
 										left: `${((CHART_SIDE_PADDING + (index / (data.length - 1)) * (CHART_WIDTH - CHART_SIDE_PADDING * 2)) / CHART_WIDTH) * 100}%`,
 										position: 'absolute',
 										top: 0,
 										transform: 'translateX(-50%)',
-										translate: '0px 0px',
 									}}
 								>
-									{label}
-								</Interactive.Div>
+									<Interactive.Div
+										name="X-axis label"
+										style={{translate: '0px 0px'}}
+									>
+										{label}
+									</Interactive.Div>
+								</div>
 							) : null,
 						)}
 					</div>

--- a/packages/docs/elements/data/vertical-bar-chart/vertical-bar-chart.tsx
+++ b/packages/docs/elements/data/vertical-bar-chart/vertical-bar-chart.tsx
@@ -216,20 +216,26 @@ export const VerticalBarChart: React.FC = () => {
 						width: 1080,
 					}}
 				>
-					<Interactive.Div
-						name="Baseline"
+					<div
 						style={{
-							backgroundColor: '#c5cad2',
 							bottom: 68,
-							height: 3,
 							left: '50%',
 							position: 'absolute',
 							transform: 'translate(-50%, 50%)',
-							translate: '0px 0px',
 							width: '100%',
 							zIndex: 1,
 						}}
-					/>
+					>
+						<Interactive.Div
+							name="Baseline"
+							style={{
+								backgroundColor: '#c5cad2',
+								height: 3,
+								translate: '0px 0px',
+								width: '100%',
+							}}
+						/>
+					</div>
 					{data.map(({highlighted, label, value}, index) => (
 						<div
 							key={label}

--- a/packages/docs/elements/data/vertical-bar-chart/vertical-bar-chart.tsx
+++ b/packages/docs/elements/data/vertical-bar-chart/vertical-bar-chart.tsx
@@ -200,6 +200,7 @@ export const VerticalBarChart: React.FC = () => {
 						letterSpacing: -3.8,
 						lineHeight: 0.95,
 						margin: 0,
+						translate: '0px 0px',
 					}}
 				>
 					Browser tabs open
@@ -223,7 +224,8 @@ export const VerticalBarChart: React.FC = () => {
 							height: 3,
 							left: '50%',
 							position: 'absolute',
-							translate: '-50% 50%',
+							transform: 'translate(-50%, 50%)',
+							translate: '0px 0px',
 							width: '100%',
 							zIndex: 1,
 						}}

--- a/packages/docs/elements/storytelling/polaroid-pictures/polaroid-pictures.tsx
+++ b/packages/docs/elements/storytelling/polaroid-pictures/polaroid-pictures.tsx
@@ -14,17 +14,11 @@ loadFont('normal', {
 });
 
 export const PolaroidPictures = () => {
-	const sequenceFrame = useCurrentFrame();
-	const {durationInFrames: sequenceDurationInFrames} = useVideoConfig();
-	// Compress the treatment when its wrapping Sequence is shorter than 150 frames.
-	const durationInFrames = Math.max(sequenceDurationInFrames, 150);
-	const frame =
-		sequenceFrame *
-		((durationInFrames - 1) / Math.max(1, sequenceDurationInFrames - 1));
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
 
 	return (
-		<Interactive.Div
-			name="Container"
+		<div
 			style={{
 				color: '#2d2620',
 				height: 640,
@@ -430,6 +424,6 @@ export const PolaroidPictures = () => {
 					one more memory
 				</Interactive.Div>
 			</Interactive.Div>
-		</Interactive.Div>
+		</div>
 	);
 };

--- a/packages/docs/elements/text/spinning-text-wheel/spinning-text-wheel.tsx
+++ b/packages/docs/elements/text/spinning-text-wheel/spinning-text-wheel.tsx
@@ -5,12 +5,12 @@ import {
 	Sequence,
 	interpolate,
 	spring,
+	useCurrentFrame,
+	useVideoConfig,
 	type InteractiveBaseProps,
 	type InteractiveTransformProps,
 	type InteractivitySchema,
 	type SequenceControls,
-	useCurrentFrame,
-	useVideoConfig,
 } from 'remotion';
 
 loadFont('normal', {
@@ -23,6 +23,10 @@ type SpinningTextWheelProps = InteractiveBaseProps &
 		readonly items?: string;
 	};
 
+type InteractiveSpinningTextWheelProps = SpinningTextWheelProps & {
+	readonly callerStyle: React.CSSProperties | null;
+};
+
 const spinningTextWheelSchema = {
 	...Interactive.baseSchema,
 	items: {
@@ -31,17 +35,19 @@ const spinningTextWheelSchema = {
 		description: 'Items (selected first, one per line)',
 	},
 	...Interactive.textSchema,
+	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
 const SpinningTextWheelInner = forwardRef<
 	HTMLDivElement,
-	SpinningTextWheelProps & {
+	InteractiveSpinningTextWheelProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
 	(
 		{
+			callerStyle,
 			controls,
 			items = 'Friday\nSaturday\nSunday\nMonday\nTuesday\nWednesday\nThursday',
 			name,
@@ -69,6 +75,16 @@ const SpinningTextWheelInner = forwardRef<
 			durationRestThreshold: 0.0001,
 		});
 		const rotation = interpolate(progress, [0, 1], [1, 0]);
+		const {
+			rotate: callerRotate,
+			scale: callerScale,
+			transform: callerTransform,
+			transformBox: callerTransformBox,
+			transformOrigin: callerTransformOrigin,
+			transformStyle: callerTransformStyle,
+			translate: callerTranslate,
+			...callerContentStyle
+		} = callerStyle ?? {};
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -81,62 +97,75 @@ const SpinningTextWheelInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
-					ref={outlineRef}
 					style={{
-						height: 200,
-						maskImage:
-							'linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 70%, transparent 100%)',
-						overflow: 'hidden',
-						WebkitMaskImage:
-							'linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 70%, transparent 100%)',
-						perspective: 10000,
-						position: 'relative',
-						width: 400,
-						...style,
+						rotate: callerRotate,
+						scale: callerScale,
+						transform: callerTransform,
+						transformBox: callerTransformBox,
+						transformOrigin: callerTransformOrigin,
+						transformStyle: callerTransformStyle,
+						translate: callerTranslate,
 					}}
 				>
-					{values.map((value, index) => {
-						const wheelIndex = index / values.length + rotation;
-						const angle = wheelIndex * Math.PI * 2;
-						const rotateX = wheelIndex * 360;
+					<div
+						ref={outlineRef}
+						style={{
+							height: 200,
+							maskImage:
+								'linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 70%, transparent 100%)',
+							overflow: 'hidden',
+							WebkitMaskImage:
+								'linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 70%, transparent 100%)',
+							perspective: 10000,
+							position: 'relative',
+							width: 400,
+							...style,
+							...callerContentStyle,
+						}}
+					>
+						{values.map((value, index) => {
+							const wheelIndex = index / values.length + rotation;
+							const angle = wheelIndex * Math.PI * 2;
+							const rotateX = wheelIndex * 360;
 
-						return (
-							<div
-								key={`${index}-${value}`}
-								style={{
-									alignItems: 'center',
-									backfaceVisibility: 'hidden',
-									display: 'flex',
-									height: '100%',
-									justifyContent: 'center',
-									left: 0,
-									opacity:
-										index === 0
-											? interpolate(progress, [0.88, 1], [0.28, 1], {
-													extrapolateLeft: 'clamp',
-													extrapolateRight: 'clamp',
-												})
-											: 0.28,
-									position: 'absolute',
-									top: 0,
-									perspective: 1000,
-									transform: `translateZ(${Math.cos(angle) * 100}px) translateY(${Math.sin(angle) * 100}px) rotateX(${rotateX}deg)`,
-									width: '100%',
-								}}
-							>
+							return (
 								<div
+									key={`${index}-${value}`}
 									style={{
+										alignItems: 'center',
 										backfaceVisibility: 'hidden',
-										textAlign: 'center',
-										transform: `rotateX(${-rotateX}deg)`,
+										display: 'flex',
+										height: '100%',
+										justifyContent: 'center',
+										left: 0,
+										opacity:
+											index === 0
+												? interpolate(progress, [0.88, 1], [0.28, 1], {
+														extrapolateLeft: 'clamp',
+														extrapolateRight: 'clamp',
+													})
+												: 0.28,
+										position: 'absolute',
+										top: 0,
+										perspective: 1000,
+										transform: `translateZ(${Math.cos(angle) * 100}px) translateY(${Math.sin(angle) * 100}px) rotateX(${rotateX}deg)`,
 										width: '100%',
 									}}
 								>
-									{value}
+									<div
+										style={{
+											backfaceVisibility: 'hidden',
+											textAlign: 'center',
+											transform: `rotateX(${-rotateX}deg)`,
+											width: '100%',
+										}}
+									>
+										{value}
+									</div>
 								</div>
-							</div>
-						);
-					})}
+							);
+						})}
+					</div>
 				</div>
 			</Sequence>
 		);
@@ -149,21 +178,26 @@ const InteractiveSpinningTextWheel = Interactive.withSchema({
 	componentIdentity: null,
 	schema: spinningTextWheelSchema,
 	supportsEffects: false,
-}) as React.FC<SpinningTextWheelProps>;
+}) as React.FC<InteractiveSpinningTextWheelProps>;
 
-export const SpinningTextWheel: React.FC<SpinningTextWheelProps> = (props) => {
+export const SpinningTextWheel: React.FC<SpinningTextWheelProps> = ({
+	style,
+	...props
+}) => {
 	return (
 		<InteractiveSpinningTextWheel
 			items={'Friday\nSaturday\nSunday\nMonday\nTuesday\nWednesday\nThursday'}
 			name="Spinning text wheel"
+			{...props}
+			callerStyle={style ?? null}
 			style={{
 				color: '#182033',
 				fontFamily: 'Mona Sans',
 				fontSize: 65,
 				fontWeight: 700,
 				lineHeight: 1,
+				translate: '0px 0px',
 			}}
-			{...props}
 		/>
 	);
 };

--- a/packages/docs/elements/youtube/youtube-comment-highlight/youtube-comment-highlight.tsx
+++ b/packages/docs/elements/youtube/youtube-comment-highlight/youtube-comment-highlight.tsx
@@ -26,22 +26,16 @@ export const YouTubeCommentHighlight: React.FC = () => {
 				width: 1120,
 			}}
 		>
-			<Interactive.Div
-				name="Container"
+			<div
 				style={{
-					alignContent: 'center',
 					backfaceVisibility: 'hidden',
 					backgroundColor: '#15161a',
 					border: '1px solid rgba(255, 255, 255, 0.09)',
 					borderRadius: 26,
 					boxShadow: '0 18px 40px rgba(0, 0, 0, 0.26)',
 					boxSizing: 'border-box',
-					columnGap: 18,
-					display: 'grid',
-					gridTemplateColumns: '88px minmax(0, 1fr)',
 					height: 300,
 					left: 0,
-					padding: '24px 40px',
 					position: 'absolute',
 					rotate: interpolate(
 						frame,
@@ -86,94 +80,126 @@ export const YouTubeCommentHighlight: React.FC = () => {
 					width: 1120,
 				}}
 			>
-				<>
-					<CanvasImage
-						fit="cover"
-						height={88}
-						name="Author avatar"
-						src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?fit=crop&w=176&h=176&q=80&fm=jpg"
-						style={{
-							backgroundColor: '#2a2b31',
-							border: '1px solid rgba(255, 255, 255, 0.12)',
-							borderRadius: 999,
-							boxSizing: 'border-box',
-							display: 'block',
-							gridColumn: 1,
-							gridRow: 1,
-							height: 88,
-							width: 88,
-						}}
-						width={88}
-					/>
-
-					<div
-						style={{
-							gridColumn: 2,
-							gridRow: 1,
-							minWidth: 0,
-						}}
-					>
-						<div
+				<Interactive.Div
+					name="Container"
+					style={{
+						alignContent: 'center',
+						boxSizing: 'border-box',
+						columnGap: 18,
+						display: 'grid',
+						gridTemplateColumns: '88px minmax(0, 1fr)',
+						height: '100%',
+						padding: '24px 40px',
+						translate: '0px 0px',
+						width: '100%',
+					}}
+				>
+					<>
+						<CanvasImage
+							fit="cover"
+							height={88}
+							name="Author avatar"
+							src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?fit=crop&w=176&h=176&q=80&fm=jpg"
 							style={{
-								alignItems: 'baseline',
-								display: 'flex',
-								gap: 12,
+								backgroundColor: '#2a2b31',
+								border: '1px solid rgba(255, 255, 255, 0.12)',
+								borderRadius: 999,
+								boxSizing: 'border-box',
+								display: 'block',
+								gridColumn: 1,
+								gridRow: 1,
+								height: 88,
+								width: 88,
 							}}
-						>
-							<Interactive.Span
-								name="Author handle"
-								style={{
-									color: '#ffffff',
-									fontFamily: 'Inter',
-									fontSize: 26,
-									fontWeight: 700,
-									lineHeight: 1.1,
-								}}
-							>
-								@alexrenders
-							</Interactive.Span>
-						</div>
-
-						<Interactive.Div
-							name="Comment"
-							style={{
-								color: '#f4f4f5',
-								fontFamily: 'Inter',
-								fontSize: 32,
-								fontWeight: 500,
-								letterSpacing: -0.35,
-								lineHeight: 1.3,
-								marginTop: 8,
-								overflowWrap: 'anywhere',
-							}}
-						>
-							This breakdown made the whole process click. Would love to see how
-							you plan the animation timing in a future video!
-						</Interactive.Div>
+							width={88}
+						/>
 
 						<div
 							style={{
-								alignItems: 'center',
-								color: '#a9abb3',
-								display: 'flex',
-								fontFamily: 'Inter',
-								fontSize: 22,
-								fontWeight: 600,
-								gap: 22,
-								lineHeight: 1,
-								marginTop: 14,
+								gridColumn: 2,
+								gridRow: 1,
+								minWidth: 0,
 							}}
 						>
 							<div
 								style={{
-									alignItems: 'center',
+									alignItems: 'baseline',
 									display: 'flex',
-									gap: 8,
+									gap: 12,
 								}}
 							>
+								<Interactive.Span
+									name="Author handle"
+									style={{
+										color: '#ffffff',
+										fontFamily: 'Inter',
+										fontSize: 26,
+										fontWeight: 700,
+										lineHeight: 1.1,
+									}}
+								>
+									@alexrenders
+								</Interactive.Span>
+							</div>
+
+							<Interactive.Div
+								name="Comment"
+								style={{
+									color: '#f4f4f5',
+									fontFamily: 'Inter',
+									fontSize: 32,
+									fontWeight: 500,
+									letterSpacing: -0.35,
+									lineHeight: 1.3,
+									marginTop: 8,
+									overflowWrap: 'anywhere',
+								}}
+							>
+								This breakdown made the whole process click. Would love to see
+								how you plan the animation timing in a future video!
+							</Interactive.Div>
+
+							<div
+								style={{
+									alignItems: 'center',
+									color: '#a9abb3',
+									display: 'flex',
+									fontFamily: 'Inter',
+									fontSize: 22,
+									fontWeight: 600,
+									gap: 22,
+									lineHeight: 1,
+									marginTop: 14,
+								}}
+							>
+								<div
+									style={{
+										alignItems: 'center',
+										display: 'flex',
+										gap: 8,
+									}}
+								>
+									<svg
+										aria-hidden="true"
+										height="28"
+										viewBox="0 0 24 24"
+										width="28"
+									>
+										<path
+											d="M7 10v11H4V10Zm2 11V10l4-7c1.4.2 2.2 1.5 1.8 2.8L14 9h4.5c1.3 0 2.3 1.2 2 2.5l-1.7 7A3.3 3.3 0 0 1 15.6 21Z"
+											fill="none"
+											stroke="currentColor"
+											strokeLinejoin="round"
+											strokeWidth="1.8"
+										/>
+									</svg>
+									<Interactive.Span name="Like count">2.4K</Interactive.Span>
+								</div>
+
 								<svg
 									aria-hidden="true"
 									height="28"
+									style={{rotate: '180deg'}}
 									viewBox="0 0 24 24"
 									width="28"
 								>
@@ -185,28 +211,11 @@ export const YouTubeCommentHighlight: React.FC = () => {
 										strokeWidth="1.8"
 									/>
 								</svg>
-								<Interactive.Span name="Like count">2.4K</Interactive.Span>
 							</div>
-
-							<svg
-								aria-hidden="true"
-								height="28"
-								style={{rotate: '180deg'}}
-								viewBox="0 0 24 24"
-								width="28"
-							>
-								<path
-									d="M7 10v11H4V10Zm2 11V10l4-7c1.4.2 2.2 1.5 1.8 2.8L14 9h4.5c1.3 0 2.3 1.2 2 2.5l-1.7 7A3.3 3.3 0 0 1 15.6 21Z"
-									fill="none"
-									stroke="currentColor"
-									strokeLinejoin="round"
-									strokeWidth="1.8"
-								/>
-							</svg>
 						</div>
-					</div>
-				</>
-			</Interactive.Div>
+					</>
+				</Interactive.Div>
+			</div>
 		</div>
 	);
 };

--- a/packages/docs/elements/youtube/youtube-comment-highlight/youtube-comment-highlight.tsx
+++ b/packages/docs/elements/youtube/youtube-comment-highlight/youtube-comment-highlight.tsx
@@ -29,11 +29,6 @@ export const YouTubeCommentHighlight: React.FC = () => {
 			<div
 				style={{
 					backfaceVisibility: 'hidden',
-					backgroundColor: '#15161a',
-					border: '1px solid rgba(255, 255, 255, 0.09)',
-					borderRadius: 26,
-					boxShadow: '0 18px 40px rgba(0, 0, 0, 0.26)',
-					boxSizing: 'border-box',
 					height: 300,
 					left: 0,
 					position: 'absolute',
@@ -84,6 +79,10 @@ export const YouTubeCommentHighlight: React.FC = () => {
 					name="Container"
 					style={{
 						alignContent: 'center',
+						backgroundColor: '#15161a',
+						border: '1px solid rgba(255, 255, 255, 0.09)',
+						borderRadius: 26,
+						boxShadow: '0 18px 40px rgba(0, 0, 0, 0.26)',
 						boxSizing: 'border-box',
 						columnGap: 18,
 						display: 'grid',


### PR DESCRIPTION
## Summary

- keep intended Remotion Element layers draggable in Studio Visual Mode by making `style.translate` analyzable as static or keyframed
- preserve caller-provided styles and transforms for custom `Interactive.withSchema()` components
- preserve existing animation timing and rendered appearance while leaving map internals intentionally non-draggable

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter=docs`
- `bunx turbo run build-docs --filter=docs`
- temporary before/after audit with `computeSequencePropsStatusFromContent()`
- baseline still comparisons for all changed Elements

## Dependency

- Based on #10764; this PR excludes its on-screen messages changes.

## Preview

- [Moving Pill Captions](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/captions/moving-pill-captions)
- [Popping Word Captions](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/captions/popping-word-captions)
- [Word Highlight Captions](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/captions/word-highlight-captions)
- [Product Collection](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/commerce/product-collection)
- [Line Chart](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/data/line-chart)
- [Vertical Bar Chart](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/data/vertical-bar-chart)
- [Polaroid Pictures](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/storytelling/polaroid-pictures)
- [Spinning Text Wheel](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/text/spinning-text-wheel)
- [YouTube Comment Highlight](https://remotion-git-fix-element-interactivity-remotion.vercel.app/elements/youtube/youtube-comment-highlight)

