### PR TITLE
`@remotion/media`: Use Mediabunny retry defaults

### DIFF
--- a/packages/brand/src/LogoHorn/index.tsx
+++ b/packages/brand/src/LogoHorn/index.tsx
@@ -1,4 +1,5 @@
 import {chromaticAberration} from '@remotion/effects/chromatic-aberration';
+import {pixelDissolve} from '@remotion/effects/pixel-dissolve';
 import {Audio} from '@remotion/media';
 import {useWindowedAudioData, visualizeAudio} from '@remotion/media-utils';
 import {ALL_FORMATS, Input, UrlSource} from 'mediabunny';
@@ -12,8 +13,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-
-import {pixelDissolve} from '@remotion/effects/pixel-dissolve';
 
 const AUDIO_FILE = staticFile('hoorn.wav');
 const LOGO_FILE = staticFile('logo/remotion/logo-on-white.svg');
@@ -52,9 +51,7 @@ export const calculateLogoHornMetadata: CalculateMetadataFunction<
 	const fps = 30;
 	const input = new Input({
 		formats: ALL_FORMATS,
-		source: new UrlSource(AUDIO_FILE, {
-			getRetryDelay: () => null,
-		}),
+		source: new UrlSource(AUDIO_FILE),
 	});
 
 	const durationInSeconds = await input.computeDuration();

--- a/packages/docs/docs/dynamic-metadata.mdx
+++ b/packages/docs/docs/dynamic-metadata.mdx
@@ -22,9 +22,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();
@@ -118,9 +116,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();
@@ -227,9 +223,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();

--- a/packages/docs/docs/lambda/cost-example.mdx
+++ b/packages/docs/docs/lambda/cost-example.mdx
@@ -36,9 +36,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();
@@ -114,9 +112,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();
@@ -188,9 +184,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();

--- a/packages/docs/docs/mediabunny/frame-rate.mdx
+++ b/packages/docs/docs/mediabunny/frame-rate.mdx
@@ -84,9 +84,7 @@ export const calculateMetadata: CalculateMetadataFunction<Props> = async ({
 }) => {
   using input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(props.src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(props.src),
   });
 
   const videoTrack = await input.getPrimaryVideoTrack();

--- a/packages/docs/docs/mediabunny/metadata.mdx
+++ b/packages/docs/docs/mediabunny/metadata.mdx
@@ -23,9 +23,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();
@@ -56,7 +54,6 @@ export const getMediaMetadata = async (src: string) => {
   <summary>Explanation</summary>
   <p>We load a URL (e.g. `https://remotion.media/video.mp4`) and parse it using Mediabunny.</p>
   <p>We don't care which format, so we load all parsers using `ALL_FORMATS`.</p>
-  <p>By setting `getRetryDelay` to `() => null`, we prevent Mediabunny from infinitely retrying if the request fails.</p>
   <p>We compute the duration, dimensions, and frame rate. If the media file is an audio file, we return `null` for the dimensions and frame rate.</p>
 </details>
 

--- a/packages/docs/docs/offthreadvideo.mdx
+++ b/packages/docs/docs/offthreadvideo.mdx
@@ -353,9 +353,7 @@ import {Input, ALL_FORMATS, UrlSource} from 'mediabunny';
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();

--- a/packages/docs/docs/sample-rate.mdx
+++ b/packages/docs/docs/sample-rate.mdx
@@ -113,9 +113,7 @@ const calculateMetadata: CalculateMetadataFunction<
 > = async ({props}) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(props.src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(props.src),
   });
 
   const audioTrack = await input.getPrimaryAudioTrack();

