### PR TITLE
`@remotion/studio`: Show source locations in read-only Studio

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1805,6 +1805,7 @@
         "@remotion/media-utils": "workspace:*",
         "@remotion/player": "workspace:*",
         "@remotion/renderer": "workspace:*",
+        "@remotion/studio-codemods": "workspace:*",
         "@remotion/studio-protocol": "workspace:*",
         "@remotion/studio-shared": "workspace:*",
         "@remotion/timeline-utils": "workspace:*",

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -101,10 +101,7 @@ export const rspackConfig = async ({
 					: null,
 			reactScan: getReactScanEntryPoint(environment),
 			environmentSetup: require.resolve('./setup-environment'),
-			sequenceStackTraces:
-				environment === 'development'
-					? require.resolve('./setup-sequence-stack-traces')
-					: null,
+			sequenceStackTraces: require.resolve('./setup-sequence-stack-traces'),
 			userDefinedComponent,
 			reactShim: require.resolve('../react-shim.js'),
 			studioRenderEntry: entry,

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -86,18 +86,26 @@ const enableProxy = <
 	});
 };
 
-// Renderer pages set this value before the bundle loads. Avoid proxying every
-// JSX call while rendering; production stack traces are only needed by Studio.
-const shouldEnableStackTraces =
-	process.env.NODE_ENV !== 'production' ||
-	(typeof window !== 'undefined' &&
-		typeof window.remotion_puppeteerTimeout === 'undefined');
+let stackTracesEnabled = false;
 
-if (shouldEnableStackTraces) {
+const enableSequenceStackTraces = () => {
+	if (stackTracesEnabled) {
+		return;
+	}
+
+	stackTracesEnabled = true;
 	React.createElement = enableProxy(originalCreateElement, true, null);
 	JsxRuntime.jsx = enableProxy(originalJsx, false, null);
 	JsxRuntime.jsxs = enableProxy(originalJsxs, false, null);
 	if (originalJsxDev) {
 		JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false, 4);
 	}
+};
+
+if (typeof window !== 'undefined') {
+	window.remotion_enableSequenceStackTraces = enableSequenceStackTraces;
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	enableSequenceStackTraces();
 }

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 import JsxRuntimeDev from 'react/jsx-dev-runtime';
 import JsxRuntime from 'react/jsx-runtime';
-import {Internals} from 'remotion';
+import {Composition, Folder, Internals, Still} from 'remotion';
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
+const componentsToAddStacksToInReadOnlyStudio = [Composition, Folder, Still];
 const sequenceComponent = Internals.getSequenceComponent();
 const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;
 const studioOriginalSourcePrefix = 'studio-original://';
