### PR TITLE
Internal: Expand templates in queued commit messages for `pi`

### DIFF
--- a/.pi/extensions/commit/index.test.ts
+++ b/.pi/extensions/commit/index.test.ts
@@ -14,7 +14,7 @@ type CommandHandler = (
 	ctx: ExtensionCommandContext,
 ) => unknown | Promise<unknown>;
 
-test('queues user messages outside the temporary commit worker branch', async () => {
+test('queues user messages outside the temporary commit worker branch with prompt expansion enabled', async () => {
 	const handlers = new Map<string, Handler>();
 	let commitCommand: CommandHandler | undefined;
 	let leafId = 'source-leaf';
@@ -116,15 +116,21 @@ test('queues user messages outside the temporary commit worker branch', async ()
 	expect(leafId).toBe('source-leaf');
 	expect(sentCustomMessages.at(-1)?.customType).toBe('remotion-commit-result');
 	expect(sentUserMessages).toEqual([
-		{content: 'Do not steer the worker', options: undefined},
+		{
+			content: 'Do not steer the worker',
+			options: {expandPromptTemplates: true},
+		},
 	]);
 
 	await handlers.get('agent_start')?.({}, context);
 	expect(sentUserMessages).toEqual([
-		{content: 'Do not steer the worker', options: undefined},
+		{
+			content: 'Do not steer the worker',
+			options: {expandPromptTemplates: true},
+		},
 		{
 			content: 'Run this after the worker exits',
-			options: {deliverAs: 'followUp'},
+			options: {deliverAs: 'followUp', expandPromptTemplates: true},
 		},
 	]);
 });

--- a/.pi/extensions/commit/index.ts
+++ b/.pi/extensions/commit/index.ts
@@ -55,9 +55,12 @@ export default function remotionCommitExtension(pi: ExtensionAPI) {
 				: [{type: 'text' as const, text: message.text}, ...message.images];
 
 		if (deliverAs) {
-			pi.sendUserMessage(content, {deliverAs});
+			pi.sendUserMessage(content, {
+				deliverAs,
+				expandPromptTemplates: true,
+			});
 		} else {
-			pi.sendUserMessage(content);
+			pi.sendUserMessage(content, {expandPromptTemplates: true});
 		}
 	};
 


### PR DESCRIPTION
## Summary

- opt queued commit-extension messages into Pi's native prompt expansion
- allow queued skill commands and prompt templates to expand after the commit worker exits
- cover both the first released message and subsequent follow-up messages

## Testing

- `bunx oxfmt .pi/extensions/commit/index.ts .pi/extensions/commit/index.test.ts --write`
- `bun test ./.pi/extensions/commit/index.test.ts`
- `bun run build`
- `bun run stylecheck`
