### PR TITLE
core: guard window.remotion_delayRenderHandles initialization

### DIFF
--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -42,7 +42,9 @@ if (typeof window !== 'undefined') {
 		window.remotion_delayRenderTimeouts = {};
 	}
 
-	window.remotion_delayRenderHandles = [];
+	if (!window.remotion_delayRenderHandles) {
+		window.remotion_delayRenderHandles = [];
+	}
 }
 
 const defaultTimeout = 30000;


### PR DESCRIPTION
## Summary

Fixes #10856

### The problem

When a bundle contains two copies of the remotion module (e.g. `remotion` ESM + `remotion/no-react` statically imported by `@remotion/studio`), the second copys module-level evaluation wipes `window.remotion_delayRenderHandles = []`, orphaning any `delayRender()` calls armed before that point. `continueRender()` then silently no-ops for those handles.

### The fix

Add the same guard already used for `remotion_delayRenderTimeouts`:

```diff
-  window.remotion_delayRenderHandles = [];
+  if (!window.remotion_delayRenderHandles) {
+    window.remotion_delayRenderHandles = [];
+  }
```

### Verification

- ✅ 678 tests pass, 0 fail
- ✅ `tsgo --noEmit` clean