### PR TITLE
fix: clarify license wording for creator tier

### DIFF
--- a/packages/promo-pages/src/components/homepage/FreePricing.tsx
+++ b/packages/promo-pages/src/components/homepage/FreePricing.tsx
@@ -399,7 +399,7 @@ export const CompanyPricing: React.FC = () => {
 				title="Remotion for Creators"
 				subtitle={
 					<>
-						Create videos for yourself
+						Create videos as an individual
 						{mobileLayout ? <br /> : ' - '}
 						$25/mo per seat
 					</>


### PR DESCRIPTION
Fixes #10854

## What
Changed "Create videos for yourself" to "Create videos as an individual" in the pricing page to make the distinction between individual creator and organization tiers clearer at a glance.

## Context
The previous wording "for yourself" was ambiguous — it could be interpreted as personal/non-commercial use rather than the intended meaning of individual creator seats. "As an individual" makes the tier distinction clearer: individual creators vs organizations.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>