### PR TITLE
Fix captions Elements not being movable or hideable in Studio

### DIFF
--- a/packages/browser-studio/e2e/captions-elements.test.ts
+++ b/packages/browser-studio/e2e/captions-elements.test.ts
@@ -1,0 +1,222 @@
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+	expect,
+	test,
+	type Frame,
+	type FrameLocator,
+	type Page,
+} from '@playwright/test';
+import {
+	createElementPayload,
+	StudioProtocolInternals,
+} from '@remotion/studio-protocol';
+
+const instrumentSequencePropsSubscriptions = async (page: Page) => {
+	const studioFrame = page.frames().find((frame) => frame !== page.mainFrame());
+	if (!studioFrame) {
+		throw new Error('No studio iframe');
+	}
+
+	await studioFrame.waitForFunction(
+		() =>
+			Boolean(
+				(window as unknown as {remotion_browserStudio: unknown})
+					.remotion_browserStudio,
+			),
+		null,
+		{timeout: 60_000},
+	);
+	await studioFrame.evaluate(() => {
+		const ops = (
+			window as unknown as {
+				remotion_browserStudio: {
+					subscribeToSequenceProps: (request: unknown) => Promise<unknown>;
+				};
+			}
+		).remotion_browserStudio;
+		const original = ops.subscribeToSequenceProps.bind(ops);
+		const log: {request: unknown; result: unknown}[] = [];
+		(window as unknown as {__subsLog: typeof log}).__subsLog = log;
+		ops.subscribeToSequenceProps = async (request: unknown) => {
+			const result = await original(request);
+			log.push({request, result});
+			return result;
+		};
+	});
+
+	return studioFrame;
+};
+
+const installElement = async (studio: FrameLocator, displayName: string) => {
+	await studio.getByRole('button', {name: /^Install/}).click();
+	await expect(studio.getByText(displayName).first()).toBeVisible();
+};
+
+const dragCaptionElement = async ({
+	page,
+	studio,
+	studioFrame,
+}: {
+	readonly page: Page;
+	readonly studio: FrameLocator;
+	readonly studioFrame: Frame;
+}) => {
+	const captionGroup = studio
+		.locator('[role="group"][aria-label^="Captions"]')
+		.first();
+	await expect(captionGroup).toBeVisible();
+
+	// Wait for the sequence-props subscription so that prop statuses (and with
+	// them the drag affordances) are available.
+	await studioFrame.waitForFunction(
+		() =>
+			((window as unknown as {__subsLog: unknown[]}).__subsLog ?? []).length >
+			0,
+		null,
+		{timeout: 30_000},
+	);
+
+	// Pause playback so caption pages don't swap mid-drag.
+	const pauseButton = studio.getByRole('button', {name: 'Pause', exact: false});
+	if (await pauseButton.isVisible().catch(() => false)) {
+		await pauseButton.click();
+	}
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const boxBefore = await captionGroup.boundingBox();
+		if (boxBefore === null) {
+			throw new Error('Caption element not visible');
+		}
+
+		const centerX = boxBefore.x + boxBefore.width / 2;
+		const centerY = boxBefore.y + boxBefore.height / 2;
+		await page.mouse.move(centerX, centerY);
+		await page.mouse.down();
+		await page.mouse.move(centerX + 120, centerY + 80, {steps: 12});
+		await page.mouse.up();
+		await page.waitForTimeout(400);
+
+		const boxAfter = await captionGroup.boundingBox();
+		const moved =
+			boxAfter !== null &&
+			(Math.round(boxAfter.x) !== Math.round(boxBefore.x) ||
+				Math.round(boxAfter.y) !== Math.round(boxBefore.y));
+		if (moved) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const elementCases = [
+	{
+		displayName: 'Moving Pill Captions',
+		slug: 'captions/moving-pill-captions',
+		sourceFile: 'moving-pill-captions.tsx',
+	},
+	{
+		displayName: 'Popping Word Captions',
+		slug: 'captions/popping-word-captions',
+		sourceFile: 'popping-word-captions.tsx',
+	},
+	{
+		displayName: 'Word Highlight Captions',
+		slug: 'captions/word-highlight-captions',
+		sourceFile: 'word-highlight-captions.tsx',
+	},
+] as const;
+
+for (const elementCase of elementCases) {
+	test(`${elementCase.displayName}: has a visibility eye, targets the composition and can be moved`, async ({
+		page,
+	}) => {
+		const sourceCode = readFileSync(
+			path.join(
+				path.dirname(fileURLToPath(import.meta.url)),
+				'..',
+				'..',
+				'..',
+				'packages',
+				'docs',
+				'elements',
+				'captions',
+				elementCase.sourceFile.replace('.tsx', ''),
+				elementCase.sourceFile,
+			),
+			'utf8',
+		);
+		const payload = createElementPayload({
+			dependencies: [
+				{name: '@remotion/captions', version: null},
+				{name: '@remotion/google-fonts', version: null},
+				{name: '@remotion/layout-utils', version: null},
+			],
+			dimensions: {width: 900, height: 180},
+			displayName: elementCase.displayName,
+			durationInFrames: 210,
+			installationMode: 'component-owned-sequence',
+			slug: elementCase.slug,
+			sourceCode,
+		});
+		const url = StudioProtocolInternals.makeBrowserStudioUrl({
+			endpoint: 'http://127.0.0.1:62338/',
+			payload,
+		});
+		await page.goto(url);
+
+		const studio = page.frameLocator('iframe');
+		await expect(
+			studio.getByText('Install Element', {exact: true}),
+		).toBeVisible();
+		const studioFrame = await instrumentSequencePropsSubscriptions(page);
+
+		await installElement(studio, elementCase.displayName);
+
+		// The sequence-props subscription must target the user's composition
+		// file, not the internal Element implementation file.
+		const subsLog = (await studioFrame.evaluate(() => {
+			return (
+				window as unknown as {
+					__subsLog: {request: {fileName: string}}[];
+				}
+			).__subsLog;
+		})) as {request: {fileName: string}}[];
+		expect(subsLog.length).toBeGreaterThan(0);
+		expect(
+			subsLog.every(
+				(entry) => entry.request.fileName === '/project/src/Composition.tsx',
+			),
+		).toBe(true);
+
+		// The timeline item must have a visibility toggle.
+		const eyes = studio.locator('[data-timeline-layer-eye]');
+		await expect(eyes.first()).toBeAttached();
+
+		const moved = await dragCaptionElement({page, studio, studioFrame});
+		expect(moved).toBe(true);
+
+		// Saving must persist the move into the composition file.
+		const compositionAfterSave = await page.evaluate(() => {
+			const browserWindow = window as typeof window & {
+				__browserStudioProject: {files: Record<string, string>};
+			};
+			return browserWindow.__browserStudioProject.files[
+				'/project/src/Composition.tsx'
+			];
+		});
+		expect(compositionAfterSave).toContain('translate');
+
+		const elementFileAfterSave = await page.evaluate((slug) => {
+			const browserWindow = window as typeof window & {
+				__browserStudioProject: {files: Record<string, string>};
+			};
+			return browserWindow.__browserStudioProject.files[
+				`/project/src/${slug.split('/').at(-1)}.element.tsx`
+			];
+		}, elementCase.slug);
+		expect(elementFileAfterSave).toBe(sourceCode);
+	});
+}

--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -33,14 +33,6 @@ type MovingPillCaptionsProps = InteractiveBaseProps &
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
-type MovingPillCaptionsLayerProps = Omit<
-	MovingPillCaptionsProps,
-	'captions'
-> & {
-	readonly callerStyle: React.CSSProperties | null;
-	readonly captions: Caption[];
-};
-
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
@@ -51,6 +43,10 @@ const pillVerticalPadding = 12;
 const pillBorderRadius = 10;
 const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
+const demoCaptionsWidth = 681;
+const demoCaptionsHeight = 252;
+const demoAreaWidth = 900;
+const demoAreaHeight = 180;
 
 const movingPillCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -79,7 +75,6 @@ const movingPillCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
-	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -87,6 +82,58 @@ const {fontFamily, waitUntilDone} = loadFont('normal', {
 	weights: [fontWeight],
 	subsets: ['latin'],
 });
+
+const demoCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const frameToMilliseconds = (frame: number, fps: number) =>
 	(frame / fps) * 1000;
@@ -388,13 +435,12 @@ const MovingPillCaptionsContent: React.FC<{
 
 const MovingPillCaptionsInner = forwardRef<
 	HTMLDivElement,
-	MovingPillCaptionsLayerProps & {
+	MovingPillCaptionsProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
 	(
 		{
-			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -408,16 +454,7 @@ const MovingPillCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
-		const {
-			rotate: callerRotate,
-			scale: callerScale,
-			transform: callerTransform,
-			transformBox: callerTransformBox,
-			transformOrigin: callerTransformOrigin,
-			transformStyle: callerTransformStyle,
-			translate: callerTranslate,
-			...callerContentStyle
-		} = callerStyle ?? {};
+		const isShowingDemoCaptions = captions === undefined;
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -442,30 +479,27 @@ const MovingPillCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
+					ref={outlineRef}
 					style={{
-						height: height ?? '100%',
-						rotate: callerRotate,
-						scale: callerScale,
-						transform: callerTransform,
-						transformBox: callerTransformBox,
-						transformOrigin: callerTransformOrigin,
-						transformStyle: callerTransformStyle,
-						translate: callerTranslate,
-						width: width ?? '100%',
+						alignItems: 'center',
+						display: 'flex',
+						height: height ?? (isShowingDemoCaptions ? demoAreaHeight : '100%'),
+						justifyContent: 'center',
+						width: width ?? (isShowingDemoCaptions ? demoAreaWidth : '100%'),
+						...style,
 					}}
 				>
 					<div
-						ref={outlineRef}
 						style={{
-							height: '100%',
-							width: '100%',
-							...style,
-							...callerContentStyle,
+							height: isShowingDemoCaptions ? demoCaptionsHeight : '100%',
+							width: isShowingDemoCaptions ? demoCaptionsWidth : '100%',
 						}}
 					>
 						<MovingPillCaptionsContent
-							captionAreaWidth={width ?? null}
-							captions={captions}
+							captionAreaWidth={
+								isShowingDemoCaptions ? demoCaptionsWidth : (width ?? null)
+							}
+							captions={captions ?? demoCaptions}
 							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
 							fontLoaded={fontLoaded}
 						/>
@@ -476,98 +510,10 @@ const MovingPillCaptionsInner = forwardRef<
 	},
 );
 
-const MovingPillCaptionsLayer = Interactive.withSchema({
+export const MovingPillCaptions = Interactive.withSchema({
 	Component: MovingPillCaptionsInner,
 	componentName: '<MovingPillCaptions>',
 	componentIdentity: null,
 	schema: movingPillCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<MovingPillCaptionsLayerProps>;
-
-export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
-	if (captions) {
-		return (
-			<MovingPillCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={captions}
-				style={{translate: '0px 0px'}}
-			/>
-		);
-	}
-
-	return (
-		<div
-			style={{
-				alignItems: 'center',
-				display: 'flex',
-				height: 180,
-				justifyContent: 'center',
-				width: 900,
-			}}
-		>
-			<MovingPillCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={[
-					{
-						text: 'Captions',
-						startMs: 0,
-						endMs: 800,
-						timestampMs: 400,
-						confidence: null,
-					},
-					{
-						text: ' can',
-						startMs: 800,
-						endMs: 1500,
-						timestampMs: 1150,
-						confidence: null,
-					},
-					{
-						text: ' move',
-						startMs: 1500,
-						endMs: 2300,
-						timestampMs: 1900,
-						confidence: null,
-					},
-					{
-						text: ' with',
-						startMs: 2300,
-						endMs: 3100,
-						timestampMs: 2700,
-						confidence: null,
-					},
-					{
-						text: ' every',
-						startMs: 3100,
-						endMs: 4000,
-						timestampMs: 3550,
-						confidence: null,
-					},
-					{
-						text: ' spoken',
-						startMs: 4000,
-						endMs: 5100,
-						timestampMs: 4550,
-						confidence: null,
-					},
-					{
-						text: ' word.',
-						startMs: 5100,
-						endMs: 6500,
-						timestampMs: 5800,
-						confidence: null,
-					},
-				]}
-				width={681}
-				height={252}
-				style={{translate: '0px 0px'}}
-			/>
-		</div>
-	);
-};
+});

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -32,14 +32,6 @@ type PoppingWordCaptionsProps = InteractiveBaseProps &
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
-type PoppingWordCaptionsLayerProps = Omit<
-	PoppingWordCaptionsProps,
-	'captions'
-> & {
-	readonly callerStyle: React.CSSProperties | null;
-	readonly captions: Caption[];
-};
-
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
@@ -47,6 +39,10 @@ const textColor = '#ffffff';
 const highlightColor = '#18ff0e';
 const activeWordScale = 1.03;
 const defaultCombineTokensWithinMilliseconds = 800;
+const demoCaptionsWidth = 681;
+const demoCaptionsHeight = 252;
+const demoAreaWidth = 900;
+const demoAreaHeight = 180;
 
 const poppingWordCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -75,7 +71,6 @@ const poppingWordCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
-	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -83,6 +78,58 @@ const {fontFamily, waitUntilDone} = loadFont('normal', {
 	weights: [fontWeight],
 	subsets: ['latin'],
 });
+
+const demoCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const frameToMilliseconds = (frame: number, fps: number) =>
 	(frame / fps) * 1000;
@@ -298,13 +345,12 @@ const PoppingWordCaptionsContent: React.FC<{
 
 const PoppingWordCaptionsInner = forwardRef<
 	HTMLDivElement,
-	PoppingWordCaptionsLayerProps & {
+	PoppingWordCaptionsProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
 	(
 		{
-			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -318,16 +364,7 @@ const PoppingWordCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
-		const {
-			rotate: callerRotate,
-			scale: callerScale,
-			transform: callerTransform,
-			transformBox: callerTransformBox,
-			transformOrigin: callerTransformOrigin,
-			transformStyle: callerTransformStyle,
-			translate: callerTranslate,
-			...callerContentStyle
-		} = callerStyle ?? {};
+		const isShowingDemoCaptions = captions === undefined;
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -352,30 +389,27 @@ const PoppingWordCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
+					ref={outlineRef}
 					style={{
-						height: height ?? '100%',
-						rotate: callerRotate,
-						scale: callerScale,
-						transform: callerTransform,
-						transformBox: callerTransformBox,
-						transformOrigin: callerTransformOrigin,
-						transformStyle: callerTransformStyle,
-						translate: callerTranslate,
-						width: width ?? '100%',
+						alignItems: 'center',
+						display: 'flex',
+						height: height ?? (isShowingDemoCaptions ? demoAreaHeight : '100%'),
+						justifyContent: 'center',
+						width: width ?? (isShowingDemoCaptions ? demoAreaWidth : '100%'),
+						...style,
 					}}
 				>
 					<div
-						ref={outlineRef}
 						style={{
-							height: '100%',
-							width: '100%',
-							...style,
-							...callerContentStyle,
+							height: isShowingDemoCaptions ? demoCaptionsHeight : '100%',
+							width: isShowingDemoCaptions ? demoCaptionsWidth : '100%',
 						}}
 					>
 						<PoppingWordCaptionsContent
-							captionAreaWidth={width ?? null}
-							captions={captions}
+							captionAreaWidth={
+								isShowingDemoCaptions ? demoCaptionsWidth : (width ?? null)
+							}
+							captions={captions ?? demoCaptions}
 							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
 							fontLoaded={fontLoaded}
 						/>
@@ -386,98 +420,10 @@ const PoppingWordCaptionsInner = forwardRef<
 	},
 );
 
-const PoppingWordCaptionsLayer = Interactive.withSchema({
+export const PoppingWordCaptions = Interactive.withSchema({
 	Component: PoppingWordCaptionsInner,
 	componentName: '<PoppingWordCaptions>',
 	componentIdentity: null,
 	schema: poppingWordCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<PoppingWordCaptionsLayerProps>;
-
-export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
-	if (captions) {
-		return (
-			<PoppingWordCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={captions}
-				style={{translate: '0px 0px'}}
-			/>
-		);
-	}
-
-	return (
-		<div
-			style={{
-				alignItems: 'center',
-				display: 'flex',
-				height: 180,
-				justifyContent: 'center',
-				width: 900,
-			}}
-		>
-			<PoppingWordCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={[
-					{
-						text: 'Captions',
-						startMs: 0,
-						endMs: 800,
-						timestampMs: 400,
-						confidence: null,
-					},
-					{
-						text: ' can',
-						startMs: 800,
-						endMs: 1500,
-						timestampMs: 1150,
-						confidence: null,
-					},
-					{
-						text: ' move',
-						startMs: 1500,
-						endMs: 2300,
-						timestampMs: 1900,
-						confidence: null,
-					},
-					{
-						text: ' with',
-						startMs: 2300,
-						endMs: 3100,
-						timestampMs: 2700,
-						confidence: null,
-					},
-					{
-						text: ' every',
-						startMs: 3100,
-						endMs: 4000,
-						timestampMs: 3550,
-						confidence: null,
-					},
-					{
-						text: ' spoken',
-						startMs: 4000,
-						endMs: 5100,
-						timestampMs: 4550,
-						confidence: null,
-					},
-					{
-						text: ' word.',
-						startMs: 5100,
-						endMs: 6500,
-						timestampMs: 5800,
-						confidence: null,
-					},
-				]}
-				width={681}
-				height={252}
-				style={{translate: '0px 0px'}}
-			/>
-		</div>
-	);
-};
+});

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -30,20 +30,16 @@ type WordHighlightCaptionsProps = InteractiveBaseProps &
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
-type WordHighlightCaptionsLayerProps = Omit<
-	WordHighlightCaptionsProps,
-	'captions'
-> & {
-	readonly callerStyle: React.CSSProperties | null;
-	readonly captions: Caption[];
-};
-
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
 const textColor = '#ffffff';
 const highlightColor = '#18ff0e';
 const defaultCombineTokensWithinMilliseconds = 800;
+const demoCaptionsWidth = 681;
+const demoCaptionsHeight = 252;
+const demoAreaWidth = 900;
+const demoAreaHeight = 180;
 
 const wordHighlightCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -72,7 +68,6 @@ const wordHighlightCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
-	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -80,6 +75,58 @@ const {fontFamily, waitUntilDone} = loadFont('normal', {
 	weights: [fontWeight],
 	subsets: ['latin'],
 });
+
+const demoCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const frameToMilliseconds = (frame: number, fps: number) =>
 	(frame / fps) * 1000;
@@ -256,13 +303,12 @@ const WordHighlightCaptionsContent: React.FC<{
 
 const WordHighlightCaptionsInner = forwardRef<
 	HTMLDivElement,
-	WordHighlightCaptionsLayerProps & {
+	WordHighlightCaptionsProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
 	(
 		{
-			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
@@ -276,16 +322,7 @@ const WordHighlightCaptionsInner = forwardRef<
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
-		const {
-			rotate: callerRotate,
-			scale: callerScale,
-			transform: callerTransform,
-			transformBox: callerTransformBox,
-			transformOrigin: callerTransformOrigin,
-			transformStyle: callerTransformStyle,
-			translate: callerTranslate,
-			...callerContentStyle
-		} = callerStyle ?? {};
+		const isShowingDemoCaptions = captions === undefined;
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -310,30 +347,27 @@ const WordHighlightCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
+					ref={outlineRef}
 					style={{
-						height: height ?? '100%',
-						rotate: callerRotate,
-						scale: callerScale,
-						transform: callerTransform,
-						transformBox: callerTransformBox,
-						transformOrigin: callerTransformOrigin,
-						transformStyle: callerTransformStyle,
-						translate: callerTranslate,
-						width: width ?? '100%',
+						alignItems: 'center',
+						display: 'flex',
+						height: height ?? (isShowingDemoCaptions ? demoAreaHeight : '100%'),
+						justifyContent: 'center',
+						width: width ?? (isShowingDemoCaptions ? demoAreaWidth : '100%'),
+						...style,
 					}}
 				>
 					<div
-						ref={outlineRef}
 						style={{
-							height: '100%',
-							width: '100%',
-							...style,
-							...callerContentStyle,
+							height: isShowingDemoCaptions ? demoCaptionsHeight : '100%',
+							width: isShowingDemoCaptions ? demoCaptionsWidth : '100%',
 						}}
 					>
 						<WordHighlightCaptionsContent
-							captionAreaWidth={width ?? null}
-							captions={captions}
+							captionAreaWidth={
+								isShowingDemoCaptions ? demoCaptionsWidth : (width ?? null)
+							}
+							captions={captions ?? demoCaptions}
 							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
 							fontLoaded={fontLoaded}
 						/>
@@ -344,98 +378,10 @@ const WordHighlightCaptionsInner = forwardRef<
 	},
 );
 
-const WordHighlightCaptionsLayer = Interactive.withSchema({
+export const WordHighlightCaptions = Interactive.withSchema({
 	Component: WordHighlightCaptionsInner,
 	componentName: '<WordHighlightCaptions>',
 	componentIdentity: null,
 	schema: wordHighlightCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<WordHighlightCaptionsLayerProps>;
-
-export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
-	if (captions) {
-		return (
-			<WordHighlightCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={captions}
-				style={{translate: '0px 0px'}}
-			/>
-		);
-	}
-
-	return (
-		<div
-			style={{
-				alignItems: 'center',
-				display: 'flex',
-				height: 180,
-				justifyContent: 'center',
-				width: 900,
-			}}
-		>
-			<WordHighlightCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={[
-					{
-						text: 'Captions',
-						startMs: 0,
-						endMs: 800,
-						timestampMs: 400,
-						confidence: null,
-					},
-					{
-						text: ' can',
-						startMs: 800,
-						endMs: 1500,
-						timestampMs: 1150,
-						confidence: null,
-					},
-					{
-						text: ' move',
-						startMs: 1500,
-						endMs: 2300,
-						timestampMs: 1900,
-						confidence: null,
-					},
-					{
-						text: ' with',
-						startMs: 2300,
-						endMs: 3100,
-						timestampMs: 2700,
-						confidence: null,
-					},
-					{
-						text: ' every',
-						startMs: 3100,
-						endMs: 4000,
-						timestampMs: 3550,
-						confidence: null,
-					},
-					{
-						text: ' spoken',
-						startMs: 4000,
-						endMs: 5100,
-						timestampMs: 4550,
-						confidence: null,
-					},
-					{
-						text: ' word.',
-						startMs: 5100,
-						endMs: 6500,
-						timestampMs: 5800,
-						confidence: null,
-					},
-				]}
-				width={681}
-				height={252}
-				style={{translate: '0px 0px'}}
-			/>
-		</div>
-	);
-};
+});

--- a/turbo.json
+++ b/turbo.json
@@ -65,7 +65,12 @@
 			"dependsOn": ["@remotion/web-renderer#make"]
 		},
 		"testbrowserstudio": {
-			"dependsOn": ["@remotion/browser-studio#make"]
+			"dependsOn": [
+				"@remotion/browser-studio#make",
+				"@remotion/captions#make",
+				"@remotion/google-fonts#make",
+				"@remotion/layout-utils#make"
+			]
 		},
 		"testlayoututils": {
 			"dependsOn": ["@remotion/layout-utils#make"]


### PR DESCRIPTION
Fixes #10778

## Problem

Opening any of the caption Elements (Moving Pill Captions, Popping Word Captions, Word Highlight Captions) in the (Browser) Studio and installing it showed two symptoms:

1. **No eye to toggle visibility** on the timeline item
2. **The Element could not be moved** — drag overrides did not behave / persist correctly

## Root cause

The three caption Elements exported a **custom wrapper component** around their `Interactive.withSchema()` layer:

```tsx
const MovingPillCaptionsLayer = Interactive.withSchema({...});

export const MovingPillCaptions = ({captions, style, ...props}) => {
  // renders <MovingPillCaptionsLayer> internally
};
```

Only the component returned by `Interactive.withSchema()` is registered for Studio stack attribution (`addSequenceStackTraces`). Because the registered layer was rendered *inside the Element file* rather than directly in the composition, the Studio resolved the timeline item's stack to the internal `<MovingPillCaptionsLayer>` JSX (e.g. line 513 of `moving-pill-captions.element.tsx`) instead of the `<MovingPillCaptions />` usage in `Composition.tsx`.

Consequences of the subscription targeting the wrong node:

- `hidden` arrives at the internal node via a props spread, so its status is `computed` — the eye toggle requires status `static`, so it was never rendered
- Drag overrides and saves were keyed to the Element file internals instead of the composition, so moving the Element did not persist to the composition

Elements that export the `withSchema()` result directly (e.g. `<AudioOscilloscope>`) are unaffected — verified as a control in Browser Studio.

## Fix

Restructure the three caption Elements to export the `Interactive.withSchema()` component directly, following the documented pattern in [Make a component interactive](https://remotion.dev/docs/studio/make-component-interactive):

- The demo captions fallback moved into the inner component (`captions === undefined`)
- The demo sizing (900×180 area with a centered 681×252 captions region) moved into the inner component
- The `callerStyle` split was removed — it only existed to shield the caller's style from the wrapper's injected `style={{translate: '0px 0px'}}`, which is unnecessary when the public component *is* the schema-managed component

## Verification

New Browser Studio e2e regression test (`e2e/captions-elements.test.ts`) for all three Elements asserts after installing via the URL-fragment flow:

- the sequence-props subscription targets `/project/src/Composition.tsx` (not the Element file)
- the timeline item has a visibility eye
- dragging the Element on the canvas moves it
- saving persists the `translate` into `Composition.tsx` and leaves the Element file untouched

All 3 pass (previously: no eye, subscription targeted the Element file, moves didn't persist).

Also verified:

- `bun test src/test/elements.test.ts` in `packages/docs` (224 pass)
- Still renders of all three demo compositions are pixel-identical in layout to before
- Full Browser Studio e2e suite (14 pass)

