### PR TITLE
`@remotion/studio`: Preview media assets on the timeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1798,6 +1798,7 @@
         "@jridgewell/trace-mapping": "0.3.31",
         "@remotion/canvas": "workspace:*",
         "@remotion/captions": "workspace:*",
+        "@remotion/media": "workspace:*",
         "@remotion/media-utils": "workspace:*",
         "@remotion/player": "workspace:*",
         "@remotion/renderer": "workspace:*",

--- a/packages/core/src/CompositionManagerContext.tsx
+++ b/packages/core/src/CompositionManagerContext.tsx
@@ -21,6 +21,12 @@ export type BaseMetadata = Pick<
 	| 'defaultSampleRate'
 >;
 
+export type AssetPreviewMetadata = BaseMetadata & {
+	asset: string;
+};
+
+export const getAssetPreviewCompositionId = (asset: string) => `asset:${asset}`;
+
 export type CanvasContent =
 	| {
 			type: 'composition';
@@ -59,6 +65,9 @@ export type CompositionManagerSetters = {
 	) => void;
 	unregisterFolder: (name: string, parent: string | null) => void;
 	setCanvasContent: React.Dispatch<React.SetStateAction<CanvasContent | null>>;
+	setCurrentAssetMetadata: React.Dispatch<
+		React.SetStateAction<AssetPreviewMetadata | null>
+	>;
 	// This is not a setter but also a value that does not change
 	onlyRenderComposition: string | null;
 };
