### PR TITLE
`@remotion/browser-studio`: Load vendor bundle during compilation

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -90,14 +90,16 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 	const studioApiRequests: string[] = [];
 	const vendorBundleRequests: string[] = [];
 	const workspacePackageRequests: string[] = [];
+	let vendorBundleStartedBeforeIframe = false;
 	let rejectPageError: (error: Error) => void = () => undefined;
 	const pageError = new Promise<never>((_resolve, reject) => {
 		rejectPageError = reject;
 	});
 	page.on('request', (request) => {
 		const requestUrl = new URL(request.url());
-		if (requestUrl.searchParams.has('projectBundleUrl')) {
+		if (requestUrl.searchParams.has('browserStudioVendor')) {
 			vendorBundleRequests.push(request.url());
+			vendorBundleStartedBeforeIframe = page.frames().length === 1;
 		}
 
 		if (
@@ -299,6 +301,7 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 		'/__remotion_browser_studio_workspace__/commits/e2e/packages/transitions/dist/esm/fade.mjs',
 	);
 	expect(vendorBundleRequests).toHaveLength(1);
+	expect(vendorBundleStartedBeforeIframe).toBe(true);
 	expect(remoteRemotionRequests).toEqual([]);
 	expect(studioApiRequests).toEqual([]);
 });
@@ -311,7 +314,7 @@ test('loads Browser Studio from one immutable release artifact set', async ({
 	const vendorBundleRequests: string[] = [];
 	page.on('request', (request) => {
 		const requestUrl = new URL(request.url());
-		if (requestUrl.searchParams.has('projectBundleUrl')) {
+		if (requestUrl.searchParams.has('browserStudioVendor')) {
 			vendorBundleRequests.push(request.url());
 		}
 

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -40,6 +40,7 @@ const localVendorEntry = new URL(
 	'./browser-studio-vendor-entry.mjs',
 	import.meta.url,
 ).href;
+const localVendorEntryWithMarker = `${localVendorEntry}?browserStudioVendor`;
 
 type BrowserStudioContentWindow = Window & {
 	remotion_browserStudioHmr: BrowserStudioHmrBridge;
@@ -365,6 +366,28 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 			remotionPackageSource.version ===
 				browserStudioDependencyVersions.remotion;
 		const useVendorBundle = !hasVendorOverride && releaseMatchesVendor;
+		// Start the large, stable vendor download alongside the compiler. The
+		// iframe later executes these same bytes from a Blob URL, avoiding a
+		// second request after compilation finishes.
+		const vendorBundlePromise = useVendorBundle
+			? fetch(localVendorEntryWithMarker)
+					.then(async (response) => {
+						if (!response.ok) {
+							throw new Error(
+								`Failed to load the Browser Studio vendor bundle: ${response.status}`,
+							);
+						}
+
+						const blob = await response.blob();
+						return {
+							blob: blob.slice(0, blob.size, 'text/javascript'),
+							type: 'success' as const,
+						};
+					})
+					.catch((error: unknown) => ({error, type: 'error' as const}))
+			: null;
+		let vendorBundleUrl: string | null = null;
+
 		if (
 			!useVendorBundle &&
 			!remotionPackageSource &&
@@ -427,8 +450,30 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 				return;
 			}
 
-			const bundleScriptUrl = useVendorBundle
-				? `${localVendorEntry}?projectBundleUrl=${encodeURIComponent(bundleUrlRef.current)}`
+			if (vendorBundlePromise && !vendorBundleUrl) {
+				const vendorBundleResult = await vendorBundlePromise;
+				if (didCancel) {
+					return;
+				}
+
+				if (vendorBundleResult.type === 'error') {
+					setCompileState({
+						status: 'error',
+						error: {
+							message:
+								vendorBundleResult.error instanceof Error
+									? vendorBundleResult.error.message
+									: String(vendorBundleResult.error),
+						},
+					});
+					return;
+				}
+
+				vendorBundleUrl ??= URL.createObjectURL(vendorBundleResult.blob);
+			}
+
+			const bundleScriptUrl = vendorBundleUrl
+				? `${vendorBundleUrl}#projectBundleUrl=${encodeURIComponent(bundleUrlRef.current)}`
 				: bundleUrlRef.current;
 
 			const html = studioHtml({
@@ -496,6 +541,10 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 
 		return () => {
 			didCancel = true;
+			if (vendorBundleUrl) {
+				URL.revokeObjectURL(vendorBundleUrl);
+			}
+
 			workerRef.current = null;
 			lastSentProjectRef.current = null;
 			worker.terminate();

--- a/packages/browser-studio/src/browser-studio-vendor-entry.ts
+++ b/packages/browser-studio/src/browser-studio-vendor-entry.ts
@@ -2,9 +2,9 @@ import ReactRefreshRuntime from 'react-refresh/runtime';
 
 ReactRefreshRuntime.injectIntoGlobalHook(globalThis);
 
-const projectBundleUrl = new URL(import.meta.url).searchParams.get(
-	'projectBundleUrl',
-);
+const projectBundleUrl = new URLSearchParams(
+	new URL(import.meta.url).hash.slice(1),
+).get('projectBundleUrl');
 if (!projectBundleUrl) {
 	throw new Error('Browser Studio project bundle URL was not provided');
 }


### PR DESCRIPTION
## Summary

- start downloading the Browser Studio vendor bundle while the compiler worker builds the project
- execute the downloaded vendor bytes from a Blob URL after compilation, avoiding a second network transfer
- pass the compiled project URL through the vendor module fragment and cover the request ordering in the browser test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testbrowserstudio`
- `bunx turbo run build-docs --filter=docs --no-update-notifier --concurrency=2`
