### PR TITLE
`@remotion/studio`: Preview font assets

### DIFF
--- a/packages/studio/src/components/FilePreview.tsx
+++ b/packages/studio/src/components/FilePreview.tsx
@@ -1,6 +1,6 @@
 import {formatBytes} from '@remotion/studio-shared';
-import React from 'react';
-import {WHITE} from '../helpers/colors';
+import React, {useEffect, useState} from 'react';
+import {LIGHT_TEXT, WHITE} from '../helpers/colors';
 import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import type {AssetFileType} from '../helpers/get-preview-file-type';
 import {JSONViewer} from './JSONViewer';
@@ -13,6 +13,92 @@ const msgStyle: React.CSSProperties = {
 	fontFamily: 'sans-serif',
 	display: 'flex',
 	justifyContent: 'center',
+};
+
+const fontPreviewContainerStyle: React.CSSProperties = {
+	display: 'flex',
+	flex: 1,
+	flexDirection: 'column',
+	justifyContent: 'center',
+	overflow: 'hidden',
+	padding: 40,
+	textAlign: 'center',
+};
+
+const fontPreviewLargeTextStyle: React.CSSProperties = {
+	color: WHITE,
+	fontSize: 'clamp(80px, 18vh, 180px)',
+	lineHeight: 1,
+};
+
+const fontPreviewTextStyle: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontSize: 'clamp(18px, 4vh, 40px)',
+	lineHeight: 1.35,
+	marginTop: 32,
+	wordBreak: 'break-word',
+};
+
+let fontPreviewId = 0;
+
+const FontPreview: React.FC<{
+	readonly src: string;
+}> = ({src}) => {
+	const [fontFamily] = useState(() => {
+		fontPreviewId++;
+		return `RemotionStudioFontPreview${fontPreviewId}`;
+	});
+	const [fontLoaded, setFontLoaded] = useState(false);
+	const [fontLoadFailed, setFontLoadFailed] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		const fontFace = new FontFace(fontFamily, `url(${JSON.stringify(src)})`);
+		setFontLoaded(false);
+		setFontLoadFailed(false);
+
+		fontFace
+			.load()
+			.then((loadedFontFace) => {
+				if (cancelled) {
+					return;
+				}
+
+				document.fonts.add(loadedFontFace);
+				setFontLoaded(true);
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setFontLoadFailed(true);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+			document.fonts.delete(fontFace);
+		};
+	}, [fontFamily, src]);
+
+	if (fontLoadFailed) {
+		return <div style={msgStyle}>Could not preview font</div>;
+	}
+
+	if (!fontLoaded) {
+		return <div style={msgStyle}>Loading font preview...</div>;
+	}
+
+	return (
+		<div style={{...fontPreviewContainerStyle, fontFamily}}>
+			<div style={fontPreviewLargeTextStyle}>Aa</div>
+			<div style={fontPreviewTextStyle}>
+				ABCDEFGHIJKLMNOPQRSTUVWXYZ
+				<br />
+				abcdefghijklmnopqrstuvwxyz
+				<br />
+				0123456789
+			</div>
+		</div>
+	);
 };
 
 export const FilePreview: React.FC<{
@@ -43,6 +129,10 @@ export const FilePreview: React.FC<{
 
 	if (fileType === 'image') {
 		return <img src={src} />;
+	}
+
+	if (fileType === 'font') {
+		return <FontPreview src={src} />;
 	}
 
 	if (fileType === 'json') {


### PR DESCRIPTION
## Summary

- load selected font assets in the Studio preview with `FontFace`
- show a responsive specimen with uppercase, lowercase, and numeric glyphs
- handle loading failures and clean up the preview font when selection changes

## Testing

- `bun run build`
- `bun run stylecheck`
- manually verified `.woff2` and `.ttf` assets in Remotion Studio

Closes #9684
