### PR TITLE
Internal: Stabilize Studio canvas E2E tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -124,6 +124,14 @@ jobs:
       - name: Test Example E2E
         run: |
           bun run teste2e
+      - name: Upload Example E2E results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-e2e-results-${{ github.run_attempt }}
+          path: packages/example/test-results
+          if-no-files-found: ignore
+          retention-days: 7
   webrenderer-tests:
     needs: affected
     if: ${{ needs.affected.outputs.webrenderer == 'true' }}

--- a/packages/example/e2e/helpers.mts
+++ b/packages/example/e2e/helpers.mts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import {expect} from '@playwright/test';
-import type {Page} from '@playwright/test';
+import type {Locator, Page} from '@playwright/test';
 import {LOGS_FILE, STUDIO_URL} from './constants.mts';
 
 export async function navigateToSchemaTest(page: Page): Promise<void> {
@@ -30,6 +30,22 @@ export async function navigateToLostNodePathE2e(page: Page): Promise<void> {
 		() => !document.body.innerText.includes('Loading...'),
 		{timeout: 30_000},
 	);
+}
+
+export async function retryCanvasInteractionUntilOutlineIsVisible({
+	interaction,
+	outline,
+	page,
+}: {
+	interaction: () => Promise<void>;
+	outline: Locator;
+	page: Page;
+}): Promise<void> {
+	await expect(async () => {
+		await page.mouse.move(0, 0);
+		await interaction();
+		await expect(outline.first()).toBeVisible({timeout: 1_000});
+	}).toPass({timeout: 30_000});
 }
 
 export async function openVisualControlsPanel(page: Page): Promise<void> {

--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -84,9 +84,9 @@ test.describe('inspector section collapse', () => {
 			{timeout: 30_000},
 		);
 
-		const selectedOutline = page
-			.locator('polygon[stroke-opacity="1"][pointer-events="all"]')
-			.first();
+		const selectedOutline = page.locator(
+			'polygon[data-remotion-directly-selected-outline="true"]',
+		);
 		const canvasRotationSurface = page.locator(
 			'[data-remotion-studio-canvas-rotation]',
 		);
@@ -163,16 +163,8 @@ test.describe('inspector section collapse', () => {
 		await expect(
 			page.getByRole('button', {name: 'Show 3D transform controls'}),
 		).toBeVisible();
-		await page.locator('.remotion-studio-composition-container').hover();
-		await page
-			.locator('polygon[pointer-events="all"]')
-			.nth(1)
-			.dispatchEvent('pointerover');
-		const outline = page
-			.locator('polygon[stroke-opacity="1"][pointer-events="all"]')
-			.nth(1);
-		await expect(outline).toBeVisible();
-		await outline.dispatchEvent('contextmenu');
+		await expect(selectedOutline).toHaveCount(1);
+		await selectedOutline.dispatchEvent('contextmenu');
 		await page.getByRole('button', {name: 'Rotate', exact: true}).click();
 		await expect(
 			page.getByRole('button', {name: 'Rotation X', exact: true}).first(),

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -8,7 +8,11 @@ import {
 	exampleDir,
 	lostNodePathE2eFile,
 } from './constants.mts';
-import {navigateToLostNodePathE2e, navigateToSchemaTest} from './helpers.mts';
+import {
+	navigateToLostNodePathE2e,
+	navigateToSchemaTest,
+	retryCanvasInteractionUntilOutlineIsVisible,
+} from './helpers.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
 const macCursorsFile = path.join(exampleDir, 'src', 'MacCursors', 'index.tsx');
@@ -374,8 +378,11 @@ test.describe('visual mode', () => {
 		const visibleOutlines = canvas.locator(
 			'> svg[aria-hidden="true"] polygon[stroke="#0b84f3"][stroke-opacity="1"]',
 		);
-		await canvas.hover();
-		await expect.poll(() => visibleOutlines.count()).toBeGreaterThan(0);
+		await retryCanvasInteractionUntilOutlineIsVisible({
+			interaction: () => canvas.hover(),
+			outline: visibleOutlines,
+			page,
+		});
 		await visibleOutlines.first().click({force: true});
 
 		await expect(revealTargetTrack).toBeVisible();
@@ -732,10 +739,14 @@ test.describe('visual mode', () => {
 		).toBeVisible();
 
 		const canvasItem = page.getByText('Performance overview', {exact: true});
-		await canvasItem.hover();
 		const canvasItemOutline = page.locator(
 			'polygon[data-remotion-prevent-selection-clear="true"][stroke-opacity="1"]',
 		);
+		await retryCanvasInteractionUntilOutlineIsVisible({
+			interaction: () => canvasItem.hover(),
+			outline: canvasItemOutline,
+			page,
+		});
 		await expect(canvasItemOutline).toHaveCount(1);
 		await canvasItemOutline.click({button: 'right'});
 
@@ -1443,14 +1454,17 @@ test.describe('visual mode', () => {
 		await expect(firstGridline).toBeVisible({timeout: 15_000});
 
 		const canvas = page.locator('.remotion-studio-composition-container');
-		const visibleOutlines = page.locator(
-			'.remotion-studio-composition-container > svg[aria-hidden="true"] polygon[stroke="#0b84f3"][stroke-opacity="1"]',
+		const visibleOutlines = canvas.locator(
+			'> svg[aria-hidden="true"] polygon[stroke="#0b84f3"][stroke-opacity="1"]',
 		);
-		await canvas.hover();
-		await expect.poll(() => visibleOutlines.count()).toBeGreaterThan(0);
+		await retryCanvasInteractionUntilOutlineIsVisible({
+			interaction: () => canvas.hover(),
+			outline: visibleOutlines,
+			page,
+		});
 		await visibleOutlines.first().click({force: true});
 		await page.mouse.move(0, 0);
-		await expect.poll(() => visibleOutlines.count()).toBeGreaterThan(0);
+		await expect(visibleOutlines.first()).toBeVisible();
 	});
 
 	test('should preserve following interactive elements after deleting a sibling', async ({

--- a/packages/example/playwright.config.ts
+++ b/packages/example/playwright.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
 	},
 	fullyParallel: false,
 	workers: 1,
-	retries: 0,
+	retries: process.env.CI ? 1 : 0,
 	use: {
 		baseURL: 'http://localhost:3123',
-		trace: 'on-first-retry',
+		trace: 'retain-on-failure',
 	},
 	projects: [
 		{


### PR DESCRIPTION
## Summary

- retry pointer-driven canvas interactions until their outlines are actually visible, instead of polling stale locator counts
- target the directly selected 2D outline in the 3D inspector workflow instead of relying on polygon order
- retry Example E2E tests once in CI and retain/upload Playwright failure artifacts for diagnosis

## Test plan

- `bun run build`
- `bun run stylecheck`
- focused Playwright run for the four affected Studio workflows: 4 passed
- focused stress run before final verification: 20 passed across 5 repetitions
