### PR TITLE
`@remotion/studio`: Add folder selection when creating compositions

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1111,10 +1111,16 @@ test.describe('visual mode', () => {
 				.getByRole('textbox', {name: 'Composition ID'})
 				.fill(compositionId);
 			await page.getByTitle('Folder').click();
-			await page
+			const schemaFolderOption = page
 				.getByRole('button', {name: 'Schema', exact: true})
-				.last()
-				.click();
+				.last();
+			const schemaFolderLabel = schemaFolderOption.getByText('Schema', {
+				exact: true,
+			});
+			await expect(schemaFolderLabel).toHaveCSS('font-size', '13px');
+			await schemaFolderOption.hover();
+			await expect(schemaFolderLabel).toHaveCSS('font-size', '13px');
+			await schemaFolderOption.click();
 			await expect(page.getByTitle('Folder')).toHaveText('Schema');
 
 			const createButton = page.getByRole('button', {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1009,6 +1009,41 @@ test.describe('visual mode', () => {
 			.toEqual(alphabeticalCompositionItems);
 		await page.getByRole('button', {name: 'More composition actions'}).click();
 		await page
+			.getByRole('button', {name: 'New composition...', exact: true})
+			.click();
+		await page.getByTitle('Folder').click();
+		const rootFolderNames = [
+			'Schema',
+			'visual-controls',
+			'lost-node-path',
+			'error-overlay',
+			'hook-order-change',
+		];
+		const getVisibleRootFolderOrder = () =>
+			page
+				.locator('[data-remotion-menu-tree-id]')
+				.last()
+				.getByRole('button')
+				.allTextContents()
+				.then((items) =>
+					items
+						.map((item) => item.trim())
+						.filter((item) => rootFolderNames.includes(item)),
+				);
+		await expect
+			.poll(getVisibleRootFolderOrder)
+			.toEqual([
+				'error-overlay',
+				'hook-order-change',
+				'lost-node-path',
+				'Schema',
+				'visual-controls',
+			]);
+		await page.keyboard.press('Escape');
+		await page.keyboard.press('Escape');
+
+		await page.getByRole('button', {name: 'More composition actions'}).click();
+		await page
 			.getByRole('button', {name: 'As registered', exact: true})
 			.click();
 		await expect
@@ -1026,6 +1061,9 @@ test.describe('visual mode', () => {
 			.getByRole('button', {name: 'New composition...', exact: true})
 			.click();
 		await expect(page.getByPlaceholder('Composition ID')).toBeVisible();
+		await page.getByTitle('Folder').click();
+		await expect.poll(getVisibleRootFolderOrder).toEqual(rootFolderNames);
+		await page.keyboard.press('Escape');
 		await page.keyboard.press('Escape');
 		await page.getByRole('button', {name: 'More composition actions'}).click();
 		await page

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -322,6 +322,7 @@ test.describe('visual mode', () => {
 			await expect(missingComposition).toBeVisible();
 			expect(await dropFile({...file, target: missingComposition})).toBe(true);
 			await expect(modalTitle).toBeVisible();
+			await expect(page.getByTitle('Folder')).toHaveText('Root');
 			await page.keyboard.press('Escape');
 
 			await page.getByText('Assets', {exact: true}).click();
@@ -1091,6 +1092,7 @@ test.describe('visual mode', () => {
 
 	test('should navigate to a newly created composition', async ({page}) => {
 		const compositionId = 'NewlyCreatedComposition';
+		const rootFile = path.join(exampleDir, 'src', 'E2eTestRoot.tsx');
 		const compositionFile = path.join(
 			exampleDir,
 			'src',
@@ -1108,6 +1110,12 @@ test.describe('visual mode', () => {
 			await page
 				.getByRole('textbox', {name: 'Composition ID'})
 				.fill(compositionId);
+			await page.getByTitle('Folder').click();
+			await page
+				.getByRole('button', {name: 'Schema', exact: true})
+				.last()
+				.click();
+			await expect(page.getByTitle('Folder')).toHaveText('Schema');
 
 			const createButton = page.getByRole('button', {
 				name: /Add to .*/,
@@ -1121,9 +1129,19 @@ test.describe('visual mode', () => {
 			await expect(page).toHaveTitle(new RegExp(compositionId), {
 				timeout: 5_000,
 			});
+			const rootContents = fs.readFileSync(rootFile, 'utf8');
+			const folderStart = rootContents.indexOf('<Folder name="Schema">');
+			const folderEnd = rootContents.indexOf('</Folder>', folderStart);
+			if (folderStart === -1 || folderEnd === -1) {
+				throw new Error('Could not find the Schema folder in the root file');
+			}
+
+			const compositionPosition = rootContents.indexOf(`id="${compositionId}"`);
+			expect(compositionPosition).toBeGreaterThan(folderStart);
+			expect(compositionPosition).toBeLessThan(folderEnd);
 		} finally {
 			const undoButton = page.getByRole('button', {name: /^Undo/});
-			if (await undoButton.isEnabled()) {
+			if ((await undoButton.count()) > 0 && (await undoButton.isEnabled())) {
 				await undoButton.click();
 				await expect.poll(() => fs.existsSync(compositionFile)).toBe(false);
 			}

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -322,7 +322,7 @@ test.describe('visual mode', () => {
 			await expect(missingComposition).toBeVisible();
 			expect(await dropFile({...file, target: missingComposition})).toBe(true);
 			await expect(modalTitle).toBeVisible();
-			await expect(page.getByTitle('Folder')).toHaveText('Root');
+			await expect(page.getByTitle('Folder')).toHaveText('None');
 			await page.keyboard.press('Escape');
 
 			await page.getByText('Assets', {exact: true}).click();

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -56,11 +56,19 @@ const folderIconStyle: React.CSSProperties = {
 
 const folderLabelStyle: React.CSSProperties = {
 	alignItems: 'center',
+	color: 'inherit',
 	display: 'flex',
+	fontFamily: 'inherit',
+	fontSize: 'inherit',
+	lineHeight: 'normal',
 	minWidth: 0,
 };
 
 const folderLabelTextStyle: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'inherit',
+	fontSize: 'inherit',
+	lineHeight: 'normal',
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -13,12 +13,14 @@ import {writeStaticFile} from '../../api/write-static-file';
 import {LIGHT_TEXT} from '../../helpers/colors';
 import {getFolderId} from '../../helpers/get-folder-id';
 import {installRequiredPackages} from '../../helpers/install-required-package';
+import {sortItemsByNonceHistory} from '../../helpers/sort-by-nonce-history';
 import {
 	getUniqueCompositionName,
 	useCreateComposition,
 } from '../../helpers/use-create-composition';
 import {Checkmark} from '../../icons/Checkmark';
 import {CollapsedFolderIcon} from '../../icons/folder';
+import {FolderContext} from '../../state/folders';
 import type {CanvasCaptureImport} from '../../state/modals';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -102,6 +104,7 @@ const NewCompositionLoaded: React.FC<{
 	readonly canvasCapture: CanvasCaptureImport | null;
 }> = ({canvasCapture, folderName, parentName, stack}) => {
 	const {compositions, folders} = useContext(Internals.CompositionManager);
+	const {compositionSortOrder} = useContext(FolderContext);
 	const [selectedFolder, setSelectedFolder] = useState(() => ({
 		folderName,
 		parentName,
@@ -115,10 +118,17 @@ const NewCompositionLoaded: React.FC<{
 		: rootFolderId;
 	const folderValues = useMemo((): ComboboxValue[] => {
 		const foldersInTreeOrder: (typeof folders)[number][] = [];
+		const sortedFolders =
+			compositionSortOrder === 'alphabetical'
+				? folders
+						.slice()
+						.sort((a, b) =>
+							a.name.localeCompare(b.name, undefined, {numeric: true}),
+						)
+				: sortItemsByNonceHistory(folders);
 		const appendFolders = (parent: string | null) => {
-			folders
+			sortedFolders
 				.filter((folder) => folder.parent === parent)
-				.sort((a, b) => a.name.localeCompare(b.name))
 				.forEach((folder) => {
 					foldersInTreeOrder.push(folder);
 					appendFolders(
@@ -187,7 +197,12 @@ const NewCompositionLoaded: React.FC<{
 				};
 			}),
 		];
-	}, [folders, selectedFolder.folderName, selectedFolderId]);
+	}, [
+		compositionSortOrder,
+		folders,
+		selectedFolder.folderName,
+		selectedFolderId,
+	]);
 	const resolvedComposition = Internals.useResolvedVideoConfig(null);
 	const initialComposition =
 		resolvedComposition?.type === 'success' ||

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -17,6 +17,7 @@ import {
 	getUniqueCompositionName,
 	useCreateComposition,
 } from '../../helpers/use-create-composition';
+import {Checkmark} from '../../icons/Checkmark';
 import {CollapsedFolderIcon} from '../../icons/folder';
 import type {CanvasCaptureImport} from '../../state/modals';
 import {Spacing} from '../layout';
@@ -48,8 +49,37 @@ const folderSelectStyle: React.CSSProperties = {
 };
 
 const folderIconStyle: React.CSSProperties = {
+	flexShrink: 0,
 	height: 16,
 	width: 16,
+};
+
+const folderLabelStyle: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	minWidth: 0,
+};
+
+const folderLabelTextStyle: React.CSSProperties = {
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
+const FolderDropdownLabel: React.FC<{
+	readonly folderPath: string | null;
+}> = ({folderPath}) => {
+	return (
+		<div style={folderLabelStyle}>
+			{folderPath === null ? (
+				<div style={folderIconStyle} />
+			) : (
+				<CollapsedFolderIcon color={LIGHT_TEXT} style={folderIconStyle} />
+			)}
+			<Spacing x={1} />
+			<span style={folderLabelTextStyle}>{folderPath ?? 'None'}</span>
+		</div>
+	);
 };
 
 const rootFolderId = 'new-composition-root-folder';
@@ -78,8 +108,8 @@ const NewCompositionLoaded: React.FC<{
 			{
 				id: rootFolderId,
 				keyHint: null,
-				label: 'None',
-				leftItem: null,
+				label: <FolderDropdownLabel folderPath={null} />,
+				leftItem: selectedFolder.folderName === null ? <Checkmark /> : null,
 				onClick: () => {
 					setSelectedFolder({
 						folderName: null,
@@ -87,7 +117,7 @@ const NewCompositionLoaded: React.FC<{
 						stack: null,
 					});
 				},
-				quickSwitcherLabel: null,
+				quickSwitcherLabel: 'None',
 				subMenu: null,
 				type: 'item',
 				value: rootFolderId,
@@ -119,10 +149,8 @@ const NewCompositionLoaded: React.FC<{
 					return {
 						id,
 						keyHint: null,
-						label: folderPath,
-						leftItem: (
-							<CollapsedFolderIcon color={LIGHT_TEXT} style={folderIconStyle} />
-						),
+						label: <FolderDropdownLabel folderPath={folderPath} />,
+						leftItem: selectedFolderId === id ? <Checkmark /> : null,
 						onClick: () => {
 							setSelectedFolder({
 								folderName: folder.name,
@@ -130,7 +158,7 @@ const NewCompositionLoaded: React.FC<{
 								stack: folder.stack,
 							});
 						},
-						quickSwitcherLabel: null,
+						quickSwitcherLabel: folderPath,
 						subMenu: null,
 						type: 'item',
 						value: id,
@@ -138,7 +166,7 @@ const NewCompositionLoaded: React.FC<{
 					};
 				}),
 		];
-	}, [folders]);
+	}, [folders, selectedFolder.folderName, selectedFolderId]);
 	const resolvedComposition = Internals.useResolvedVideoConfig(null);
 	const initialComposition =
 		resolvedComposition?.type === 'success' ||

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -3,23 +3,28 @@ import React, {
 	useCallback,
 	useContext,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
 import {getStaticFiles} from '../../api/get-static-files';
 import {writeStaticFile} from '../../api/write-static-file';
+import {getFolderId} from '../../helpers/get-folder-id';
 import {installRequiredPackages} from '../../helpers/install-required-package';
 import {
 	getUniqueCompositionName,
 	useCreateComposition,
 } from '../../helpers/use-create-composition';
+import {Checkmark} from '../../icons/Checkmark';
 import type {CanvasCaptureImport} from '../../state/modals';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
 import {label, optionRow, rightRow} from '../RenderModal/layout';
 import {CodemodFooter} from './CodemodFooter';
+import type {ComboboxValue} from './ComboBox';
+import {Combobox} from './ComboBox';
 import {DismissableModal} from './DismissableModal';
 import {getNewCompositionDefaults} from './get-new-composition-defaults';
 import {InputAndValidationContainer} from './InputAndValidationContainer';
@@ -36,9 +41,13 @@ const content: React.CSSProperties = {
 	minWidth: 500,
 };
 
-const folderPathStyle: React.CSSProperties = {
-	fontSize: 14,
+const folderSelectStyle: React.CSSProperties = {
+	boxSizing: 'border-box',
+	width: 250,
 };
+
+const rootFolderId = 'new-composition-root-folder';
+const folderSelectIdPrefix = 'new-composition-folder-';
 
 const NewCompositionLoaded: React.FC<{
 	readonly folderName: string | null;
@@ -46,7 +55,74 @@ const NewCompositionLoaded: React.FC<{
 	readonly stack: string | null;
 	readonly canvasCapture: CanvasCaptureImport | null;
 }> = ({canvasCapture, folderName, parentName, stack}) => {
-	const {compositions} = useContext(Internals.CompositionManager);
+	const {compositions, folders} = useContext(Internals.CompositionManager);
+	const [selectedFolder, setSelectedFolder] = useState(() => ({
+		folderName,
+		parentName,
+		stack,
+	}));
+	const selectedFolderId = selectedFolder.folderName
+		? `${folderSelectIdPrefix}${getFolderId({
+				folderName: selectedFolder.folderName,
+				parentName: selectedFolder.parentName,
+			})}`
+		: rootFolderId;
+	const folderValues = useMemo((): ComboboxValue[] => {
+		return [
+			{
+				id: rootFolderId,
+				keyHint: null,
+				label: 'Root',
+				leftItem: selectedFolder.folderName === null ? <Checkmark /> : null,
+				onClick: () => {
+					setSelectedFolder({
+						folderName: null,
+						parentName: null,
+						stack: null,
+					});
+				},
+				quickSwitcherLabel: null,
+				subMenu: null,
+				type: 'item',
+				value: rootFolderId,
+			},
+			...folders
+				.slice()
+				.sort((a, b) => {
+					return getFolderId({
+						folderName: a.name,
+						parentName: a.parent,
+					}).localeCompare(
+						getFolderId({folderName: b.name, parentName: b.parent}),
+					);
+				})
+				.map((folder): ComboboxValue => {
+					const folderPath = getFolderId({
+						folderName: folder.name,
+						parentName: folder.parent,
+					});
+					const id = `${folderSelectIdPrefix}${folderPath}`;
+					return {
+						id,
+						keyHint: null,
+						label: folderPath,
+						leftItem: selectedFolderId === id ? <Checkmark /> : null,
+						onClick: () => {
+							setSelectedFolder({
+								folderName: folder.name,
+								parentName: folder.parent,
+								stack: folder.stack,
+							});
+						},
+						quickSwitcherLabel: null,
+						subMenu: null,
+						type: 'item',
+						value: id,
+						disabled: folder.stack === null,
+					};
+				}),
+		];
+	}, [folders, selectedFolder.folderName, selectedFolderId]);
 	const resolvedComposition = Internals.useResolvedVideoConfig(null);
 	const initialComposition =
 		resolvedComposition?.type === 'success' ||
@@ -138,9 +214,9 @@ const NewCompositionLoaded: React.FC<{
 	} = useCreateComposition({
 		compositions,
 		durationInFrames,
-		folderName,
+		folderName: selectedFolder.folderName,
 		newId,
-		parentName,
+		parentName: selectedFolder.parentName,
 		selectedFrameRate,
 		size,
 		canvasCapture:
@@ -193,8 +269,6 @@ const NewCompositionLoaded: React.FC<{
 		e.preventDefault();
 	}, []);
 
-	const folderPath = [parentName, folderName].filter(Boolean).join('/');
-
 	return (
 		<>
 			<ModalHeader
@@ -204,14 +278,17 @@ const NewCompositionLoaded: React.FC<{
 			/>
 			<form onSubmit={onSubmit}>
 				<div style={content}>
-					{folderPath ? (
-						<div style={optionRow}>
-							<div style={label}>Folder</div>
-							<div style={rightRow}>
-								<span style={folderPathStyle}>{folderPath}</span>
-							</div>
+					<div style={optionRow}>
+						<div style={label}>Folder</div>
+						<div style={rightRow}>
+							<Combobox
+								values={folderValues}
+								selectedId={selectedFolderId}
+								style={folderSelectStyle}
+								title="Folder"
+							/>
 						</div>
-					) : null}
+					</div>
 					<div style={optionRow}>
 						<div style={label}>ID</div>
 						<div style={rightRow}>
@@ -334,7 +411,7 @@ const NewCompositionLoaded: React.FC<{
 						genericSubmitLabel="Add to root file"
 						submitLabel={({relativeRootPath}) => `Add to ${relativeRootPath}`}
 						codemod={codemod}
-						stack={stack}
+						stack={selectedFolder.stack}
 						valid={valid}
 						onSuccess={null}
 						applyCodemod={({signal, symbolicatedStack}) =>

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -78,10 +78,8 @@ const NewCompositionLoaded: React.FC<{
 			{
 				id: rootFolderId,
 				keyHint: null,
-				label: 'Root',
-				leftItem: (
-					<CollapsedFolderIcon color={LIGHT_TEXT} style={folderIconStyle} />
-				),
+				label: 'None',
+				leftItem: null,
 				onClick: () => {
 					setSelectedFolder({
 						folderName: null,
@@ -94,6 +92,14 @@ const NewCompositionLoaded: React.FC<{
 				type: 'item',
 				value: rootFolderId,
 			},
+			...(folders.length === 0
+				? []
+				: [
+						{
+							id: 'new-composition-root-folder-divider',
+							type: 'divider' as const,
+						},
+					]),
 			...folders
 				.slice()
 				.sort((a, b) => {

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -10,13 +10,14 @@ import React, {
 import {Internals} from 'remotion';
 import {getStaticFiles} from '../../api/get-static-files';
 import {writeStaticFile} from '../../api/write-static-file';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {getFolderId} from '../../helpers/get-folder-id';
 import {installRequiredPackages} from '../../helpers/install-required-package';
 import {
 	getUniqueCompositionName,
 	useCreateComposition,
 } from '../../helpers/use-create-composition';
-import {Checkmark} from '../../icons/Checkmark';
+import {CollapsedFolderIcon} from '../../icons/folder';
 import type {CanvasCaptureImport} from '../../state/modals';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -46,6 +47,11 @@ const folderSelectStyle: React.CSSProperties = {
 	width: 250,
 };
 
+const folderIconStyle: React.CSSProperties = {
+	height: 16,
+	width: 16,
+};
+
 const rootFolderId = 'new-composition-root-folder';
 const folderSelectIdPrefix = 'new-composition-folder-';
 
@@ -73,7 +79,9 @@ const NewCompositionLoaded: React.FC<{
 				id: rootFolderId,
 				keyHint: null,
 				label: 'Root',
-				leftItem: selectedFolder.folderName === null ? <Checkmark /> : null,
+				leftItem: (
+					<CollapsedFolderIcon color={LIGHT_TEXT} style={folderIconStyle} />
+				),
 				onClick: () => {
 					setSelectedFolder({
 						folderName: null,
@@ -106,7 +114,9 @@ const NewCompositionLoaded: React.FC<{
 						id,
 						keyHint: null,
 						label: folderPath,
-						leftItem: selectedFolderId === id ? <Checkmark /> : null,
+						leftItem: (
+							<CollapsedFolderIcon color={LIGHT_TEXT} style={folderIconStyle} />
+						),
 						onClick: () => {
 							setSelectedFolder({
 								folderName: folder.name,
@@ -122,7 +132,7 @@ const NewCompositionLoaded: React.FC<{
 					};
 				}),
 		];
-	}, [folders, selectedFolder.folderName, selectedFolderId]);
+	}, [folders]);
 	const resolvedComposition = Internals.useResolvedVideoConfig(null);
 	const initialComposition =
 		resolvedComposition?.type === 'success' ||

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -67,10 +67,12 @@ const folderLabelTextStyle: React.CSSProperties = {
 };
 
 const FolderDropdownLabel: React.FC<{
+	readonly indentation: number;
 	readonly folderPath: string | null;
-}> = ({folderPath}) => {
+}> = ({folderPath, indentation}) => {
 	return (
 		<div style={folderLabelStyle}>
+			<Spacing x={indentation * 1.5} />
 			{folderPath === null ? (
 				<div style={folderIconStyle} />
 			) : (
@@ -104,11 +106,26 @@ const NewCompositionLoaded: React.FC<{
 			})}`
 		: rootFolderId;
 	const folderValues = useMemo((): ComboboxValue[] => {
+		const foldersInTreeOrder: (typeof folders)[number][] = [];
+		const appendFolders = (parent: string | null) => {
+			folders
+				.filter((folder) => folder.parent === parent)
+				.sort((a, b) => a.name.localeCompare(b.name))
+				.forEach((folder) => {
+					foldersInTreeOrder.push(folder);
+					appendFolders(
+						getFolderId({folderName: folder.name, parentName: folder.parent}),
+					);
+				});
+		};
+
+		appendFolders(null);
+
 		return [
 			{
 				id: rootFolderId,
 				keyHint: null,
-				label: <FolderDropdownLabel folderPath={null} />,
+				label: <FolderDropdownLabel folderPath={null} indentation={0} />,
 				leftItem: selectedFolder.folderName === null ? <Checkmark /> : null,
 				onClick: () => {
 					setSelectedFolder({
@@ -130,41 +147,37 @@ const NewCompositionLoaded: React.FC<{
 							type: 'divider' as const,
 						},
 					]),
-			...folders
-				.slice()
-				.sort((a, b) => {
-					return getFolderId({
-						folderName: a.name,
-						parentName: a.parent,
-					}).localeCompare(
-						getFolderId({folderName: b.name, parentName: b.parent}),
-					);
-				})
-				.map((folder): ComboboxValue => {
-					const folderPath = getFolderId({
-						folderName: folder.name,
-						parentName: folder.parent,
-					});
-					const id = `${folderSelectIdPrefix}${folderPath}`;
-					return {
-						id,
-						keyHint: null,
-						label: <FolderDropdownLabel folderPath={folderPath} />,
-						leftItem: selectedFolderId === id ? <Checkmark /> : null,
-						onClick: () => {
-							setSelectedFolder({
-								folderName: folder.name,
-								parentName: folder.parent,
-								stack: folder.stack,
-							});
-						},
-						quickSwitcherLabel: folderPath,
-						subMenu: null,
-						type: 'item',
-						value: id,
-						disabled: folder.stack === null,
-					};
-				}),
+			...foldersInTreeOrder.map((folder): ComboboxValue => {
+				const folderPath = getFolderId({
+					folderName: folder.name,
+					parentName: folder.parent,
+				});
+				const indentation = folder.parent?.split('/').length ?? 0;
+				const id = `${folderSelectIdPrefix}${folderPath}`;
+				return {
+					id,
+					keyHint: null,
+					label: (
+						<FolderDropdownLabel
+							folderPath={folderPath}
+							indentation={indentation}
+						/>
+					),
+					leftItem: selectedFolderId === id ? <Checkmark /> : null,
+					onClick: () => {
+						setSelectedFolder({
+							folderName: folder.name,
+							parentName: folder.parent,
+							stack: folder.stack,
+						});
+					},
+					quickSwitcherLabel: folderPath,
+					subMenu: null,
+					type: 'item',
+					value: id,
+					disabled: folder.stack === null,
+				};
+			}),
 		];
 	}, [folders, selectedFolder.folderName, selectedFolderId]);
 	const resolvedComposition = Internals.useResolvedVideoConfig(null);


### PR DESCRIPTION
## Summary

- add a folder picker to the new composition dialog
- use the selected folder for codemod previews, creation, and navigation
- cover regular composition creation and Canvas Capture imports in Studio E2E tests

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should route Canvas Capture drops|should navigate to a newly created composition"`

Closes #10845
