### PR TITLE
Studio: Add disabled keyframes

### DIFF
--- a/packages/core/src/interpolate-colors.ts
+++ b/packages/core/src/interpolate-colors.ts
@@ -7,7 +7,7 @@ import {interpolate, type InterpolateOptions} from './interpolate.js';
 
 export type InterpolateColorsOptions = Pick<
 	InterpolateOptions,
-	'easing' | 'posterize'
+	'disabledKeyframes' | 'easing' | 'posterize'
 >;
 
 type MatcherType = RegExp | undefined;

--- a/packages/core/src/interpolate-keyframed-status.ts
+++ b/packages/core/src/interpolate-keyframed-status.ts
@@ -61,6 +61,9 @@ export const interpolateKeyframedStatus = ({
 	const sortedKeyframes = [...keyframes].sort((a, b) => a.frame - b.frame);
 	const inputRange = sortedKeyframes.map((k) => k.frame);
 	const outputs = sortedKeyframes.map((k) => k.value);
+	const disabledKeyframes = sortedKeyframes.flatMap((keyframe) =>
+		keyframe.disabled ? [keyframe.frame] : [],
+	);
 
 	if (interpolationFunction === 'interpolateColors') {
 		if (!outputs.every((v) => typeof v === 'string')) {
@@ -73,6 +76,7 @@ export const interpolateKeyframedStatus = ({
 
 		try {
 			return interpolateColors(frame, inputRange, outputs as string[], {
+				disabledKeyframes,
 				easing: easing.map((e) =>
 					easingToFn({easing: e, forceSpringAllowTail}),
 				),
@@ -93,6 +97,7 @@ export const interpolateKeyframedStatus = ({
 			inputRange,
 			outputs as (number | string | number[])[],
 			{
+				disabledKeyframes,
 				easing: easing.map((e) =>
 					easingToFn({easing: e, forceSpringAllowTail}),
 				),

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -21,6 +21,7 @@ export type InterpolateOptions = Partial<{
 	extrapolateRight: ExtrapolateType;
 	output: InterpolateOutputOption;
 	posterize: number;
+	disabledKeyframes: readonly number[];
 }>;
 
 type InterpolateSegmentResolvedOptions = {
@@ -1192,6 +1193,30 @@ export function interpolate(
 
 	if (!Array.isArray(outputRange)) {
 		throw new Error('outputRange must contain only numbers');
+	}
+
+	if (options?.disabledKeyframes && options.disabledKeyframes.length > 0) {
+		const enabledIndexes = inputRange.flatMap((keyframe, index) =>
+			options.disabledKeyframes?.includes(keyframe) ? [] : [index],
+		);
+		if (enabledIndexes.length === 0) {
+			return outputRange[0];
+		}
+
+		const easingArray = Array.isArray(options.easing)
+			? (options.easing as readonly EasingFunction[])
+			: null;
+		const easing = easingArray
+			? enabledIndexes
+					.slice(0, -1)
+					.map((keyframeIndex) => easingArray[keyframeIndex] ?? Easing.linear)
+			: options.easing;
+		return interpolate(
+			input,
+			enabledIndexes.map((index) => inputRange[index]),
+			enabledIndexes.map((index) => outputRange[index]),
+			{...options, disabledKeyframes: undefined, easing},
+		);
 	}
 
 	const hasStringOutput = outputRange.some(

--- a/packages/core/src/test/interpolate-keyframed-status.test.ts
+++ b/packages/core/src/test/interpolate-keyframed-status.test.ts
@@ -442,3 +442,85 @@ test('interpolates 3D rotation keyframes as one property', () => {
 	});
 	expect(result).toBe('1 0 0 45deg');
 });
+
+test('excludes disabled keyframes and preserves their data when re-enabled', () => {
+	const status: CanUpdateSequencePropStatusKeyframed = {
+		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: 0},
+			{frame: 30, value: 100, disabled: true},
+			{frame: 60, value: 60},
+		],
+		easing: [{type: 'linear'}, {type: 'linear'}],
+		clamping: {left: 'extend', right: 'extend'},
+		posterize: undefined,
+		output: undefined,
+	};
+
+	expect(
+		interpolateKeyframedStatus({forceSpringAllowTail: null, frame: 30, status}),
+	).toBe(30);
+	expect(status.keyframes[1]).toEqual({
+		frame: 30,
+		value: 100,
+		disabled: true,
+	});
+
+	const reEnabled = {
+		...status,
+		keyframes: status.keyframes.map((keyframe) => ({
+			...keyframe,
+			disabled: false,
+		})),
+	};
+	expect(
+		interpolateKeyframedStatus({
+			forceSpringAllowTail: null,
+			frame: 30,
+			status: reEnabled,
+		}),
+	).toBe(100);
+});
+
+test('handles disabled first, last, and all keyframes', () => {
+	const makeStatus = (
+		disabledFrames: number[],
+	): CanUpdateSequencePropStatusKeyframed => ({
+		status: 'keyframed',
+		keyframeDisplayOffsetAdjustment: null,
+		interpolationFunction: 'interpolate',
+		keyframes: [
+			{frame: 0, value: 10, disabled: disabledFrames.includes(0)},
+			{frame: 30, value: 30, disabled: disabledFrames.includes(30)},
+			{frame: 60, value: 60, disabled: disabledFrames.includes(60)},
+		],
+		easing: [{type: 'linear'}, {type: 'linear'}],
+		clamping: {left: 'clamp', right: 'clamp'},
+		posterize: undefined,
+		output: undefined,
+	});
+
+	expect(
+		interpolateKeyframedStatus({
+			forceSpringAllowTail: null,
+			frame: 0,
+			status: makeStatus([0]),
+		}),
+	).toBe(30);
+	expect(
+		interpolateKeyframedStatus({
+			forceSpringAllowTail: null,
+			frame: 60,
+			status: makeStatus([60]),
+		}),
+	).toBe(30);
+	expect(
+		interpolateKeyframedStatus({
+			forceSpringAllowTail: null,
+			frame: 45,
+			status: makeStatus([0, 30, 60]),
+		}),
+	).toBe(10);
+});

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -822,3 +822,16 @@ test('wrap option', () => {
 	expect(interpolate(1.5, [0, 1], [0, 2], {extrapolateRight: 'wrap'})).toBe(1);
 	expect(interpolate(-0.5, [0, 1], [0, 2], {extrapolateLeft: 'wrap'})).toBe(1);
 });
+
+test('disabledKeyframes excludes input and output pairs', () => {
+	expect(
+		interpolate(30, [0, 30, 60], [0, 100, 60], {
+			disabledKeyframes: [30],
+		}),
+	).toBe(30);
+	expect(
+		interpolate(30, [0, 30, 60], [0, 100, 60], {
+			disabledKeyframes: [0, 30, 60],
+		}),
+	).toBe(0);
+});

--- a/packages/core/src/use-schema.ts
+++ b/packages/core/src/use-schema.ts
@@ -30,6 +30,7 @@ export type CanUpdateSequencePropStatusKeyframe = {
 	frame: number;
 	value: unknown;
 	frameExpression?: VideoConfigNumericExpression;
+	disabled?: boolean;
 };
 
 export type VideoConfigNumericExpression =

--- a/packages/docs/docs/interpolate.mdx
+++ b/packages/docs/docs/interpolate.mdx
@@ -287,6 +287,21 @@ interpolate(frame, [0, 100, 200], [0, 1, 2], {
 });
 ```
 
+### disabledKeyframes?<AvailableFrom v="4.0.518" />
+
+An array of input-range values to temporarily exclude from interpolation while keeping their matching input and output values in code.
+
+```ts twoslash
+import {interpolate, useCurrentFrame} from 'remotion';
+const frame = useCurrentFrame();
+
+interpolate(frame, [0, 30, 60], [0, 100, 60], {
+  disabledKeyframes: [30],
+});
+```
+
+This behaves like interpolating between `[0, 60]` and `[0, 60]`. Per-segment easing uses the easing attached to the previous enabled keyframe. If every keyframe is disabled, the first output value is returned.
+
 ### output?<AvailableFrom v="4.0.490" />
 
 _Default_: `linear`

--- a/packages/studio-codemods/src/sequence-props.ts
+++ b/packages/studio-codemods/src/sequence-props.ts
@@ -358,6 +358,7 @@ const getInterpolationMetadata = (
 	clamping: PropClamping;
 	posterize: PropPosterize;
 	output: PropOutput;
+	disabledKeyframes: number[];
 } | null => {
 	const segments = Math.max(0, keyframeCount - 1);
 	const defaultClamping: PropClamping =
@@ -375,6 +376,7 @@ const getInterpolationMetadata = (
 		clamping: defaultClamping,
 		posterize: undefined,
 		output: undefined,
+		disabledKeyframes: [] as number[],
 	};
 
 	const optionsArg = callExpression.arguments[3];
@@ -390,6 +392,7 @@ const getInterpolationMetadata = (
 	let {clamping}: {clamping: PropClamping} = defaults;
 	let posterize: PropPosterize;
 	let {output}: {output: PropOutput} = defaults;
+	let {disabledKeyframes} = defaults;
 
 	for (const property of optionsArg.properties) {
 		if (property.type !== 'ObjectProperty' || property.computed) {
@@ -467,6 +470,24 @@ const getInterpolationMetadata = (
 			continue;
 		}
 
+		if (key === 'disabledKeyframes') {
+			if (value.type !== 'ArrayExpression') {
+				return null;
+			}
+
+			const parsed = value.elements.map((element) =>
+				element && element.type !== 'SpreadElement'
+					? getNumericValue(element as Expression)
+					: null,
+			);
+			if (parsed.some((frame) => frame === null)) {
+				return null;
+			}
+
+			disabledKeyframes = parsed as number[];
+			continue;
+		}
+
 		return null;
 	}
 
@@ -475,6 +496,7 @@ const getInterpolationMetadata = (
 		clamping,
 		posterize,
 		output,
+		disabledKeyframes,
 	};
 };
 
@@ -644,7 +666,12 @@ const getInterpolationKeyframes = (
 
 	return {
 		interpolationFunction,
-		keyframes,
+		keyframes: keyframes.map((keyframe) => ({
+			...keyframe,
+			...(metadata.disabledKeyframes.includes(keyframe.frame)
+				? {disabled: true}
+				: {}),
+		})),
 		easing: metadata.easing,
 		clamping: metadata.clamping,
 		posterize: metadata.posterize,

--- a/packages/studio-codemods/src/update-keyframes.ts
+++ b/packages/studio-codemods/src/update-keyframes.ts
@@ -179,6 +179,11 @@ export type KeyframeOperation =
 			easing: KeyframeEasing;
 	  }
 	| {
+			type: 'disabled';
+			frame: number;
+			disabled: boolean;
+	  }
+	| {
 			type: 'move';
 			moves: {
 				fromFrame: number;
@@ -212,6 +217,7 @@ type MissingPropInitialValue = {
 };
 
 type InterpolateKeyframe = {
+	disabled: boolean;
 	frame: number;
 	frameExpression: ExpressionKind;
 	frameNumericExpression: VideoConfigNumericExpression;
@@ -296,6 +302,7 @@ const getInterpolationExpression = (
 		}
 
 		keyframes.push({
+			disabled: false,
 			frame: frameExpression.value,
 			frameExpression: inputElement as ExpressionKind,
 			frameNumericExpression: frameExpression,
@@ -317,6 +324,32 @@ const getInterpolationExpression = (
 		}
 
 		extraArgs.push(supportedArg);
+	}
+
+	const options = getInlineOptionsFromExtraArgs(extraArgs);
+	const disabledProperty = options
+		? findObjectOptionProperty(options, 'disabledKeyframes').prop
+		: undefined;
+	if (disabledProperty) {
+		if (disabledProperty.value.type !== 'ArrayExpression') {
+			return null;
+		}
+
+		const disabledFrames = disabledProperty.value.elements.map((element) =>
+			element && element.type !== 'SpreadElement'
+				? (parseVideoConfigNumericExpression({
+						node: element as Expression,
+						videoConfigValues,
+					})?.value ?? null)
+				: null,
+		);
+		if (disabledFrames.some((frame) => frame === null)) {
+			return null;
+		}
+
+		for (const keyframe of keyframes) {
+			keyframe.disabled = disabledFrames.includes(keyframe.frame);
+		}
 	}
 
 	return {
@@ -1009,6 +1042,39 @@ const createInterpolateExpression = ({
 	const sortedKeyframes = [...keyframes].sort(
 		(first, second) => first.frame - second.frame,
 	);
+	const existingOptions = getInlineOptionsFromExtraArgs(extraArgs);
+	const hasDisabledOption =
+		existingOptions !== null &&
+		findObjectOptionProperty(existingOptions, 'disabledKeyframes').prop !==
+			undefined;
+	let synchronizedExtraArgs = extraArgs;
+	if (
+		hasDisabledOption ||
+		sortedKeyframes.some((keyframe) => keyframe.disabled)
+	) {
+		const options =
+			existingOptions ??
+			(extraArgs.length === 0 ? createEmptyOptionsExpression() : null);
+		if (options === null) {
+			throw new Error(
+				'Cannot update disabled keyframes: options must be inline',
+			);
+		}
+
+		const disabledFrames = sortedKeyframes
+			.filter((keyframe) => keyframe.disabled)
+			.map((keyframe) => b.numericLiteral(keyframe.frame));
+		setOptionsProperty({
+			options,
+			propertyName: 'disabledKeyframes',
+			value:
+				disabledFrames.length === 0
+					? null
+					: (b.arrayExpression(disabledFrames) as ExpressionKind),
+		});
+		synchronizedExtraArgs = getExtraArgsWithOptions({extraArgs, options});
+	}
+
 	return b.callExpression(callee, [
 		input,
 		b.arrayExpression(
@@ -1022,8 +1088,39 @@ const createInterpolateExpression = ({
 			),
 		),
 		b.arrayExpression(sortedKeyframes.map((keyframe) => keyframe.output)),
-		...extraArgs,
+		...synchronizedExtraArgs,
 	]) as ExpressionKind;
+};
+
+const updateKeyframeDisabled = ({
+	expression,
+	frame,
+	disabled,
+	videoConfigValues,
+}: {
+	expression: Expression;
+	frame: number;
+	disabled: boolean;
+	videoConfigValues: VideoConfigIdentifierValues;
+}): ExpressionKind => {
+	const existing = getInterpolationExpression(expression, videoConfigValues);
+	if (!existing) {
+		throw new Error('Cannot disable keyframe in non-interpolated expression');
+	}
+
+	const keyframeIndex = existing.keyframes.findIndex(
+		(keyframe) => keyframe.frame === frame,
+	);
+	if (keyframeIndex === -1) {
+		throw new Error(`Cannot disable keyframe at frame ${frame}: not found`);
+	}
+
+	return createInterpolateExpression({
+		...existing,
+		keyframes: existing.keyframes.map((keyframe, index) =>
+			index === keyframeIndex ? {...keyframe, disabled} : keyframe,
+		),
+	});
 };
 
 export type IntroducedKeyframeIdentifiers = {
@@ -1081,6 +1178,7 @@ const addKeyframe = ({
 				? [
 						...existing.keyframes,
 						{
+							disabled: false,
 							frame,
 							frameExpression: createFrameExpression(frame),
 							frameNumericExpression: {type: 'literal', value: frame},
@@ -1138,6 +1236,7 @@ const addKeyframe = ({
 		staticNumericExpression?.value ?? extractStaticValue(expression);
 	const keyframes: InterpolateKeyframe[] = [
 		{
+			disabled: false,
 			frame,
 			frameExpression: createFrameExpression(frame),
 			frameNumericExpression: {type: 'literal', value: frame},
@@ -1384,6 +1483,18 @@ const applyKeyframeOperation = ({
 				...noIntroducedIdentifiers,
 				needsEasingImport: updated.needsEasingImport,
 			},
+		};
+	}
+
+	if (operation.type === 'disabled') {
+		return {
+			expression: updateKeyframeDisabled({
+				expression,
+				frame: operation.frame,
+				disabled: operation.disabled,
+				videoConfigValues,
+			}),
+			introduced: noIntroducedIdentifiers,
 		};
 	}
 

--- a/packages/studio-server/src/preview-server/routes/batch-update-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/batch-update-keyframe-settings.ts
@@ -76,19 +76,7 @@ const groupBy = <T>(items: T[], getKey: (item: T) => string): T[][] => {
 	return [...groups.values()];
 };
 
-const toOperation = (settings: KeyframeSettings) =>
-	settings.type === 'settings'
-		? {
-				type: 'settings' as const,
-				clamping: settings.clamping,
-				posterize: settings.posterize,
-				output: settings.output,
-			}
-		: {
-				type: 'easing' as const,
-				segmentIndex: settings.segmentIndex,
-				easing: settings.easing,
-			};
+const toOperation = (settings: KeyframeSettings) => settings;
 
 export const batchUpdateKeyframeSettings = async ({
 	sequenceKeyframes,

--- a/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/can-update-sequence-props.ts
@@ -421,6 +421,7 @@ const getInterpolationMetadata = (
 	clamping: PropClamping;
 	posterize: PropPosterize;
 	output: PropOutput;
+	disabledKeyframes: number[];
 } | null => {
 	const segments = Math.max(0, keyframeCount - 1);
 	const defaultClamping: PropClamping =
@@ -438,6 +439,7 @@ const getInterpolationMetadata = (
 		clamping: defaultClamping,
 		posterize: undefined,
 		output: undefined,
+		disabledKeyframes: [] as number[],
 	};
 
 	const optionsArg = callExpression.arguments[3];
@@ -453,6 +455,7 @@ const getInterpolationMetadata = (
 	let {clamping}: {clamping: PropClamping} = defaults;
 	let posterize: PropPosterize;
 	let {output}: {output: PropOutput} = defaults;
+	let {disabledKeyframes} = defaults;
 
 	for (const property of optionsArg.properties) {
 		if (property.type !== 'ObjectProperty' || property.computed) {
@@ -530,6 +533,24 @@ const getInterpolationMetadata = (
 			continue;
 		}
 
+		if (key === 'disabledKeyframes') {
+			if (value.type !== 'ArrayExpression') {
+				return null;
+			}
+
+			const parsed = value.elements.map((element) =>
+				element && element.type !== 'SpreadElement'
+					? getNumericValue(element as Expression)
+					: null,
+			);
+			if (parsed.some((frame) => frame === null)) {
+				return null;
+			}
+
+			disabledKeyframes = parsed as number[];
+			continue;
+		}
+
 		return null;
 	}
 
@@ -538,6 +559,7 @@ const getInterpolationMetadata = (
 		clamping,
 		posterize,
 		output,
+		disabledKeyframes,
 	};
 };
 
@@ -675,7 +697,12 @@ const getInterpolationKeyframes = (
 
 	return {
 		interpolationFunction,
-		keyframes,
+		keyframes: keyframes.map((keyframe) => ({
+			...keyframe,
+			...(metadata.disabledKeyframes.includes(keyframe.frame)
+				? {disabled: true}
+				: {}),
+		})),
 		easing: metadata.easing,
 		clamping: metadata.clamping,
 		posterize: metadata.posterize,

--- a/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
@@ -67,19 +67,7 @@ export const updateEffectKeyframeSettingsHandler: ApiHandler<
 			updates: [
 				{
 					key,
-					operation:
-						settings.type === 'settings'
-							? {
-									type: 'settings',
-									clamping: settings.clamping,
-									posterize: settings.posterize,
-									output: settings.output,
-								}
-							: {
-									type: 'easing',
-									segmentIndex: settings.segmentIndex,
-									easing: settings.easing,
-								},
+					operation: settings,
 				},
 			],
 		});

--- a/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
@@ -54,19 +54,7 @@ export const updateSequenceKeyframeSettingsHandler: ApiHandler<
 			updates: [
 				{
 					key,
-					operation:
-						settings.type === 'settings'
-							? {
-									type: 'settings',
-									clamping: settings.clamping,
-									posterize: settings.posterize,
-									output: settings.output,
-								}
-							: {
-									type: 'easing',
-									segmentIndex: settings.segmentIndex,
-									easing: settings.easing,
-								},
+					operation: settings,
 				},
 			],
 		});

--- a/packages/studio-server/src/test/update-keyframes.test.ts
+++ b/packages/studio-server/src/test/update-keyframes.test.ts
@@ -567,6 +567,61 @@ export const Example: React.FC = () => {
 	expect(output).not.toContain('posterize');
 });
 
+test('updateSequenceKeyframes disables and re-enables a keyframe without losing it', async () => {
+	const input = `import React from 'react';
+import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
+
+export const Example: React.FC = () => {
+	const frame = useCurrentFrame();
+	return <AbsoluteFill style={{scale: interpolate(frame, [0, 30, 60], [1, 9, 3])}} />;
+};
+`;
+	const disabled = await updateSequenceKeyframes({
+		videoConfigValues: null,
+		input,
+		nodePath: lineColumnToNodePath(input, getLine(input, 'AbsoluteFill style')),
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'disabled', frame: 30, disabled: true},
+			},
+		],
+	});
+
+	expect(disabled.output).toContain('disabledKeyframes: [30]');
+	expect(disabled.output).toContain('[0, 30, 60], [1, 9, 3]');
+	const status = computeSequencePropsStatusFromContent({
+		fileContents: disabled.output,
+		nodePath: disabled.updatedNodePath,
+		componentIdentity: null,
+		keys: ['style.scale'],
+		effects: [],
+		videoConfigValues: null,
+	});
+	expect(status.props['style.scale']).toMatchObject({
+		status: 'keyframed',
+		keyframes: [
+			{frame: 0, value: 1},
+			{frame: 30, value: 9, disabled: true},
+			{frame: 60, value: 3},
+		],
+	});
+
+	const reEnabled = await updateSequenceKeyframes({
+		videoConfigValues: null,
+		input: disabled.output,
+		nodePath: disabled.updatedNodePath,
+		updates: [
+			{
+				key: 'style.scale',
+				operation: {type: 'disabled', frame: 30, disabled: false},
+			},
+		],
+	});
+	expect(reEnabled.output).not.toContain('disabledKeyframes');
+	expect(reEnabled.output).toContain('[0, 30, 60], [1, 9, 3]');
+});
+
 test('updateSequenceKeyframes updates output settings', async () => {
 	const input = `import React from 'react';
 import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -692,6 +692,11 @@ export type KeyframeSettings =
 			type: 'easing';
 			segmentIndex: number;
 			easing: KeyframeEasing;
+	  }
+	| {
+			type: 'disabled';
+			frame: number;
+			disabled: boolean;
 	  };
 
 export type UpdateSequenceKeyframeSettingsRequest = {

--- a/packages/studio-shared/src/optimistic-update-keyframe-settings.ts
+++ b/packages/studio-shared/src/optimistic-update-keyframe-settings.ts
@@ -61,6 +61,15 @@ const applySettingsToStatus = (
 					}),
 				}
 			: {}),
+		...(settings.type === 'disabled'
+			? {
+					keyframes: status.keyframes.map((keyframe) =>
+						keyframe.frame === settings.frame
+							? {...keyframe, disabled: settings.disabled}
+							: keyframe,
+					),
+				}
+			: {}),
 	};
 };
 

--- a/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
+++ b/packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts
@@ -131,3 +131,45 @@ test('optimisticUpdateSequenceKeyframeSettings updates output', () => {
 	expect(status.output).toBe('perceptual-scale');
 	expect(status.posterize).toBe(3);
 });
+
+test('optimisticUpdateSequenceKeyframeSettings toggles a keyframe without losing data', () => {
+	const disabled = optimisticUpdateSequenceKeyframeSettings({
+		previous,
+		fieldKey: 'scale',
+		settings: {type: 'disabled', frame: 20, disabled: true},
+	});
+	if (!disabled.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const disabledStatus = disabled.props.scale;
+	if (!disabledStatus || disabledStatus.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(disabledStatus.keyframes[1]).toEqual({
+		frame: 20,
+		value: 2,
+		disabled: true,
+	});
+
+	const reEnabled = optimisticUpdateSequenceKeyframeSettings({
+		previous: disabled,
+		fieldKey: 'scale',
+		settings: {type: 'disabled', frame: 20, disabled: false},
+	});
+	if (!reEnabled.canUpdate) {
+		throw new Error('expected updateable sequence');
+	}
+
+	const reEnabledStatus = reEnabled.props.scale;
+	if (!reEnabledStatus || reEnabledStatus.status !== 'keyframed') {
+		throw new Error('expected keyframed status');
+	}
+
+	expect(reEnabledStatus.keyframes[1]).toEqual({
+		frame: 20,
+		value: 2,
+		disabled: false,
+	});
+});

--- a/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/KeyframeInspector.tsx
@@ -32,6 +32,10 @@ import {
 	callDeleteSequenceKeyframe,
 } from '../Timeline/call-delete-keyframe';
 import {callMoveKeyframes} from '../Timeline/call-move-keyframe';
+import {
+	callUpdateEffectKeyframeSettings,
+	callUpdateSequenceKeyframeSettings,
+} from '../Timeline/call-update-keyframe-settings';
 import {getEasingSelectionAfterKeyframeDelete} from '../Timeline/get-easing-selection-after-keyframe-delete';
 import {getKeyframeDisplayOffset} from '../Timeline/get-timeline-keyframes';
 import {getCurrentFrame} from '../Timeline/imperative-state';
@@ -137,6 +141,22 @@ const TrashIcon: React.FC<{readonly color: string}> = ({color}) => {
 				fill={color}
 				d="M160.5 27.4c2-6.8 8.3-11.4 15.3-11.4l96.4 0c7.1 0 13.3 4.6 15.3 11.4l11 36.6-149 0 11-36.6zM116.1 64L16 64C7.2 64 0 71.2 0 80S7.2 96 16 96l416 0c8.8 0 16-7.2 16-16s-7.2-16-16-16l-100.1 0-13.7-45.8C312.1-2.1 293.4-16 272.2-16l-96.4 0c-21.2 0-39.9 13.9-46 34.2L116.1 64zM28.7 144L51.6 452.7c2.5 33.4 30.3 59.3 63.8 59.3l217.1 0c33.5 0 61.3-25.9 63.8-59.3l22.9-308.7-32.1 0-22.7 306.4c-1.2 16.7-15.2 29.6-31.9 29.6l-217.1 0c-16.8 0-30.7-12.9-31.9-29.6L60.8 144 28.7 144z"
 			/>
+		</svg>
+	);
+};
+
+const DisabledKeyframeIcon: React.FC<{readonly color: string}> = ({color}) => {
+	return (
+		<svg viewBox="0 0 16 16" style={removeKeyframeIcon}>
+			<circle
+				cx="8"
+				cy="8"
+				r="5.5"
+				fill="none"
+				stroke={color}
+				strokeWidth="1.5"
+			/>
+			<path d="M4 12 12 4" fill="none" stroke={color} strokeWidth="1.5" />
 		</svg>
 	);
 };
@@ -518,6 +538,50 @@ export const KeyframeInspector: React.FC<{
 			setPropStatuses,
 		],
 	);
+	const selectedKeyframeDisabled =
+		details?.propStatus.keyframes.find(
+			(keyframe) => keyframe.frame === details.sourceFrame,
+		)?.disabled === true;
+	const onToggleDisabled = useCallback<
+		React.MouseEventHandler<HTMLButtonElement>
+	>(
+		(event) => {
+			event.stopPropagation();
+			if (details === null || previewServerState.type !== 'connected') {
+				return;
+			}
+
+			const settings = {
+				type: 'disabled' as const,
+				frame: details.sourceFrame,
+				disabled: !selectedKeyframeDisabled,
+			};
+			if (details.type === 'sequence') {
+				callUpdateSequenceKeyframeSettings({
+					fileName: details.fileName,
+					nodePath: details.nodePath,
+					fieldKey: details.field.key,
+					settings,
+					schema: details.schema,
+					setPropStatuses,
+					clientId: previewServerState.clientId,
+				}).catch(() => undefined);
+				return;
+			}
+
+			callUpdateEffectKeyframeSettings({
+				fileName: details.fileName,
+				nodePath: details.nodePath,
+				effectIndex: details.effectIndex,
+				fieldKey: details.field.key,
+				settings,
+				schema: details.schema,
+				setPropStatuses,
+				clientId: previewServerState.clientId,
+			}).catch(() => undefined);
+		},
+		[details, previewServerState, selectedKeyframeDisabled, setPropStatuses],
+	);
 
 	if (details === null || track === null) {
 		return <InspectorMessage>Keyframe unavailable</InspectorMessage>;
@@ -588,6 +652,13 @@ export const KeyframeInspector: React.FC<{
 					</div>
 				</div>
 				<InspectorQuickActionsSection>
+					<InspectorQuickAction
+						disabled={removeDisabled}
+						onClick={onToggleDisabled}
+						renderIcon={(color) => <DisabledKeyframeIcon color={color} />}
+					>
+						{selectedKeyframeDisabled ? 'Enable keyframe' : 'Disable keyframe'}
+					</InspectorQuickAction>
 					<InspectorQuickAction
 						disabled={removeDisabled}
 						onClick={onRemoveKeyframe}

--- a/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
+++ b/packages/studio/src/components/Timeline/TimelineExpandedKeyframeRow.tsx
@@ -82,6 +82,7 @@ const TimelineExpandedKeyframeRowUnmemoized: React.FC<
 					{keyframes.map((keyframe) => (
 						<TimelineKeyframeDiamond
 							key={keyframe.frame}
+							disabled={keyframe.disabled === true}
 							frame={keyframe.frame}
 							rowHeight={height}
 							nodePathInfo={nodePathInfo}

--- a/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
+++ b/packages/studio/src/components/Timeline/TimelineKeyframeDiamond.tsx
@@ -29,10 +29,11 @@ const diamondBase: React.CSSProperties = {
 };
 
 const TimelineKeyframeDiamondUnmemoized: React.FC<{
+	readonly disabled: boolean;
 	readonly frame: number;
 	readonly rowHeight: number;
 	readonly nodePathInfo: SequenceNodePathInfo;
-}> = ({frame, rowHeight, nodePathInfo}) => {
+}> = ({disabled, frame, rowHeight, nodePathInfo}) => {
 	const videoConfig = useVideoConfig();
 	const timelineWidth = useContext(TimelineWidthContext);
 	const ref = useRef<HTMLButtonElement>(null);
@@ -57,10 +58,11 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 					timelineWidth,
 				) - TIMELINE_PADDING,
 			pointerEvents: 'auto',
+			opacity: disabled ? 0.4 : 1,
 			top: rowHeight / 2,
 			transform: 'translate(-50%, -50%)',
 		};
-	}, [frame, rowHeight, timelineWidth, videoConfig.durationInFrames]);
+	}, [disabled, frame, rowHeight, timelineWidth, videoConfig.durationInFrames]);
 
 	const onPointerDown = useTimelineKeyframeDrag({
 		frame,
@@ -80,7 +82,7 @@ const TimelineKeyframeDiamondUnmemoized: React.FC<{
 			{...{[TIMELINE_MARQUEE_ITEM_ATTR]: true}}
 			type="button"
 			style={style}
-			title={`Keyframe at frame ${frame}`}
+			title={`${disabled ? 'Disabled keyframe' : 'Keyframe'} at frame ${frame}`}
 			aria-label={`Select keyframe at frame ${frame}`}
 			onPointerDown={selectable ? onPointerDown : undefined}
 		>

--- a/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-easing-segments.ts
@@ -10,8 +10,14 @@ export const getTimelineEasingSegments = (
 	keyframes: ReturnType<typeof getTimelineKeyframes>,
 ): TimelineEasingSegment[] => {
 	return keyframes.flatMap((keyframe, index) => {
-		const nextKeyframe = keyframes[index + 1];
-		if (!nextKeyframe) {
+		if (keyframe.disabled) {
+			return [];
+		}
+
+		const nextKeyframe = keyframes
+			.slice(index + 1)
+			.find((candidate) => !candidate.disabled);
+		if (nextKeyframe === undefined) {
 			return [];
 		}
 

--- a/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-keyframes.ts
@@ -3,7 +3,7 @@ import type {CanUpdateSequencePropStatus} from 'remotion';
 export const getTimelineKeyframes = (
 	propStatus: CanUpdateSequencePropStatus | null | undefined,
 	keyframeDisplayOffset = 0,
-): {frame: number; value: unknown}[] => {
+): {frame: number; value: unknown; disabled?: boolean}[] => {
 	if (!propStatus) {
 		return [];
 	}


### PR DESCRIPTION
## Summary

- Add `disabledKeyframes` to interpolation options so input/output pairs remain in source but are skipped during interpolation and segment easing.
- Surface disabled state in Studio's keyframe model, parser, codemods, optimistic updates, timeline, and inspector for sequence and effect keyframes.
- Preserve backward compatibility: existing interpolation calls are unchanged; re-enabling removes the metadata without changing frame/value data. If all keyframes are disabled, interpolation returns the first output value.

## Test plan

- `bunx turbo run make lint formatting --filter='remotion' --filter='@remotion/studio-shared' --filter='@remotion/studio-codemods' --filter='@remotion/studio-server' --filter='@remotion/studio'`
- `bun test packages/core/src/test/interpolate.test.ts packages/core/src/test/interpolate-keyframed-status.test.ts`
- `bun test packages/studio-shared/src/test/optimistic-update-keyframe-settings.test.ts`
- `bun test packages/studio-server/src/test/update-keyframes.test.ts`

Made with [Cursor](https://cursor.com)