### PR TITLE
Elements: Fix visibility toggles for caption Elements

### DIFF
--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -556,8 +556,8 @@ const MovingPillCaptionsWithControls: React.FC<
 					},
 				]}
 				controls={controls}
-				width={681}
-				height={252}
+				width={props.width ?? 681}
+				height={props.height ?? 252}
 				style={{translate: '0px 0px'}}
 			/>
 		</div>

--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -476,25 +476,16 @@ const MovingPillCaptionsInner = forwardRef<
 	},
 );
 
-const MovingPillCaptionsLayer = Interactive.withSchema({
-	Component: MovingPillCaptionsInner,
-	componentName: '<MovingPillCaptions>',
-	componentIdentity: null,
-	schema: movingPillCaptionsSchema,
-	supportsEffects: false,
-}) as React.FC<MovingPillCaptionsLayerProps>;
-
-export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
+const MovingPillCaptionsWithControls: React.FC<
+	MovingPillCaptionsProps & {readonly controls: SequenceControls | undefined}
+> = ({captions, controls, style, ...props}) => {
 	if (captions) {
 		return (
-			<MovingPillCaptionsLayer
+			<MovingPillCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={captions}
+				controls={controls}
 				style={{translate: '0px 0px'}}
 			/>
 		);
@@ -510,7 +501,7 @@ export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 				width: 900,
 			}}
 		>
-			<MovingPillCaptionsLayer
+			<MovingPillCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={[
@@ -564,6 +555,7 @@ export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 						confidence: null,
 					},
 				]}
+				controls={controls}
 				width={681}
 				height={252}
 				style={{translate: '0px 0px'}}
@@ -571,3 +563,11 @@ export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
 		</div>
 	);
 };
+
+export const MovingPillCaptions = Interactive.withSchema({
+	Component: MovingPillCaptionsWithControls,
+	componentName: '<MovingPillCaptions>',
+	componentIdentity: null,
+	schema: movingPillCaptionsSchema,
+	supportsEffects: false,
+}) as React.FC<MovingPillCaptionsProps>;

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -466,8 +466,8 @@ const PoppingWordCaptionsWithControls: React.FC<
 					},
 				]}
 				controls={controls}
-				width={681}
-				height={252}
+				width={props.width ?? 681}
+				height={props.height ?? 252}
 				style={{translate: '0px 0px'}}
 			/>
 		</div>

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -386,25 +386,16 @@ const PoppingWordCaptionsInner = forwardRef<
 	},
 );
 
-const PoppingWordCaptionsLayer = Interactive.withSchema({
-	Component: PoppingWordCaptionsInner,
-	componentName: '<PoppingWordCaptions>',
-	componentIdentity: null,
-	schema: poppingWordCaptionsSchema,
-	supportsEffects: false,
-}) as React.FC<PoppingWordCaptionsLayerProps>;
-
-export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
+const PoppingWordCaptionsWithControls: React.FC<
+	PoppingWordCaptionsProps & {readonly controls: SequenceControls | undefined}
+> = ({captions, controls, style, ...props}) => {
 	if (captions) {
 		return (
-			<PoppingWordCaptionsLayer
+			<PoppingWordCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={captions}
+				controls={controls}
 				style={{translate: '0px 0px'}}
 			/>
 		);
@@ -420,7 +411,7 @@ export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 				width: 900,
 			}}
 		>
-			<PoppingWordCaptionsLayer
+			<PoppingWordCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={[
@@ -474,6 +465,7 @@ export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 						confidence: null,
 					},
 				]}
+				controls={controls}
 				width={681}
 				height={252}
 				style={{translate: '0px 0px'}}
@@ -481,3 +473,11 @@ export const PoppingWordCaptions: React.FC<PoppingWordCaptionsProps> = ({
 		</div>
 	);
 };
+
+export const PoppingWordCaptions = Interactive.withSchema({
+	Component: PoppingWordCaptionsWithControls,
+	componentName: '<PoppingWordCaptions>',
+	componentIdentity: null,
+	schema: poppingWordCaptionsSchema,
+	supportsEffects: false,
+}) as React.FC<PoppingWordCaptionsProps>;

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -424,8 +424,8 @@ const WordHighlightCaptionsWithControls: React.FC<
 					},
 				]}
 				controls={controls}
-				width={681}
-				height={252}
+				width={props.width ?? 681}
+				height={props.height ?? 252}
 				style={{translate: '0px 0px'}}
 			/>
 		</div>

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -344,25 +344,16 @@ const WordHighlightCaptionsInner = forwardRef<
 	},
 );
 
-const WordHighlightCaptionsLayer = Interactive.withSchema({
-	Component: WordHighlightCaptionsInner,
-	componentName: '<WordHighlightCaptions>',
-	componentIdentity: null,
-	schema: wordHighlightCaptionsSchema,
-	supportsEffects: false,
-}) as React.FC<WordHighlightCaptionsLayerProps>;
-
-export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
+const WordHighlightCaptionsWithControls: React.FC<
+	WordHighlightCaptionsProps & {readonly controls: SequenceControls | undefined}
+> = ({captions, controls, style, ...props}) => {
 	if (captions) {
 		return (
-			<WordHighlightCaptionsLayer
+			<WordHighlightCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={captions}
+				controls={controls}
 				style={{translate: '0px 0px'}}
 			/>
 		);
@@ -378,7 +369,7 @@ export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 				width: 900,
 			}}
 		>
-			<WordHighlightCaptionsLayer
+			<WordHighlightCaptionsInner
 				{...props}
 				callerStyle={style ?? null}
 				captions={[
@@ -432,6 +423,7 @@ export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 						confidence: null,
 					},
 				]}
+				controls={controls}
 				width={681}
 				height={252}
 				style={{translate: '0px 0px'}}
@@ -439,3 +431,11 @@ export const WordHighlightCaptions: React.FC<WordHighlightCaptionsProps> = ({
 		</div>
 	);
 };
+
+export const WordHighlightCaptions = Interactive.withSchema({
+	Component: WordHighlightCaptionsWithControls,
+	componentName: '<WordHighlightCaptions>',
+	componentIdentity: null,
+	schema: wordHighlightCaptionsSchema,
+	supportsEffects: false,
+}) as React.FC<WordHighlightCaptionsProps>;


### PR DESCRIPTION
## Summary

- make each exported caption Element the `Interactive.withSchema()` boundary
- forward the generated controls through the fallback renderer to the owned `<Sequence>`
- restore the timeline visibility toggle for Moving Pill, Popping Word, and Word Highlight captions

This is a follow-up to #10798: caption dragging was fixed there, but the internal schema wrapper still prevented Studio from attributing `hidden` to the Element call site.

## Verification

- `bunx oxfmt packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx --write`
- `bun test packages/docs/src/test/elements.test.ts` (224 pass)
- focused TypeScript check for the three changed files
- `bun run build`
- `bun run stylecheck`
- red/green verified in local Remotion Studio; all three caption timeline rows expose the visibility eye
