### PR TITLE
`@remotion/studio`: Prevent blank Browser Studio history entry

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1053,7 +1053,7 @@ export const BrowserElement = () => <Rect width={320} height={180} fill="red" />
 	await expect(studio.getByText('Browser Element')).toBeVisible();
 });
 
-test('confirms and imports an Element payload from the URL fragment', async ({
+test('confirms and imports an Element payload without adding a blank browser history entry', async ({
 	page,
 }) => {
 	const payload = createElementPayload({
@@ -1136,6 +1136,18 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 				).__browserStudioInstallPreservedIframe,
 		),
 	).toBe(true);
+	const historyClient = await page.context().newCDPSession(page);
+	const history = await historyClient.send('Page.getNavigationHistory');
+	const currentEntry = history.entries[history.currentIndex];
+	const previousEntry = history.entries[history.currentIndex - 1];
+	if (!currentEntry || !previousEntry) {
+		throw new Error('Expected current and previous browser history entries');
+	}
+
+	expect(previousEntry.url).not.toBe(currentEntry.url);
+	await expect(
+		studio.locator('.remotion-studio-composition-container'),
+	).toBeVisible();
 });
 
 test('reports inline SVG imports as unsupported without changing the project', async ({

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -5,7 +5,7 @@ import {Internals} from 'remotion';
 import {getKeysToExpand} from '../helpers/create-folder-tree';
 import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
-import {getRoute, pushUrl} from '../helpers/url-state';
+import {getRoute, pushUrl, replaceUrl} from '../helpers/url-state';
 import {
 	CompositionListContext,
 	compositionListRenderedRef,
@@ -136,7 +136,8 @@ export const InitialCompositionLoader: React.FC = () => {
 		}
 
 		if (compositions.length > 0) {
-			selectComposition(compositions[0], true);
+			replaceUrl(`/${compositions[0].id}`);
+			selectComposition(compositions[0], false);
 		} else {
 			setCompositionListState('ready');
 		}


### PR DESCRIPTION
## Summary

- replace the initial composition URL instead of pushing an empty Browser Studio history entry
- keep subsequent user-driven Studio navigation in browser history
- extend the Browser Studio element-import workflow to assert the composition remains the active history state

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testbrowserstudio --grep "without adding a blank browser history entry"`

Closes #10839
