### PR TITLE
`@remotion/media`: Retry transient frame fetch failures

### DIFF
--- a/packages/media/src/test/frame-fetch-retries.test.ts
+++ b/packages/media/src/test/frame-fetch-retries.test.ts
@@ -1,0 +1,11 @@
+import {expect, test} from 'vitest';
+import {getRetryDelay} from '../video-extraction/get-frames-since-keyframe';
+
+test('retries frame fetches twice with bounded delays', () => {
+	const error = new Error('Failed to fetch');
+	const src = 'blob:test';
+
+	expect(getRetryDelay(1, error, src)).toBe(0.25);
+	expect(getRetryDelay(2, error, src)).toBe(0.5);
+	expect(getRetryDelay(3, error, src)).toBe(null);
+});

--- a/packages/media/src/test/frame-fetch-retries.test.ts
+++ b/packages/media/src/test/frame-fetch-retries.test.ts
@@ -3,18 +3,9 @@ import {getRetryDelay} from '../video-extraction/get-frames-since-keyframe';
 
 test('retries frame fetches twice with bounded delays', () => {
 	const error = new Error('Failed to fetch');
-	const src = URL.createObjectURL(new Blob());
+	const src = 'blob:test';
 
 	expect(getRetryDelay(1, error, src)).toBe(0.25);
 	expect(getRetryDelay(2, error, src)).toBe(0.5);
 	expect(getRetryDelay(3, error, src)).toBe(null);
-
-	URL.revokeObjectURL(src);
-});
-
-test('does not retry likely cross-origin CORS errors', () => {
-	const error = new Error('Failed to fetch');
-	const src = 'https://cors-error.invalid/video.mp4';
-
-	expect(getRetryDelay(1, error, src)).toBe(null);
 });

--- a/packages/media/src/test/frame-fetch-retries.test.ts
+++ b/packages/media/src/test/frame-fetch-retries.test.ts
@@ -3,7 +3,18 @@ import {getRetryDelay} from '../video-extraction/get-frames-since-keyframe';
 
 test('retries frame fetches twice with bounded delays', () => {
 	const error = new Error('Failed to fetch');
-	const src = 'blob:test';
+	const src = URL.createObjectURL(new Blob());
+
+	expect(getRetryDelay(1, error, src)).toBe(0.25);
+	expect(getRetryDelay(2, error, src)).toBe(0.5);
+	expect(getRetryDelay(3, error, src)).toBe(null);
+
+	URL.revokeObjectURL(src);
+});
+
+test('retries cross-origin fetch failures', () => {
+	const error = new Error('Failed to fetch');
+	const src = 'https://media.example.com/video.mp4';
 
 	expect(getRetryDelay(1, error, src)).toBe(0.25);
 	expect(getRetryDelay(2, error, src)).toBe(0.5);

--- a/packages/media/src/test/frame-fetch-retries.test.ts
+++ b/packages/media/src/test/frame-fetch-retries.test.ts
@@ -3,9 +3,18 @@ import {getRetryDelay} from '../video-extraction/get-frames-since-keyframe';
 
 test('retries frame fetches twice with bounded delays', () => {
 	const error = new Error('Failed to fetch');
-	const src = 'blob:test';
+	const src = URL.createObjectURL(new Blob());
 
 	expect(getRetryDelay(1, error, src)).toBe(0.25);
 	expect(getRetryDelay(2, error, src)).toBe(0.5);
 	expect(getRetryDelay(3, error, src)).toBe(null);
+
+	URL.revokeObjectURL(src);
+});
+
+test('does not retry likely cross-origin CORS errors', () => {
+	const error = new Error('Failed to fetch');
+	const src = 'https://cors-error.invalid/video.mp4';
+
+	expect(getRetryDelay(1, error, src)).toBe(null);
 });

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -43,8 +43,12 @@ export type VideoSinkResult =
 	| 'unknown-container-format'
 	| 'network-error';
 
-const getRetryDelay = (() => {
-	return null;
+export const getRetryDelay = ((previousAttempts) => {
+	if (previousAttempts > 2) {
+		return null;
+	}
+
+	return previousAttempts * 0.25;
 }) satisfies UrlSourceOptions['getRetryDelay'];
 
 const getFormatOrNullOrNetworkError = async (

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -43,7 +43,39 @@ export type VideoSinkResult =
 	| 'unknown-container-format'
 	| 'network-error';
 
-export const getRetryDelay = ((previousAttempts) => {
+export const getRetryDelay = ((previousAttempts, error, src) => {
+	const couldBeCorsError =
+		error instanceof Error &&
+		[
+			'Failed to fetch',
+			'Load failed',
+			'NetworkError when attempting to fetch resource',
+		].some((message) => error.message.includes(message)) &&
+		typeof window !== 'undefined';
+
+	if (couldBeCorsError) {
+		const isOnline =
+			typeof navigator === 'undefined' ||
+			typeof navigator.onLine !== 'boolean' ||
+			navigator.onLine;
+		const srcString =
+			typeof Request !== 'undefined' && src instanceof Request
+				? src.url
+				: src.toString();
+
+		try {
+			if (
+				isOnline &&
+				new URL(srcString, window.location.href).origin !==
+					window.location.origin
+			) {
+				return null;
+			}
+		} catch {
+			// Let the bounded retry policy handle malformed URLs.
+		}
+	}
+
 	if (previousAttempts > 2) {
 		return null;
 	}

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -43,39 +43,7 @@ export type VideoSinkResult =
 	| 'unknown-container-format'
 	| 'network-error';
 
-export const getRetryDelay = ((previousAttempts, error, src) => {
-	const couldBeCorsError =
-		error instanceof Error &&
-		[
-			'Failed to fetch',
-			'Load failed',
-			'NetworkError when attempting to fetch resource',
-		].some((message) => error.message.includes(message)) &&
-		typeof window !== 'undefined';
-
-	if (couldBeCorsError) {
-		const isOnline =
-			typeof navigator === 'undefined' ||
-			typeof navigator.onLine !== 'boolean' ||
-			navigator.onLine;
-		const srcString =
-			typeof Request !== 'undefined' && src instanceof Request
-				? src.url
-				: src.toString();
-
-		try {
-			if (
-				isOnline &&
-				new URL(srcString, window.location.href).origin !==
-					window.location.origin
-			) {
-				return null;
-			}
-		} catch {
-			// Let the bounded retry policy handle malformed URLs.
-		}
-	}
-
+export const getRetryDelay = ((previousAttempts) => {
 	if (previousAttempts > 2) {
 		return null;
 	}


### PR DESCRIPTION
## Summary

Frame extraction currently configures Mediabunny's `UrlSource` to fail on the first rejected fetch. This means a transient network read immediately fails the render.

Retry failed fetches from every origin twice, with bounded delays of 250ms and 500ms. Persistent failures, including CORS failures, still surface after 750ms, avoiding Mediabunny's default unbounded retry behavior for same-origin sources while giving cross-origin media a chance to recover from transient failures.

## Test plan

- `cd packages/media && bunx vitest src/test/frame-fetch-retries.test.ts --browser --run`
- `cd packages/media && bun run formatting`
- `cd packages/media && bun run lint` (passes with existing warnings)

Made with [Cursor](https://cursor.com)