### PR TITLE
`@remotion/studio`: Remove asset inspector quick action scrollbar

### DIFF
--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -22,7 +22,6 @@ import type {QuickSwitcherMode} from './NoResults';
 const quickSwitcherArea: React.CSSProperties = {
 	padding: '4px 8px',
 	borderBottom: `1px solid ${BLACK_HEX}`,
-	overflowY: 'auto',
 	display: 'flex',
 	alignItems: 'center',
 	gap: 4,


### PR DESCRIPTION
## Summary

- remove vertical scrolling from the explorer quick action header
- prevent the asset inspector quick action from showing a scrollbar

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio'`

Closes #10847
