### PR TITLE
`@remotion/studio`: Add license confirmation to Browser Studio project download

### DIFF
--- a/packages/studio/src/components/ConfigureLicenseModal.tsx
+++ b/packages/studio/src/components/ConfigureLicenseModal.tsx
@@ -1,7 +1,8 @@
 import type {ConfigUpdate} from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {BLUE, LIGHT_TEXT, WHITE} from '../helpers/colors';
+import {BLUE, LIGHT_TEXT} from '../helpers/colors';
 import {Spacing} from './layout';
+import {LicenseExplanation} from './LicenseExplanation';
 import {
 	fetchLicenseKeyDetails,
 	hasActiveCompanyLicense,
@@ -37,16 +38,11 @@ const description: React.CSSProperties = {
 	margin: 0,
 };
 
-const descriptionLink: React.CSSProperties = {
-	color: WHITE,
+const externalDescriptionLink: React.CSSProperties = {
+	color: BLUE,
 	fontFamily: 'sans-serif',
 	fontSize: 14,
 	lineHeight: '21px',
-};
-
-const externalDescriptionLink: React.CSSProperties = {
-	...descriptionLink,
-	color: BLUE,
 };
 
 const externalLinkIndicator: React.CSSProperties = {
@@ -55,60 +51,6 @@ const externalLinkIndicator: React.CSSProperties = {
 	marginLeft: 4,
 	verticalAlign: -2,
 	width: 12,
-};
-
-const licenseExplanation: React.CSSProperties = {
-	display: 'flex',
-	flexDirection: 'column',
-	gap: 12,
-};
-
-const licenseExplanationRow: React.CSSProperties = {
-	display: 'flex',
-	alignItems: 'center',
-	gap: 12,
-};
-
-const people: React.CSSProperties = {
-	display: 'grid',
-	gridTemplateColumns: 'repeat(4, 9px)',
-	gap: 3,
-	flexShrink: 0,
-};
-
-const person: React.CSSProperties = {
-	display: 'block',
-	height: 24,
-	overflow: 'visible',
-	width: 9,
-};
-
-const PersonIcon: React.FC<{
-	readonly handsUp: boolean;
-	readonly opacity: number;
-}> = ({handsUp, opacity}) => {
-	return (
-		<svg
-			aria-hidden="true"
-			opacity={opacity}
-			style={person}
-			viewBox="0 0 192 512"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<path
-				fill={LIGHT_TEXT}
-				d="M128 64a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zM32 64A64 64 0 1 1 160 64 64 64 0 1 1 32 64zm0 128l0 128 128 0 0-128-128 0zM0 160l192 0 0 192-32 0 0 160-32 0 0-160-64 0 0 160-32 0 0-160-32 0 0-192z"
-			/>
-			{handsUp ? (
-				<path
-					d="M10.667 192 0 -32 M181.333 192 192 -32"
-					fill="none"
-					stroke={LIGHT_TEXT}
-					strokeWidth="32"
-				/>
-			) : null}
-		</svg>
-	);
 };
 
 const freeLicenseMessage: React.CSSProperties = {
@@ -284,46 +226,7 @@ export const LicenseSettings: React.FC = () => {
 	return (
 		<div style={container}>
 			<div style={content}>
-				<div style={licenseExplanation}>
-					<div style={licenseExplanationRow}>
-						<div style={people}>
-							<PersonIcon handsUp opacity={1} />
-							<PersonIcon handsUp opacity={1} />
-							<PersonIcon handsUp opacity={1} />
-						</div>
-						<p style={description}>
-							Remotion is free to use if you are an individual or company of 3
-							or less.
-						</p>
-					</div>
-					<div style={licenseExplanationRow}>
-						<div style={people}>
-							<PersonIcon handsUp={false} opacity={1} />
-							<PersonIcon handsUp={false} opacity={1} />
-							<PersonIcon handsUp={false} opacity={1} />
-							<PersonIcon handsUp={false} opacity={1} />
-						</div>
-						<p style={description}>
-							If used in an organization with 4+ people, you need a{' '}
-							<a style={descriptionLink} href="https://remotion.pro/license">
-								Company License
-							</a>
-							.
-						</p>
-					</div>
-					<div style={licenseExplanationRow}>
-						<div style={people}>
-							<PersonIcon handsUp={false} opacity={1} />
-							<PersonIcon handsUp={false} opacity={0.3} />
-							<PersonIcon handsUp={false} opacity={0.3} />
-							<PersonIcon handsUp={false} opacity={0.3} />
-						</div>
-						<p style={description}>
-							The total headcount matters, not the amount of people using
-							Remotion.
-						</p>
-					</div>
-				</div>
+				<LicenseExplanation />
 				<Spacing y={2} />
 				<div aria-label="License type" role="radiogroup">
 					<RadioButton

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -8,6 +8,7 @@ import React, {
 import type {_InternalTypes} from 'remotion';
 import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {downloadBlob} from '../../helpers/download-blob';
 import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
 import {CloudDownloadIcon} from '../../icons/cloud-download';
@@ -63,8 +64,19 @@ const actionIconStyle: React.CSSProperties = {
 };
 
 const downloadLicenseAgreement: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: 1.5,
 	marginBottom: 0,
 	marginTop: 20,
+};
+
+const downloadLicenseLink: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: '21px',
 };
 
 const CompositionActions: React.FC = () => {
@@ -93,7 +105,16 @@ const CompositionActions: React.FC = () => {
 				<>
 					<LicenseExplanation />
 					<p style={downloadLicenseAgreement}>
-						By downloading this project, you agree to comply with the license.
+						By downloading this project, you agree to comply with the{' '}
+						<a
+							href="https://remotion.dev/license"
+							rel="noopener noreferrer"
+							style={downloadLicenseLink}
+							target="_blank"
+						>
+							license
+						</a>
+						.
 					</p>
 				</>
 			),

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -15,8 +15,10 @@ import {PicIcon} from '../../icons/frame';
 import {SolidIcon} from '../../icons/solid';
 import {FilmIcon} from '../../icons/video';
 import {VisualControlsContext} from '../../visual-controls/VisualControls';
+import {useConfirmationDialog} from '../ConfirmationDialog';
 import {DefaultPropsEditor} from '../DefaultPropsEditor';
 import {useZodIfPossible, useZodTypesIfPossible} from '../get-zod-if-possible';
+import {LicenseExplanation} from '../LicenseExplanation';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {ObserveDefaultPropsContext} from '../ObserveDefaultPropsContext';
@@ -60,6 +62,11 @@ const actionIconStyle: React.CSSProperties = {
 	width: 18,
 };
 
+const downloadLicenseAgreement: React.CSSProperties = {
+	marginBottom: 0,
+	marginTop: 20,
+};
+
 const CompositionActions: React.FC = () => {
 	const {
 		canInsertAsset,
@@ -73,9 +80,27 @@ const CompositionActions: React.FC = () => {
 		insertSolid,
 	} = useCompositionActions();
 	const downloadProject = getBrowserStudioOperations()?.downloadProject ?? null;
+	const confirm = useConfirmationDialog();
 
 	const onDownloadProject = useCallback(async () => {
 		if (downloadProject === null) {
+			return;
+		}
+
+		const accepted = await confirm({
+			title: 'Download project',
+			message: (
+				<>
+					<LicenseExplanation />
+					<p style={downloadLicenseAgreement}>
+						By downloading this project, you agree to comply with the license.
+					</p>
+				</>
+			),
+			confirmLabel: 'Accept and download',
+			cancelLabel: 'Cancel',
+		});
+		if (!accepted) {
 			return;
 		}
 
@@ -97,7 +122,7 @@ const CompositionActions: React.FC = () => {
 				2000,
 			);
 		}
-	}, [downloadProject]);
+	}, [confirm, downloadProject]);
 
 	if (
 		!canShowInsertAsset &&

--- a/packages/studio/src/components/LicenseExplanation.tsx
+++ b/packages/studio/src/components/LicenseExplanation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {LIGHT_TEXT, WHITE} from '../helpers/colors';
+import {LIGHT_TEXT} from '../helpers/colors';
 
 const description: React.CSSProperties = {
 	color: LIGHT_TEXT,
@@ -10,7 +10,7 @@ const description: React.CSSProperties = {
 };
 
 const descriptionLink: React.CSSProperties = {
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 14,
 	lineHeight: '21px',

--- a/packages/studio/src/components/LicenseExplanation.tsx
+++ b/packages/studio/src/components/LicenseExplanation.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {LIGHT_TEXT, WHITE} from '../helpers/colors';
+
+const description: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: 1.5,
+	margin: 0,
+};
+
+const descriptionLink: React.CSSProperties = {
+	color: WHITE,
+	fontFamily: 'sans-serif',
+	fontSize: 14,
+	lineHeight: '21px',
+};
+
+const licenseExplanation: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: 12,
+};
+
+const licenseExplanationRow: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: 12,
+};
+
+const people: React.CSSProperties = {
+	display: 'grid',
+	gridTemplateColumns: 'repeat(4, 9px)',
+	gap: 3,
+	flexShrink: 0,
+};
+
+const person: React.CSSProperties = {
+	display: 'block',
+	height: 24,
+	overflow: 'visible',
+	width: 9,
+};
+
+const PersonIcon: React.FC<{
+	readonly handsUp: boolean;
+	readonly opacity: number;
+}> = ({handsUp, opacity}) => {
+	return (
+		<svg
+			aria-hidden="true"
+			opacity={opacity}
+			style={person}
+			viewBox="0 0 192 512"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fill={LIGHT_TEXT}
+				d="M128 64a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zM32 64A64 64 0 1 1 160 64 64 64 0 1 1 32 64zm0 128l0 128 128 0 0-128-128 0zM0 160l192 0 0 192-32 0 0 160-32 0 0-160-64 0 0 160-32 0 0-160-32 0 0-192z"
+			/>
+			{handsUp ? (
+				<path
+					d="M10.667 192 0 -32 M181.333 192 192 -32"
+					fill="none"
+					stroke={LIGHT_TEXT}
+					strokeWidth="32"
+				/>
+			) : null}
+		</svg>
+	);
+};
+
+export const LicenseExplanation: React.FC = () => {
+	return (
+		<div style={licenseExplanation}>
+			<div style={licenseExplanationRow}>
+				<div style={people}>
+					<PersonIcon handsUp opacity={1} />
+					<PersonIcon handsUp opacity={1} />
+					<PersonIcon handsUp opacity={1} />
+				</div>
+				<p style={description}>
+					Remotion is free to use if you are an individual or company of 3 or
+					less.
+				</p>
+			</div>
+			<div style={licenseExplanationRow}>
+				<div style={people}>
+					<PersonIcon handsUp={false} opacity={1} />
+					<PersonIcon handsUp={false} opacity={1} />
+					<PersonIcon handsUp={false} opacity={1} />
+					<PersonIcon handsUp={false} opacity={1} />
+				</div>
+				<p style={description}>
+					If used in an organization with 4+ people, you need a{' '}
+					<a style={descriptionLink} href="https://remotion.pro/license">
+						Company License
+					</a>
+					.
+				</p>
+			</div>
+			<div style={licenseExplanationRow}>
+				<div style={people}>
+					<PersonIcon handsUp={false} opacity={1} />
+					<PersonIcon handsUp={false} opacity={0.3} />
+					<PersonIcon handsUp={false} opacity={0.3} />
+					<PersonIcon handsUp={false} opacity={0.3} />
+				</div>
+				<p style={description}>
+					The total headcount matters, not the amount of people using Remotion.
+				</p>
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary

- show the Remotion license disclaimer before Browser Studio downloads a project
- reuse the same license explanation and icons in the License settings tab and download confirmation
- only start generating the project archive after the user accepts

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio' --filter='@remotion/browser-studio'`
- visually verified the confirmation in Browser Studio

Closes #10838
