### PR TITLE
fix: lock Social Safe Zones overlay to 9:16 aspect ratio

### DIFF
--- a/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
+++ b/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
@@ -66,7 +66,11 @@ const SocialSafeZonesInner = forwardRef<
 		ref,
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
-		const {height, width} = useVideoConfig();
+		const {height: compHeight, width: compWidth} = useVideoConfig();
+		// Social safe zones are always 9:16 (1080×1920), centered in the composition
+		const SAFETY_WIDTH = 1080;
+		const SAFETY_HEIGHT = 1920;
+		const safetyScale = Math.min(compWidth / SAFETY_WIDTH, compHeight / SAFETY_HEIGHT);
 		const maskId = `social-safe-zone-${useId().replaceAll(':', '')}`;
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
@@ -102,12 +106,12 @@ const SocialSafeZonesInner = forwardRef<
 					ref={outlineRef}
 					style={{
 						...style,
-						height,
-						left: 0,
+						height: SAFETY_HEIGHT * safetyScale,
+						left: (compWidth - SAFETY_WIDTH * safetyScale) / 2,
 						pointerEvents: 'none',
 						position: 'absolute',
-						top: 0,
-						width,
+						top: (compHeight - SAFETY_HEIGHT * safetyScale) / 2,
+						width: SAFETY_WIDTH * safetyScale,
 						zIndex: 2147483647,
 					}}
 				>


### PR DESCRIPTION
Fixes #10835

## What
The `<SocialSafeZones>` overlay previously scaled to fill the full composition dimensions, which distorted the safe zone guides on widescreen compositions (e.g. 1920×1080). The safe zones are designed for 9:16 vertical video.

## Fix
The overlay container now maintains a fixed 9:16 aspect ratio (1080×1920) and is centered in the composition, regardless of composition dimensions. This ensures the safe zone paths and interface overlays are always accurate representations of actual TikTok/Instagram layouts.

## Testing
- TypeScript compiles clean (no new errors from this change)
- All existing studio tests pass