### PR TITLE
Elements: Lock Social Safe Zones to 1080×1920

### DIFF
--- a/packages/docs/elements/overlays/social-safe-zones/index.mdx
+++ b/packages/docs/elements/overlays/social-safe-zones/index.mdx
@@ -13,6 +13,6 @@ import {elementDefinitions} from '@site/src/components/Elements/element-definiti
 
 ## Accuracy
 
-The presets were measured at 9:16 from representative iOS captures of full-green videos in TikTok and Instagram Reels. The interface references are transparent images extracted from those captures, rather than redrawn approximations. Author-specific text and avatars were replaced with generic content. The guide scales to other composition dimensions so it remains visible in previews of any aspect ratio.
+The presets were measured at 9:16 from representative iOS captures of full-green videos in TikTok and Instagram Reels. The interface references are transparent images extracted from those captures, rather than redrawn approximations. Author-specific text and avatars were replaced with generic content. The Element has fixed 1080 × 1920 dimensions to preserve the calibrated geometry.
 
-Live interfaces can vary by device, app version, locale, account state, caption length, and placement. Treat the clear region as a capture-calibrated reference, not a guarantee from either platform. The captured geometry is exact at 9:16 and scaled at other aspect ratios. The guide is rendered like any other Element, so hide or remove it when it should not appear in the final video.
+Live interfaces can vary by device, app version, locale, account state, caption length, and placement. Treat the clear region as a capture-calibrated reference, not a guarantee from either platform. The guide is rendered like any other Element, so hide or remove it when it should not appear in the final video.

--- a/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
+++ b/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
@@ -7,7 +7,6 @@ import {
 	type InteractiveTransformProps,
 	type InteractivitySchema,
 	type SequenceControls,
-	useVideoConfig,
 } from 'remotion';
 
 type SocialSafeZonesProps = InteractiveBaseProps &
@@ -66,7 +65,6 @@ const SocialSafeZonesInner = forwardRef<
 		ref,
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
-		const {height, width} = useVideoConfig();
 		const maskId = `social-safe-zone-${useId().replaceAll(':', '')}`;
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
@@ -102,12 +100,12 @@ const SocialSafeZonesInner = forwardRef<
 					ref={outlineRef}
 					style={{
 						...style,
-						height,
+						height: 1920,
 						left: 0,
 						pointerEvents: 'none',
 						position: 'absolute',
 						top: 0,
-						width,
+						width: 1080,
 						zIndex: 2147483647,
 					}}
 				>
@@ -153,6 +151,7 @@ const SocialSafeZonesInner = forwardRef<
 						<CanvasImage
 							aria-hidden="true"
 							fit="contain"
+							height={1920}
 							src={
 								platform === 'tiktok'
 									? 'https://remotion.media/elements/social-safe-zones/tiktok-interface.png'
@@ -165,6 +164,7 @@ const SocialSafeZonesInner = forwardRef<
 								top: 0,
 								width: '100%',
 							}}
+							width={1080}
 						/>
 					) : null}
 				</div>

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -171,7 +171,11 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 					<ElementPreview
 						component={PreviewComponent}
 						durationInFrames={durationInFrames}
+						elementHeight={definition.elementHeight}
+						elementWidth={definition.elementWidth}
 						fps={fps}