@@ -66,6 +75,7 @@ export type CompositionManagerSetters = {
 export type CompositionManagerContext = {
 	compositions: AnyComposition[];
 	currentCompositionMetadata: BaseMetadata | null;
+	currentAssetMetadata: AssetPreviewMetadata | null;
 	folders: TFolder[];
 	canvasContent: CanvasContent | null;
 };
@@ -74,6 +84,7 @@ export const CompositionManager = createContext<CompositionManagerContext>({
 	compositions: [],
 	folders: [],
 	currentCompositionMetadata: null,
+	currentAssetMetadata: null,
 	canvasContent: null,
 });
 
@@ -83,5 +94,6 @@ export const CompositionSetters = createContext<CompositionManagerSetters>({
 	registerFolder: () => undefined,
 	unregisterFolder: () => undefined,
 	setCanvasContent: () => undefined,
+	setCurrentAssetMetadata: () => undefined,
 	onlyRenderComposition: null,
 });

--- a/packages/core/src/CompositionManagerProvider.tsx
+++ b/packages/core/src/CompositionManagerProvider.tsx
@@ -9,6 +9,7 @@ import type {AnyZodObject} from './any-zod-type.js';
 import type {TComposition} from './CompositionManager';
 import {compositionsRef, type AnyComposition} from './CompositionManager';
 import type {
+	AssetPreviewMetadata,
 	CanvasContent,
 	CompositionManagerContext,
 	CompositionManagerSetters,
@@ -38,6 +39,8 @@ export const CompositionManagerProvider = ({
 	const [canvasContent, setCanvasContent] = useState<CanvasContent | null>(
 		initialCanvasContent,
 	);
+	const [currentAssetMetadata, setCurrentAssetMetadata] =
+		useState<AssetPreviewMetadata | null>(null);
 	const [compositions, setCompositions] =
 		useState<AnyComposition[]>(initialCompositions);
 
@@ -124,6 +127,7 @@ export const CompositionManagerProvider = ({
 			registerFolder,
 			unregisterFolder,
 			setCanvasContent,
+			setCurrentAssetMetadata,
 			onlyRenderComposition,
 		};
 	}, [
@@ -140,9 +144,16 @@ export const CompositionManagerProvider = ({
 				compositions,
 				folders,
 				currentCompositionMetadata,
+				currentAssetMetadata,
 				canvasContent,
 			};
-		}, [compositions, folders, currentCompositionMetadata, canvasContent]);
+		}, [
+			compositions,
+			folders,
+			currentCompositionMetadata,
+			currentAssetMetadata,
+			canvasContent,
+		]);
 
 	return (
 		<CompositionManager.Provider value={compositionManagerContextValue}>

--- a/packages/core/src/ResolveCompositionConfig.tsx
+++ b/packages/core/src/ResolveCompositionConfig.tsx
@@ -1,6 +1,9 @@
 import {createContext, createRef, useContext, useMemo} from 'react';
 import type {AnyComposition} from './CompositionManager.js';
-import {CompositionManager} from './CompositionManagerContext.js';
+import {
+	CompositionManager,
+	getAssetPreviewCompositionId,
+} from './CompositionManagerContext.js';
 import {getInputProps} from './config/input-props.js';
 import {EditorPropsContext} from './EditorProps.js';
 import type {VideoConfigMetadataSource} from './resolve-video-config.js';
@@ -54,8 +57,12 @@ export const useResolvedVideoConfig = (
 
 	const {props: allEditorProps} = useContext(EditorPropsContext);
 
-	const {compositions, canvasContent, currentCompositionMetadata} =
-		useContext(CompositionManager);
+	const {
+		compositions,
+		canvasContent,
+		currentCompositionMetadata,
+		currentAssetMetadata,
+	} = useContext(CompositionManager);
 	const currentComposition =
 		canvasContent?.type === 'composition' ? canvasContent.compositionId : null;
 	const compositionId = preferredCompositionId ?? currentComposition;
@@ -68,6 +75,22 @@ export const useResolvedVideoConfig = (
 	const env = useRemotionEnvironment();
 
 	return useMemo(() => {
+		if (
+			preferredCompositionId === null &&
+			canvasContent?.type === 'asset' &&
+			currentAssetMetadata?.asset === canvasContent.asset
+		) {
+			return {
+				type: 'success',
+				metadataSource: null,
+				result: {
+					...currentAssetMetadata,
+					id: getAssetPreviewCompositionId(canvasContent.asset),
+					defaultProps: {},
+				},
+			} as const;
+		}
+
 		if (!composition) {
 			return null;
 		}
@@ -148,8 +171,11 @@ export const useResolvedVideoConfig = (
 		return context[composition.id] as VideoConfigState;
 	}, [
 		composition,
+		canvasContent,
 		context,
+		currentAssetMetadata,
 		currentCompositionMetadata,
+		preferredCompositionId,
 		selectedEditorProps,
 		env.isPlayer,
 	]);

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -283,6 +283,7 @@ import {evaluateVolume} from './volume-prop.js';
 import {warnAboutTooHighVolume} from './volume-safeguard.js';
 import type {WatchRemotionStaticFilesPayload} from './watch-static-file.js';
 import {WATCH_REMOTION_STATIC_FILES} from './watch-static-file.js';
+import {DisableInteractivityProvider} from './with-interactivity-schema.js';
 import {
 	RemotionContextProvider,
 	useRemotionContexts,
@@ -379,6 +380,7 @@ export const Internals = {
 	SetTimelineContext,
 	CanUseRemotionHooksProvider,
 	CanUseRemotionHooks,
+	DisableInteractivityProvider,
 	PrefetchProvider,
 	DurationsContextProvider,
 	IsPlayerContextProvider,

--- a/packages/core/src/test/still-stack.test.tsx
+++ b/packages/core/src/test/still-stack.test.tsx
@@ -23,6 +23,7 @@ const makeCompositionSetters = (
 	registerFolder: () => undefined,
 	unregisterFolder: () => undefined,
 	setCanvasContent: () => undefined,
+	setCurrentAssetMetadata: () => undefined,
 	onlyRenderComposition: null,
 });
 

--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -39,6 +39,7 @@ const makeMockCompositionContext = (
 		},
 	],
 	folders: [],
+	currentAssetMetadata: null,
 	canvasContent: {type: 'composition', compositionId: 'my-comp'},
 	currentCompositionMetadata: {
 		defaultCodec: null,

--- a/packages/core/src/use-video.ts
+++ b/packages/core/src/use-video.ts
@@ -1,6 +1,9 @@
 import type {ComponentType, LazyExoticComponent} from 'react';
 import {useContext, useMemo} from 'react';
-import {CompositionManager} from './CompositionManagerContext.js';
+import {
+	CompositionManager,
+	getAssetPreviewCompositionId,
+} from './CompositionManagerContext.js';
 import {useResolvedVideoConfig} from './ResolveCompositionConfig.js';
 import type {VideoConfig} from './video-config.js';
 
@@ -12,9 +15,15 @@ type ReturnType =
 	  })
 	| null;
 
+const AssetPreviewComposition = () => null;
+
 export const useVideo = (): ReturnType => {
-	const {canvasContent, compositions, currentCompositionMetadata} =
-		useContext(CompositionManager);
+	const {
+		canvasContent,
+		compositions,
+		currentCompositionMetadata,
+		currentAssetMetadata,
+	} = useContext(CompositionManager);
 
 	const selected = compositions.find((c) => {
 		return (
@@ -25,6 +34,18 @@ export const useVideo = (): ReturnType => {
 	const resolved = useResolvedVideoConfig(selected?.id ?? null);
 
 	return useMemo((): ReturnType => {
+		if (
+			canvasContent?.type === 'asset' &&
+			currentAssetMetadata?.asset === canvasContent.asset
+		) {
+			return {
+				...currentAssetMetadata,
+				id: getAssetPreviewCompositionId(canvasContent.asset),
+				defaultProps: {},
+				component: AssetPreviewComposition,
+			};
+		}
+
 		if (!resolved) {
 			return null;
 		}
@@ -50,5 +71,11 @@ export const useVideo = (): ReturnType => {
 			...(currentCompositionMetadata ?? {}),
 			component: selected.component,
 		};
-	}, [currentCompositionMetadata, resolved, selected]);
+	}, [
+		canvasContent,
+		currentAssetMetadata,
+		currentCompositionMetadata,
+		resolved,
+		selected,
+	]);
 };

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -1,4 +1,5 @@
 import React, {
+	createContext,
 	forwardRef,
 	useContext,
 	useLayoutEffect,
@@ -168,6 +169,18 @@ export type WithInteractivitySchemaOptions<
 	supportsEffects: boolean;
 };
 
+const DisableInteractivityContext = createContext(false);
+
+export const DisableInteractivityProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	return React.createElement(
+		DisableInteractivityContext.Provider,
+		{value: true},
+		children,
+	);
+};
+
 export const withInteractivitySchema = <
 	S extends InteractivitySchema,
 	Props extends object,
@@ -191,8 +204,14 @@ export const withInteractivitySchema = <
 		const cleanProps = propsWithoutInternalStack as Props;
 		const env = useRemotionEnvironment();
 		const canUseRemotionHooks = useContext(CanUseRemotionHooks);
+		const disableInteractivity = useContext(DisableInteractivityContext);
 
-		if (!env.isStudio || env.isRendering || !canUseRemotionHooks) {
+		if (
+			!env.isStudio ||
+			env.isRendering ||
+			!canUseRemotionHooks ||
+			disableInteractivity
+		) {
 			return React.createElement(Component, {
 				...cleanProps,
 				controls: null,

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -184,6 +184,114 @@ test.describe('visual mode', () => {
 		).toBeVisible();
 	});
 
+	test('should preview media assets as a non-interactive timeline', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/assets/prores.mov`);
+
+		await expect(page.getByTestId('asset-media-preview')).toBeVisible({
+			timeout: 15_000,
+		});
+		const checkerboardToggle = page.getByRole('button', {
+			name: /Show transparency as checkerboard/,
+		});
+		await expect(checkerboardToggle).toBeVisible();
+		const checkerboardWasPressed =
+			(await checkerboardToggle.getAttribute('aria-pressed')) === 'true';
+		await checkerboardToggle.click();
+		await expect(checkerboardToggle).toHaveAttribute(
+			'aria-pressed',
+			String(!checkerboardWasPressed),
+		);
+		await checkerboardToggle.click();
+
+		const rulersToggle = page.getByRole('button', {
+			name: /^(Show|Hide) rulers$/,
+		});
+		const rulersWerePressed =
+			(await rulersToggle.getAttribute('aria-pressed')) === 'true';
+		await rulersToggle.click();
+		await expect(rulersToggle).toHaveAttribute(
+			'aria-pressed',
+			String(!rulersWerePressed),
+		);
+		if (rulersWerePressed) {
+			await rulersToggle.click();
+		}
+		const horizontalRuler = page.getByLabel('Horizontal ruler', {exact: true});
+		await expect(horizontalRuler).toBeVisible();
+		await expect(horizontalRuler).toHaveAttribute('aria-readonly', 'true');
+		await expect(
+			page.getByLabel('Vertical ruler', {exact: true}),
+		).toBeVisible();
+		if (!rulersWerePressed) {
+			await page
+				.getByRole('button', {name: 'Hide rulers', exact: true})
+				.click();
+		}
+
+		const timeline = page.locator('[data-timeline-scrollable]');
+		await expect(timeline).toBeVisible();
+		const mediaTrack = page.getByTitle('prores.mov').last();
+		await expect(mediaTrack).toBeVisible();
+		await expect(timeline.locator('canvas').first()).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Play', exact: true}),
+		).toBeEnabled();
+		await expect(
+			page.getByText(/Failed to execute getVideoMetadata/),
+		).toHaveCount(0);
+
+		await mediaTrack.dblclick();
+		await expect(page.getByRole('textbox')).toHaveCount(0);
+
+		await page.goto(`${STUDIO_URL}/assets/whip.mp3`);
+		await expect(
+			page.getByRole('img', {name: 'Audio asset', exact: true}),
+		).toBeVisible();
+		await expect(page.getByTestId('asset-media-preview')).not.toBeInViewport();
+		await expect(page.locator('[data-timeline-scrollable]')).toBeVisible();
+		await expect(page.getByTitle('whip.mp3').last()).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Play', exact: true}),
+		).toBeEnabled();
+		await expect(checkerboardToggle).toHaveCount(0);
+		await expect(rulersToggle).toHaveCount(0);
+		await expect(horizontalRuler).toHaveCount(0);
+		await expect(
+			page.locator('.remotion-studio-composition-container'),
+		).toHaveCSS('background-image', 'none');
+		await expect(
+			page.locator('.remotion-studio-composition-container'),
+		).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+		await page.goto(`${STUDIO_URL}/assets/blush-2x.mp4`);
+		await expect(page.getByTestId('asset-media-preview')).toBeVisible();
+		const squarePreview = page.locator(
+			'.remotion-studio-composition-container',
+		);
+		await expect(squarePreview).toBeVisible();
+		await expect
+			.poll(async () => {
+				const outerBox = await squarePreview.boundingBox();
+				const mediaBox = await page
+					.getByTestId('asset-media-preview')
+					.boundingBox();
+				if (outerBox === null || mediaBox === null) {
+					return null;
+				}
+
+				return Math.max(
+					Math.abs(outerBox.x - mediaBox.x),
+					Math.abs(outerBox.y - mediaBox.y),
+					Math.abs(outerBox.width - outerBox.height),
+					Math.abs(outerBox.width - mediaBox.width),
+					Math.abs(outerBox.height - mediaBox.height),
+				);
+			})
+			.toBeLessThan(1);
+	});
+
 	test('should route Canvas Capture drops by Studio target', async ({page}) => {
 		test.setTimeout(90_000);
 		const canvasCapture = fs.readFileSync(

--- a/packages/example/src/e2e-test-entry.ts
+++ b/packages/example/src/e2e-test-entry.ts
@@ -1,4 +1,6 @@
+import {registerProresDecoder} from '@mediabunny/prores';
 import {registerRoot} from 'remotion';
 import {E2eTestRoot} from './E2eTestRoot';
 
+registerProresDecoder();
 registerRoot(E2eTestRoot);

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -89,6 +89,7 @@ const compositionContext = {
 	],
 	folders: [],
 	canvasContent: {type: 'composition' as const, compositionId: 'comp'},
+	currentAssetMetadata: null,
 	currentCompositionMetadata: {
 		defaultCodec: null,
 		defaultOutName: null,

--- a/packages/mac-cursors/src/test/resolve-cursor.test.ts
+++ b/packages/mac-cursors/src/test/resolve-cursor.test.ts
@@ -101,6 +101,7 @@ test('<MacOSCursor> renders the default cursor when the cursor prop is omitted',
 		],
 		folders: [],
 		canvasContent: {type: 'composition' as const, compositionId: 'comp'},
+		currentAssetMetadata: null,
 		currentCompositionMetadata: compositionMetadata,
 	} as React.ContextType<typeof Internals.CompositionManager>;
 	const timeline = {

--- a/packages/player/src/SharedPlayerContext.tsx
+++ b/packages/player/src/SharedPlayerContext.tsx
@@ -80,6 +80,7 @@ export const SharedPlayerContexts: React.FC<{
 				},
 			],
 			folders: [],
+			currentAssetMetadata: null,
 			currentCompositionMetadata: {
 				defaultCodec: null,
 				defaultOutName: null,

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -30,6 +30,7 @@
 		"semver": "7.5.3",
 		"remotion": "workspace:*",
 		"@remotion/captions": "workspace:*",
+		"@remotion/media": "workspace:*",
 		"@remotion/player": "workspace:*",
 		"@remotion/media-utils": "workspace:*",
 		"@remotion/renderer": "workspace:*",

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -30,6 +30,7 @@ import {
 	getEffectiveTranslation,
 	getUnboundedCenterPointWhileScrolling,
 } from '../helpers/get-effective-translation';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {getMissingPackages} from '../helpers/install-required-package';
 import {useCachedCompositionComponentInfo} from '../helpers/open-in-editor';
 import {
@@ -226,6 +227,7 @@ export const Canvas: React.FC<{
 	const {editorShowGuides} = useContext(EditorShowGuidesContext);
 	const {editorSnapping} = useContext(EditorSnappingContext);
 	const {compositions} = useContext(Internals.CompositionManager);
+	const {setCurrentAssetMetadata} = useContext(Internals.CompositionSetters);
 	const {previewServerState, subscribeToEvent} = useContext(
 		StudioServerConnectionCtx,
 	);
@@ -250,6 +252,7 @@ export const Canvas: React.FC<{
 	const [assetResolution, setAssetResolution] = useState<AssetMetadata | null>(
 		null,
 	);
+	const metadataRequestRef = useRef(0);
 
 	const currentCompositionId =
 		canvasContent.type === 'composition' ? canvasContent.compositionId : null;
@@ -719,8 +722,10 @@ export const Canvas: React.FC<{
 	}, [keybindings, onReset, onZoomIn, onZoomOut]);
 
 	const fetchMetadata = useCallback(async () => {
+		const request = ++metadataRequestRef.current;
 		setAssetResolution(null);
 		if (canvasContent.type === 'composition') {
+			setCurrentAssetMetadata(null);
 			return;
 		}
 
@@ -728,8 +733,57 @@ export const Canvas: React.FC<{
 			canvasContent,
 			canvasContent.type === 'asset',
 		);
+		if (request !== metadataRequestRef.current) {
+			return;
+		}
+
 		setAssetResolution(metadata);
-	}, [canvasContent]);
+		if (
+			canvasContent.type !== 'asset' ||
+			metadata.type !== 'found' ||
+			metadata.mediaMetadata === null ||
+			!Number.isFinite(metadata.mediaMetadata.duration) ||
+			metadata.mediaMetadata.duration <= 0
+		) {
+			setCurrentAssetMetadata(null);
+			return;
+		}
+
+		const fileType = getPreviewFileType(canvasContent.asset);
+		if (fileType !== 'audio' && fileType !== 'video') {
+			setCurrentAssetMetadata(null);
+			return;
+		}
+
+		const detectedFps = metadata.mediaMetadata.fps;
+		const fps =
+			detectedFps !== null && Number.isFinite(detectedFps) && detectedFps > 0
+				? detectedFps
+				: 30;
+		const {dimensions} = metadata;
+		if (dimensions === null || dimensions === 'none') {
+			setCurrentAssetMetadata(null);
+			return;
+		}
+
+		setCurrentAssetMetadata({
+			asset: canvasContent.asset,
+			width: dimensions.width,
+			height: dimensions.height,
+			fps,
+			durationInFrames: Math.max(
+				1,
+				Math.ceil(metadata.mediaMetadata.duration * fps),
+			),
+			props: {},
+			defaultCodec: null,
+			defaultOutName: null,
+			defaultVideoImageFormat: null,
+			defaultPixelFormat: null,
+			defaultProResProfile: null,
+			defaultSampleRate: metadata.mediaMetadata.sampleRate,
+		});
+	}, [canvasContent, setCurrentAssetMetadata]);
 
 	useEffect(() => {
 		if (canvasContent.type !== 'asset') {
@@ -1464,6 +1518,7 @@ export const Canvas: React.FC<{
 			</div>
 			{areRulersVisible && (
 				<EditorRulers
+					canCreateGuides={canvasContent.type === 'composition'}
 					contentDimensions={contentDimensions}
 					canvasSize={size}
 					assetMetadata={assetResolution}

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -22,15 +22,17 @@ import {
 	BORDER_TIMELINE_DROP_BLUE,
 	TIMELINE_DROP_BLUE_ALPHA_16,
 } from '../helpers/colors';
-import type {AssetMetadata} from '../helpers/get-asset-metadata';
-import {getAssetMetadata} from '../helpers/get-asset-metadata';
+import {
+	getAssetMetadata,
+	getAssetPreviewMetadata,
+	type AssetMetadata,
+} from '../helpers/get-asset-metadata';
 import {
 	applyZoomAroundFocalPoint,
 	getCenterPointWhileScrolling,
 	getEffectiveTranslation,
 	getUnboundedCenterPointWhileScrolling,
 } from '../helpers/get-effective-translation';
-import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {getMissingPackages} from '../helpers/install-required-package';
 import {useCachedCompositionComponentInfo} from '../helpers/open-in-editor';
 import {
@@ -738,51 +740,7 @@ export const Canvas: React.FC<{
 		}
 
 		setAssetResolution(metadata);
-		if (
-			canvasContent.type !== 'asset' ||
-			metadata.type !== 'found' ||
-			metadata.mediaMetadata === null ||
-			!Number.isFinite(metadata.mediaMetadata.duration) ||
-			metadata.mediaMetadata.duration <= 0
-		) {
-			setCurrentAssetMetadata(null);
-			return;
-		}
-
-		const fileType = getPreviewFileType(canvasContent.asset);
-		if (fileType !== 'audio' && fileType !== 'video') {
-			setCurrentAssetMetadata(null);
-			return;
-		}
-
-		const detectedFps = metadata.mediaMetadata.fps;
-		const fps =
-			detectedFps !== null && Number.isFinite(detectedFps) && detectedFps > 0
-				? detectedFps
-				: 30;
-		const {dimensions} = metadata;
-		if (dimensions === null || dimensions === 'none') {
-			setCurrentAssetMetadata(null);
-			return;
-		}
-
-		setCurrentAssetMetadata({
-			asset: canvasContent.asset,
-			width: dimensions.width,
-			height: dimensions.height,
-			fps,
-			durationInFrames: Math.max(
-				1,
-				Math.ceil(metadata.mediaMetadata.duration * fps),
-			),
-			props: {},
-			defaultCodec: null,
-			defaultOutName: null,
-			defaultVideoImageFormat: null,
-			defaultPixelFormat: null,
-			defaultProResProfile: null,
-			defaultSampleRate: metadata.mediaMetadata.sampleRate,
-		});
+		setCurrentAssetMetadata(getAssetPreviewMetadata({canvasContent, metadata}));
 	}, [canvasContent, setCurrentAssetMetadata]);
 
 	useEffect(() => {

--- a/packages/studio/src/components/CanvasOrLoading.tsx
+++ b/packages/studio/src/components/CanvasOrLoading.tsx
@@ -85,11 +85,11 @@ export const CanvasOrLoading: React.FC<{
 			) : null}
 		</>
 	);
-	if (
-		canvasContent.type === 'asset' ||
-		canvasContent.type === 'output' ||
-		canvasContent.type === 'output-blob'
-	) {
+	if (canvasContent.type === 'output' || canvasContent.type === 'output-blob') {
+		return content;
+	}
+
+	if (canvasContent.type === 'asset' && resolved === null) {
 		return content;
 	}
 

--- a/packages/studio/src/components/CheckboardToggle.tsx
+++ b/packages/studio/src/components/CheckboardToggle.tsx
@@ -25,6 +25,7 @@ export const CheckboardToggle: React.FC = () => {
 		<ControlButton
 			title={accessibilityLabel}
 			aria-label={accessibilityLabel}
+			aria-pressed={checkerboard}
 			onClick={onClick}
 		>
 			{(color) => (

--- a/packages/studio/src/components/EditorContent.tsx
+++ b/packages/studio/src/components/EditorContent.tsx
@@ -52,10 +52,15 @@ export const EditorContent: React.FC<{
 	readonly readOnlyStudio: boolean;
 	readonly children: React.ReactNode;
 }> = ({readOnlyStudio, children}) => {
-	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {canvasContent, currentAssetMetadata} = useContext(
+		Internals.CompositionManager,
+	);
 
 	const showTimeline =
-		canvasContent !== null && canvasContent.type === 'composition';
+		canvasContent !== null &&
+		(canvasContent.type === 'composition' ||
+			(canvasContent.type === 'asset' &&
+				currentAssetMetadata?.asset === canvasContent.asset));
 
 	const content = (
 		<SplitterContainer

--- a/packages/studio/src/components/EditorRuler/Ruler.tsx
+++ b/packages/studio/src/components/EditorRuler/Ruler.tsx
@@ -29,6 +29,7 @@ interface RulerProps {
 	readonly markingGaps: number;
 	readonly orientation: 'horizontal' | 'vertical';
 	readonly size: Size;
+	readonly canCreateGuides: boolean;
 	readonly onPointerSessionStart: (
 		event: React.PointerEvent<HTMLCanvasElement>,
 		guideId: string,
@@ -47,6 +48,7 @@ const Ruler: React.FC<RulerProps> = ({
 	size,
 	markingGaps,
 	orientation,
+	canCreateGuides,
 	onPointerSessionStart,
 }) => {
 	const rulerCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -67,7 +69,8 @@ const Ruler: React.FC<RulerProps> = ({
 		throw new Error('Video config not set');
 	}
 
-	const cursor = isVerticalRuler ? 'ew-resize' : 'ns-resize';
+	const guideCursor = isVerticalRuler ? 'ew-resize' : 'ns-resize';
+	const cursor = canCreateGuides ? guideCursor : 'default';
 
 	const guideHighlight = useMemo(
 		() =>
@@ -128,7 +131,7 @@ const Ruler: React.FC<RulerProps> = ({
 	const onPointerDown: React.PointerEventHandler<HTMLCanvasElement> =
 		useCallback(
 			(e: React.PointerEvent<HTMLCanvasElement>) => {
-				if (e.button !== 0) {
+				if (!canCreateGuides || e.button !== 0) {
 					return;
 				}
 
@@ -136,7 +139,7 @@ const Ruler: React.FC<RulerProps> = ({
 				// Prevent deselection of currently selected items
 				e.stopPropagation();
 				shouldCreateGuideRef.current = true;
-				forceSpecificCursor(cursor);
+				forceSpecificCursor(guideCursor);
 				const guideId = makeGuideId();
 				setEditorShowGuides(() => true);
 				setDraggingGuideId(() => guideId);
@@ -162,8 +165,9 @@ const Ruler: React.FC<RulerProps> = ({
 				orientation,
 				originOffset,
 				unsafeVideoConfig.id,
-				cursor,
+				guideCursor,
 				onPointerSessionStart,
+				canCreateGuides,
 			],
 		);
 
@@ -173,6 +177,8 @@ const Ruler: React.FC<RulerProps> = ({
 			width={rulerWidth * window.devicePixelRatio}
 			height={rulerHeight * window.devicePixelRatio}
 			style={rulerStyle}
+			aria-label={`${isVerticalRuler ? 'Vertical' : 'Horizontal'} ruler`}
+			aria-readonly={!canCreateGuides}
 			{...{[PREVENT_CLEAR_SELECTION_ON_POINTER_DOWN_ATTR]: 'true'}}
 			onPointerDown={onPointerDown}
 		/>

--- a/packages/studio/src/components/EditorRuler/index.tsx
+++ b/packages/studio/src/components/EditorRuler/index.tsx
@@ -44,7 +44,14 @@ export const EditorRulers: React.FC<{
 	readonly contentDimensions: Dimensions | 'none' | null;
 	readonly assetMetadata: AssetMetadata | null;
 	readonly containerRef: React.RefObject<HTMLDivElement | null>;
-}> = ({contentDimensions, canvasSize, assetMetadata, containerRef}) => {
+	readonly canCreateGuides: boolean;
+}> = ({
+	contentDimensions,
+	canvasSize,
+	assetMetadata,
+	containerRef,
+	canCreateGuides,
+}) => {
 	const {scale, canvasPosition} = useStudioCanvasDimensions({
 		canvasSize,
 		contentDimensions,
@@ -272,6 +279,7 @@ export const EditorRulers: React.FC<{
 	return (
 		<>
 			<Ruler
+				canCreateGuides={canCreateGuides}
 				orientation="horizontal"
 				scale={scale}
 				points={horizontalRulerPoints}
@@ -282,6 +290,7 @@ export const EditorRulers: React.FC<{
 				onPointerSessionStart={onPointerSessionStart}
 			/>
 			<Ruler
+				canCreateGuides={canCreateGuides}
 				orientation="vertical"
 				scale={scale}
 				points={verticalRulerPoints}

--- a/packages/studio/src/components/EditorRuler/use-is-ruler-visible.ts
+++ b/packages/studio/src/components/EditorRuler/use-is-ruler-visible.ts
@@ -1,12 +1,20 @@
 import {useContext} from 'react';
 import {Internals} from 'remotion';
+import {getPreviewFileType} from '../../helpers/get-preview-file-type';
 import {EditorShowRulersContext} from '../../state/editor-rulers';
 
 export const useIsRulerVisible = () => {
-	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {canvasContent, currentAssetMetadata} = useContext(
+		Internals.CompositionManager,
+	);
 	const {editorShowRulers} = useContext(EditorShowRulersContext);
 
 	return (
-		editorShowRulers && canvasContent && canvasContent.type === 'composition'
+		editorShowRulers &&
+		canvasContent !== null &&
+		(canvasContent.type === 'composition' ||
+			(canvasContent.type === 'asset' &&
+				getPreviewFileType(canvasContent.asset) === 'video' &&
+				currentAssetMetadata?.asset === canvasContent.asset))
 	);
 };

--- a/packages/studio/src/components/PlaybackRateSelector.tsx
+++ b/packages/studio/src/components/PlaybackRateSelector.tsx
@@ -74,7 +74,7 @@ export const PlaybackRateSelector: React.FC<PlaybackRateMenuItemsProps> = ({
 		setPlaybackRate,
 	});
 
-	if (isStill || canvasContent === null || canvasContent.type === 'asset') {
+	if (isStill || canvasContent === null) {
 		return null;
 	}
 

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -1,3 +1,4 @@
+import {Audio, Video} from '@remotion/media';
 import type {Size} from '@remotion/player';
 import {PlayerInternals} from '@remotion/player';
 import React, {
@@ -9,9 +10,11 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
+import {createPortal} from 'react-dom';
 import type {CanvasContent} from 'remotion';
-import {Internals} from 'remotion';
+import {Internals, staticFile} from 'remotion';
 import {ErrorLoader} from '../error-overlay/remotion-overlay/ErrorLoader';
+import {addAssetCacheBust} from '../helpers/add-asset-cache-bust';
 import {
 	checkerboardBackgroundColor,
 	checkerboardBackgroundImage,
@@ -23,6 +26,7 @@ import type {AssetMetadata} from '../helpers/get-asset-metadata';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import type {Dimensions} from '../helpers/is-current-selected-still';
 import {calculateStudioCanvasTransformation} from '../helpers/studio-fit-padding';
+import {AudioFileIcon} from '../icons/audio';
 import {CheckerboardContext} from '../state/checkerboard';
 import {EditorShowPixelGridContext} from '../state/editor-pixel-grid';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from './Menu/is-menu-item';
@@ -154,7 +158,10 @@ export const VideoPreview: React.FC<{
 		);
 	}
 
-	if (contentDimensions === null) {
+	if (
+		contentDimensions === null ||
+		(canvasContent.type !== 'composition' && assetMetadata === null)
+	) {
 		return (
 			<div style={centeredContainer}>
 				<Spinner duration={0.5} size={24} />
@@ -179,6 +186,7 @@ const CompWhenItHasDimensions: React.FC<{
 	readonly assetMetadata: AssetMetadata | null;
 }> = ({contentDimensions, canvasSize, canvasContent, assetMetadata}) => {
 	const {size: previewSize} = useContext(Internals.PreviewSizeContext);
+	const {currentAssetMetadata} = useContext(Internals.CompositionManager);
 	const [canvasHovered, setCanvasHovered] = useState(false);
 	const compositionContainerRef = useRef<HTMLDivElement>(null);
 	useEffect(() => {
@@ -225,6 +233,19 @@ const CompWhenItHasDimensions: React.FC<{
 					previewSize: previewSize.size,
 				});
 	}, [canvasContent.type, canvasSize, contentDimensions, previewSize.size]);
+	const assetFileType =
+		canvasContent.type === 'asset'
+			? getPreviewFileType(canvasContent.asset)
+			: null;
+	const mediaCompositionFileType =
+		(assetFileType === 'audio' || assetFileType === 'video') &&
+		assetMetadata?.type === 'found' &&
+		assetMetadata.mediaMetadata !== null &&
+		canvasContent.type === 'asset' &&
+		currentAssetMetadata?.asset === canvasContent.asset &&
+		contentDimensions !== 'none'
+			? assetFileType
+			: null;
 
 	const outer: React.CSSProperties = useMemo(() => {
 		return {
@@ -240,10 +261,14 @@ const CompWhenItHasDimensions: React.FC<{
 			left: centerX - previewSize.translation.x,
 			top: centerY - previewSize.translation.y,
 			overflow: canvasContent.type === 'composition' ? 'visible' : 'hidden',
-			justifyContent: canvasContent.type === 'asset' ? 'center' : 'flex-start',
+			justifyContent:
+				canvasContent.type === 'asset' && mediaCompositionFileType === null
+					? 'center'
+					: 'flex-start',
 			alignItems:
 				canvasContent.type === 'asset' &&
-				getPreviewFileType(canvasContent.asset) === 'audio'
+				mediaCompositionFileType === null &&
+				assetFileType === 'audio'
 					? 'center'
 					: 'normal',
 		};
@@ -255,9 +280,55 @@ const CompWhenItHasDimensions: React.FC<{
 		previewSize.translation.y,
 		centerY,
 		canvasContent,
+		mediaCompositionFileType,
+		assetFileType,
 	]);
 
 	if (canvasContent.type === 'asset') {
+		if (
+			mediaCompositionFileType !== null &&
+			assetMetadata?.type === 'found' &&
+			contentDimensions !== 'none'
+		) {
+			return (
+				<div
+					ref={compositionContainerRef}
+					className="remotion-studio-composition-container"
+					style={outer}
+				>
+					{mediaCompositionFileType === 'audio' ? (
+						<AudioFileIcon
+							aria-label="Audio asset"
+							color={LIGHT_TEXT}
+							role="img"
+							style={{
+								height: 64,
+								left: '50%',
+								opacity: 0.25,
+								pointerEvents: 'none',
+								position: 'absolute',
+								top: '50%',
+								transform: 'translate(-50%, -50%)',
+								width: 64,
+							}}
+						/>
+					) : null}
+					<PortalContainer
+						contentDimensions={contentDimensions}
+						offscreen={mediaCompositionFileType === 'audio'}
+						scale={scale}
+						xCorrection={xCorrection}
+						yCorrection={yCorrection}
+					/>
+					<AssetMediaComposition
+						asset={canvasContent.asset}
+						fetchedAt={assetMetadata.fetchedAt}
+						fileType={mediaCompositionFileType}
+					/>
+				</div>
+			);
+		}
+
 		return (
 			<div style={outer}>
 				<StaticFilePreview
@@ -299,6 +370,7 @@ const CompWhenItHasDimensions: React.FC<{
 		>
 			<PortalContainer
 				contentDimensions={contentDimensions as Dimensions}
+				offscreen={false}
 				scale={scale}
 				xCorrection={xCorrection}
 				yCorrection={yCorrection}
@@ -316,17 +388,59 @@ const CompWhenItHasDimensions: React.FC<{
 	);
 };
 
+const AssetMediaComposition: React.FC<{
+	readonly asset: string;
+	readonly fetchedAt: number;
+	readonly fileType: 'audio' | 'video';
+}> = ({asset, fetchedAt, fileType}) => {
+	const src = addAssetCacheBust({
+		fetchedAt,
+		src: staticFile(asset),
+	});
+	const style: React.CSSProperties = {
+		width: '100%',
+		height: '100%',
+	};
+
+	return createPortal(
+		<Internals.CanUseRemotionHooksProvider>
+			<Internals.DisableInteractivityProvider>
+				<div data-testid="asset-media-preview" style={style}>
+					{fileType === 'video' ? (
+						<Video name={asset} src={src} style={style} />
+					) : (
+						<Audio name={asset} src={src} />
+					)}
+				</div>
+			</Internals.DisableInteractivityProvider>
+		</Internals.CanUseRemotionHooksProvider>,
+		Internals.portalNode(),
+	);
+};
+
 const PortalContainer: React.FC<{
+	readonly offscreen: boolean;
 	readonly scale: number;
 	readonly xCorrection: number;
 	readonly yCorrection: number;
 	readonly contentDimensions: Dimensions;
-}> = ({scale, xCorrection, yCorrection, contentDimensions}) => {
+}> = ({offscreen, scale, xCorrection, yCorrection, contentDimensions}) => {
 	const {checkerboard} = useContext(CheckerboardContext);
 	const {clearSelection} = useTimelineSelection();
 	const portalContainer = useRef<HTMLDivElement>(null);
 
 	const style = useMemo((): React.CSSProperties => {
+		if (offscreen) {
+			return {
+				height: contentDimensions.height,
+				left: -999999,
+				overflow: 'hidden',
+				position: 'fixed',
+				top: 0,
+				width: contentDimensions.width,
+			};
+		}
+
 		return containerStyle({
 			checkerboard,
 			scale,
@@ -339,6 +453,7 @@ const PortalContainer: React.FC<{
 		checkerboard,
 		contentDimensions.height,
 		contentDimensions.width,
+		offscreen,
 		scale,
 		xCorrection,
 		yCorrection,

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useState} from 'react';
 import {Internals} from 'remotion';
 import {checkFullscreenSupport} from '../helpers/check-fullscreen-support';
 import {BACKGROUND, BORDER_BLACK_ALPHA_50} from '../helpers/colors';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {
 	useIsStill,
 	useIsVideoComposition,
@@ -92,6 +93,11 @@ export const PreviewToolbar: React.FC<{
 	const {setPlayerMuted} = useContext(Internals.SetMediaVolumeContext);
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const isVideoComposition = useIsVideoComposition();
+	const showCompositionControls = canvasContent?.type === 'composition';
+	const showCanvasViewControls =
+		showCompositionControls ||
+		(canvasContent?.type === 'asset' &&
+			getPreviewFileType(canvasContent.asset) === 'video');
 
 	const isStill = useIsStill();
 
@@ -138,7 +144,8 @@ export const PreviewToolbar: React.FC<{
 								showFullscreen={Boolean(canvasContent && isFullscreenSupported)}
 								showPlaybackRate={isVideoComposition}
 								showLoop={isVideoComposition}
-								showCompositionControls={canvasContent?.type === 'composition'}
+								showCanvasViewControls={showCanvasViewControls}
+								showCompositionControls={showCompositionControls}
 								playbackRate={playbackRate}
 								setPlaybackRate={setPlaybackRate}
 								loop={loop}
@@ -178,7 +185,7 @@ export const PreviewToolbar: React.FC<{
 					<Spacing x={2} />
 				</>
 			) : null}
-			{canvasContent?.type === 'composition' ? (
+			{showCanvasViewControls ? (
 				<>
 					{isMobileLayout ? null : (
 						<PreviewToolbarControl>
@@ -186,20 +193,22 @@ export const PreviewToolbar: React.FC<{
 						</PreviewToolbarControl>
 					)}
 					{isMobileLayout ? null : <Spacing x={0.25} />}
-					{isMobileLayout ? null : (
+					{isMobileLayout || !showCompositionControls ? null : (
 						<PreviewToolbarControl>
 							<OutlineToggle />
 						</PreviewToolbarControl>
 					)}
 					{isMobileLayout ? null : (
 						<>
-							<Spacing x={0.25} />
+							{showCompositionControls ? <Spacing x={0.25} /> : null}
 							<PreviewToolbarControl>
-								<RulersAndGuidesToggle />
+								<RulersAndGuidesToggle showGuides={showCompositionControls} />
 							</PreviewToolbarControl>
 						</>
 					)}
-					{readOnlyStudio || isMobileLayout ? null : (
+					{readOnlyStudio ||
+					isMobileLayout ||
+					!showCompositionControls ? null : (
 						<>
 							<Spacing x={0.25} />
 							<PreviewToolbarControl>

--- a/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
+++ b/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
@@ -23,6 +23,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 	readonly showFullscreen: boolean;
 	readonly showPlaybackRate: boolean;
 	readonly showLoop: boolean;
+	readonly showCanvasViewControls: boolean;
 	readonly showCompositionControls: boolean;
 	readonly playbackRate: number;
 	readonly setPlaybackRate: React.Dispatch<React.SetStateAction<number>>;
@@ -32,6 +33,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 	showFullscreen,
 	showPlaybackRate,
 	showLoop,
+	showCanvasViewControls,
 	showCompositionControls,
 	playbackRate,
 	setPlaybackRate,
@@ -129,7 +131,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 			});
 		}
 
-		if (showCompositionControls) {
+		if (showCanvasViewControls) {
 			items.push({
 				type: 'item',
 				id: 'checkerboard',
@@ -141,6 +143,9 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				subMenu: null,
 				quickSwitcherLabel: null,
 			});
+		}
+
+		if (showCompositionControls) {
 			items.push({
 				type: 'item',
 				id: 'outlines',
@@ -152,6 +157,9 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				subMenu: null,
 				quickSwitcherLabel: null,
 			});
+		}
+
+		if (showCanvasViewControls) {
 			items.push({
 				type: 'item',
 				id: 'rulers',
@@ -163,6 +171,9 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				subMenu: null,
 				quickSwitcherLabel: null,
 			});
+		}
+
+		if (showCompositionControls) {
 			items.push({
 				type: 'item',
 				id: 'guides',
@@ -199,6 +210,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 		showFullscreen,
 		showLoop,
 		showPlaybackRate,
+		showCanvasViewControls,
 		showCompositionControls,
 		loop,
 		checkerboard,

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -146,6 +146,7 @@ const RenderButtonInner: React.FC<{
 	}, [controlSize]);
 
 	const video = Internals.useVideo();
+	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {getCurrentFrame} = PlayerInternals.usePlayerMethods();
 
 	const {props} = useContext(Internals.EditorPropsContext);
@@ -428,7 +429,7 @@ const RenderButtonInner: React.FC<{
 		tooltip,
 	]);
 
-	if (!video) {
+	if (!video || canvasContent?.type !== 'composition') {
 		return null;
 	}
 

--- a/packages/studio/src/components/RulersAndGuidesToggle.tsx
+++ b/packages/studio/src/components/RulersAndGuidesToggle.tsx
@@ -4,23 +4,37 @@ import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowRulersContext} from '../state/editor-rulers';
 import {ControlButton} from './ControlButton';
 
-export const RulersAndGuidesToggle: React.FC = () => {
+export const RulersAndGuidesToggle: React.FC<{
+	readonly showGuides: boolean;
+}> = ({showGuides}) => {
 	const {editorShowGuides, setEditorShowGuides} = useContext(
 		EditorShowGuidesContext,
 	);
 	const {editorShowRulers, setEditorShowRulers} = useContext(
 		EditorShowRulersContext,
 	);
-	const rulersOrGuidesAreVisible = editorShowRulers || editorShowGuides;
+	const rulersOrGuidesAreVisible =
+		editorShowRulers || (showGuides && editorShowGuides);
 
 	const onClick = useCallback(() => {
 		setEditorShowRulers(() => !rulersOrGuidesAreVisible);
-		setEditorShowGuides(() => !rulersOrGuidesAreVisible);
-	}, [rulersOrGuidesAreVisible, setEditorShowGuides, setEditorShowRulers]);
+		if (showGuides) {
+			setEditorShowGuides(() => !rulersOrGuidesAreVisible);
+		}
+	}, [
+		rulersOrGuidesAreVisible,
+		setEditorShowGuides,
+		setEditorShowRulers,
+		showGuides,
+	]);
 
-	const accessibilityLabel = rulersOrGuidesAreVisible
-		? 'Hide rulers and guides'
-		: 'Show rulers and guides';
+	const accessibilityLabel = showGuides
+		? rulersOrGuidesAreVisible
+			? 'Hide rulers and guides'
+			: 'Show rulers and guides'
+		: editorShowRulers
+			? 'Hide rulers'
+			: 'Show rulers';
 
 	return (
 		<ControlButton

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -65,14 +65,19 @@ export const TimelineDragHandler: React.FC = () => {
 	const video = Internals.useUnsafeVideoConfig();
 
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
-	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {canvasContent, currentAssetMetadata} = useContext(
+		Internals.CompositionManager,
+	);
 
 	const containerStyle: React.CSSProperties = useMemo(() => {
-		if (!canvasContent || canvasContent.type !== 'composition') {
+		if (!canvasContent) {
 			return {};
 		}
 
-		const zoom = zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
+		const zoom =
+			canvasContent.type === 'composition'
+				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
+				: TIMELINE_MIN_ZOOM;
 		return {
 			...container,
 			width: 100 * zoom + '%',
@@ -80,7 +85,11 @@ export const TimelineDragHandler: React.FC = () => {
 		};
 	}, [canvasContent, zoomMap]);
 
-	if (!canvasContent || canvasContent.type !== 'composition') {
+	const hasPlayableContent =
+		canvasContent?.type === 'composition' ||
+		(canvasContent?.type === 'asset' &&
+			currentAssetMetadata?.asset === canvasContent.asset);
+	if (!hasPlayableContent) {
 		return null;
 	}
 

--- a/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
@@ -42,9 +42,9 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 			: null;
 	const zoom = compositionId
 		? (zoomMap[compositionId] ?? TIMELINE_MIN_ZOOM)
-		: null;
+		: TIMELINE_MIN_ZOOM;
 
-	if (zoom && video) {
+	if (video) {
 		setCurrentFrame(timelinePosition);
 		setCurrentZoom(zoom);
 		setCurrentDuration(video.durationInFrames);

--- a/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
@@ -40,6 +40,8 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 		canvasContent && canvasContent.type === 'composition'
 			? canvasContent.compositionId
 			: null;
+	// Asset previews have a synthetic video config, but no composition ID
+	// with which to look up a persisted timeline zoom.
 	const zoom = compositionId
 		? (zoomMap[compositionId] ?? TIMELINE_MIN_ZOOM)
 		: TIMELINE_MIN_ZOOM;

--- a/packages/studio/src/helpers/get-asset-metadata.ts
+++ b/packages/studio/src/helpers/get-asset-metadata.ts
@@ -36,6 +36,58 @@ export type AssetMetadata =
 			mediaMetadata: MediaMetadata | null;
 	  };
 
+export const getAssetPreviewMetadata = ({
+	canvasContent,
+	metadata,
+}: {
+	canvasContent: CanvasContent;
+	metadata: AssetMetadata;
+}) => {
+	if (
+		canvasContent.type !== 'asset' ||
+		metadata.type !== 'found' ||
+		metadata.mediaMetadata === null ||
+		!Number.isFinite(metadata.mediaMetadata.duration) ||
+		metadata.mediaMetadata.duration <= 0
+	) {
+		return null;
+	}
+
+	const fileType = getPreviewFileType(canvasContent.asset);
+	if (fileType !== 'audio' && fileType !== 'video') {
+		return null;
+	}
+
+	const {dimensions} = metadata;
+	if (dimensions === null || dimensions === 'none') {
+		return null;
+	}
+
+	const detectedFps = metadata.mediaMetadata.fps;
+	const fps =
+		detectedFps !== null && Number.isFinite(detectedFps) && detectedFps > 0
+			? detectedFps
+			: 30;
+
+	return {
+		asset: canvasContent.asset,
+		width: dimensions.width,
+		height: dimensions.height,
+		fps,
+		durationInFrames: Math.max(
+			1,
+			Math.ceil(metadata.mediaMetadata.duration * fps),
+		),
+		props: {},
+		defaultCodec: null,
+		defaultOutName: null,
+		defaultVideoImageFormat: null,
+		defaultPixelFormat: null,
+		defaultProResProfile: null,
+		defaultSampleRate: metadata.mediaMetadata.sampleRate,
+	};
+};
+
 export const getAssetMetadata = async (
 	canvasContent: CanvasContent,
 	addTime: boolean,

--- a/packages/studio/src/helpers/get-asset-metadata.ts
+++ b/packages/studio/src/helpers/get-asset-metadata.ts
@@ -1,9 +1,9 @@
-import {getVideoMetadata} from '@remotion/media-utils';
 import type {CanvasContent} from 'remotion';
 import {staticFile} from 'remotion';
 import {addAssetCacheBust} from './add-asset-cache-bust';
 import {getPreviewFileType} from './get-preview-file-type';
 import type {Dimensions} from './is-current-selected-still';
+import {getMediaMetadata, type MediaMetadata} from './use-media-metadata';
 
 export const remotion_outputsBase = window.remotion_staticBase.replace(
 	'static',
@@ -33,6 +33,7 @@ export type AssetMetadata =
 			size: number;
 			dimensions: Dimensions | 'none' | null;
 			fetchedAt: number;
+			mediaMetadata: MediaMetadata | null;
 	  };
 
 export const getAssetMetadata = async (
@@ -45,6 +46,7 @@ export const getAssetMetadata = async (
 			size: canvasContent.sizeInBytes,
 			dimensions: {width: canvasContent.width, height: canvasContent.height},
 			fetchedAt: Date.now(),
+			mediaMetadata: null,
 		};
 	}
 
@@ -91,13 +93,20 @@ export const getAssetMetadata = async (
 
 		const fileType = getPreviewFileType(src);
 
-		if (fileType === 'video') {
-			const resolution = await getVideoMetadata(srcWithTime);
+		if (fileType === 'video' || fileType === 'audio') {
+			const mediaMetadata = await getMediaMetadata(srcWithTime);
+			if (mediaMetadata === null) {
+				throw new Error(`Could not read media metadata for ${src}`);
+			}
+
+			const width = mediaMetadata.width ?? 1920;
+			const height = mediaMetadata.height ?? 1080;
 			return {
 				type: 'found',
 				size,
-				dimensions: {width: resolution.width, height: resolution.height},
+				dimensions: {width, height},
 				fetchedAt,
+				mediaMetadata,
 			};
 		}
 
@@ -110,6 +119,7 @@ export const getAssetMetadata = async (
 						size,
 						dimensions: {width: img.width, height: img.height},
 						fetchedAt,
+						mediaMetadata: null,
 					});
 				};
 
@@ -127,6 +137,7 @@ export const getAssetMetadata = async (
 			dimensions: 'none',
 			size,
 			fetchedAt,
+			mediaMetadata: null,
 		};
 	} catch (err) {
 		return {

--- a/packages/studio/src/helpers/is-current-selected-still.ts
+++ b/packages/studio/src/helpers/is-current-selected-still.ts
@@ -19,7 +19,9 @@ export const useIsStill = () => {
 
 export const useIsVideoComposition = () => {
 	const isStill = useIsStill();
-	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {canvasContent, currentAssetMetadata} = useContext(
+		Internals.CompositionManager,
+	);
 
 	if (canvasContent === null) {
 		return false;
@@ -29,5 +31,9 @@ export const useIsVideoComposition = () => {
 		return false;
 	}
 
-	return canvasContent.type === 'composition';
+	return (
+		canvasContent.type === 'composition' ||
+		(canvasContent.type === 'asset' &&
+			currentAssetMetadata?.asset === canvasContent.asset)
+	);
 };

--- a/packages/test-utils/src/composition-manager-context.ts
+++ b/packages/test-utils/src/composition-manager-context.ts
@@ -8,6 +8,7 @@ const Mock: React.FC = () => null;
 export const makeMockCompositionManagerContext =
 	(): CompositionManagerContext => {
 		return {
+			currentAssetMetadata: null,
 			currentCompositionMetadata: {
 				durationInFrames: 500,
 				fps: 30,

--- a/packages/web-renderer/src/create-scaffold.tsx
+++ b/packages/web-renderer/src/create-scaffold.tsx
@@ -295,6 +295,7 @@ export function createScaffold<Props extends Record<string, unknown>>({
 										type: 'composition',
 										compositionId: id,
 									},
+									currentAssetMetadata: null,
 									currentCompositionMetadata: {
 										props: resolvedProps,
 										durationInFrames,


### PR DESCRIPTION
## Summary

- preview selected video and audio assets through `@remotion/media` using a synthetic composition and playable timeline
- derive duration, frame rate, dimensions, and audio metadata with Mediabunny, including ProRes assets
- keep asset previews non-interactive, expose read-only canvas controls for video, and show audio as a standalone note icon

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should preview media assets as a non-interactive timeline"`

Closes #9768
