### PR TITLE
Studio: open number input when tabbing into an InputDragger

### DIFF
--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -500,12 +500,12 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	);
 
 	const onFocus = useCallback(() => {
-		if (!small || pointerDownRef.current) {
+		if (pointerDownRef.current) {
 			return;
 		}
 
 		setInputFallback(true);
-	}, [small]);
+	}, []);
 
 	const onClick: MouseEventHandler<HTMLButtonElement> = useCallback((e) => {
 		if (!getClickLock()) {


### PR DESCRIPTION
## Summary

Fixes #10844

### The problem

Tabbing from one composition metadata field (e.g. `width`) to the next (`height`) focused the value button, which required pressing Enter or clicking before a number could be typed. Only the compact timeline variant (`small`) switched to the editable input on keyboard focus.

### The fix

Remove the `!small` guard from the `onFocus` callback in `InputDragger.tsx`. Now any keyboard focus (including Tab) opens the editable input regardless of the `size` prop. Pointer focus is still guarded by `pointerDownRef.current` so dragging a value is unaffected.

```diff
 const onFocus = useCallback(() => {
-    if (!small || pointerDownRef.current) {
+    if (pointerDownRef.current) {
         return;
     }
     setInputFallback(true);
-}, [small]);
+}, []);
```

### Verification

- ✅ 614 tests pass, 0 fail
- ✅ `tsgo --noEmit` clean