+						previewLayout={definition.preview.previewLayout}
+						safeArea={definition.safeArea}
 					/>
 					{children ? (
 						<div className={styles.sourceArea}>

--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -1,21 +1,58 @@
 import {Player} from '@remotion/player';
 import React, {useState, type ComponentType} from 'react';
+import type {ElementPreviewLayout} from './element-definitions';
 
 type ElementPreviewProps = {
 	readonly component: ComponentType<Record<string, never>>;
 	readonly durationInFrames: number;
+	readonly elementHeight: number | null;
+	readonly elementWidth: number | null;
 	readonly fps: number;
+	readonly previewLayout: ElementPreviewLayout;
+	readonly safeArea: number;
 };
 
-const previewWidth = 1920;
 const previewHeight = 1080;
+const previewWidth = 1920;
+const checkerboardBackground =
+	'conic-gradient(rgba(0, 0, 0, 0.1) 25%, transparent 0 50%, rgba(0, 0, 0, 0.1) 0 75%, transparent 0)';
 
 export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	component,
 	durationInFrames,
+	elementHeight,
+	elementWidth,
 	fps,
+	previewLayout,
+	safeArea,
 }) => {
 	const [checkerboard, setCheckerboard] = useState(true);
+	let centeredElementBackground: React.CSSProperties | null = null;
+	if (previewLayout === 'vertical') {
+		if (elementHeight === null || elementWidth === null) {
+			throw new Error(
+				'A vertical Element preview requires fixed Element dimensions.',
+			);
+		}
+
+		const scale = Math.min(
+			1,
+			(previewWidth - safeArea * 2) / elementWidth,
+			(previewHeight - safeArea * 2) / elementHeight,
+		);
+		centeredElementBackground = {
+			backgroundColor: checkerboard ? 'white' : '#f5f6f7',
+			backgroundImage: checkerboard ? checkerboardBackground : undefined,
+			backgroundSize: checkerboard ? '32px 32px' : undefined,
+			height: `${(elementHeight * scale * 100) / previewHeight}%`,
+			left: '50%',
+			position: 'absolute',
+			top: '50%',
+			transform: 'translate(-50%, -50%)',
+			width: `${(elementWidth * scale * 100) / previewWidth}%`,
+		};
+	}
+
 	const transparencyLabel = checkerboard
 		? 'Use light preview background'
 		: 'Show transparency as checkerboard';
@@ -30,9 +67,27 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 			<div
 				style={{
 					aspectRatio: `${previewWidth} / ${previewHeight}`,
+					backgroundColor:
+						centeredElementBackground === null
+							? checkerboard
+								? 'white'
+								: '#f5f6f7'
+							: 'var(--ifm-background-surface-color)',
+					backgroundImage:
+						centeredElementBackground === null && checkerboard
+							? checkerboardBackground
+							: undefined,
+					backgroundSize:
+						centeredElementBackground === null && checkerboard
+							? '32px 32px'
+							: undefined,
+					position: 'relative',
 					width: '100%',
 				}}
 			>
+				{centeredElementBackground === null ? null : (
+					<div style={centeredElementBackground} />
+				)}
 				<Player
 					acknowledgeRemotionLicense
 					autoPlay
@@ -94,11 +149,7 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 						</button>
 					)}
 					style={{
-						backgroundColor: checkerboard ? 'white' : '#f5f6f7',
-						backgroundImage: checkerboard
-							? 'conic-gradient(rgba(0, 0, 0, 0.1) 25%, transparent 0 50%, rgba(0, 0, 0, 0.1) 0 75%, transparent 0)'
-							: undefined,
-						backgroundSize: checkerboard ? '32px 32px' : undefined,
+						backgroundColor: 'transparent',
 						height: '100%',
 						width: '100%',
 					}}