--- a/packages/docs/docs/videos/align-duration.mdx
+++ b/packages/docs/docs/videos/align-duration.mdx
@@ -48,9 +48,7 @@ import type {CalculateMetadataFunction} from 'remotion';
 export const calculateMetadata: CalculateMetadataFunction<MyCompProps> = async ({props}) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(props.src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(props.src),
   });
 
   const [durationInSeconds, videoTrack] = await Promise.all([

--- a/packages/docs/docs/videos/sequence.mdx
+++ b/packages/docs/docs/videos/sequence.mdx
@@ -75,9 +75,7 @@ import type {VideosInSequenceProps} from './VideosInSequence';
 const getVideoDuration = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   return input.computeDuration();

--- a/packages/example/src/get-media-metadata.ts
+++ b/packages/example/src/get-media-metadata.ts
@@ -20,9 +20,7 @@ const snapToCommonFps = (fps: number) => {
 export const getMediaMetadata = async (src: string) => {
 	const input = new Input({
 		formats: ALL_FORMATS,
-		source: new UrlSource(src, {
-			getRetryDelay: () => null,
-		}),
+		source: new UrlSource(src),
 	});
 
 	const durationInSeconds = await input.computeDuration();

--- a/packages/media/src/video-extraction/get-frames-since-keyframe.ts
+++ b/packages/media/src/video-extraction/get-frames-since-keyframe.ts
@@ -1,4 +1,4 @@
-import type {InputFormat, UrlSourceOptions} from 'mediabunny';
+import type {InputFormat} from 'mediabunny';
 import {
 	ALL_FORMATS,
 	AudioSampleSink,
@@ -43,10 +43,6 @@ export type VideoSinkResult =
 	| 'unknown-container-format'
 	| 'network-error';
 
-const getRetryDelay = (() => {
-	return null;
-}) satisfies UrlSourceOptions['getRetryDelay'];
-
 const getFormatOrNullOrNetworkError = async (
 	input: Input,
 ): Promise<InputFormat | 'network-error' | null> => {
@@ -71,7 +67,6 @@ export const makeSinks = (
 	const input = new Input({
 		formats: ALL_FORMATS,
 		source: new UrlSource(src, {
-			getRetryDelay,
 			maxCacheSize: getMaxSourceCacheSize(logLevel),
 			...(resolvedRequestInit ? {requestInit: resolvedRequestInit} : undefined),
 		}),

--- a/packages/skills/skills/remotion-multimedia/get-audio-duration.md
+++ b/packages/skills/skills/remotion-multimedia/get-audio-duration.md
@@ -17,9 +17,7 @@ import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
 export const getAudioDuration = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();

--- a/packages/skills/skills/remotion-multimedia/get-video-dimensions.md
+++ b/packages/skills/skills/remotion-multimedia/get-video-dimensions.md
@@ -17,9 +17,7 @@ import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
 export const getVideoDimensions = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const videoTrack = await input.getPrimaryVideoTrack();

--- a/packages/skills/skills/remotion-multimedia/get-video-duration.md
+++ b/packages/skills/skills/remotion-multimedia/get-video-duration.md
@@ -17,9 +17,7 @@ import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
 export const getVideoDuration = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();

--- a/packages/template-music-visualization/src/Root.tsx
+++ b/packages/template-music-visualization/src/Root.tsx
@@ -36,9 +36,7 @@ export const RemotionRoot: React.FC = () => {
         // Determine the length of the video based on the duration of the audio file
         calculateMetadata={async ({ props }) => {
           const input = new Input({
-            source: new UrlSource(props.audioFileUrl, {
-              getRetryDelay: () => null,
-            }),
+            source: new UrlSource(props.audioFileUrl),
             formats: ALL_FORMATS,
           });
 

--- a/packages/template-three/src/helpers/get-media-metadata.ts
+++ b/packages/template-three/src/helpers/get-media-metadata.ts
@@ -3,9 +3,7 @@ import { ALL_FORMATS, Input, UrlSource } from "mediabunny";
 export const getMediaMetadata = async (src: string) => {
   const input = new Input({
     formats: ALL_FORMATS,
-    source: new UrlSource(src, {
-      getRetryDelay: () => null,
-    }),
+    source: new UrlSource(src),
   });
 
   const durationInSeconds = await input.computeDuration();


### PR DESCRIPTION
## Summary

- rely on Mediabunny's default retry behavior in `@remotion/media`
- remove `getRetryDelay` overrides from templates and examples
- update documentation and Remotion multimedia skill snippets

## Testing

- `bun run build`
- `bun run stylecheck`

## Preview

- [Variable duration and dimensions](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/dynamic-metadata)
- [Lambda cost example](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/lambda/cost-example)
- [Getting the frame rate of a video](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/mediabunny/frame-rate)
- [Getting metadata from a video](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/mediabunny/metadata)
- [`<OffthreadVideo>`](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/offthreadvideo)
- [Audio sample rate](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/sample-rate)
- [Align composition and video duration](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/videos/align-duration)
- [Playing videos in sequence](https://remotion-git-codex-remove-mediabunny-retry-delay-remotion.vercel.app/docs/videos/sequence)
