### PR TITLE
`@remotion/studio`: Add explorer header actions

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -999,6 +999,11 @@ test.describe('visual mode', () => {
 				mimeType: 'text/plain',
 				buffer: Buffer.from(uploadedFileContents),
 			});
+			await expect(
+				page.getByText(`Uploaded ${uploadedFileName} to public folder`, {
+					exact: true,
+				}),
+			).toBeVisible();
 			await expect
 				.poll(() =>
 					fs.existsSync(uploadedFilePath)

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -965,6 +965,55 @@ test.describe('visual mode', () => {
 			'Schema',
 			'AnimatedBarChart',
 		]);
+		await page.getByRole('button', {name: 'More composition actions'}).click();
+		await expect(
+			page.getByRole('button', {name: 'New composition...', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'New folder...', exact: true}),
+		).toBeVisible();
+		await page
+			.getByRole('button', {name: 'New composition...', exact: true})
+			.click();
+		await expect(page.getByPlaceholder('Composition ID')).toBeVisible();
+		await page.keyboard.press('Escape');
+		await page.getByRole('button', {name: 'More composition actions'}).click();
+		await page
+			.getByRole('button', {name: 'New folder...', exact: true})
+			.click();
+		await expect(page.getByPlaceholder('Folder name')).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		const uploadedFileName = 'explorer-header-upload-e2e.txt';
+		const uploadedFileContents = 'Uploaded from the explorer header';
+		const uploadedFilePath = path.join(exampleDir, 'public', uploadedFileName);
+		fs.rmSync(uploadedFilePath, {force: true});
+		try {
+			await page.getByRole('button', {name: 'Assets', exact: true}).click();
+			await page.getByRole('button', {name: 'More asset actions'}).click();
+			const fileChooserPromise = page.waitForEvent('filechooser');
+			await page.getByRole('button', {name: 'Upload...', exact: true}).click();
+			const fileChooser = await fileChooserPromise;
+			await fileChooser.setFiles({
+				name: uploadedFileName,
+				mimeType: 'text/plain',
+				buffer: Buffer.from(uploadedFileContents),
+			});
+			await expect
+				.poll(() =>
+					fs.existsSync(uploadedFilePath)
+						? fs.readFileSync(uploadedFilePath, 'utf8')
+						: null,
+				)
+				.toBe(uploadedFileContents);
+			await expect(
+				page.getByText(uploadedFileName, {exact: true}),
+			).toBeVisible();
+		} finally {
+			fs.rmSync(uploadedFilePath, {force: true});
+		}
+
+		await page.getByRole('button', {name: 'Compositions', exact: true}).click();
 
 		await page.keyboard.press('ControlOrMeta+k');
 		await page

--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -78,7 +78,13 @@ export const AssetSelector: React.FC<{
 		return buildAssetFolderStructure(staticFiles, null, assetFoldersExpanded);
 	}, [assetFoldersExpanded, staticFiles]);
 	const writeFilesToPublicFolder = useCallback(
-		async ({files, assetPath}: {files: File[]; assetPath: string | null}) => {
+		async ({
+			files,
+			assetPath,
+		}: {
+			files: File[];
+			assetPath: string | null;
+		}): Promise<boolean> => {
 			const makePath = (file: File) => {
 				return [assetPath, file.name].filter(Boolean).join('/');
 			};
@@ -98,7 +104,7 @@ export const AssetSelector: React.FC<{
 					)} already exists and is different`,
 					4000,
 				);
-				return;
+				return false;
 			}
 
 			for (const file of files) {
@@ -108,6 +114,8 @@ export const AssetSelector: React.FC<{
 					filePath: makePath(file),
 				});
 			}
+
+			return true;
 		},
 		[staticFiles],
 	);
@@ -186,7 +194,22 @@ export const AssetSelector: React.FC<{
 	const uploadAssets = useCallback(async () => {
 		try {
 			const files = await pickFilesToImport();
-			await writeFilesToPublicFolder({files, assetPath: null});
+			if (files.length === 0) {
+				return;
+			}
+
+			const wereWritten = await writeFilesToPublicFolder({
+				files,
+				assetPath: null,
+			});
+			if (wereWritten) {
+				showNotification(
+					files.length === 1
+						? `Uploaded ${files[0].name} to public folder`
+						: `Uploaded ${files.length} assets to public folder`,
+					3000,
+				);
+			}
 		} catch (error) {
 			showNotification(`Error during upload: ${error}`, 3000);
 		}

--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -14,7 +14,9 @@ import useAssetDragEvents, {
 import {FolderContext} from '../state/folders';
 import {useZIndex} from '../state/z-index';
 import {AssetFolderTree} from './AssetSelectorItem';
+import {pickFilesToImport} from './import-assets';
 import {inlineCodeSnippet} from './Menu/styles';
+import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {ExplorerQuickSwitcherTrigger} from './QuickSwitcher/ExplorerQuickSwitcherTrigger';
 import {useStaticFiles} from './use-static-files';
@@ -75,6 +77,40 @@ export const AssetSelector: React.FC<{
 	const assetTree = useMemo(() => {
 		return buildAssetFolderStructure(staticFiles, null, assetFoldersExpanded);
 	}, [assetFoldersExpanded, staticFiles]);
+	const writeFilesToPublicFolder = useCallback(
+		async ({files, assetPath}: {files: File[]; assetPath: string | null}) => {
+			const makePath = (file: File) => {
+				return [assetPath, file.name].filter(Boolean).join('/');
+			};
+
+			const differentExistingFile = files.find((file) => {
+				const filePath = makePath(file);
+				return staticFiles.some(
+					(staticFile) =>
+						staticFile.name === filePath &&
+						staticFile.sizeInBytes !== file.size,
+				);
+			});
+			if (differentExistingFile) {
+				showNotification(
+					`File with name ${makePath(
+						differentExistingFile,
+					)} already exists and is different`,
+					4000,
+				);
+				return;
+			}
+
+			for (const file of files) {
+				const body = await file.arrayBuffer();
+				await writeStaticFile({
+					contents: body,
+					filePath: makePath(file),
+				});
+			}
+		},
+		[staticFiles],
+	);
 
 	const toggleFolder = useCallback(
 		(folderName: string, parentName: string | null) => {
@@ -138,43 +174,39 @@ export const AssetSelector: React.FC<{
 					return;
 				}
 
-				const makePath = (file: File) => {
-					return [assetPath, file.name].filter(Boolean).join('/');
-				};
-
-				const differentExistingFile = Array.from(files).find((file) => {
-					const filePath = makePath(file);
-					return staticFiles.some(
-						(staticFile) =>
-							staticFile.name === filePath &&
-							staticFile.sizeInBytes !== file.size,
-					);
-				});
-				if (differentExistingFile) {
-					showNotification(
-						`File with name ${makePath(
-							differentExistingFile,
-						)} already exists and is different`,
-						4000,
-					);
-					return;
-				}
-
-				for (const file of files) {
-					const body = await file.arrayBuffer();
-					await writeStaticFile({
-						contents: body,
-						filePath: makePath(file),
-					});
-				}
+				await writeFilesToPublicFolder({files, assetPath});
 			} catch (error) {
 				showNotification(`Error during upload: ${error}`, 3000);
 			} finally {
 				setDropLocation(null);
 			}
 		},
-		[dropLocation, staticFiles],
+		[dropLocation, writeFilesToPublicFolder],
 	);
+	const uploadAssets = useCallback(async () => {
+		try {
+			const files = await pickFilesToImport();
+			await writeFilesToPublicFolder({files, assetPath: null});
+		} catch (error) {
+			showNotification(`Error during upload: ${error}`, 3000);
+		}
+	}, [writeFilesToPublicFolder]);
+	const getAssetActions = useCallback((): ComboboxValue[] => {
+		return [
+			{
+				id: 'upload-assets',
+				keyHint: null,
+				label: 'Upload...',
+				leftItem: null,
+				onClick: uploadAssets,
+				quickSwitcherLabel: 'Upload assets...',
+				subMenu: null,
+				type: 'item',
+				value: 'upload-assets',
+				disabled: !shouldAllowUpload,
+			},
+		];
+	}, [shouldAllowUpload, uploadAssets]);
 
 	return (
 		<div
@@ -187,6 +219,7 @@ export const AssetSelector: React.FC<{
 				mode="assets"
 				showShortcut
 				tabIndex={tabIndex}
+				getActions={getAssetActions}
 			/>
 			{staticFiles.length === 0 ? (
 				publicFolderExists ? (

--- a/packages/studio/src/components/CompositionSelector.tsx
+++ b/packages/studio/src/components/CompositionSelector.tsx
@@ -356,6 +356,7 @@ export const CompositionSelector: React.FC = () => {
 				mode="compositions"
 				showShortcut
 				tabIndex={tabIndex}
+				getActions={getRootContextMenuItems}
 			/>
 			<div
 				ref={listRef}

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -20,7 +20,7 @@ import type {ComboboxValue} from '../NewComposition/ComboBox';
 import type {QuickSwitcherMode} from './NoResults';
 
 const quickSwitcherArea: React.CSSProperties = {
-	padding: '4px 4px 4px 8px',
+	padding: '4px 8px',
 	borderBottom: `1px solid ${BLACK_HEX}`,
 	overflowY: 'auto',
 	display: 'flex',

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -82,7 +82,7 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 		mode === 'assets' ? 'More asset actions' : 'More composition actions';
 
 	return (
-		<div style={quickSwitcherArea} className="__remotion-vertical-scrollbar">
+		<div style={quickSwitcherArea}>
 			<button
 				type="button"
 				style={quickSwitcherTrigger}

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -47,18 +47,6 @@ const quickSwitcherTrigger: React.CSSProperties = {
 	}),
 };
 
-const moreActionsStyle: React.CSSProperties = {
-	height: 26,
-	width: 26,
-	borderRadius: 4,
-	...hoverableStyle({
-		idleBackground: WHITE_ALPHA_06,
-		hoverBackground: WHITE_ALPHA_06,
-		idleColor: LIGHT_TEXT,
-		hoverColor: WHITE,
-	}),
-};
-
 const ellipsisSvgProps: React.SVGProps<SVGSVGElement> = {
 	style: {
 		height: 12,
@@ -112,7 +100,6 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 				title={moreActionsTitle}
 				renderAction={renderMoreActions}
 				getItems={getActions}
-				style={moreActionsStyle}
 				className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
 			/>
 		</div>

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -1,29 +1,68 @@
 import React, {useCallback, useContext} from 'react';
 import {cmdOrCtrlCharacter} from '../../error-overlay/remotion-overlay/ShortcutHint';
-import {BLACK_HEX, LIGHT_TEXT, WHITE_ALPHA_06} from '../../helpers/colors';
+import {
+	BLACK_HEX,
+	LIGHT_TEXT,
+	WHITE,
+	WHITE_ALPHA_06,
+} from '../../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../../helpers/hoverable';
 import {areKeyboardShortcutsDisabled} from '../../helpers/use-keybinding';
+import {EllipsisIcon} from '../../icons/ellipsis';
 import {SetSelectedModalContext} from '../../state/modals';
+import type {RenderInlineAction} from '../InlineAction';
+import {InlineDropdown} from '../InlineDropdown';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
 import type {QuickSwitcherMode} from './NoResults';
 
 const quickSwitcherArea: React.CSSProperties = {
 	padding: '4px 4px 4px 8px',
 	borderBottom: `1px solid ${BLACK_HEX}`,
 	overflowY: 'auto',
+	display: 'flex',
+	alignItems: 'center',
+	gap: 4,
 };
 
 const quickSwitcherTrigger: React.CSSProperties = {
-	backgroundColor: WHITE_ALPHA_06,
 	borderRadius: 4,
 	padding: '4px 10px 4px 12px',
-	color: LIGHT_TEXT,
 	fontSize: 12,
-	cursor: 'pointer',
+	cursor: 'default',
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'space-between',
 	border: 'none',
-	width: '100%',
+	flex: 1,
 	appearance: 'none',
+	...hoverableStyle({
+		idleBackground: WHITE_ALPHA_06,
+		hoverBackground: WHITE_ALPHA_06,
+		idleColor: LIGHT_TEXT,
+		hoverColor: WHITE,
+	}),
+};
+
+const moreActionsStyle: React.CSSProperties = {
+	height: 26,
+	width: 26,
+	borderRadius: 4,
+	...hoverableStyle({
+		idleBackground: WHITE_ALPHA_06,
+		hoverBackground: WHITE_ALPHA_06,
+		idleColor: LIGHT_TEXT,
+		hoverColor: WHITE,
+	}),
+};
+
+const ellipsisSvgProps: React.SVGProps<SVGSVGElement> = {
+	style: {
+		height: 12,
+	},
 };
 
 const shortcutLabel: React.CSSProperties = {
@@ -35,7 +74,8 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 	readonly mode: QuickSwitcherMode;
 	readonly showShortcut: boolean;
 	readonly tabIndex: number;
-}> = ({mode, showShortcut, tabIndex}) => {
+	readonly getActions: () => ComboboxValue[];
+}> = ({mode, showShortcut, tabIndex, getActions}) => {
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 
 	const openQuickSwitcher = useCallback(() => {
@@ -47,6 +87,11 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 			compositionSelection: null,
 		});
 	}, [mode, setSelectedModal]);
+	const renderMoreActions: RenderInlineAction = useCallback((color) => {
+		return <EllipsisIcon svgProps={ellipsisSvgProps} fill={color} />;
+	}, []);
+	const moreActionsTitle =
+		mode === 'assets' ? 'More asset actions' : 'More composition actions';
 
 	return (
 		<div style={quickSwitcherArea} className="__remotion-vertical-scrollbar">
@@ -55,12 +100,21 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 				style={quickSwitcherTrigger}
 				onClick={openQuickSwitcher}
 				tabIndex={tabIndex}
+				className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 			>
 				Search...
 				{showShortcut && !areKeyboardShortcutsDisabled() ? (
 					<span style={shortcutLabel}>{cmdOrCtrlCharacter}+K</span>
 				) : null}
 			</button>
+			<InlineDropdown
+				variant={null}
+				title={moreActionsTitle}
+				renderAction={renderMoreActions}
+				getItems={getActions}
+				style={moreActionsStyle}
+				className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

- add a tab-specific ellipsis button next to the explorer Search control
- expose New composition and New folder from the Compositions header
- expose Upload from the Assets header, sharing the existing public-folder validation and write path

Follow-up to #10830.

## Testing

- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `bunx playwright test e2e/studio.test.mts --grep 'should show and search the composition list'`
- manually verified both header menus and pointerless control styling in Remotion Studio
- red/green verified the E2E workflow by disconnecting the shared header dropdown