--- a/packages/docs/src/components/Elements/ElementPreview.tsx
+++ b/packages/docs/src/components/Elements/ElementPreview.tsx
@@ -14,6 +14,7 @@ type ElementPreviewProps = {
 
 const previewHeight = 1080;
 const previewWidth = 1920;
+const lightPreviewBackground = '#f5f6f7';
 const checkerboardBackground =
 	'conic-gradient(rgba(0, 0, 0, 0.1) 25%, transparent 0 50%, rgba(0, 0, 0, 0.1) 0 75%, transparent 0)';
 
@@ -27,7 +28,16 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	safeArea,
 }) => {
 	const [checkerboard, setCheckerboard] = useState(true);
-	let centeredElementBackground: React.CSSProperties | null = null;
+	const transparencyBackgroundStyle: React.CSSProperties = checkerboard
+		? {
+				backgroundColor: 'white',
+				backgroundImage: checkerboardBackground,
+				backgroundSize: '32px 32px',
+			}
+		: {backgroundColor: lightPreviewBackground};
+	let previewBackgroundStyle = transparencyBackgroundStyle;
+	let verticalBackgroundStyle: React.CSSProperties | null = null;
+
 	if (previewLayout === 'vertical') {
 		if (elementHeight === null || elementWidth === null) {
 			throw new Error(
@@ -40,16 +50,20 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 			(previewWidth - safeArea * 2) / elementWidth,
 			(previewHeight - safeArea * 2) / elementHeight,
 		);
-		centeredElementBackground = {
-			backgroundColor: checkerboard ? 'white' : '#f5f6f7',
-			backgroundImage: checkerboard ? checkerboardBackground : undefined,
-			backgroundSize: checkerboard ? '32px 32px' : undefined,
-			height: `${(elementHeight * scale * 100) / previewHeight}%`,
+		const displayedElementHeight = elementHeight * scale;
+		const displayedElementWidth = elementWidth * scale;
+
+		previewBackgroundStyle = {
+			backgroundColor: 'var(--ifm-background-surface-color)',
+		};
+		verticalBackgroundStyle = {
+			...transparencyBackgroundStyle,
+			height: `${(displayedElementHeight * 100) / previewHeight}%`,
 			left: '50%',
 			position: 'absolute',
 			top: '50%',
 			transform: 'translate(-50%, -50%)',
-			width: `${(elementWidth * scale * 100) / previewWidth}%`,
+			width: `${(displayedElementWidth * 100) / previewWidth}%`,
 		};
 	}
 
@@ -60,33 +74,20 @@ export const ElementPreview: React.FC<ElementPreviewProps> = ({
 	return (
 		<div
 			style={{
-				backgroundColor: '#f5f6f7',
+				backgroundColor: lightPreviewBackground,
 				overflow: 'hidden',
 			}}
 		>
 			<div
 				style={{
+					...previewBackgroundStyle,
 					aspectRatio: `${previewWidth} / ${previewHeight}`,
-					backgroundColor:
-						centeredElementBackground === null
-							? checkerboard
-								? 'white'
-								: '#f5f6f7'
-							: 'var(--ifm-background-surface-color)',
-					backgroundImage:
-						centeredElementBackground === null && checkerboard
-							? checkerboardBackground
-							: undefined,
-					backgroundSize:
-						centeredElementBackground === null && checkerboard
-							? '32px 32px'
-							: undefined,
 					position: 'relative',
 					width: '100%',
 				}}
 			>
-				{centeredElementBackground === null ? null : (
-					<div style={centeredElementBackground} />
+				{verticalBackgroundStyle === null ? null : (
+					<div style={verticalBackgroundStyle} />
 				)}
 				<Player
 					acknowledgeRemotionLicense

--- a/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
+++ b/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
@@ -54,13 +54,24 @@ export const ElementPreviewComposition: React.FC<{
 			<Sequence height={elementHeight} layout="none" width={elementWidth}>
 				<div
 					style={{
-						height: elementHeight,
+						height: elementHeight * scale,
 						position: 'relative',
-						scale,
-						width: elementWidth,
+						width: elementWidth * scale,
 					}}
 				>
-					<Component />
+					<div
+						style={{
+							height: elementHeight,
+							left: 0,
+							position: 'absolute',
+							top: 0,
+							transform: `scale(${scale})`,
+							transformOrigin: 'top left',
+							width: elementWidth,
+						}}
+					>
+						<Component />
+					</div>
 				</div>
 			</Sequence>
 		</AbsoluteFill>

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -46,7 +46,10 @@ import {
 	type ElementSlug,
 } from './element-registry';
 
+export type ElementPreviewLayout = 'composition' | 'vertical';
+
 export type ElementPreviewMetadata = {
+	readonly previewLayout: ElementPreviewLayout;
 	readonly posterUrl:
 		| `/elements/${string}-preview.png`
 		| `https://remotion.media/elements/${string}-preview.png`;
@@ -92,6 +95,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 105,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/audio-oscilloscope-preview.png',
 			videoUrl:
@@ -117,6 +121,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 105,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/audio-mirrored-spectrum-preview.png',
 			videoUrl:
@@ -139,6 +144,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 120,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/backgrounds-liquid-contours-preview.png',
 			videoUrl:
@@ -164,6 +170,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 240,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl: 'https://remotion.media/elements/maps-map-flyover-preview.png',
 			videoUrl: 'https://remotion.media/elements/maps-map-flyover-preview.mp4',
 		},
@@ -187,6 +194,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 145,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/maps-watercolor-map-preview.png',
 			videoUrl:
@@ -208,6 +216,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 0,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/backgrounds-notebook-paper-preview.png',
 			videoUrl:
@@ -230,6 +239,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/backgrounds-paper-texture-preview.png',
 			videoUrl:
@@ -251,6 +261,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 120,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.png',
 			videoUrl:
@@ -272,6 +283,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/overlays-location-lower-third-preview.png',
 			videoUrl:
@@ -294,6 +306,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/overlays-name-lower-third-preview.png',
 			videoUrl:
@@ -310,12 +323,13 @@ const elementImplementations = {
 			'Capture-calibrated safe-area guides for TikTok and Instagram Reels.',
 		dependencies: [],
 		durationInFrames: 120,
-		elementHeight: null,
-		elementWidth: null,
+		elementHeight: 1920,
+		elementWidth: 1080,
 		fps: 30,
 		height: 1920,
 		posterFrame: 0,
 		preview: {
+			previewLayout: 'vertical',
 			posterUrl:
 				'https://remotion.media/elements/overlays-social-safe-zones-preview.png',
 			videoUrl:
@@ -337,6 +351,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 135,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/youtube-youtube-comment-highlight-preview.png',
 			videoUrl:
@@ -359,6 +374,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 75,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/overlays-social-endcard-preview.png',
 			videoUrl:
@@ -385,6 +401,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 50,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/youtube-youtube-subscribe-nudge-preview.png',
 			videoUrl:
@@ -406,6 +423,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 70,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/data-horizontal-bar-chart-preview.png',
 			videoUrl:
@@ -427,6 +445,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 70,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl: 'https://remotion.media/elements/data-line-chart-preview.png',
 			videoUrl: 'https://remotion.media/elements/data-line-chart-preview.mp4',
 		},
@@ -447,6 +466,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 70,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl: 'https://remotion.media/elements/data-pie-chart-preview.png',
 			videoUrl: 'https://remotion.media/elements/data-pie-chart-preview.mp4',
 		},
@@ -472,6 +492,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/data-number-counter-preview.png',
 			videoUrl:
@@ -494,6 +515,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 115,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/data-vertical-bar-chart-preview.png',
 			videoUrl:
@@ -516,6 +538,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 90,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/commerce-product-collection-preview.png',
 			videoUrl:
@@ -541,6 +564,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 57,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/commerce-product-discount-callout-preview.png',
 			videoUrl:
@@ -563,6 +587,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 75,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/commerce-product-offer-preview.png',
 			videoUrl:
@@ -588,6 +613,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/text-circle-marker-preview.png',
 			videoUrl:
@@ -613,6 +639,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl: 'https://remotion.media/elements/text-crossed-off-preview.png',
 			videoUrl: 'https://remotion.media/elements/text-crossed-off-preview.mp4',
 		},
@@ -633,6 +660,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 105,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/text-spinning-text-wheel-preview.png',
 			videoUrl:
@@ -655,6 +683,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 114,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/storytelling-on-screen-messages-preview.png',
 			videoUrl:
@@ -677,6 +706,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 82,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/storytelling-polaroid-pictures-preview.png',
 			videoUrl:
@@ -699,6 +729,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 100,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/text-news-article-highlight-preview.png',
 			videoUrl:
@@ -724,6 +755,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/text-strike-through-preview.png',
 			videoUrl:
@@ -749,6 +781,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 60,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl: 'https://remotion.media/elements/text-text-marker-preview.png',
 			videoUrl: 'https://remotion.media/elements/text-text-marker-preview.mp4',
 		},
@@ -773,6 +806,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 75,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/captions-moving-pill-captions-preview.png',
 			videoUrl:
@@ -798,6 +832,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 75,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/captions-popping-word-captions-preview.png',
 			videoUrl:
@@ -823,6 +858,7 @@ const elementImplementations = {
 		height: 1080,
 		posterFrame: 75,
 		preview: {
+			previewLayout: 'composition',
 			posterUrl:
 				'https://remotion.media/elements/captions-word-highlight-captions-preview.png',
 			videoUrl:

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -25,7 +25,11 @@ import {
 	getElementDimensionsLabel,
 } from '../components/Elements/element-utils';
 import {ElementLibrary} from '../components/Elements/ElementLibrary';
-import {getElementPreviewDimensions} from '../components/Elements/ElementPreviewComposition';
+import {ElementPreview} from '../components/Elements/ElementPreview';
+import {
+	ElementPreviewComposition,
+	getElementPreviewDimensions,
+} from '../components/Elements/ElementPreviewComposition';
 import {Seo} from '../components/Seo';
 
 const elementsRoot = path.join(__dirname, '..', '..', 'elements');
@@ -802,6 +806,47 @@ describe('Element preview definitions', () => {
 			expect(source).not.toContain(`width={${definition.width}}`);
 			expect(source).not.toContain(`height={${definition.height}}`);
 		}
+	});
+
+	test('Social Safe Zones keeps its calibrated 9:16 dimensions in Studio and the docs preview', () => {
+		const slug = 'overlays/social-safe-zones';
+		const definition = elementDefinitions[slug];
+		const element = productionElements.find((entry) => entry.name === slug);
+		if (!element) {
+			throw new Error(`Could not find Element source for ${slug}`);
+		}
+
+		const source = readFileSync(element.tsxPath, 'utf8');
+		const payload = createElementPayloadFromDefinition({
+			definition,
+			sourceCode: source,
+		});
+		const preview = renderToStaticMarkup(
+			React.createElement(ElementPreview, {
+				component: () =>
+					React.createElement(ElementPreviewComposition, {definition}),
+				durationInFrames: definition.durationInFrames,
+				elementHeight: definition.elementHeight,
+				elementWidth: definition.elementWidth,
+				fps: definition.fps,
+				previewLayout: definition.preview.previewLayout,
+				safeArea: definition.safeArea,
+			}),
+		);
+
+		expect(definition.elementWidth).toBe(1080);
+		expect(definition.elementHeight).toBe(1920);
+		expect(payload.element.dimensions).toEqual({width: 1080, height: 1920});
+		expect(definition.preview.previewLayout).toBe('vertical');
+		expect(preview).toContain('aspect-ratio:1920 / 1080');
+		expect(preview).toContain('width:31.640625%');
+		expect(preview).toContain('height:1080px;position:relative;width:607.5px');
+		expect(preview).toContain(
+			'transform:scale(0.5625);transform-origin:top left',
+		);
+		expect(source).not.toContain('useVideoConfig');
+		expect(source).toContain('width: 1080');
+		expect(source).toContain('height: 1920');
 	});
 
 	test('uses stable composition IDs and flat review or published preview paths', () => {


### PR DESCRIPTION
## Summary

- lock Social Safe Zones to its calibrated 1080×1920 dimensions in the Element source and Studio install payload
- add vertical Element preview metadata so the portrait overlay is centered inside the 1920×1080 docs Player
- scope the transparency background to the vertical Element and correct fixed-Element preview scaling

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`

Closes #10835

## Preview

- [Social Safe Zones Element](https://remotion-git-fix-social-safe-zones-dimensions-remotion.vercel.app/elements/overlays/social-safe-zones/)