@@ -50,7 +51,11 @@ const enableProxy = <
 ): T => {
 	return new Proxy(api, {
 		apply(target, thisArg, argArray) {
-			if (componentsToAddStacksTo.includes(argArray[0])) {
+			const component = argArray[0];
+			const shouldAddStack =
+				process.env.NODE_ENV !== 'production' ||
+				componentsToAddStacksToInReadOnlyStudio.includes(component);
+			if (shouldAddStack && componentsToAddStacksTo.includes(component)) {
 				const [first, props, ...rest] = argArray;
 				const children = isCreateElement
 					? rest.length === 0
@@ -85,7 +90,18 @@ const enableProxy = <
 	});
 };
 
-React.createElement = enableProxy(originalCreateElement, true, null);
-JsxRuntime.jsx = enableProxy(originalJsx, false, null);
-JsxRuntime.jsxs = enableProxy(originalJsxs, false, null);
-JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false, 4);
+// Renderer pages set this value before the bundle loads. Avoid proxying every
+// JSX call while rendering; production stack traces are only needed by Studio.
+const shouldEnableStackTraces =
+	process.env.NODE_ENV !== 'production' ||
+	(typeof window !== 'undefined' &&
+		typeof window.remotion_puppeteerTimeout === 'undefined');
+
+if (shouldEnableStackTraces) {
+	React.createElement = enableProxy(originalCreateElement, true, null);
+	JsxRuntime.jsx = enableProxy(originalJsx, false, null);
+	JsxRuntime.jsxs = enableProxy(originalJsxs, false, null);
+	if (originalJsxDev) {
+		JsxRuntimeDev.jsxDEV = enableProxy(originalJsxDev, false, 4);
+	}
+}

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -7,12 +7,6 @@ type ReactRefreshRuntime = {
 	getFamilyByType: (component: unknown) => unknown;
 };
 
-const RefreshRuntime = require('react-refresh/runtime') as ReactRefreshRuntime;
-
-Internals.setComponentIdentityResolver((component) => {
-	return RefreshRuntime.getFamilyByType(component) ?? component;
-});
-
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
 const sequenceComponent = Internals.getSequenceComponent();
 const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;
@@ -117,5 +111,10 @@ if (typeof window !== 'undefined') {
 }
 
 if (process.env.NODE_ENV !== 'production') {
+	const RefreshRuntime =
+		require('react-refresh/runtime') as ReactRefreshRuntime;
+	Internals.setComponentIdentityResolver((component) => {
+		return RefreshRuntime.getFamilyByType(component) ?? component;
+	});
 	enableSequenceStackTraces();
 }

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -1,10 +1,9 @@
 import React from 'react';
 import JsxRuntimeDev from 'react/jsx-dev-runtime';
 import JsxRuntime from 'react/jsx-runtime';
-import {Composition, Folder, Internals, Still} from 'remotion';
+import {Internals} from 'remotion';
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
-const componentsToAddStacksToInReadOnlyStudio = [Composition, Folder, Still];
 const sequenceComponent = Internals.getSequenceComponent();
 const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;
 const studioOriginalSourcePrefix = 'studio-original://';
@@ -52,10 +51,7 @@ const enableProxy = <
 	return new Proxy(api, {
 		apply(target, thisArg, argArray) {
 			const component = argArray[0];
-			const shouldAddStack =
-				process.env.NODE_ENV !== 'production' ||
-				componentsToAddStacksToInReadOnlyStudio.includes(component);
-			if (shouldAddStack && componentsToAddStacksTo.includes(component)) {
+			if (componentsToAddStacksTo.includes(component)) {
 				const [first, props, ...rest] = argArray;
 				const children = isCreateElement
 					? rest.length === 0

--- a/packages/bundler/src/test/override-order.test.ts
+++ b/packages/bundler/src/test/override-order.test.ts
@@ -102,6 +102,20 @@ test('includes React Scan only in an explicitly enabled development bundle', asy
 			).toBe(false);
 		}
 
+		for (const config of [
+			productionWebpackConfig,
+			productionRspackConfig,
+			developmentWebpackConfig,
+			developmentRspackConfig,
+		]) {
+			expect(Array.isArray(config.entry)).toBe(true);
+			expect(
+				(config.entry as string[]).some((entry) =>
+					entry.includes('setup-sequence-stack-traces'),
+				),
+			).toBe(true);
+		}
+
 		for (const config of [developmentWebpackConfig, developmentRspackConfig]) {
 			expect(Array.isArray(config.entry)).toBe(true);
 			expect(

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'bun:test';
 import React from 'react';
 import JsxRuntimeDev from 'react/jsx-dev-runtime';
-import {Internals} from 'remotion';
+import {Composition, Internals} from 'remotion';
 
 test('injects a namespaced source stack without conflicting with application props', async () => {
 	const Component: React.FC<{readonly stack: string}> = () => null;
@@ -28,15 +28,34 @@ test('injects a namespaced source stack without conflicting with application pro
 		};
 	expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
 
+	const previousNodeEnv = process.env.NODE_ENV;
 	Object.defineProperty(globalThis, 'window', {
 		configurable: true,
-		value: {remotion_cwd: '/project'},
+		value: {
+			remotion_cwd: '/project',
+		},
 	});
 
 	try {
+		process.env.NODE_ENV = 'production';
+		const renderingElement = React.createElement(Component, {
+			stack: 'application-stack',
+		});
+		expect(
+			(renderingElement.props as {_remotionInternalStack?: string})
+				._remotionInternalStack,
+		).toBeUndefined();
+
 		const sourceElement = JsxRuntimeDev.jsxDEV(
-			Component,
-			{stack: 'application-stack'},
+			Composition,
+			{
+				component: Component,
+				durationInFrames: 30,
+				fps: 30,
+				height: 1080,
+				id: 'read-only-stack-test',
+				width: 1920,
+			},
 			undefined,
 			false,
 			{
@@ -53,6 +72,12 @@ test('injects a namespaced source stack without conflicting with application pro
 			'Error\n    at remotionOriginalSource (studio-original://.%2Fsrc%2FVideo.tsx:12:4)',
 		);
 	} finally {
+		if (previousNodeEnv === undefined) {
+			delete process.env.NODE_ENV;
+		} else {
+			process.env.NODE_ENV = previousNodeEnv;
+		}
+
 		Reflect.deleteProperty(globalThis, 'window');
 	}
 });

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -44,7 +44,7 @@ test('injects a namespaced source stack without conflicting with application pro
 		expect(
 			(renderingElement.props as {_remotionInternalStack?: string})
 				._remotionInternalStack,
-		).toBeUndefined();
+		).toContain('Error');
 
 		const sourceElement = JsxRuntimeDev.jsxDEV(
 			Composition,

--- a/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
+++ b/packages/bundler/src/test/setup-sequence-stack-traces.test.ts
@@ -3,31 +3,9 @@ import React from 'react';
 import JsxRuntimeDev from 'react/jsx-dev-runtime';
 import {Composition, Internals} from 'remotion';
 
-test('injects a namespaced source stack without conflicting with application props', async () => {
+test('defers and idempotently enables source stack injection in production', async () => {
 	const Component: React.FC<{readonly stack: string}> = () => null;
 	Internals.addSequenceStackTraces(Component);
-	await import('../setup-sequence-stack-traces');
-
-	const element = React.createElement(Component, {stack: 'application-stack'});
-	const props = element.props as typeof element.props & {
-		readonly _remotionInternalStack: string;
-	};
-
-	expect(props.stack).toBe('application-stack');
-	expect(props._remotionInternalStack).toContain('Error');
-
-	const existingStackElement = React.createElement(Component, {
-		stack: 'application-stack',
-		_remotionInternalStack: 'existing-source-stack',
-	} as React.ComponentProps<typeof Component> & {
-		readonly _remotionInternalStack: string;
-	});
-	const existingProps =
-		existingStackElement.props as typeof existingStackElement.props & {
-			readonly _remotionInternalStack: string;
-		};
-	expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
-
 	const previousNodeEnv = process.env.NODE_ENV;
 	Object.defineProperty(globalThis, 'window', {
 		configurable: true,
@@ -38,6 +16,38 @@ test('injects a namespaced source stack without conflicting with application pro
 
 	try {
 		process.env.NODE_ENV = 'production';
+		const originalCreateElement = React.createElement;
+		await import('../setup-sequence-stack-traces');
+		expect(React.createElement).toBe(originalCreateElement);
+
+		window.remotion_enableSequenceStackTraces?.();
+		const proxiedCreateElement = React.createElement;
+		expect(proxiedCreateElement).not.toBe(originalCreateElement);
+		window.remotion_enableSequenceStackTraces?.();
+		expect(React.createElement).toBe(proxiedCreateElement);
+
+		const element = React.createElement(Component, {
+			stack: 'application-stack',
+		});
+		const props = element.props as typeof element.props & {
+			readonly _remotionInternalStack: string;
+		};
+
+		expect(props.stack).toBe('application-stack');
+		expect(props._remotionInternalStack).toContain('Error');
+
+		const existingStackElement = React.createElement(Component, {
+			stack: 'application-stack',
+			_remotionInternalStack: 'existing-source-stack',
+		} as React.ComponentProps<typeof Component> & {
+			readonly _remotionInternalStack: string;
+		});
+		const existingProps =
+			existingStackElement.props as typeof existingStackElement.props & {
+				readonly _remotionInternalStack: string;
+			};
+		expect(existingProps._remotionInternalStack).toBe('existing-source-stack');
+
 		const renderingElement = React.createElement(Component, {
 			stack: 'application-stack',
 		});

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -71,10 +71,7 @@ export const webpackConfig = async ({
 					: null,
 			reactScan: getReactScanEntryPoint(environment),
 			environmentSetup: require.resolve('./setup-environment'),
-			sequenceStackTraces:
-				environment === 'development'
-					? require.resolve('./setup-sequence-stack-traces')
-					: null,
+			sequenceStackTraces: require.resolve('./setup-sequence-stack-traces'),
 			userDefinedComponent,
 			reactShim: require.resolve('../react-shim.js'),
 			studioRenderEntry: entry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ declare global {
 		remotion_isPlayer: boolean;
 		remotion_isStudio: boolean;
 		remotion_isReadOnlyStudio: boolean;
+		remotion_enableSequenceStackTraces: (() => void) | null;
 		remotion_isBuilding: undefined | (() => void);
 		remotion_finishedBuilding: undefined | (() => void);
 		siteVersion: '11';

--- a/packages/it-tests/src/bundle/bundle-studio.test.ts
+++ b/packages/it-tests/src/bundle/bundle-studio.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'bun:test';
 import {existsSync, readFileSync} from 'fs';
 import path from 'path';
-import {RenderInternals, openBrowser} from '@remotion/renderer';
+import {openBrowser} from '@remotion/renderer';
 import {
 	getRemotionVersionFromIndexHtml,
 	VERSION,
@@ -48,22 +48,27 @@ test(
 		const version = getRemotionVersionFromIndexHtml(indexHtmlContent);
 		expect(version).toBe(VERSION);
 
-		const {port, close} = await RenderInternals.serveStatic(
-			path.join(process.cwd(), '..', 'example', 'build'),
-			{
-				port: null,
-				offthreadVideoThreads: 1,
-				downloadMap: RenderInternals.makeDownloadMap(48000),
-				indent: false,
-				logLevel: 'info',
-				offthreadVideoCacheSizeInBytes: null,
-				remotionRoot: path.join(process.cwd(), '..', 'example'),
-				binariesDirectory: null,
-				forceIPv4: false,
+		const server = Bun.serve({
+			port: 0,
+			fetch: async (request) => {
+				const url = new URL(request.url);
+				const requestedPath =
+					url.pathname === '/' ? 'index.html' : url.pathname.slice(1);
+				const filePath = path.resolve(folder, requestedPath);
+				if (!filePath.startsWith(`${folder}${path.sep}`)) {
+					return new Response('Forbidden', {status: 403});
+				}
+
+				const file = Bun.file(filePath);
+				if (!(await file.exists())) {
+					return new Response('Not found', {status: 404});
+				}
+
+				return new Response(file);
 			},
-		);
+		});
 		await tab.goto({
-			url: `http://localhost:${port}`,
+			url: `http://localhost:${server.port}`,
 			timeout: 10000,
 			options: {},
 		});
@@ -76,6 +81,36 @@ test(
 			return document.querySelectorAll('.css-reset').length;
 		});
 		expect(result.toString()).toBeGreaterThan(1);
+
+		const sourceLocation = await tab.evaluateHandle(async () => {
+			let openedInspector = false;
+			for (let attempt = 0; attempt < 100; attempt++) {
+				const inspectorSourceLocation = document.querySelector(
+					'[aria-label="Inspector source location"]',
+				);
+				if (inspectorSourceLocation?.textContent?.includes('Root.tsx:')) {
+					return inspectorSourceLocation.textContent;
+				}
+				if (inspectorSourceLocation) {
+					openedInspector = true;
+				}
+
+				if (!openedInspector) {
+					const inspectorToggle = document.querySelector<HTMLElement>(
+						'[data-sidebar-toggle="right"]',
+					);
+					if (inspectorToggle) {
+						openedInspector = true;
+						inspectorToggle.click();
+					}
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+
+			return null;
+		});
+		expect(sourceLocation.toString()).toMatch(/Root\.tsx:\d+/);
 
 		const fontLoaded = await tab.evaluateHandle(() => {
 			let loaded = false;
@@ -95,8 +130,15 @@ test(
 		});
 		expect(Number(orphanedFontTimeouts.toString())).toBe(0);
 
+		await Promise.all([
+			result.dispose(),
+			sourceLocation.dispose(),
+			fontLoaded.dispose(),
+			orphanedFontTimeouts.dispose(),
+		]);
+		await tab.close();
 		await (await browser).close({silent: false});
-		await close();
+		await server.stop(true);
 	},
-	{timeout: 20000},
+	{timeout: 20_000},
 );

--- a/packages/it-tests/src/bundle/bundle-studio.test.ts
+++ b/packages/it-tests/src/bundle/bundle-studio.test.ts
@@ -68,7 +68,7 @@ test(
 			},
 		});
 		await tab.goto({
-			url: `http://localhost:${server.port}`,
+			url: `http://localhost:${server.port}/?/WidthHeight`,
 			timeout: 10000,
 			options: {},
 		});
@@ -111,6 +111,34 @@ test(
 			return null;
 		});
 		expect(sourceLocation.toString()).toMatch(/Root\.tsx:\d+/);
+		expect(sourceLocation.toString()).toMatch(/WidthHeightSequences\.tsx:\d+/);
+		const sequenceSourceLocation = await tab.evaluateHandle(async () => {
+			const label = document.querySelector<HTMLElement>('[title="<Sequence>"]');
+			label?.parentElement?.parentElement?.dispatchEvent(
+				new PointerEvent('pointerdown', {bubbles: true, button: 0}),
+			);
+
+			for (let attempt = 0; attempt < 100; attempt++) {
+				const inspectorSourceLocation = document.querySelector(
+					'[aria-label="Inspector source location"]',
+				);
+				if (
+					inspectorSourceLocation?.textContent?.startsWith('<Sequence>') &&
+					inspectorSourceLocation.textContent.includes(
+						'WidthHeightSequences.tsx:',
+					)
+				) {
+					return inspectorSourceLocation.textContent;
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+
+			return null;
+		});
+		expect(sequenceSourceLocation.toString()).toMatch(
+			/<Sequence>WidthHeightSequences\.tsx:\d+/,
+		);
 
 		const fontLoaded = await tab.evaluateHandle(() => {
 			let loaded = false;
@@ -133,6 +161,7 @@ test(
 		await Promise.all([
 			result.dispose(),
 			sourceLocation.dispose(),
+			sequenceSourceLocation.dispose(),
 			fontLoaded.dispose(),
 			orphanedFontTimeouts.dispose(),
 		]);

--- a/packages/studio-codemods/bundle.ts
+++ b/packages/studio-codemods/bundle.ts
@@ -9,12 +9,18 @@ const external = ['@remotion/studio-shared', 'recast'];
 
 console.time('Generated.');
 const esmOutput = await build({
-	entrypoints: ['src/index.ts'],
+	entrypoints: [
+		'src/index.ts',
+		'src/resolve-composition-component-location.ts',
+	],
 	naming: '[name].mjs',
 	external,
 });
 const cjsOutput = await build({
-	entrypoints: ['src/index.ts'],
+	entrypoints: [
+		'src/index.ts',
+		'src/resolve-composition-component-location.ts',
+	],
 	naming: '[name].cjs',
 	format: 'cjs',
 	external,

--- a/packages/studio-codemods/package.json
+++ b/packages/studio-codemods/package.json
@@ -38,6 +38,12 @@
 			"module": "./dist/esm/index.mjs",
 			"import": "./dist/esm/index.mjs"
 		},
+		"./resolve-composition-component-location": {
+			"types": "./dist/resolve-composition-component-location.d.ts",
+			"require": "./dist/resolve-composition-component-location.cjs",
+			"module": "./dist/esm/resolve-composition-component-location.mjs",
+			"import": "./dist/esm/resolve-composition-component-location.mjs"
+		},
 		"./package.json": "./package.json"
 	},
 	"devDependencies": {

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '@remotion/studio-shared';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
+import {resolveCompositionComponentInProject} from './resolve-composition-component-location';
 import {getNodePathForRecastPath} from './sequence-props';
 import {parseAst} from './sequence-props/parse-ast';
 
@@ -109,15 +110,6 @@ type AstNode = {
 		end: {line: number; column: number};
 	} | null;
 	[key: string]: unknown;
-};
-
-type ResolvedComponent = {
-	canAddSequence: boolean;
-	declaration: AstNode;
-	exportName: string | 'default';
-	filePath: string;
-	root: AstNode;
-	source: string;
 };
 
 type TextEdit = {
@@ -367,47 +359,6 @@ const jsxAttributeString = (attribute: AstNode | null) => {
 		: null;
 };
 
-const jsxAttributeIdentifier = (attribute: AstNode | null) => {
-	const value = attribute ? getNode(attribute, 'value') : null;
-	const expression =
-		value?.type === 'JSXExpressionContainer'
-			? getNode(value, 'expression')
-			: null;
-
-	return expression?.type === 'Identifier'
-		? getString(expression, 'name')
-		: null;
-};
-
-const findDynamicImport = (attribute: AstNode | null) => {
-	let importPath: string | null = null;
-	const value = attribute ? getNode(attribute, 'value') : null;
-	visit(value, (node) => {
-		if (node.type === 'ImportExpression') {
-			const source = getNode(node, 'source');
-			if (source?.type === 'StringLiteral') {
-				importPath = getString(source, 'value');
-				return true;
-			}
-		}
-
-		if (
-			node.type === 'CallExpression' &&
-			getNode(node, 'callee')?.type === 'Import'
-		) {
-			const argument = getNodes(node, 'arguments')[0];
-			if (argument?.type === 'StringLiteral') {
-				importPath = getString(argument, 'value');
-				return true;
-			}
-		}
-
-		return false;
-	});
-
-	return importPath;
-};
-
 const findCompositionElement = ({
 	ast,
 	compositionId,
@@ -508,36 +459,6 @@ const findDefaultDeclaration = (ast: AstNode) => {
 	return null;
 };
 
-const findImport = ({ast, localName}: {ast: AstNode; localName: string}) => {
-	for (const statement of programStatements(ast)) {
-		if (statement.type !== 'ImportDeclaration') {
-			continue;
-		}
-
-		const source = getString(getNode(statement, 'source'), 'value');
-		for (const specifier of getNodes(statement, 'specifiers')) {
-			if (getString(getNode(specifier, 'local'), 'name') !== localName) {
-				continue;
-			}
-
-			if (specifier.type === 'ImportDefaultSpecifier') {
-				return {exportName: 'default' as const, importPath: source};
-			}
-
-			if (specifier.type === 'ImportSpecifier') {
-				const imported = getNode(specifier, 'imported');
-				return {
-					exportName:
-						getString(imported, 'name') ?? getString(imported, 'value'),
-					importPath: source,
-				};
-			}
-		}
-	}
-
-	return null;
-};
-
 const unwrapExpression = (node: AstNode | null): AstNode | null => {
 	let current = node;
 	while (
@@ -619,196 +540,6 @@ const canAddToRoot = (root: AstNode | null): root is AstNode => {
 		(root.type === 'JSXElement' || root.type === 'JSXFragment') &&
 		!isCanvasRoot(root)
 	);
-};
-
-const resolveReExport = ({
-	ast,
-	exportName,
-	filePath,
-	project,
-}: {
-	ast: AstNode;
-	exportName: string;
-	filePath: string;
-	project: CodemodProject;
-}): {exportName: string | 'default'; filePath: string} | null => {
-	for (const statement of programStatements(ast)) {
-		if (
-			statement.type !== 'ExportNamedDeclaration' ||
-			!getNode(statement, 'source')
-		) {
-			continue;
-		}
-
-		const importPath = getString(getNode(statement, 'source'), 'value');
-		for (const specifier of getNodes(statement, 'specifiers')) {
-			const exported =
-				getString(getNode(specifier, 'exported'), 'name') ??
-				getString(getNode(specifier, 'exported'), 'value');
-			if (exported !== exportName) {
-				continue;
-			}
-
-			const imported =
-				getString(getNode(specifier, 'local'), 'name') ??
-				getString(getNode(specifier, 'local'), 'value');
-			if (!importPath || !imported) {
-				return null;
-			}
-
-			return {
-				exportName: imported,
-				filePath: resolveImportFile({fromFile: filePath, importPath, project}),
-			};
-		}
-	}
-
-	return null;
-};
-
-const resolveComponentDeclaration = ({
-	exportName,
-	filePath,
-	project,
-	visited,
-}: {
-	exportName: string | 'default';
-	filePath: string;
-	project: CodemodProject;
-	visited: Set<string>;
-}): {
-	ast: AstNode;
-	declaration: AstNode;
-	exportName: string | 'default';
-	filePath: string;
-	source: string;
-} => {
-	const key = `${filePath}:${exportName}`;
-	if (visited.has(key)) {
-		throw new Error(
-			`Circular component export while resolving "${exportName}"`,
-		);
-	}
-
-	visited.add(key);
-	const source = project.files[filePath];
-	if (typeof source !== 'string') {
-		throw new Error(`Could not read source file "${filePath}"`);
-	}
-
-	const ast = parseSource(source);
-	const declaration =
-		exportName === 'default'
-			? findDefaultDeclaration(ast)
-			: findNamedDeclaration(ast, exportName);
-	if (declaration) {
-		return {ast, declaration, exportName, filePath, source};
-	}
-
-	if (exportName !== 'default') {
-		const reExport = resolveReExport({
-			ast,
-			exportName,
-			filePath,
-			project,
-		});
-		if (reExport) {
-			return resolveComponentDeclaration({
-				...reExport,
-				project,
-				visited,
-			});
-		}
-	}
-
-	throw new Error(`Could not find composition component "${exportName}"`);
-};
-
-const resolveCompositionComponent = ({
-	compositionFile,
-	compositionId,
-	project,
-}: {
-	compositionFile: string;
-	compositionId: string;
-	project: CodemodProject;
-}): ResolvedComponent => {
-	const registrationFile = findProjectFile({
-		filePath: compositionFile,
-		project,
-	});
-	const registrationSource = project.files[registrationFile];
-	if (typeof registrationSource !== 'string') {
-		throw new Error(`Could not read source file "${registrationFile}"`);
-	}
-
-	const registrationAst = parseSource(registrationSource);
-	const compositionElement = findCompositionElement({
-		ast: registrationAst,
-		compositionId,
-	});
-	if (!compositionElement) {
-		throw new Error(`Could not find composition "${compositionId}"`);
-	}
-
-	const lazyImportPath = findDynamicImport(
-		getJsxAttribute(compositionElement, 'lazyComponent'),
-	);
-	let componentFile = registrationFile;
-	let exportName: string | 'default';
-	if (lazyImportPath) {
-		componentFile = resolveImportFile({
-			fromFile: registrationFile,
-			importPath: lazyImportPath,
-			project,
-		});
-		exportName = 'default';
-	} else {
-		const componentName = jsxAttributeIdentifier(
-			getJsxAttribute(compositionElement, 'component'),
-		);
-		if (!componentName) {
-			throw new Error(
-				`Could not find a component prop for composition "${compositionId}"`,
-			);
-		}
-
-		const componentImport = findImport({
-			ast: registrationAst,
-			localName: componentName,
-		});
-		if (componentImport?.importPath && componentImport.exportName) {
-			componentFile = resolveImportFile({
-				fromFile: registrationFile,
-				importPath: componentImport.importPath,
-				project,
-			});
-			exportName = componentImport.exportName;
-		} else {
-			exportName = componentName;
-		}
-	}
-
-	const resolved = resolveComponentDeclaration({
-		exportName,
-		filePath: componentFile,
-		project,
-		visited: new Set(),
-	});
-	const root = getReturnedRoot(resolved.declaration);
-
-	return {
-		canAddSequence: canAddToRoot(root),
-		declaration: resolved.declaration,
-		exportName: resolved.exportName,
-		filePath: resolved.filePath,
-		root:
-			root ??
-			(() => {
-				throw new Error('Composition component does not return JSX');
-			})(),
-		source: resolved.source,
-	};
 };
 
 const collectBindings = (ast: AstNode) => {
@@ -1305,7 +1036,7 @@ export const insertSolidIntoProjectWithNodePathRemappings = <
 		throw new Error('from must be a non-negative integer');
 	}
 
-	const resolved = resolveCompositionComponent({
+	const resolved = resolveCompositionComponentInProject({
 		compositionFile: request.compositionFile,
 		compositionId: request.compositionId,
 		project,
@@ -1364,7 +1095,7 @@ export const getCompositionComponentInfo = ({
 	project: CodemodProject;
 	request: CompositionComponentInfoRequest;
 }) => {
-	const resolved = resolveCompositionComponent({
+	const resolved = resolveCompositionComponentInProject({
 		compositionFile: request.compositionFile,
 		compositionId: request.compositionId,
 		project,
@@ -1372,11 +1103,7 @@ export const getCompositionComponentInfo = ({
 
 	return {
 		canAddSequence: resolved.canAddSequence,
-		location: {
-			source: relativeToRoot(resolved.filePath, project.rootDir),
-			line: resolved.declaration.loc?.start.line ?? 1,
-			column: resolved.declaration.loc?.start.column ?? 0,
-		},
+		location: resolved.location,
 	};
 };
 

--- a/packages/studio-codemods/src/resolve-composition-component-location.ts
+++ b/packages/studio-codemods/src/resolve-composition-component-location.ts
@@ -17,6 +17,20 @@ export type SourceMapProject = {
 	rootDir: string;
 };
 
+export type ResolvedCompositionComponentInProject = {
+	canAddSequence: boolean;
+	declaration: Node;
+	exportName: string | 'default';
+	filePath: string;
+	location: {
+		column: number;
+		line: number;
+		source: string;
+	};
+	root: Node;
+	source: string;
+};
+
 const parseSource = (source: string): File => {
 	return parse(source, {
 		errorRecovery: false,
@@ -315,7 +329,12 @@ const resolveDeclaration = ({
 	exportName: string | 'default';
 	project: SourceMapProject;
 	visited: Set<string>;
-}): {declaration: Node; filePath: string} => {
+}): {
+	declaration: Node;
+	exportName: string | 'default';
+	filePath: string;
+	source: string;
+} => {
 	const key = `${filePath}:${exportName}`;
 	if (visited.has(key)) {
 		throw new Error(
@@ -338,19 +357,22 @@ const resolveDeclaration = ({
 			defaultExport?.type === 'ExportDefaultDeclaration' &&
 			defaultExport.declaration.type === 'Identifier'
 		) {
-			return resolveDeclaration({
-				filePath,
-				exportName: defaultExport.declaration.name,
-				project,
-				visited,
-			});
+			for (const statement of file.program.body) {
+				const declaration = getDeclaration(
+					statement,
+					defaultExport.declaration.name,
+				);
+				if (declaration) {
+					return {declaration, exportName, filePath, source};
+				}
+			}
 		}
 	}
 
 	for (const statement of file.program.body) {
 		const declaration = getDeclaration(statement, exportName);
 		if (declaration) {
-			return {declaration, filePath};
+			return {declaration, exportName, filePath, source};
 		}
 	}
 
@@ -415,7 +437,84 @@ const findImportedComponent = (file: File, localName: string) => {
 	return null;
 };
 
-export const resolveCompositionComponentLocation = ({
+const unwrapExpression = (node: Node | null): Node | null => {
+	let current = node;
+	while (
+		current &&
+		(current.type === 'TSAsExpression' ||
+			current.type === 'TSSatisfiesExpression' ||
+			current.type === 'TypeCastExpression' ||
+			current.type === 'ParenthesizedExpression')
+	) {
+		current = current.expression;
+	}
+
+	return current;
+};
+
+const getReturnedRoot = (declaration: Node) => {
+	let fn: Node | null = declaration;
+	if (declaration.type === 'VariableDeclarator') {
+		fn = unwrapExpression(declaration.init ?? null);
+	}
+
+	if (
+		!fn ||
+		(fn.type !== 'ArrowFunctionExpression' &&
+			fn.type !== 'FunctionExpression' &&
+			fn.type !== 'FunctionDeclaration')
+	) {
+		return null;
+	}
+
+	const body = unwrapExpression(fn.body);
+	if (!body) {
+		return null;
+	}
+
+	if (body.type !== 'BlockStatement') {
+		return body;
+	}
+
+	const returnStatements = body.body.filter(
+		(statement) => statement.type === 'ReturnStatement',
+	);
+	if (
+		returnStatements.length !== 1 ||
+		returnStatements[0] !== body.body.at(-1)
+	) {
+		return null;
+	}
+
+	return unwrapExpression(returnStatements[0].argument ?? null);
+};
+
+const isCanvasRoot = (root: Node) => {
+	if (root.type !== 'JSXElement') {
+		return false;
+	}
+
+	const name = jsxName(root.openingElement.name);
+	return (
+		name === 'ThreeCanvas' ||
+		name === 'RiveCanvas' ||
+		name === 'SkiaCanvas' ||
+		name === 'canvas'
+	);
+};
+
+const canAddToRoot = (root: Node) => {
+	if (root.type === 'NullLiteral') {
+		return true;
+	}
+
+	return (
+		(root.type === 'JSXElement' || root.type === 'JSXFragment') &&
+		!isCanvasRoot(root)
+	);
+};
+
+const resolveCompositionComponentDeclaration = ({
 	compositionFile,
 	compositionId,
 	project,
@@ -471,21 +570,66 @@ export const resolveCompositionComponentLocation = ({
 		}
 	}
 
-	const {declaration, filePath} = resolveDeclaration({
+	const resolved = resolveDeclaration({
 		filePath: componentFile,
 		exportName,
 		project,
 		visited: new Set(),
 	});
-	const normalizedFile = normalizePath(filePath);
+	const normalizedFile = normalizePath(resolved.filePath);
 	const normalizedRoot = normalizePath(project.rootDir).replace(/\/$/, '');
 	const source = normalizedFile.startsWith(`${normalizedRoot}/`)
 		? normalizedFile.slice(normalizedRoot.length + 1)
 		: normalizedFile.replace(/^\//, '');
 
 	return {
-		source,
-		line: declaration.loc?.start.line ?? 1,
-		column: declaration.loc?.start.column ?? 0,
+		...resolved,
+		location: {
+			source,
+			line: resolved.declaration.loc?.start.line ?? 1,
+			column: resolved.declaration.loc?.start.column ?? 0,
+		},
 	};
+};
+
+export const resolveCompositionComponentInProject = ({
+	compositionFile,
+	compositionId,
+	project,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	project: SourceMapProject;
+}): ResolvedCompositionComponentInProject => {
+	const resolved = resolveCompositionComponentDeclaration({
+		compositionFile,
+		compositionId,
+		project,
+	});
+	const root = getReturnedRoot(resolved.declaration);
+	if (!root) {
+		throw new Error('Composition component does not return JSX');
+	}
+
+	return {
+		...resolved,
+		canAddSequence: canAddToRoot(root),
+		root,
+	};
+};
+
+export const resolveCompositionComponentLocation = ({
+	compositionFile,
+	compositionId,
+	project,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	project: SourceMapProject;
+}) => {
+	return resolveCompositionComponentDeclaration({
+		compositionFile,
+		compositionId,
+		project,
+	}).location;
 };

--- a/packages/studio-codemods/src/resolve-composition-component-location.ts
+++ b/packages/studio-codemods/src/resolve-composition-component-location.ts
@@ -1,0 +1,491 @@
+import {parse} from '@babel/parser';
+import type {
+	File,
+	Identifier,
+	JSXAttribute,
+	JSXOpeningElement,
+	Node,
+	Statement,
+	StringLiteral,
+} from '@babel/types';
+
+// Keep this entry browser-safe. The main codemod entry imports Recast, which
+// depends on Node built-ins and cannot be loaded by a static Studio bundle.
+
+export type SourceMapProject = {
+	files: Record<string, string>;
+	rootDir: string;
+};
+
+const parseSource = (source: string): File => {
+	return parse(source, {
+		errorRecovery: false,
+		plugins: ['decorators-legacy', 'jsx', 'typescript', 'importAttributes'],
+		sourceType: 'module',
+	});
+};
+
+const isNode = (value: unknown): value is Node => {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'type' in value &&
+		typeof value.type === 'string'
+	);
+};
+
+const visit = (value: unknown, visitor: (node: Node) => boolean): boolean => {
+	if (Array.isArray(value)) {
+		return value.some((item) => visit(item, visitor));
+	}
+
+	if (!isNode(value)) {
+		return false;
+	}
+
+	if (visitor(value)) {
+		return true;
+	}
+
+	return Object.entries(value).some(([key, child]) => {
+		if (
+			key === 'loc' ||
+			key === 'start' ||
+			key === 'end' ||
+			key === 'extra' ||
+			key === 'comments'
+		) {
+			return false;
+		}
+
+		return visit(child, visitor);
+	});
+};
+
+const normalizePath = (input: string) => {
+	const hasLeadingSlash = input.startsWith('/');
+	const parts: string[] = [];
+
+	for (const part of input.replaceAll('\\', '/').split('/')) {
+		if (!part || part === '.') {
+			continue;
+		}
+
+		if (part === '..') {
+			parts.pop();
+			continue;
+		}
+
+		parts.push(part);
+	}
+
+	return `${hasLeadingSlash ? '/' : ''}${parts.join('/')}`;
+};
+
+const getProjectFile = ({
+	filePath,
+	project,
+}: {
+	filePath: string;
+	project: SourceMapProject;
+}) => {
+	const normalizedInput = normalizePath(
+		filePath
+			.replace(/^webpack:\/\/\/?/, '/')
+			.replace(/^file:\/\//, '')
+			.split(/[?#]/, 1)[0],
+	);
+	const normalizedRoot = normalizePath(project.rootDir);
+	const normalizedFiles = new Map(
+		Object.keys(project.files).map((key) => [normalizePath(key), key]),
+	);
+	const candidates = [
+		normalizedInput,
+		normalizePath(`/${normalizedInput}`),
+		normalizePath(`${normalizedRoot}/${normalizedInput.replace(/^\//, '')}`),
+	];
+
+	for (const candidate of candidates) {
+		const match = normalizedFiles.get(candidate);
+		if (match) {
+			return match;
+		}
+	}
+
+	const suffix = `/${normalizedInput.replace(/^\//, '')}`;
+	const suffixMatches = [...normalizedFiles.entries()].filter(([key]) =>
+		key.endsWith(suffix),
+	);
+	if (suffixMatches.length === 1) {
+		return suffixMatches[0][1];
+	}
+
+	throw new Error(`Could not find source file "${filePath}"`);
+};
+
+const resolveImport = ({
+	fromFile,
+	importPath,
+	project,
+}: {
+	fromFile: string;
+	importPath: string;
+	project: SourceMapProject;
+}) => {
+	if (!importPath.startsWith('.')) {
+		throw new Error(`Cannot resolve package import "${importPath}"`);
+	}
+
+	const normalizedFrom = normalizePath(fromFile);
+	const lastSlash = normalizedFrom.lastIndexOf('/');
+	const directory = lastSlash === -1 ? '' : normalizedFrom.slice(0, lastSlash);
+	const basePath = normalizePath(`${directory}/${importPath}`);
+	const candidates = [
+		basePath,
+		...['.tsx', '.ts', '.jsx', '.js'].map(
+			(extension) => `${basePath}${extension}`,
+		),
+		...['.tsx', '.ts', '.jsx', '.js'].map(
+			(extension) => `${basePath}/index${extension}`,
+		),
+	];
+	const normalizedFiles = new Map(
+		Object.keys(project.files).map((key) => [normalizePath(key), key]),
+	);
+
+	for (const candidate of candidates) {
+		const match = normalizedFiles.get(candidate);
+		if (match) {
+			return match;
+		}
+	}
+
+	throw new Error(`Could not find imported component file "${importPath}"`);
+};
+
+const jsxName = (name: JSXOpeningElement['name']): string | null => {
+	if (name.type === 'JSXIdentifier') {
+		return name.name;
+	}
+
+	if (name.type === 'JSXMemberExpression') {
+		const object = jsxName(name.object);
+		const property = jsxName(name.property);
+		return object && property ? `${object}.${property}` : null;
+	}
+
+	return null;
+};
+
+const getAttribute = (element: JSXOpeningElement, name: string) => {
+	return (
+		element.attributes.find(
+			(attribute): attribute is JSXAttribute =>
+				attribute.type === 'JSXAttribute' &&
+				attribute.name.type === 'JSXIdentifier' &&
+				attribute.name.name === name,
+		) ?? null
+	);
+};
+
+const getStringAttribute = (attribute: JSXAttribute | null) => {
+	if (attribute?.value?.type === 'StringLiteral') {
+		return attribute.value.value;
+	}
+
+	if (
+		attribute?.value?.type === 'JSXExpressionContainer' &&
+		attribute.value.expression.type === 'StringLiteral'
+	) {
+		return attribute.value.expression.value;
+	}
+
+	return null;
+};
+
+const getIdentifierAttribute = (attribute: JSXAttribute | null) => {
+	return attribute?.value?.type === 'JSXExpressionContainer' &&
+		attribute.value.expression.type === 'Identifier'
+		? attribute.value.expression.name
+		: null;
+};
+
+const findComposition = (file: File, compositionId: string) => {
+	let result: JSXOpeningElement | null = null;
+	visit(file, (node) => {
+		if (node.type !== 'JSXOpeningElement') {
+			return false;
+		}
+
+		const name = jsxName(node.name);
+		if (
+			name !== 'Composition' &&
+			name !== 'Still' &&
+			!name?.endsWith('.Composition') &&
+			!name?.endsWith('.Still')
+		) {
+			return false;
+		}
+
+		if (getStringAttribute(getAttribute(node, 'id')) === compositionId) {
+			result = node;
+			return true;
+		}
+
+		return false;
+	});
+
+	return result;
+};
+
+const findLazyImport = (attribute: JSXAttribute | null) => {
+	let importPath: string | null = null;
+	visit(attribute, (node) => {
+		if (
+			node.type === 'ImportExpression' &&
+			node.source.type === 'StringLiteral'
+		) {
+			importPath = node.source.value;
+			return true;
+		}
+
+		if (
+			node.type === 'CallExpression' &&
+			node.callee.type === 'Import' &&
+			node.arguments[0]?.type === 'StringLiteral'
+		) {
+			importPath = node.arguments[0].value;
+			return true;
+		}
+
+		return false;
+	});
+
+	return importPath;
+};
+
+const getDeclaration = (
+	statement: Statement,
+	name: string | 'default',
+): Node | null => {
+	if (name === 'default' && statement.type === 'ExportDefaultDeclaration') {
+		return statement.declaration.type === 'Identifier'
+			? null
+			: statement.declaration;
+	}
+
+	const declaration =
+		statement.type === 'ExportNamedDeclaration'
+			? statement.declaration
+			: statement;
+	if (!declaration) {
+		return null;
+	}
+
+	if (
+		(declaration.type === 'FunctionDeclaration' ||
+			declaration.type === 'ClassDeclaration') &&
+		declaration.id?.name === name
+	) {
+		return declaration;
+	}
+
+	if (declaration.type === 'VariableDeclaration') {
+		return (
+			declaration.declarations.find(
+				(item) => item.id.type === 'Identifier' && item.id.name === name,
+			) ?? null
+		);
+	}
+
+	return null;
+};
+
+const getExportedName = (name: Identifier | StringLiteral) => {
+	return name.type === 'Identifier' ? name.name : name.value;
+};
+
+const resolveDeclaration = ({
+	filePath,
+	exportName,
+	project,
+	visited,
+}: {
+	filePath: string;
+	exportName: string | 'default';
+	project: SourceMapProject;
+	visited: Set<string>;
+}): {declaration: Node; filePath: string} => {
+	const key = `${filePath}:${exportName}`;
+	if (visited.has(key)) {
+		throw new Error(
+			`Circular component export while resolving "${exportName}"`,
+		);
+	}
+
+	visited.add(key);
+	const source = project.files[filePath];
+	if (typeof source !== 'string') {
+		throw new Error(`Could not read source file "${filePath}"`);
+	}
+
+	const file = parseSource(source);
+	if (exportName === 'default') {
+		const defaultExport = file.program.body.find(
+			(statement) => statement.type === 'ExportDefaultDeclaration',
+		);
+		if (
+			defaultExport?.type === 'ExportDefaultDeclaration' &&
+			defaultExport.declaration.type === 'Identifier'
+		) {
+			return resolveDeclaration({
+				filePath,
+				exportName: defaultExport.declaration.name,
+				project,
+				visited,
+			});
+		}
+	}
+
+	for (const statement of file.program.body) {
+		const declaration = getDeclaration(statement, exportName);
+		if (declaration) {
+			return {declaration, filePath};
+		}
+	}
+
+	if (exportName !== 'default') {
+		for (const statement of file.program.body) {
+			if (
+				statement.type !== 'ExportNamedDeclaration' ||
+				statement.source?.type !== 'StringLiteral'
+			) {
+				continue;
+			}
+
+			for (const specifier of statement.specifiers) {
+				if (
+					specifier.type !== 'ExportSpecifier' ||
+					getExportedName(specifier.exported) !== exportName
+				) {
+					continue;
+				}
+
+				return resolveDeclaration({
+					filePath: resolveImport({
+						fromFile: filePath,
+						importPath: statement.source.value,
+						project,
+					}),
+					exportName: getExportedName(specifier.local),
+					project,
+					visited,
+				});
+			}
+		}
+	}
+
+	throw new Error(`Could not find composition component "${exportName}"`);
+};
+
+const findImportedComponent = (file: File, localName: string) => {
+	for (const statement of file.program.body) {
+		if (statement.type !== 'ImportDeclaration') {
+			continue;
+		}
+
+		for (const specifier of statement.specifiers) {
+			if (specifier.local.name !== localName) {
+				continue;
+			}
+
+			if (specifier.type === 'ImportDefaultSpecifier') {
+				return {exportName: 'default' as const, path: statement.source.value};
+			}
+
+			if (specifier.type === 'ImportSpecifier') {
+				return {
+					exportName: getExportedName(specifier.imported),
+					path: statement.source.value,
+				};
+			}
+		}
+	}
+
+	return null;
+};
+
+export const resolveCompositionComponentLocation = ({
+	compositionFile,
+	compositionId,
+	project,
+}: {
+	compositionFile: string;
+	compositionId: string;
+	project: SourceMapProject;
+}) => {
+	const registrationFile = getProjectFile({
+		filePath: compositionFile,
+		project,
+	});
+	const registrationSource = project.files[registrationFile];
+	if (typeof registrationSource !== 'string') {
+		throw new Error(`Could not read source file "${registrationFile}"`);
+	}
+
+	const registration = parseSource(registrationSource);
+	const composition = findComposition(registration, compositionId);
+	if (!composition) {
+		throw new Error(`Could not find composition "${compositionId}"`);
+	}
+
+	const lazyImport = findLazyImport(getAttribute(composition, 'lazyComponent'));
+	let componentFile = registrationFile;
+	let exportName: string | 'default' = 'default';
+	if (lazyImport) {
+		componentFile = resolveImport({
+			fromFile: registrationFile,
+			importPath: lazyImport,
+			project,
+		});
+	} else {
+		const componentName = getIdentifierAttribute(
+			getAttribute(composition, 'component'),
+		);
+		if (!componentName) {
+			throw new Error(
+				`Could not find a component prop for composition "${compositionId}"`,
+			);
+		}
+
+		const imported = findImportedComponent(registration, componentName);
+		if (imported) {
+			componentFile = resolveImport({
+				fromFile: registrationFile,
+				importPath: imported.path,
+				project,
+			});
+			exportName = imported.exportName;
+		} else {
+			exportName = componentName;
+		}
+	}
+
+	const {declaration, filePath} = resolveDeclaration({
+		filePath: componentFile,
+		exportName,
+		project,
+		visited: new Set(),
+	});
+	const normalizedFile = normalizePath(filePath);
+	const normalizedRoot = normalizePath(project.rootDir).replace(/\/$/, '');
+	const source = normalizedFile.startsWith(`${normalizedRoot}/`)
+		? normalizedFile.slice(normalizedRoot.length + 1)
+		: normalizedFile.replace(/^\//, '');
+
+	return {
+		source,
+		line: declaration.loc?.start.line ?? 1,
+		column: declaration.loc?.start.column ?? 0,
+	};
+};

--- a/packages/studio-codemods/src/test/resolve-composition-component-location.test.ts
+++ b/packages/studio-codemods/src/test/resolve-composition-component-location.test.ts
@@ -1,0 +1,41 @@
+import {expect, test} from 'bun:test';
+import {resolveCompositionComponentLocation} from '../resolve-composition-component-location';
+
+test('resolves a composition component from source map contents', () => {
+	const location = resolveCompositionComponentLocation({
+		compositionFile: './src/Root.tsx',
+		compositionId: 'WidthHeight',
+		project: {
+			rootDir: '.',
+			files: {
+				'./src/Root.tsx': [
+					"import {Composition} from 'remotion';",
+					"import {WidthHeightSequences} from './Sequence/WidthHeightSequences';",
+					'export const Root = () => (',
+					'  <Composition',
+					'    id="WidthHeight"',
+					'    component={WidthHeightSequences}',
+					'    durationInFrames={120}',
+					'    fps={30}',
+					'    width={1080}',
+					'    height={1080}',
+					'  />',
+					');',
+				].join('\n'),
+				'./src/Sequence/WidthHeightSequences.tsx': [
+					"import {Sequence} from 'remotion';",
+					'',
+					'export const WidthHeightSequences = () => {',
+					'  return <Sequence />;',
+					'};',
+				].join('\n'),
+			},
+		},
+	});
+
+	expect(location).toEqual({
+		column: 13,
+		line: 3,
+		source: 'src/Sequence/WidthHeightSequences.tsx',
+	});
+});

--- a/packages/studio-codemods/src/test/resolve-composition-component-location.test.ts
+++ b/packages/studio-codemods/src/test/resolve-composition-component-location.test.ts
@@ -1,36 +1,40 @@
 import {expect, test} from 'bun:test';
-import {resolveCompositionComponentLocation} from '../resolve-composition-component-location';
+import {
+	resolveCompositionComponentInProject,
+	resolveCompositionComponentLocation,
+} from '../resolve-composition-component-location';
 
 test('resolves a composition component from source map contents', () => {
+	const project = {
+		rootDir: '.',
+		files: {
+			'./src/Root.tsx': [
+				"import {Composition} from 'remotion';",
+				"import {WidthHeightSequences} from './Sequence/WidthHeightSequences';",
+				'export const Root = () => (',
+				'  <Composition',
+				'    id="WidthHeight"',
+				'    component={WidthHeightSequences}',
+				'    durationInFrames={120}',
+				'    fps={30}',
+				'    width={1080}',
+				'    height={1080}',
+				'  />',
+				');',
+			].join('\n'),
+			'./src/Sequence/WidthHeightSequences.tsx': [
+				"import {Sequence} from 'remotion';",
+				'',
+				'export const WidthHeightSequences = () => {',
+				'  return <Sequence />;',
+				'};',
+			].join('\n'),
+		},
+	};
 	const location = resolveCompositionComponentLocation({
 		compositionFile: './src/Root.tsx',
 		compositionId: 'WidthHeight',
-		project: {
-			rootDir: '.',
-			files: {
-				'./src/Root.tsx': [
-					"import {Composition} from 'remotion';",
-					"import {WidthHeightSequences} from './Sequence/WidthHeightSequences';",
-					'export const Root = () => (',
-					'  <Composition',
-					'    id="WidthHeight"',
-					'    component={WidthHeightSequences}',
-					'    durationInFrames={120}',
-					'    fps={30}',
-					'    width={1080}',
-					'    height={1080}',
-					'  />',
-					');',
-				].join('\n'),
-				'./src/Sequence/WidthHeightSequences.tsx': [
-					"import {Sequence} from 'remotion';",
-					'',
-					'export const WidthHeightSequences = () => {',
-					'  return <Sequence />;',
-					'};',
-				].join('\n'),
-			},
-		},
+		project,
 	});
 
 	expect(location).toEqual({
@@ -38,4 +42,49 @@ test('resolves a composition component from source map contents', () => {
 		line: 3,
 		source: 'src/Sequence/WidthHeightSequences.tsx',
 	});
+
+	const resolved = resolveCompositionComponentInProject({
+		compositionFile: './src/Root.tsx',
+		compositionId: 'WidthHeight',
+		project,
+	});
+	expect({
+		canAddSequence: resolved.canAddSequence,
+		exportName: resolved.exportName,
+		filePath: resolved.filePath,
+		location: resolved.location,
+		source: resolved.source,
+	}).toEqual({
+		canAddSequence: true,
+		exportName: 'WidthHeightSequences',
+		filePath: './src/Sequence/WidthHeightSequences.tsx',
+		location,
+		source: project.files['./src/Sequence/WidthHeightSequences.tsx'],
+	});
+});
+
+test('preserves default exports when resolving a named declaration', () => {
+	const project = {
+		rootDir: '.',
+		files: {
+			'./src/Root.tsx': [
+				"import {Composition} from 'remotion';",
+				"import Video from './Video';",
+				'export const Root = () => <Composition id="Video" component={Video} />;',
+			].join('\n'),
+			'./src/Video.tsx': [
+				'const Video = () => <div />;',
+				'export default Video;',
+			].join('\n'),
+		},
+	};
+	const resolved = resolveCompositionComponentInProject({
+		compositionFile: './src/Root.tsx',
+		compositionId: 'Video',
+		project,
+	});
+
+	expect(resolved.exportName).toBe('default');
+	expect(resolved.filePath).toBe('./src/Video.tsx');
+	expect(resolved.canAddSequence).toBe(true);
 });

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -27,6 +27,7 @@
 		"@tanstack/react-virtual": "3.14.9",
 		"@remotion/canvas": "workspace:*",
 		"@remotion/studio-protocol": "workspace:*",
+		"@remotion/studio-codemods": "workspace:*",
 		"semver": "7.5.3",
 		"remotion": "workspace:*",
 		"@remotion/captions": "workspace:*",

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -6,6 +6,10 @@ import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {LIGHT_TEXT} from '../helpers/colors';
 import {
+	hasReadOnlyGitSource,
+	openGitSource,
+} from '../helpers/get-git-menu-item';
+import {
 	openInCodingAgent,
 	openInGitClient,
 	openInTerminal,
@@ -13,6 +17,7 @@ import {
 } from '../helpers/open-in-editor';
 import {CaretDown} from '../icons/caret';
 import {EditorIcon} from '../icons/editor';
+import {GitHubIcon} from '../icons/github';
 import {SetSelectedModalContext} from '../state/modals';
 import {getOpenInMenuItems} from './get-open-in-menu-items';
 import type {ComboboxValue} from './NewComposition/ComboBox';
@@ -54,6 +59,8 @@ export const InspectorOpenInEditor: React.FC<{
 		editorInfo,
 	} = useEditorOpening(previewServerState.type === 'connected');
 	const codingAgentInfo = useDefaultCodingAgentInfo(canConfigureApps);
+	const canOpenInGitHub = hasReadOnlyGitSource();
+	const defaultActionIsGitHub = !canOpenInEditor && canOpenInGitHub;
 
 	const openWithEditor = useCallback(
 		async (editorId: EditorPickerId) => {
@@ -86,25 +93,37 @@ export const InspectorOpenInEditor: React.FC<{
 		},
 		[contextForAgents],
 	);
-	const editorName = defaultEditorName ?? 'default editor';
-	const canOpenDefault = location !== null && canOpenInEditor;
+	const defaultAppName = defaultActionIsGitHub
+		? 'GitHub'
+		: (defaultEditorName ?? 'default editor');
+	const canOpenDefault =
+		location !== null && (canOpenInEditor || canOpenInGitHub);
 	const onOpenDefault: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(event) => {
 			event.stopPropagation();
-			if (defaultEditorId) {
+			if (defaultActionIsGitHub) {
+				openGitSource({folder: locationType === 'folder', location});
+			} else if (defaultEditorId) {
 				openWithEditor(defaultEditorId).catch(() => undefined);
 			}
 		},
-		[defaultEditorId, openWithEditor],
+		[
+			defaultActionIsGitHub,
+			defaultEditorId,
+			location,
+			locationType,
+			openWithEditor,
+		],
 	);
 	const menuItems = useMemo((): ComboboxValue[] => {
-		return getOpenInMenuItems({
+		const items = getOpenInMenuItems({
 			codingAgentInfo,
-			editorDisabled: location === null,
+			editorDisabled: location === null || !canOpenInEditor,
 			editorInfo,
 			excludeCodingAgentId: null,
 			excludeEditorId: defaultEditorId,
-			fileManagerDisabled: !location?.source,
+			fileManagerDisabled:
+				!location?.source || previewServerState.type !== 'connected',
 			folder: locationType === 'folder',
 			location,
 			onConfigureApps: canConfigureApps
@@ -167,21 +186,28 @@ export const InspectorOpenInEditor: React.FC<{
 					});
 			},
 		});
+
+		return defaultActionIsGitHub
+			? items.filter((item) => item.id !== 'open-in-github')
+			: items;
 	}, [
 		codingAgentInfo,
 		canConfigureApps,
+		canOpenInEditor,
+		defaultActionIsGitHub,
 		defaultEditorId,
 		editorInfo,
 		location,
 		locationType,
 		openWithCodingAgent,
 		openWithEditor,
+		previewServerState.type,
 		setSelectedModal,
 	]);
 	const segments = useMemo((): SegmentedButtonSegment[] => {
-		return [
+		const result: SegmentedButtonSegment[] = [
 			{
-				ariaLabel: `Open in ${editorName}`,
+				ariaLabel: `Open in ${defaultAppName}`,
 				buttonId: null,
 				disabled: !canOpenDefault,
 				idleColor: LIGHT_TEXT,
@@ -190,18 +216,25 @@ export const InspectorOpenInEditor: React.FC<{
 				renderContent: () => (
 					<>
 						{label}
-						<EditorIcon
-							editorId={defaultEditorId}
-							size={editorButtonIconSize}
-						/>
+						{defaultActionIsGitHub ? (
+							<GitHubIcon size={editorButtonIconSize} />
+						) : (
+							<EditorIcon
+								editorId={defaultEditorId}
+								size={editorButtonIconSize}
+							/>
+						)}
 					</>
 				),
 				segmentId: 'default-editor',
 				style: mainSegmentStyle,
-				title: `Open in ${editorName}`,
+				title: `Open in ${defaultAppName}`,
 				type: 'action',
 			},
-			{
+		];
+
+		if (menuItems.length > 0) {
+			result.push({
 				ariaLabel: 'Open in another app',
 				buttonId: null,
 				disabled: false,
@@ -215,21 +248,25 @@ export const InspectorOpenInEditor: React.FC<{
 				title: 'Open in another app',
 				type: 'menu',
 				values: menuItems,
-			},
-		];
+			});
+		}
+
+		return result;
 	}, [
 		canOpenDefault,
+		defaultActionIsGitHub,
+		defaultAppName,
 		defaultEditorId,
-		editorName,
 		label,
 		menuItems,
 		onOpenDefault,
 	]);
 
-	if (
-		previewServerState.type !== 'connected' ||
-		getBrowserStudioOperations() !== null
-	) {
+	if (getBrowserStudioOperations() !== null) {
+		return null;
+	}
+
+	if (previewServerState.type !== 'connected' && !canOpenInGitHub) {
 		return null;
 	}
 

--- a/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspectorHeader.tsx
@@ -8,6 +8,10 @@ import {
 import {Internals} from 'remotion';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {
+	hasReadOnlyGitSource,
+	openGitSource,
+} from '../../helpers/get-git-menu-item';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {
 	openOriginalPositionInEditor,
@@ -50,6 +54,7 @@ export const CompositionInspectorHeader = () => {
 	const {canOpenInEditor, defaultEditorId} = useEditorOpening(
 		previewServerState.type === 'connected',
 	);
+	const canOpenInGitHub = hasReadOnlyGitSource();
 
 	const currentComposition = useMemo(() => {
 		if (!video) {
@@ -97,28 +102,31 @@ export const CompositionInspectorHeader = () => {
 		});
 	}, [compositionFile, compositionId]);
 
+	const openSourceLocation = useCallback(
+		(location: OriginalPosition) => {
+			if (canOpenInEditor && defaultEditorId) {
+				openOriginalPositionInEditor(location, defaultEditorId).catch((err) => {
+					showNotification((err as Error).message, 2000);
+				});
+				return;
+			}
+
+			if (canOpenInGitHub) {
+				openGitSource({folder: false, location});
+			}
+		},
+		[canOpenInEditor, canOpenInGitHub, defaultEditorId],
+	);
 	const openFileLocation = useCallback(() => {
-		if (!validatedLocation || !defaultEditorId || !canOpenInEditor) {
-			return;
+		if (validatedLocation) {
+			openSourceLocation(validatedLocation);
 		}
-
-		openOriginalPositionInEditor(validatedLocation, defaultEditorId).catch(
-			(err) => {
-				showNotification((err as Error).message, 2000);
-			},
-		);
-	}, [canOpenInEditor, defaultEditorId, validatedLocation]);
+	}, [openSourceLocation, validatedLocation]);
 	const openComponentLocation = useCallback(() => {
-		if (!componentLocation || !defaultEditorId || !canOpenInEditor) {
-			return;
+		if (componentLocation) {
+			openSourceLocation(componentLocation);
 		}
-
-		openOriginalPositionInEditor(componentLocation, defaultEditorId).catch(
-			(err) => {
-				showNotification((err as Error).message, 2000);
-			},
-		);
-	}, [canOpenInEditor, componentLocation, defaultEditorId]);
+	}, [componentLocation, openSourceLocation]);
 	const renderCompositionIcon = useCallback(
 		(color: string) => {
 			if (!video) {
@@ -153,7 +161,9 @@ export const CompositionInspectorHeader = () => {
 					/>
 					<InspectorSourceLocation
 						location={validatedLocation}
-						canOpen={validatedLocation !== null && canOpenInEditor}
+						canOpen={
+							validatedLocation !== null && (canOpenInEditor || canOpenInGitHub)
+						}
 						onOpen={openFileLocation}
 						renderIcon={renderCompositionIcon}
 						size="quick-action"
@@ -165,7 +175,10 @@ export const CompositionInspectorHeader = () => {
 					) : (
 						<InspectorSourceLocation
 							location={componentLocation}
-							canOpen={componentLocation !== null && canOpenInEditor}
+							canOpen={
+								componentLocation !== null &&
+								(canOpenInEditor || canOpenInGitHub)
+							}
 							onOpen={openComponentLocation}
 							renderIcon={renderReactIcon}
 							size="quick-action"

--- a/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceInspectorHeader.tsx
@@ -2,6 +2,10 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import type {CodePosition} from '../../error-overlay/react-overlay/utils/get-source-map';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {CURRENT_COLOR} from '../../helpers/colors';
+import {
+	hasReadOnlyGitSource,
+	openGitSource,
+} from '../../helpers/get-git-menu-item';
 import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
 import {ReactIcon} from '../../icons/react';
 import {InlineEditableTitle} from '../InlineEditableTitle';
@@ -54,7 +58,7 @@ const externalTabIndicatorStyle: React.CSSProperties = {
 };
 
 type SequenceInspectorSourceLocation = {
-	readonly canOpenInEditor: boolean;
+	readonly canOpen: boolean;
 	readonly openFileLocation: () => void;
 	readonly validatedLocation: CodePosition | null;
 };
@@ -64,6 +68,7 @@ export const useSequenceInspectorSourceLocation = (
 ): SequenceInspectorSourceLocation => {
 	const {canOpenInEditor, openInEditor, originalLocation} =
 		useOpenSequenceInApps(sequence);
+	const canOpenInGitHub = hasReadOnlyGitSource();
 
 	const validatedLocation = useMemo(() => {
 		if (
@@ -82,15 +87,18 @@ export const useSequenceInspectorSourceLocation = (
 	}, [originalLocation]);
 
 	const openFileLocation = useCallback(() => {
-		if (!canOpenInEditor) {
+		if (canOpenInEditor) {
+			openInEditor(null);
 			return;
 		}
 
-		openInEditor(null);
-	}, [canOpenInEditor, openInEditor]);
+		if (canOpenInGitHub && validatedLocation) {
+			openGitSource({folder: false, location: validatedLocation});
+		}
+	}, [canOpenInEditor, canOpenInGitHub, openInEditor, validatedLocation]);
 
 	return {
-		canOpenInEditor,
+		canOpen: validatedLocation !== null && (canOpenInEditor || canOpenInGitHub),
 		openFileLocation,
 		validatedLocation,
 	};
@@ -178,7 +186,7 @@ export const SequenceInspectorHeader: React.FC<{
 				)}
 				<InspectorSourceLocation
 					location={sourceLocation.validatedLocation}
-					canOpen={sourceLocation.canOpenInEditor}
+					canOpen={sourceLocation.canOpen}
 					onOpen={sourceLocation.openFileLocation}
 					renderIcon={renderReactIcon}
 					size="quick-action"

--- a/packages/studio/src/components/Timeline/TimelineStack/get-stack.ts
+++ b/packages/studio/src/components/Timeline/TimelineStack/get-stack.ts
@@ -7,12 +7,14 @@ import {
 
 const traceMapCache: Partial<Record<string, TraceMap>> = {};
 const traceMapPromises: Partial<Record<string, Promise<TraceMap>>> = {};
+const traceMapsByOriginalSource = new Map<string, TraceMap>();
+const sourceMapFilesCache = new WeakMap<TraceMap, Record<string, string>>();
 const browserStudioOriginalSourcePrefix = 'browser-studio-original://';
 const studioOriginalSourcePrefix = 'studio-original://';
 
-const getSourceMapCache = async (fileName: string) => {
+const getSourceMapCache = (fileName: string): Promise<TraceMap> => {
 	if (traceMapCache[fileName]) {
-		return traceMapCache[fileName];
+		return Promise.resolve(traceMapCache[fileName]);
 	}
 
 	if (traceMapPromises[fileName]) {
@@ -24,6 +26,14 @@ const getSourceMapCache = async (fileName: string) => {
 		.then((json) => {
 			const map = new TraceMap(json as SourceMapInput);
 			traceMapCache[fileName] = map;
+			for (let index = 0; index < map.sources.length; index++) {
+				const source = map.sources[index];
+				const content = map.sourcesContent?.[index];
+				if (source !== null && typeof content === 'string') {
+					traceMapsByOriginalSource.set(source, map);
+				}
+			}
+
 			return map;
 		})
 		.finally(() => {
@@ -31,6 +41,32 @@ const getSourceMapCache = async (fileName: string) => {
 		});
 
 	return traceMapPromises[fileName];
+};
+
+export const getSourceMapFilesForSource = (
+	source: string,
+): Record<string, string> | null => {
+	const map = traceMapsByOriginalSource.get(source);
+	if (!map) {
+		return null;
+	}
+
+	const cached = sourceMapFilesCache.get(map);
+	if (cached) {
+		return cached;
+	}
+
+	const files: Record<string, string> = {};
+	for (let index = 0; index < map.sources.length; index++) {
+		const fileName = map.sources[index];
+		const content = map.sourcesContent?.[index];
+		if (fileName !== null && typeof content === 'string') {
+			files[fileName] = content;
+		}
+	}
+
+	sourceMapFilesCache.set(map, files);
+	return files;
 };
 
 export const getOriginalLocationFromStack = async (

--- a/packages/studio/src/components/get-open-in-menu-items.tsx
+++ b/packages/studio/src/components/get-open-in-menu-items.tsx
@@ -9,10 +9,7 @@ import React from 'react';
 import {NoReactInternals} from 'remotion/no-react';
 import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
 import {getFileManagerName} from '../helpers/get-file-manager-name';
-import {
-	getGitRefUrl,
-	getGitSourceBranchUrl,
-} from '../helpers/get-git-menu-item';
+import {openGitSource} from '../helpers/get-git-menu-item';
 import {EditorIcon} from '../icons/editor';
 import {FinderIcon} from '../icons/finder';
 import {GitClientIcon} from '../icons/git-client';
@@ -109,17 +106,7 @@ export const getOpenInMenuItems = ({
 				label: <span style={menuLabel}>GitHub.com</span>,
 				leftItem: <GitHubIcon size={18} />,
 				onClick: () => {
-					const gitSource = window.remotion_gitSource;
-					if (!gitSource) {
-						return;
-					}
-
-					window.open(
-						folder || !location
-							? getGitSourceBranchUrl(gitSource)
-							: getGitRefUrl(gitSource, location, window.remotion_cwd),
-						'_blank',
-					);
+					openGitSource({folder, location});
 				},
 				quickSwitcherLabel: null,
 				subMenu: null,

--- a/packages/studio/src/helpers/get-git-menu-item.ts
+++ b/packages/studio/src/helpers/get-git-menu-item.ts
@@ -72,6 +72,30 @@ export const getGitRefUrl = (
 	throw new Error('Unknown git source type');
 };
 
+export const hasReadOnlyGitSource = () => {
+	return Boolean(window.remotion_isReadOnlyStudio && window.remotion_gitSource);
+};
+
+export const openGitSource = ({
+	folder,
+	location,
+}: {
+	folder: boolean;
+	location: OriginalPosition | null;
+}) => {
+	const gitSource = window.remotion_gitSource;
+	if (!gitSource) {
+		return;
+	}
+
+	window.open(
+		folder || !location
+			? getGitSourceBranchUrl(gitSource)
+			: getGitRefUrl(gitSource, location, window.remotion_cwd),
+		'_blank',
+	);
+};
+
 export const getGitMenuItem = (): ComboboxValue | null => {
 	if (!window.remotion_gitSource) {
 		return null;

--- a/packages/studio/src/helpers/open-in-editor.ts
+++ b/packages/studio/src/helpers/open-in-editor.ts
@@ -8,6 +8,7 @@ import type {
 } from '@remotion/studio-shared';
 import {useEffect, useSyncExternalStore} from 'react';
 import {callApi} from '../components/call-api';
+import {getSourceMapFilesForSource} from '../components/Timeline/TimelineStack/get-stack';
 import type {
 	CodePosition,
 	OriginalPosition,
@@ -222,7 +223,27 @@ export const loadCompositionComponentInfo = async ({
 		const browserStudioOperations = getBrowserStudioOperations();
 		const body = browserStudioOperations
 			? await browserStudioOperations.getCompositionComponentInfo(request)
-			: await callApi('/api/composition-component-info', request);
+			: typeof window !== 'undefined' && window.remotion_isReadOnlyStudio
+				? await (async () => {
+						const files = getSourceMapFilesForSource(compositionFile);
+						if (files === null) {
+							throw new Error(
+								`Could not find source map contents for ${compositionFile}`,
+							);
+						}
+
+						const {resolveCompositionComponentLocation} =
+							await import('@remotion/studio-codemods/resolve-composition-component-location');
+						return {
+							canAddSequence: false,
+							location: resolveCompositionComponentLocation({
+								compositionFile,
+								compositionId,
+								project: {files, rootDir: '.'},
+							}),
+						};
+					})()
+				: await callApi('/api/composition-component-info', request);
 
 		const result = {
 			location: body.location,

--- a/packages/studio/src/renderEntry.tsx
+++ b/packages/studio/src/renderEntry.tsx
@@ -308,6 +308,7 @@ const renderContent = (Root: React.FC) => {
 				window.remotion_isStudio = true;
 				window.remotion_isReadOnlyStudio = true;
 				window.remotion_inputProps = '{}';
+				window.remotion_enableSequenceStackTraces?.();
 
 				renderToDOM(<StudioInternals.Studio readOnly rootComponent={Root} />);
 			})

--- a/packages/studio/src/test/git-source-open.test.ts
+++ b/packages/studio/src/test/git-source-open.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, expect, test} from 'bun:test';
+import type {GitSource} from '@remotion/studio-shared';
+import {
+	hasReadOnlyGitSource,
+	openGitSource,
+} from '../helpers/get-git-menu-item';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+	globalThis,
+	'window',
+);
+
+afterEach(() => {
+	if (originalWindowDescriptor) {
+		Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+	} else {
+		Reflect.deleteProperty(globalThis, 'window');
+	}
+});
+
+const gitSource: GitSource = {
+	name: 'remotion',
+	org: 'remotion-dev',
+	ref: 'feature/branch',
+	relativeFromGitRoot: 'packages/docs',
+	type: 'github',
+};
+
+const installTestWindow = ({
+	git,
+	readOnly,
+}: {
+	git: GitSource | null;
+	readOnly: boolean;
+}) => {
+	const openedUrls: string[] = [];
+	const testWindow: Pick<
+		Window,
+		'open' | 'remotion_cwd' | 'remotion_gitSource' | 'remotion_isReadOnlyStudio'
+	> = {
+		open: (url) => {
+			openedUrls.push(String(url));
+			return null;
+		},
+		remotion_cwd: '/repo/packages/docs',
+		remotion_gitSource: git,
+		remotion_isReadOnlyStudio: readOnly,
+	};
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: testWindow,
+	});
+
+	return openedUrls;
+};
+
+test('uses GitHub as an open target in a read-only Studio', () => {
+	const openedUrls = installTestWindow({git: gitSource, readOnly: true});
+
+	expect(hasReadOnlyGitSource()).toBe(true);
+	openGitSource({
+		folder: false,
+		location: {
+			column: 3,
+			line: 12,
+			source: '/repo/packages/docs/src/Video.tsx',
+		},
+	});
+
+	expect(openedUrls).toEqual([
+		'https://github.com/remotion-dev/remotion/blob/feature/branch/packages/docs/src/Video.tsx#L12',
+	]);
+});
+
+test('opens the project folder on the configured GitHub ref', () => {
+	const openedUrls = installTestWindow({git: gitSource, readOnly: true});
+
+	openGitSource({folder: true, location: null});
+
+	expect(openedUrls).toEqual([
+		'https://github.com/remotion-dev/remotion/tree/feature/branch/packages/docs',
+	]);
+});
+
+test('does not use GitHub as the fallback in an editable Studio', () => {
+	installTestWindow({git: gitSource, readOnly: false});
+	expect(hasReadOnlyGitSource()).toBe(false);
+});


### PR DESCRIPTION
## Summary

- capture source stacks for all timeline-aware Remotion components in production read-only Studio while keeping renderer pages unproxied
- resolve composition component declarations from emitted source-map contents without requiring a Studio server
- expose the browser-safe component resolver as a lazy `@remotion/studio-codemods` entry
- verify composition registration, component declaration, and selected sequence locations in a production Studio bundle

## Testing

- `bunx turbo run make --filter='@remotion/studio-codemods' --filter='@remotion/studio' --filter='@remotion/bundler'`
- `bunx turbo run lint formatting --filter='@remotion/studio-codemods' --filter='@remotion/studio' --filter='@remotion/bundler' --filter='@remotion/it-tests'`
- `bun test src/test/zero-delay-rspack-refresh-loader.test.ts src/test/setup-sequence-stack-traces.test.ts` from `packages/bundler`
- `bun test src/bundle/bundle-studio.test.ts` from `packages/it-tests`
- package test suites for Studio, Studio Codemods, and Bundler

The complete `@remotion/it-tests` rendering suite also ran; 53 tests passed and 2 unrelated output-path assertions failed in `rendering.test.ts`.