### PR TITLE
`@remotion/studio`: Fix checkerboard bleeding through video edges

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -295,15 +295,17 @@ test.describe('visual mode', () => {
 				);
 			})
 			.toBeLessThan(1);
+	});
 
-		await page.goto(`${STUDIO_URL}/assets/framer.webm`);
+	test('should not let the checkerboard bleed through opaque video edges', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/opaque-video-checkerboard-e2e`);
 		const opaqueVideoPreview = page.locator(
 			'.remotion-studio-composition-container',
 		);
 		await expect(opaqueVideoPreview).toBeVisible();
-		const opaqueVideoCanvas = page
-			.getByTestId('asset-media-preview')
-			.locator('canvas');
+		const opaqueVideoCanvas = opaqueVideoPreview.locator('canvas');
 		await expect
 			.poll(() =>
 				opaqueVideoCanvas.evaluate((canvas: HTMLCanvasElement) => {
@@ -312,6 +314,9 @@ test.describe('visual mode', () => {
 				}),
 			)
 			.toBe(255);
+		const checkerboardToggle = page.getByRole('button', {
+			name: /Show transparency as checkerboard/,
+		});
 		if ((await checkerboardToggle.getAttribute('aria-pressed')) === 'true') {
 			await checkerboardToggle.click();
 		}

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import {expect, test, type Locator, type Page} from '@playwright/test';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
+import sharp from 'sharp';
 import {
 	STUDIO_URL,
 	effectKeyframeE2eFile,
@@ -294,6 +295,68 @@ test.describe('visual mode', () => {
 				);
 			})
 			.toBeLessThan(1);
+
+		await page.goto(`${STUDIO_URL}/assets/framer.webm`);
+		const opaqueVideoPreview = page.locator(
+			'.remotion-studio-composition-container',
+		);
+		await expect(opaqueVideoPreview).toBeVisible();
+		const opaqueVideoCanvas = page
+			.getByTestId('asset-media-preview')
+			.locator('canvas');
+		await expect
+			.poll(() =>
+				opaqueVideoCanvas.evaluate((canvas: HTMLCanvasElement) => {
+					const context = canvas.getContext('2d');
+					return context?.getImageData(0, 0, 1, 1).data[3] ?? 0;
+				}),
+			)
+			.toBe(255);
+		if ((await checkerboardToggle.getAttribute('aria-pressed')) === 'true') {
+			await checkerboardToggle.click();
+		}
+
+		const withoutCheckerboard = await opaqueVideoPreview.screenshot();
+		await checkerboardToggle.click();
+		const withCheckerboard = await opaqueVideoPreview.screenshot();
+		const without = await sharp(withoutCheckerboard)
+			.raw()
+			.toBuffer({resolveWithObject: true});
+		const withCheckerboardRaw = await sharp(withCheckerboard)
+			.raw()
+			.toBuffer({resolveWithObject: true});
+		expect(withCheckerboardRaw.info).toEqual(without.info);
+		let largestPerimeterDifference = 0;
+		let largestPerimeterDifferenceAt = '';
+		for (let y = 0; y < without.info.height; y++) {
+			for (let x = 0; x < without.info.width; x++) {
+				if (
+					x > 1 &&
+					x < without.info.width - 2 &&
+					y > 1 &&
+					y < without.info.height - 2
+				) {
+					continue;
+				}
+
+				const offset = (y * without.info.width + x) * without.info.channels;
+				for (let channel = 0; channel < 3; channel++) {
+					const difference = Math.abs(
+						(without.data[offset + channel] ?? 0) -
+							(withCheckerboardRaw.data[offset + channel] ?? 0),
+					);
+					if (difference > largestPerimeterDifference) {
+						largestPerimeterDifference = difference;
+						largestPerimeterDifferenceAt = `${x},${y},${channel}: ${without.data[offset + channel]} -> ${withCheckerboardRaw.data[offset + channel]}`;
+					}
+				}
+			}
+		}
+
+		expect(
+			largestPerimeterDifference,
+			largestPerimeterDifferenceAt,
+		).toBeLessThanOrEqual(2);
 	});
 
 	test('should route Canvas Capture drops by Studio target', async ({page}) => {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -305,7 +305,7 @@ test.describe('visual mode', () => {
 			'.remotion-studio-composition-container',
 		);
 		await expect(opaqueVideoPreview).toBeVisible();
-		const opaqueVideoCanvas = opaqueVideoPreview.locator('canvas');
+		const opaqueVideoCanvas = opaqueVideoPreview.locator('canvas').first();
 		await expect
 			.poll(() =>
 				opaqueVideoCanvas.evaluate((canvas: HTMLCanvasElement) => {
@@ -317,6 +317,35 @@ test.describe('visual mode', () => {
 		const checkerboardToggle = page.getByRole('button', {
 			name: /Show transparency as checkerboard/,
 		});
+		const marker = page.getByTestId('video-overscan-marker');
+		const previewBox = await opaqueVideoPreview.boundingBox();
+		const markerBox = await marker.boundingBox();
+		if (previewBox === null || markerBox === null) {
+			throw new Error('Could not measure video preview geometry');
+		}
+
+		expect(
+			Math.max(
+				Math.abs(previewBox.x - markerBox.x),
+				Math.abs(previewBox.y - markerBox.y),
+			),
+		).toBeLessThan(0.1);
+		const smallVideoContainer = page.getByTestId('small-video-container');
+		const smallVideoCanvas = smallVideoContainer.locator('canvas');
+		const smallVideoContainerBox = await smallVideoContainer.boundingBox();
+		const smallVideoCanvasBox = await smallVideoCanvas.boundingBox();
+		if (smallVideoContainerBox === null || smallVideoCanvasBox === null) {
+			throw new Error('Could not measure small video geometry');
+		}
+
+		expect(
+			Math.max(
+				Math.abs(smallVideoContainerBox.x - smallVideoCanvasBox.x),
+				Math.abs(smallVideoContainerBox.y - smallVideoCanvasBox.y),
+				Math.abs(smallVideoContainerBox.width - smallVideoCanvasBox.width),
+				Math.abs(smallVideoContainerBox.height - smallVideoCanvasBox.height),
+			),
+		).toBeLessThan(0.1);
 		if ((await checkerboardToggle.getAttribute('aria-pressed')) === 'true') {
 			await checkerboardToggle.click();
 		}

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -63,7 +63,37 @@ const UseCurrentScaleOnLoad: React.FC = () => {
 };
 
 const OpaqueVideoCheckerboard: React.FC = () => {
-	return <Video src={staticFile('vp9.webm')} />;
+	return (
+		<AbsoluteFill>
+			<Video src={staticFile('vp9.webm')} />
+			<div
+				data-testid="small-video-container"
+				style={{
+					height: 540,
+					left: 480,
+					position: 'absolute',
+					top: 270,
+					width: 960,
+				}}
+			>
+				<Video
+					src={staticFile('vp9.webm')}
+					style={{height: '100%', width: '100%'}}
+				/>
+			</div>
+			<div
+				data-testid="video-overscan-marker"
+				style={{
+					backgroundColor: 'red',
+					height: 100,
+					left: 0,
+					position: 'absolute',
+					top: 0,
+					width: 100,
+				}}
+			/>
+		</AbsoluteFill>
+	);
 };
 
 export const E2eTestRoot: React.FC = () => {

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,5 +1,12 @@
+import {Video} from '@remotion/media';
 import React from 'react';
-import {AbsoluteFill, Composition, Folder, useCurrentScale} from 'remotion';
+import {
+	AbsoluteFill,
+	Composition,
+	Folder,
+	staticFile,
+	useCurrentScale,
+} from 'remotion';
 import {BarChart} from './BarChart';
 import {
 	CAPTIONS_DURATION_IN_FRAMES,
@@ -53,6 +60,10 @@ const UseCurrentScaleOnLoad: React.FC = () => {
 			</div>
 		</AbsoluteFill>
 	);
+};
+
+const OpaqueVideoCheckerboard: React.FC = () => {
+	return <Video src={staticFile('vp9.webm')} />;
 };
 
 export const E2eTestRoot: React.FC = () => {
@@ -242,6 +253,14 @@ export const E2eTestRoot: React.FC = () => {
 				id="inspector-control-layout-e2e"
 				component={InspectorControlLayoutE2e}
 				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
+			<Composition
+				id="opaque-video-checkerboard-e2e"
+				component={OpaqueVideoCheckerboard}
+				width={1920}
 				height={1080}
 				fps={30}
 				durationInFrames={90}

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -460,12 +460,12 @@ const PortalContainer: React.FC<{
 				height: contentDimensions.height,
 			}),
 			// Chromium composites <Video>'s canvas separately from this background.
-			// Extending the portal content by one source pixel on each side moves
+			// Extending the portal content by one preview pixel on each side moves
 			// the canvas texture boundary outside the composition clip.
 			'--remotion-studio-video-overscan-x':
-				(contentDimensions.width + 2) / contentDimensions.width,
+				(contentDimensions.width + 2 / scale) / contentDimensions.width,
 			'--remotion-studio-video-overscan-y':
-				(contentDimensions.height + 2) / contentDimensions.height,
+				(contentDimensions.height + 2 / scale) / contentDimensions.height,
 		} as React.CSSProperties;
 	}, [
 		checkerboard,

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -61,6 +61,15 @@ const assetMetadataErrorContainer: React.CSSProperties = {
 
 const checkerboardSize = 49;
 const PIXEL_GRID_MIN_SCALE = 4;
+const portalContainerClassName = 'remotion-studio-portal-container';
+const videoCanvasOverscanCss = `
+.${portalContainerClassName}:has(canvas.${Internals.OBJECTFIT_CONTAIN_CLASS_NAME}) > div {
+	transform: scale(
+		var(--remotion-studio-video-overscan-x),
+		var(--remotion-studio-video-overscan-y)
+	);
+}
+`;
 
 const containerStyle = (options: {
 	scale: number;
@@ -441,14 +450,23 @@ const PortalContainer: React.FC<{
 			};
 		}
 
-		return containerStyle({
-			checkerboard,
-			scale,
-			xCorrection,
-			yCorrection,
-			width: contentDimensions.width,
-			height: contentDimensions.height,
-		});
+		return {
+			...containerStyle({
+				checkerboard,
+				scale,
+				xCorrection,
+				yCorrection,
+				width: contentDimensions.width,
+				height: contentDimensions.height,
+			}),
+			// Chromium composites <Video>'s canvas separately from this background.
+			// Extending the portal content by one source pixel on each side moves
+			// the canvas texture boundary outside the composition clip.
+			'--remotion-studio-video-overscan-x':
+				(contentDimensions.width + 2) / contentDimensions.width,
+			'--remotion-studio-video-overscan-y':
+				(contentDimensions.height + 2) / contentDimensions.height,
+		} as React.CSSProperties;
 	}, [
 		checkerboard,
 		contentDimensions.height,
@@ -500,5 +518,14 @@ const PortalContainer: React.FC<{
 		};
 	}, [onPointerDown]);
 
-	return <div ref={portalContainer} style={style} />;
+	return (
+		<>
+			<style>{videoCanvasOverscanCss}</style>
+			<div
+				ref={portalContainer}
+				className={portalContainerClassName}
+				style={style}
+			/>
+		</>
+	);
 };

--- a/packages/studio/src/components/Preview.tsx
+++ b/packages/studio/src/components/Preview.tsx
@@ -62,12 +62,14 @@ const assetMetadataErrorContainer: React.CSSProperties = {
 const checkerboardSize = 49;
 const PIXEL_GRID_MIN_SCALE = 4;
 const portalContainerClassName = 'remotion-studio-portal-container';
+const fullBleedVideoCanvasAttribute =
+	'data-remotion-studio-full-bleed-video-canvas';
+const videoCanvasSelector = `canvas.${Internals.OBJECTFIT_CONTAIN_CLASS_NAME}`;
 const videoCanvasOverscanCss = `
-.${portalContainerClassName}:has(canvas.${Internals.OBJECTFIT_CONTAIN_CLASS_NAME}) > div {
-	transform: scale(
-		var(--remotion-studio-video-overscan-x),
-		var(--remotion-studio-video-overscan-y)
-	);
+.${portalContainerClassName} ${videoCanvasSelector}[${fullBleedVideoCanvasAttribute}] {
+	scale:
+		var(--remotion-studio-video-overscan-x)
+		var(--remotion-studio-video-overscan-y);
 }
 `;
 
@@ -493,6 +495,70 @@ const PortalContainer: React.FC<{
 	useLayoutEffect(() => {
 		Internals.setPortalNodeCurrentScale(scale);
 	}, [scale]);
+
+	useLayoutEffect(() => {
+		if (offscreen) {
+			return;
+		}
+
+		const portalNode = Internals.portalNode();
+		const updateFullBleedVideoCanvases = () => {
+			const videoCanvases =
+				portalNode.querySelectorAll<HTMLCanvasElement>(videoCanvasSelector);
+			for (const canvas of videoCanvases) {
+				canvas.removeAttribute(fullBleedVideoCanvasAttribute);
+				resizeObserver.observe(canvas);
+			}
+
+			const portalRect = portalNode.getBoundingClientRect();
+			for (const canvas of videoCanvases) {
+				const canvasRect = canvas.getBoundingClientRect();
+				const isFullBleed =
+					canvasRect.width > 0 &&
+					canvasRect.height > 0 &&
+					Math.abs(canvasRect.left - portalRect.left) < 0.1 &&
+					Math.abs(canvasRect.top - portalRect.top) < 0.1 &&
+					Math.abs(canvasRect.right - portalRect.right) < 0.1 &&
+					Math.abs(canvasRect.bottom - portalRect.bottom) < 0.1;
+				canvas.toggleAttribute(fullBleedVideoCanvasAttribute, isFullBleed);
+			}
+		};
+
+		const resizeObserver = new ResizeObserver(updateFullBleedVideoCanvases);
+		resizeObserver.observe(portalNode);
+		const mutationObserver = new MutationObserver((mutations) => {
+			const videoGeometryMayHaveChanged = mutations.some((mutation) => {
+				if (mutation.type === 'childList') {
+					return true;
+				}
+
+				return (
+					mutation.target instanceof Element &&
+					(mutation.target.matches(videoCanvasSelector) ||
+						mutation.target.querySelector(videoCanvasSelector) !== null)
+				);
+			});
+
+			if (videoGeometryMayHaveChanged) {
+				updateFullBleedVideoCanvases();
+			}
+		});
+		mutationObserver.observe(portalNode, {
+			attributeFilter: ['class', 'style'],
+			attributes: true,
+			childList: true,
+			subtree: true,
+		});
+		updateFullBleedVideoCanvases();
+
+		return () => {
+			mutationObserver.disconnect();
+			resizeObserver.disconnect();
+			for (const canvas of portalNode.querySelectorAll(videoCanvasSelector)) {
+				canvas.removeAttribute(fullBleedVideoCanvasAttribute);
+			}
+		};
+	}, [offscreen]);
 
 	const onPointerDown = useCallback(
 		(event: PointerEvent) => {


### PR DESCRIPTION
## Summary

- detect video canvases whose rendered bounds exactly match the composition preview
- overscan only those full-bleed video canvases by one preview pixel so the checkerboard cannot bleed through their separately composited edges
- preserve the geometry of composition overlays and non-full-bleed videos
- add a 1920×1080 visual regression composition matching the `/NewVideo` preview geometry
- compare its opaque video perimeter pixels with the checkerboard disabled and enabled, and assert that overlay and smaller-video geometry does not move

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should preview media assets|should not let the checkerboard"`
