### PR TITLE
`@remotion/studio`: Keep input mode when tabbing between number inputs

### DIFF
--- a/packages/example/e2e/input-dragger.test.mts
+++ b/packages/example/e2e/input-dragger.test.mts
@@ -1,0 +1,31 @@
+import {expect, test} from '@playwright/test';
+import {EXPANDED_SIDEBAR_STATE, STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test.describe('Input dragger', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('keeps input mode when tabbing to the next input dragger', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+
+		const widthButton = page.getByRole('button', {name: 'Width'});
+		await expect(widthButton).toBeVisible({timeout: 15_000});
+		await widthButton.click();
+
+		const widthInput = page.getByRole('textbox', {name: 'Width'});
+		await expect(widthInput).toBeFocused();
+		await widthInput.press('Tab');
+
+		await expect(page.getByRole('textbox', {name: 'Height'})).toBeFocused();
+	});
+});

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -66,6 +66,44 @@ const compactInputDraggerContainerStyle: React.CSSProperties = {
 	...compactInputDraggerStyle,
 };
 
+let activateInputDraggerOnNextFocus = false;
+
+const clearInputDraggerActivationRequest = () => {
+	// Let the receiving dragger's React onFocus handler consume the request first.
+	setTimeout(() => {
+		activateInputDraggerOnNextFocus = false;
+	}, 0);
+	document.removeEventListener(
+		'focusin',
+		clearInputDraggerActivationRequest,
+		true,
+	);
+};
+
+const requestInputDraggerActivationOnNextFocus = () => {
+	activateInputDraggerOnNextFocus = true;
+	document.addEventListener(
+		'focusin',
+		clearInputDraggerActivationRequest,
+		true,
+	);
+};
+
+const consumeInputDraggerActivationRequest = () => {
+	if (!activateInputDraggerOnNextFocus) {
+		return false;
+	}
+
+	activateInputDraggerOnNextFocus = false;
+	document.removeEventListener(
+		'focusin',
+		clearInputDraggerActivationRequest,
+		true,
+	);
+
+	return true;
+};
+
 const isInt = (num: number) => {
 	return num % 1 === 0;
 };
@@ -500,11 +538,14 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	);
 
 	const onFocus = useCallback(() => {
-		if (!small || pointerDownRef.current) {
+		if (pointerDownRef.current) {
 			return;
 		}
 
-		setInputFallback(true);
+		const wasActivatedByInputDragger = consumeInputDraggerActivationRequest();
+		if (small || wasActivatedByInputDragger) {
+			setInputFallback(true);
+		}
 	}, [small]);
 
 	const onClick: MouseEventHandler<HTMLButtonElement> = useCallback((e) => {
@@ -586,6 +627,11 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 	const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> =
 		useCallback(
 			(e) => {
+				if (e.key === 'Tab') {
+					requestInputDraggerActivationOnNextFocus();
+					return;
+				}
+
 				if (e.key === 'Enter') {
 					fallbackRef.current?.blur();
 					return;


### PR DESCRIPTION
## Summary

- Keep number input mode active when tabbing from one input dragger to another
- Add a Studio browser regression test covering Width to Height focus transfer

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/input-dragger.test.mts`

Closes #10844
