### PR TITLE
`@remotion/studio`: Preserve sidebar order and refine asset actions

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -944,6 +944,16 @@ test.describe('visual mode', () => {
 		await expect(page.getByRole('button', {name: 'Schema'})).toBeVisible({
 			timeout: 15_000,
 		});
+		const firstCompositionItems = await page
+			.locator('.__remotion-composition-selector-item')
+			.evaluateAll((items) =>
+				items.slice(0, 3).map((item) => item.getAttribute('title')),
+			);
+		expect(firstCompositionItems).toEqual([
+			'use-current-scale-on-load',
+			'Schema',
+			'AnimatedBarChart',
+		]);
 
 		await page.keyboard.press('ControlOrMeta+k');
 		await page

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -23,6 +23,10 @@ import {copyText} from '../helpers/copy-text';
 import type {AssetFolder, AssetStructure} from '../helpers/create-folder-tree';
 import {getFileManagerName} from '../helpers/get-file-manager-name';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	NO_HOVER_BACKGROUND_STYLE,
+} from '../helpers/hoverable';
 import {openInRemotionConvert} from '../helpers/open-in-remotion-convert';
 import {
 	markAssetSidebarScrollFromRowClick,
@@ -34,7 +38,7 @@ import useAssetDragEvents, {
 } from '../helpers/use-asset-drag-events';
 import {getCachedImageMetadata} from '../helpers/use-image-metadata';
 import {getCachedMediaMetadata} from '../helpers/use-media-metadata';
-import {ClipboardIcon} from '../icons/clipboard';
+import {EllipsisIcon} from '../icons/ellipsis';
 import {CollapsedFolderIcon, ExpandedFolderIcon} from '../icons/folder';
 import {SetSelectedModalContext} from '../state/modals';
 import {AssetFileIcon} from './AssetFileIcon';
@@ -42,6 +46,7 @@ import {ContextMenu} from './ContextMenu';
 import {getAssetElementFromPath} from './import-assets';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
+import {InlineDropdown} from './InlineDropdown';
 import {COMPACT_CONTROL_ROW_HEIGHT, Row, Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
@@ -92,6 +97,12 @@ const revealIconStyle: React.CSSProperties = {
 	color: CURRENT_COLOR,
 };
 
+const ellipsisIconStyle: React.SVGProps<SVGSVGElement> = {
+	style: {
+		height: 12,
+	},
+};
+
 export const getAssetActionAvailability = ({
 	browserStudioCanMutateAssets,
 	readOnlyStudio,
@@ -129,6 +140,7 @@ export const getAssetContextMenuItems = ({
 	fileManagerName,
 	copyFileName,
 	copyStaticFilePath,
+	copyAbsolutePath,
 	openAssetInConvert,
 	openAssetInExplorer,
 	renameAsset,
@@ -141,6 +153,7 @@ export const getAssetContextMenuItems = ({
 	fileManagerName: string;
 	copyFileName: () => void;
 	copyStaticFilePath: () => void;
+	copyAbsolutePath: (() => void) | null;
 	openAssetInConvert: () => void;
 	openAssetInExplorer: () => void;
 	renameAsset: () => void;
@@ -193,6 +206,19 @@ export const getAssetContextMenuItems = ({
 			type: 'item',
 			value: 'copy-asset-static-file-path',
 		},
+		copyAbsolutePath
+			? {
+					id: 'copy-asset-absolute-path',
+					keyHint: null,
+					label: 'Copy absolute path',
+					leftItem: null,
+					onClick: copyAbsolutePath,
+					quickSwitcherLabel: 'Copy asset absolute path',
+					subMenu: null,
+					type: 'item',
+					value: 'copy-asset-absolute-path',
+				}
+			: null,
 		{
 			type: 'divider',
 			id: 'asset-file-actions-divider',
@@ -550,8 +576,8 @@ const AssetSelectorItem: React.FC<{
 		return <ExpandedFolderIcon style={revealIconStyle} color={color} />;
 	}, []);
 
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon style={revealIconStyle} color={color} />;
+	const renderContextMenuAction: RenderInlineAction = useCallback((color) => {
+		return <EllipsisIcon svgProps={ellipsisIconStyle} fill={color} />;
 	}, []);
 
 	const copyFileName = useCallback(() => {
@@ -566,6 +592,21 @@ const AssetSelectorItem: React.FC<{
 
 	const copyStaticFilePath = useCallback(() => {
 		const content = `staticFile("${relativePath}")`;
+		copyText(content)
+			.then(() => {
+				showNotification(`Copied '${content}' to clipboard`, 1000);
+			})
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [relativePath]);
+
+	const copyAbsolutePath = useCallback(() => {
+		if (window.remotion_publicFolderExists === null) {
+			return;
+		}
+
+		const content = `${window.remotion_publicFolderExists}/${relativePath}`;
 		copyText(content)
 			.then(() => {
 				showNotification(`Copied '${content}' to clipboard`, 1000);
@@ -615,6 +656,8 @@ const AssetSelectorItem: React.FC<{
 			fileManagerName,
 			copyFileName,
 			copyStaticFilePath,
+			copyAbsolutePath:
+				window.remotion_publicFolderExists === null ? null : copyAbsolutePath,
 			openAssetInConvert,
 			openAssetInExplorer,
 			renameAsset,
@@ -626,6 +669,7 @@ const AssetSelectorItem: React.FC<{
 	}, [
 		copyFileName,
 		copyStaticFilePath,
+		copyAbsolutePath,
 		deleteAsset,
 		fileExplorerDisabled,
 		fileManagerName,
@@ -643,15 +687,6 @@ const AssetSelectorItem: React.FC<{
 				openAssetInExplorer();
 			},
 			[openAssetInExplorer],
-		);
-
-	const copyToClipboard: React.MouseEventHandler<HTMLButtonElement> =
-		useCallback(
-			(e) => {
-				e.stopPropagation();
-				copyStaticFilePath();
-			},
-			[copyStaticFilePath],
 		);
 
 	return (
@@ -679,11 +714,13 @@ const AssetSelectorItem: React.FC<{
 					{hovered && !isDragging ? (
 						<>
 							<Spacing x={0.5} />
-							<InlineAction
+							<InlineDropdown
 								variant={null}
-								title="Copy staticFile() path"
-								renderAction={renderCopyAction}
-								onClick={copyToClipboard}
+								title="More actions"
+								renderAction={renderContextMenuAction}
+								getItems={getContextMenuItems}
+								style={NO_HOVER_BACKGROUND_STYLE}
+								className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
 							/>
 							{fileExplorerDisabled ? null : (
 								<>
@@ -693,6 +730,8 @@ const AssetSelectorItem: React.FC<{
 										title={`Show in ${fileManagerName}`}
 										renderAction={renderFileExplorerAction}
 										onClick={revealInExplorer}
+										style={NO_HOVER_BACKGROUND_STYLE}
+										className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
 									/>
 								</>
 							)}

--- a/packages/studio/src/components/CompositionContextButton.tsx
+++ b/packages/studio/src/components/CompositionContextButton.tsx
@@ -1,6 +1,10 @@
 import type {SVGProps} from 'react';
 import React, {useCallback, useContext, useMemo} from 'react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	NO_HOVER_BACKGROUND_STYLE,
+} from '../helpers/hoverable';
 import {EllipsisIcon} from '../icons/ellipsis';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineDropdown} from './InlineDropdown';
@@ -37,6 +41,8 @@ export const CompositionContextButton: React.FC<{
 			renderAction={renderAction}
 			getItems={getItems}
 			variant={null}
+			style={NO_HOVER_BACKGROUND_STYLE}
+			className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
 		/>
 	);
 };

--- a/packages/studio/src/components/SidebarRenderButton.tsx
+++ b/packages/studio/src/components/SidebarRenderButton.tsx
@@ -11,6 +11,10 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	NO_HOVER_BACKGROUND_STYLE,
+} from '../helpers/hoverable';
 import {ThinRenderIcon} from '../icons/render';
 import {SetSelectedModalContext} from '../state/modals';
 import type {RenderInlineAction} from './InlineAction';
@@ -118,6 +122,8 @@ export const SidebarRenderButton: React.FC<{
 			renderAction={renderAction}
 			onClick={onClick}
 			variant={null}
+			style={NO_HOVER_BACKGROUND_STYLE}
+			className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
 		/>
 	);
 };

--- a/packages/studio/src/helpers/create-folder-tree.ts
+++ b/packages/studio/src/helpers/create-folder-tree.ts
@@ -1,6 +1,7 @@
 import type {_InternalTypes, StaticFile, TFolder} from 'remotion';
 import type {CompositionSelectorItemType} from '../components/CompositionSelectorItem';
 import {openFolderKey} from './persist-open-folders';
+import {sortItemsByNonceHistory} from './sort-by-nonce-history';
 
 export type AssetFolder = {
 	name: string;
@@ -236,5 +237,26 @@ export const createFolderTree = (
 		list.push(toPush);
 	}
 
-	return items;
+	const sortTreeItems = (
+		treeItems: CompositionSelectorItemType[],
+	): CompositionSelectorItemType[] => {
+		return sortItemsByNonceHistory(
+			treeItems.map((item) => ({
+				item,
+				nonce:
+					item.type === 'folder' ? item.folder.nonce : item.composition.nonce,
+			})),
+		).map(({item}) => {
+			if (item.type === 'composition') {
+				return item;
+			}
+
+			return {
+				...item,
+				items: sortTreeItems(item.items),
+			};
+		});
+	};
+
+	return sortTreeItems(items);
 };

--- a/packages/studio/src/helpers/hoverable.ts
+++ b/packages/studio/src/helpers/hoverable.ts
@@ -18,6 +18,10 @@ const HOVER_BG_VARIABLE = '--remotion-hoverable-hover-bg';
 const COLOR_VARIABLE = '--remotion-hoverable-color';
 const HOVER_COLOR_VARIABLE = '--remotion-hoverable-hover-color';
 
+export const NO_HOVER_BACKGROUND_STYLE = {
+	[HOVER_BG_VARIABLE]: TRANSPARENT,
+} as React.CSSProperties;
+
 // To disable the hover effect (e.g. for a disabled control), pass the idle
 // values as the hover values.
 export const hoverableStyle = ({

--- a/packages/studio/src/test/asset-context-menu.test.ts
+++ b/packages/studio/src/test/asset-context-menu.test.ts
@@ -31,6 +31,7 @@ test('keeps copy and open-in-new-window asset actions enabled in read-only Studi
 		fileManagerName: 'Finder',
 		copyFileName: noop,
 		copyStaticFilePath: noop,
+		copyAbsolutePath: noop,
 		openAssetInConvert: noop,
 		openAssetInExplorer: noop,
 		renameAsset: noop,
@@ -43,6 +44,7 @@ test('keeps copy and open-in-new-window asset actions enabled in read-only Studi
 	expect(getItem(items, 'open-asset-in-convert').disabled).not.toBe(true);
 	expect(getItem(items, 'copy-asset-file-name').disabled).not.toBe(true);
 	expect(getItem(items, 'copy-asset-static-file-path').disabled).not.toBe(true);
+	expect(getItem(items, 'copy-asset-absolute-path').disabled).not.toBe(true);
 	expect(getItem(items, 'open-asset-in-explorer').disabled).toBe(true);
 	expect(getItem(items, 'rename-asset').disabled).toBe(true);
 	expect(getItem(items, 'delete-asset').disabled).toBe(true);
@@ -54,6 +56,7 @@ test('hides file-manager asset actions in Browser Studio', () => {
 		fileManagerName: 'Finder',
 		copyFileName: noop,
 		copyStaticFilePath: noop,
+		copyAbsolutePath: null,
 		openAssetInConvert: noop,
 		openAssetInExplorer: noop,
 		renameAsset: noop,
@@ -66,6 +69,9 @@ test('hides file-manager asset actions in Browser Studio', () => {
 	expect(items.find((item) => item.id === 'open-asset-in-explorer')).toBe(
 		undefined,
 	);
+	expect(items.find((item) => item.id === 'copy-asset-absolute-path')).toBe(
+		undefined,
+	);
 });
 
 test('only offers Remotion Convert for audio and video assets', () => {
@@ -75,6 +81,7 @@ test('only offers Remotion Convert for audio and video assets', () => {
 			fileManagerName: 'Finder',
 			copyFileName: noop,
 			copyStaticFilePath: noop,
+			copyAbsolutePath: noop,
 			openAssetInConvert: noop,
 			openAssetInExplorer: noop,
 			renameAsset: noop,

--- a/packages/studio/src/test/folder-tree.test.ts
+++ b/packages/studio/src/test/folder-tree.test.ts
@@ -8,10 +8,10 @@ const SampleComp: React.FC<{}> = () => null;
 const component = React.lazy(() =>
 	Promise.resolve({default: SampleComp as ComponentType<unknown>}),
 );
-const testFolder = (name: string, parent: string | null) => ({
+const testFolder = (name: string, parent: string | null, nonce = 0) => ({
 	name,
 	parent,
-	nonce: [[0, 0]] as [[number, number]],
+	nonce: [[0, nonce]] as [[number, number]],
 	stack: null,
 });
 
@@ -200,6 +200,80 @@ test('Should handle nested folders well', async () => {
 			],
 			type: 'folder',
 		},
+	]);
+});
+
+test('Should interleave folders and compositions in render order', async () => {
+	const z = await getZ();
+	const obj = z.object({});
+	const composition = {
+		component,
+		defaultProps: {},
+		durationInFrames: 200,
+		fps: 30,
+		height: 1080,
+		width: 1080,
+		calculateMetadata: null,
+		schema: obj,
+		stack: null,
+	};
+
+	const tree = createFolderTree(
+		[
+			{
+				...composition,
+				id: 'root-before',
+				folderName: null,
+				parentFolderName: null,
+				nonce: [[0, 0]],
+			},
+			{
+				...composition,
+				id: 'inside-before',
+				folderName: 'group',
+				parentFolderName: null,
+				nonce: [[0, 2]],
+			},
+			{
+				...composition,
+				id: 'inside-nested',
+				folderName: 'nested',
+				parentFolderName: 'group',
+				nonce: [[0, 4]],
+			},
+			{
+				...composition,
+				id: 'inside-after',
+				folderName: 'group',
+				parentFolderName: null,
+				nonce: [[0, 5]],
+			},
+			{
+				...composition,
+				id: 'root-after',
+				folderName: null,
+				parentFolderName: null,
+				nonce: [[0, 6]],
+			},
+		],
+		[testFolder('group', null, 1), testFolder('nested', 'group', 3)],
+		{},
+	);
+
+	expect(tree.map((item) => item.key)).toEqual([
+		'root-before',
+		'group',
+		'root-after',
+	]);
+	const group = tree[1];
+	if (group.type !== 'folder') {
+		throw new Error('Expected group to be a folder');
+	}
+
+	expect(group.items.map((item) => item.key)).toEqual([
+		'inside-before',
+		'nested',
+		'inside-after',
 	]);
 });
 


### PR DESCRIPTION
## Summary

- preserve the internal registration order when compositions and folders are rendered in the Studio sidebar
- remove nested hover backgrounds from inline composition and asset actions
- use an ellipsis menu for asset actions and add a local-only `Copy absolute path` action

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio'`
- manually verified the composition and asset sidebars in Remotion Studio
