### PR TITLE
`@remotion/promo-pages`: Fix HLS video playback in Chrome

### DIFF
--- a/packages/docs/src/components/MuxVideo.tsx
+++ b/packages/docs/src/components/MuxVideo.tsx
@@ -25,14 +25,12 @@ const MuxVideoForward: React.ForwardRefRenderFunction<
 		let hls: Hls;
 		if (videoRef.current) {
 			const {current} = videoRef;
-			if (current.canPlayType('application/vnd.apple.mpegurl')) {
-				// Some browers (safari and ie edge) support HLS natively
-				current.src = vidUrl;
-			} else if (Hls.isSupported()) {
-				// This will run in all other modern browsers
+			if (Hls.isSupported()) {
 				hls = new Hls();
 				hls.loadSource(vidUrl);
 				hls.attachMedia(current);
+			} else if (current.canPlayType('application/vnd.apple.mpegurl')) {
+				current.src = vidUrl;
 			} else {
 				console.error("This is a legacy browser that doesn't support MSE");
 			}

--- a/packages/docs/src/components/VideoPlayerWithControls.tsx
+++ b/packages/docs/src/components/VideoPlayerWithControls.tsx
@@ -150,11 +150,7 @@ export const VideoPlayerWithControls = forwardRef<
 					captions: {active: true, language: 'auto', update: true},
 				});
 
-				if (video.canPlayType('application/vnd.apple.mpegurl')) {
-					// This will run in safari, where HLS is supported natively
-					video.src = src;
-				} else if (Hls.isSupported()) {
-					// This will run in all other modern browsers
+				if (Hls.isSupported()) {
 					hls = new Hls();
 					hls.loadSource(src);
 					hls.attachMedia(video);
@@ -163,6 +159,8 @@ export const VideoPlayerWithControls = forwardRef<
 							videoError(new ErrorEvent('HLS.js fatal error'));
 						}
 					});
+				} else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+					video.src = src;
 				} else {
 					console.error(
 						'This is an old browser that does not support MSE https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API',

--- a/packages/promo-pages/src/components/homepage/MuxVideo.tsx
+++ b/packages/promo-pages/src/components/homepage/MuxVideo.tsx
@@ -24,14 +24,12 @@ const MuxVideoForward: React.ForwardRefRenderFunction<
 		let hls: Hls;
 		if (videoRef.current) {
 			const {current} = videoRef;
-			if (current.canPlayType('application/vnd.apple.mpegurl')) {
-				// Some browers (safari and ie edge) support HLS natively
-				current.src = vidUrl;
-			} else if (Hls.isSupported()) {
-				// This will run in all other modern browsers
+			if (Hls.isSupported()) {
 				hls = new Hls();
 				hls.loadSource(vidUrl);
 				hls.attachMedia(current);
+			} else if (current.canPlayType('application/vnd.apple.mpegurl')) {
+				current.src = vidUrl;
 			} else {
 				// eslint-disable-next-line no-console
 				console.error("This is a legacy browser that doesn't support MSE");

--- a/packages/promo-pages/src/components/homepage/VideoPlayerWithControls.tsx
+++ b/packages/promo-pages/src/components/homepage/VideoPlayerWithControls.tsx
@@ -136,11 +136,7 @@ export const VideoPlayerWithControls = forwardRef<
 					captions: {active: true, language: 'auto', update: true},
 				});
 
-				if (video.canPlayType('application/vnd.apple.mpegurl')) {
-					// This will run in safari, where HLS is supported natively
-					video.src = src;
-				} else if (Hls.isSupported()) {
-					// This will run in all other modern browsers
+				if (Hls.isSupported()) {
 					hls = new Hls();
 					hls.loadSource(src);
 					hls.attachMedia(video);
@@ -149,6 +145,8 @@ export const VideoPlayerWithControls = forwardRef<
 							videoError(new ErrorEvent('HLS.js fatal error'));
 						}
 					});
+				} else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+					video.src = src;
 				} else {
 					console.error(
 						'This is an old browser that does not support MSE https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API',


### PR DESCRIPTION
## Summary

- prefer `hls.js` over native HLS when Media Source Extensions are available
- keep native HLS as the fallback for browsers without `hls.js` support
- apply the same playback selection to template previews and controlled docs videos

Chrome now reports native HLS support, but loading the Mux playlists directly fails. This keeps Chrome on the existing `hls.js` playback path while preserving native playback for Safari.

## Verification

- `bun run build`
- `bun run stylecheck`
- local Chrome 151 smoke test of `/templates/music-visualization` (1080×1080 video loaded and played)
