### PR TITLE
`@remotion/studio`: Remove inspector dividers

### DIFF
--- a/packages/studio/src/components/CaptionInspector.tsx
+++ b/packages/studio/src/components/CaptionInspector.tsx
@@ -3,10 +3,7 @@ import React from 'react';
 import {LIGHT_TEXT} from '../helpers/colors';
 import {CaptionTextEditor} from './CaptionTextEditor';
 import {CollapsibleInspectorSectionHeader} from './InspectorPanel/CollapsibleInspectorSectionHeader';
-import {
-	InspectorSectionDivider,
-	InspectorSectionHeader,
-} from './InspectorPanel/common';
+import {InspectorSectionHeader} from './InspectorPanel/common';
 import {sectionHeaderEnd} from './InspectorPanel/styles';
 
 const readOnlyStatus: React.CSSProperties = {
@@ -39,7 +36,6 @@ export const CaptionInspector: React.FC<{
 }) => {
 	return (
 		<>
-			<InspectorSectionDivider />
 			<InspectorSectionHeader>
 				<CollapsibleInspectorSectionHeader
 					action={

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -37,7 +37,6 @@ import {
 	InspectorQuickActionsSection,
 	InspectorDefaultPropsWarnings,
 	InspectorQuickAction,
-	InspectorSectionDivider,
 	InspectorSectionHeader,
 } from './common';
 import {CompositionInspectorHeader} from './CompositionInspectorHeader';
@@ -227,54 +226,51 @@ const CompositionDefaultPropsSection: React.FC<{
 	}
 
 	return (
-		<>
-			<InspectorSectionDivider />
-			<div style={compositionDefaultPropsSection}>
-				<InspectorSectionHeader>
-					<div style={sectionHeaderRow}>
-						<div style={sectionHeaderStart}>
-							<span style={sectionHeaderTitle}>Default Props</span>
-							<SegmentedControl
-								items={defaultPropsModeItems}
-								needsWrapping={false}
+		<div style={compositionDefaultPropsSection}>
+			<InspectorSectionHeader>
+				<div style={sectionHeaderRow}>
+					<div style={sectionHeaderStart}>
+						<span style={sectionHeaderTitle}>Default Props</span>
+						<SegmentedControl
+							items={defaultPropsModeItems}
+							needsWrapping={false}
+							size="compact"
+						/>
+					</div>
+					<div style={sectionHeaderEnd}>
+						{defaultPropsWarnings.length > 0 ? (
+							<WarningIndicatorButton
+								setShowWarning={setShowWarning}
+								showWarning={showWarning}
+								warningCount={defaultPropsWarnings.length}
 								size="compact"
 							/>
-						</div>
-						<div style={sectionHeaderEnd}>
-							{defaultPropsWarnings.length > 0 ? (
-								<WarningIndicatorButton
-									setShowWarning={setShowWarning}
-									showWarning={showWarning}
-									warningCount={defaultPropsWarnings.length}
-									size="compact"
-								/>
-							) : null}
-						</div>
+						) : null}
 					</div>
-				</InspectorSectionHeader>
-				{defaultPropsWarnings.length > 0 && showWarning ? (
-					<div style={defaultPropsWarningContainer}>
-						<InspectorDefaultPropsWarnings warnings={defaultPropsWarnings} />
-					</div>
-				) : null}
-				<DefaultPropsEditor
-					key={composition.id}
-					unresolvedComposition={composition}
-					defaultProps={currentDefaultProps}
-					setDefaultProps={setDefaultProps}
-					propsEditType="default-props"
-					schemaErrorMode="compact"
-					layout="inspector"
-					mode={defaultPropsMode}
-					onModeChange={setDefaultPropsMode}
-					hideModeControls={canShowDefaultPropsSection}
-					warnings={defaultPropsWarnings}
-					showWarning={false}
-					setShowWarning={setShowWarning}
-					hideWarningButton
-				/>
-			</div>
-		</>
+				</div>
+			</InspectorSectionHeader>
+			{defaultPropsWarnings.length > 0 && showWarning ? (
+				<div style={defaultPropsWarningContainer}>
+					<InspectorDefaultPropsWarnings warnings={defaultPropsWarnings} />
+				</div>
+			) : null}
+			<DefaultPropsEditor
+				key={composition.id}
+				unresolvedComposition={composition}
+				defaultProps={currentDefaultProps}
+				setDefaultProps={setDefaultProps}
+				propsEditType="default-props"
+				schemaErrorMode="compact"
+				layout="inspector"
+				mode={defaultPropsMode}
+				onModeChange={setDefaultPropsMode}
+				hideModeControls={canShowDefaultPropsSection}
+				warnings={defaultPropsWarnings}
+				showWarning={false}
+				setShowWarning={setShowWarning}
+				hideWarningButton
+			/>
+		</div>
 	);
 };
 
@@ -292,13 +288,10 @@ const CompositionVisualControlsSection: React.FC<{
 	}
 
 	return (
-		<>
-			<InspectorSectionDivider />
-			<div style={compositionVisualControlsSection}>
-				<InspectorSectionHeader>Visual Controls</InspectorSectionHeader>
-				<VisualControlsContent />
-			</div>
-		</>
+		<div style={compositionVisualControlsSection}>
+			<InspectorSectionHeader>Visual Controls</InspectorSectionHeader>
+			<VisualControlsContent />
+		</div>
 	);
 };
 
@@ -314,7 +307,6 @@ export const CompositionInspector: React.FC<{
 		<div style={scrollableContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<div style={inspectorOverviewSection}>
 				<CompositionInspectorHeader />
-				<InspectorSectionDivider />
 				<CompositionMetadata
 					compositionId={composition.id}
 					disabled={readOnlyStudio || previewServerState.type !== 'connected'}

--- a/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/EasingInspector.tsx
@@ -30,7 +30,6 @@ import {
 	InspectorBackAction,
 	InspectorQuickAction,
 	InspectorMessage,
-	InspectorSectionDivider,
 } from './common';
 import {getEasingSelectionFromCurrentKeyframes} from './easing-inspector-selection';
 import {KeyframeEasingNavigator} from './KeyframeEasingNavigator';
@@ -296,7 +295,6 @@ export const EasingInspector: React.FC<{
 				>
 					{fieldLabel}
 				</InspectorBackAction>
-				<InspectorSectionDivider />
 				{easingUpdate === null || track === null ? null : (
 					<KeyframeEasingNavigator
 						currentSelection={currentEasingSelection ?? selection}
@@ -334,13 +332,11 @@ export const EasingInspector: React.FC<{
 	return (
 		<div style={selectedContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<SequenceInspectorSections track={track} />
-			<InspectorSectionDivider />
 			<EasingEditor
 				key={getTimelineSelectionKey(currentEasingSelection)}
 				state={state}
 				renderHeader={renderHeader}
 			/>
-			<InspectorSectionDivider />
 			<KeyframeSettings update={easingUpdate} />
 			{canAddKeyframeAtPlayhead ? (
 				<InspectorQuickActionsSection>

--- a/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
@@ -50,7 +50,6 @@ import {
 	InspectorDetailRow,
 	InspectorQuickAction,
 	InspectorMessage,
-	InspectorSectionDivider,
 } from './common';
 import {
 	clampInspectorKeyframeDisplayFrame,
@@ -527,7 +526,6 @@ export const KeyframeInspector: React.FC<{
 	return (
 		<div style={selectedContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<SequenceInspectorSections track={track} />
-			<InspectorSectionDivider />
 			<InspectorBackAction
 				disabled={parentSelection === null}
 				onClick={onSelectParent}
@@ -535,7 +533,6 @@ export const KeyframeInspector: React.FC<{
 			>
 				{details.fieldLabel}
 			</InspectorBackAction>
-			<InspectorSectionDivider />
 			<KeyframeEasingNavigator
 				currentSelection={selection}
 				includeEasings={canEditEasingForInterpolationFunction(

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -12,11 +12,7 @@ import {InspectorSourceLocation} from '../InspectorSourceLocation';
 import {COMPACT_CONTROL_ROW_HEIGHT} from '../layout';
 import {useOpenSequenceInApps} from '../Timeline/use-open-sequence-in-apps';
 import {useRenameSequence} from '../Timeline/use-rename-sequence';
-import {
-	InspectorQuickAction,
-	InspectorSection,
-	InspectorSectionDivider,
-} from './common';
+import {InspectorQuickAction, InspectorSection} from './common';
 import {
 	ConnectedCompositionsSection,
 	useConnectedCompositions,
@@ -235,12 +231,9 @@ export const SequenceInspectorSections: React.FC<{
 			<SequenceInspectorHeader sourceLocation={sourceLocation} track={track} />
 			<SequenceInspectorDuplicationSection track={track} />
 			{connectedCompositions.length > 0 ? (
-				<>
-					<InspectorSectionDivider />
-					<ConnectedCompositionsSection
-						connectedCompositions={connectedCompositions}
-					/>
-				</>
+				<ConnectedCompositionsSection
+					connectedCompositions={connectedCompositions}
+				/>
 			) : null}
 		</>
 	);

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -33,7 +33,6 @@ import {
 	InspectorQuickActionsSection,
 	InspectorQuickAction,
 	InspectorMessage,
-	InspectorSectionDivider,
 } from './common';
 import {
 	ConnectedCompositionsSection,
@@ -322,12 +321,9 @@ const SequenceExpandedInspector: React.FC<{
 			/>
 			<SequenceInspectorDuplicationSection track={track} />
 			{connectedCompositions.length > 0 ? (
-				<>
-					<InspectorSectionDivider />
-					<ConnectedCompositionsSection
-						connectedCompositions={connectedCompositions}
-					/>
-				</>
+				<ConnectedCompositionsSection
+					connectedCompositions={connectedCompositions}
+				/>
 			) : null}
 			{validatedLocation ? (
 				<>

--- a/packages/studio/src/components/InspectorPanel/common.tsx
+++ b/packages/studio/src/components/InspectorPanel/common.tsx
@@ -19,7 +19,6 @@ import {
 	detailValue,
 	inspectorQuickActionsSection,
 	inspectorSectionBody,
-	inspectorSectionDivider,
 	resolveLinkStyle,
 	sectionHeader,
 } from './styles';
@@ -28,18 +27,9 @@ export const InspectorSectionHeader: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => <div style={sectionHeader}>{children}</div>;
 
-export const InspectorSectionDivider: React.FC = () => (
-	<div style={inspectorSectionDivider} />
-);
-
 export const InspectorQuickActionsSection: React.FC<{
 	readonly children: React.ReactNode;
-}> = ({children}) => (
-	<>
-		<InspectorSectionDivider />
-		<div style={inspectorQuickActionsSection}>{children}</div>
-	</>
-);
+}> = ({children}) => <div style={inspectorQuickActionsSection}>{children}</div>;
 
 export const InspectorSection: React.FC<{
 	readonly children: React.ReactNode;
@@ -47,7 +37,6 @@ export const InspectorSection: React.FC<{
 }> = ({children, header}) => {
 	return (
 		<>
-			<InspectorSectionDivider />
 			<InspectorSectionHeader>{header}</InspectorSectionHeader>
 			{children === null ? null : (
 				<div style={inspectorSectionBody}>{children}</div>

--- a/packages/studio/src/components/InspectorPanel/styles.ts
+++ b/packages/studio/src/components/InspectorPanel/styles.ts
@@ -40,10 +40,6 @@ export const inspectorOverviewSection: React.CSSProperties = {
 	flexDirection: 'column',
 };
 
-export const inspectorSectionDivider: React.CSSProperties = {
-	borderBottom: `1px solid ${LINE_COLOR}`,
-};
-
 export const sequenceHeaderDivider: React.CSSProperties = {
 	backgroundColor: LINE_COLOR,
 	flexShrink: 0,


### PR DESCRIPTION
## Summary

- remove divider lines from the sequence, asset, and composition inspectors
- remove the shared inspector divider primitive and its remaining call sites
- retain section headers, body spacing, and inspector behavior

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/studio`
