### PR TITLE
Elements: Stabilize product collection title wrapping

### DIFF
--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -288,6 +288,7 @@ const ProductCardInner = forwardRef<
 									overflowWrap: 'anywhere',
 									textTransform: 'uppercase',
 									textWrap: 'balance',
+									width: 230,
 								}}
 							>
 								{title}


### PR DESCRIPTION
## Summary

- keep product card titles at a fixed layout width while carousel padding animates
- prevent the Studio Headset title from jumping between one and two lines

Closes #10766.

## Testing

- `bunx oxfmt packages/docs/elements/commerce/product-collection/product-collection.tsx --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- rendered and visually inspected Product Collection stills at frames 74, 82, 90, 98, 106, and 114


## Preview

- [Product Collection](https://remotion-git-product-collection-linebreaks-remotion.vercel.app/elements/commerce/product-collection/)
