### PR TITLE
`remotion`: Fix allowTail interpolation continuity

### DIFF
--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -787,11 +787,19 @@ const interpolateString = ({
 				// angle interpolates away from zero.
 				const adjacentAxisRotation =
 					parsed.values[0] === 0
-						? index === segmentIndex
-							? initiallyParsedOutputRange[index + 1]
-							: index === segmentIndex + 1
-								? initiallyParsedOutputRange[index - 1]
-								: undefined
+						? index === 0
+							? initiallyParsedOutputRange.find(
+									(candidate) => candidate.axisRotation,
+								)
+							: index === initiallyParsedOutputRange.length - 1
+								? [...initiallyParsedOutputRange]
+										.reverse()
+										.find((candidate) => candidate.axisRotation)
+								: index === segmentIndex
+									? initiallyParsedOutputRange[index + 1]
+									: index === segmentIndex + 1
+										? initiallyParsedOutputRange[index - 1]
+										: undefined
 						: undefined;
 				const axis = adjacentAxisRotation?.axisRotation
 					? adjacentAxisRotation.values

--- a/packages/core/src/spring/spring-utils.ts
+++ b/packages/core/src/spring/spring-utils.ts
@@ -139,14 +139,21 @@ export function springCalculation({
 	const frameClamped = Math.max(0, frame);
 	const unevenRest = frameClamped % 1;
 	for (let f = 0; f <= Math.floor(frameClamped); f++) {
-		if (f === Math.floor(frameClamped)) {
-			f += unevenRest;
-		}
-
 		const time = (f / fps) * 1000;
 		animation = advance({
 			animation,
 			now: time,
+			config: {
+				...defaultSpringConfig,
+				...config,
+			},
+		});
+	}
+
+	if (unevenRest > 0) {
+		animation = advance({
+			animation,
+			now: (frameClamped / fps) * 1000,
 			config: {
 				...defaultSpringConfig,
 				...config,

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -758,6 +758,90 @@ test('Allow tail spring keeps previous string segment settling while the next se
 	expect(yWithTail).toBeLessThan(10);
 });
 
+test('Allow tail spring stays continuous when followed by a hold segment', () => {
+	const easing = [
+		Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			stiffness: 100,
+		}),
+		Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			stiffness: 100,
+		}),
+	] as const;
+	const options = {
+		easing,
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+		output: 'perceptual-scale',
+	} as const;
+
+	const immediatelyBeforeHold = interpolate(
+		169.999,
+		[21, 170, 591],
+		[1.26, 6.02, 6.02],
+		options,
+	);
+	const atHold = interpolate(170, [21, 170, 591], [1.26, 6.02, 6.02], options);
+
+	expect(immediatelyBeforeHold).toBeCloseTo(atHold, 5);
+});
+
+test('Allow tail axis rotation keeps its axis while settling into a hold segment', () => {
+	const axisRotation = '0.945221 -0.227695 0.233905 45.778028deg';
+	const easing = [
+		Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			stiffness: 100,
+		}),
+		Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			stiffness: 100,
+		}),
+		Easing.spring({
+			allowTail: true,
+			damping: 200,
+			durationRestThreshold: 0.02,
+			mass: 1,
+			stiffness: 100,
+		}),
+	] as const;
+	const options = {
+		easing,
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+	} as const;
+	const atHold = interpolate(
+		170,
+		[21, 170, 591, 620],
+		['0deg', axisRotation, axisRotation, '0deg'],
+		options,
+	);
+	const afterHold = interpolate(
+		171,
+		[21, 170, 591, 620],
+		['0deg', axisRotation, axisRotation, '0deg'],
+		options,
+	);
+
+	expect(afterHold).toStartWith('0.945221 -0.227695 0.233905 ');
+	expect(Number(afterHold.split(' ')[3].replace('deg', ''))).toBeGreaterThan(
+		Number(atHold.split(' ')[3].replace('deg', '')),
+	);
+});
+
 test('Clamp left test', () => {
 	expect(
 		interpolate(-2000, [0, 1, 1000], [Math.PI, 1, -1000], {


### PR DESCRIPTION
## Summary

- keep `allowTail` interpolation continuous when an animated segment is followed by a hold
- preserve the neighboring axis for axis-angle rotations at zero-valued range boundaries
- evaluate fractional spring frames without skipping the preceding whole frame
- add regression coverage for held perceptual-scale and axis-angle interpolation

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/interpolate.test.ts` (from `packages/core`)
