### PR TITLE
`@remotion/studio`: Expand Effects section after adding an effect

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -504,7 +504,7 @@ test.describe('visual mode', () => {
 		}
 	});
 
-	test('should preserve the sequence inspector scroll position when adding an effect', async ({
+	test('should expand Effects and preserve the inspector scroll position when adding an effect', async ({
 		page,
 	}) => {
 		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
@@ -518,6 +518,12 @@ test.describe('visual mode', () => {
 			await page.getByTitle('Scale precision', {exact: true}).first().click();
 			await expect(addEffectButton).toBeVisible({timeout: 1000});
 		}).toPass({timeout: 15_000});
+		await page
+			.getByRole('button', {name: 'Collapse Effects', exact: true})
+			.click();
+		await expect(
+			page.getByRole('button', {name: 'Expand Effects', exact: true}),
+		).toBeVisible();
 		const inspector = page
 			.locator('.__remotion-vertical-scrollbar')
 			.filter({has: addEffectButton});
@@ -538,6 +544,9 @@ test.describe('visual mode', () => {
 		await expect
 			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
 			.toContain("import {blur} from '@remotion/effects/blur';");
+		await expect(
+			page.getByRole('button', {name: 'Collapse Effects', exact: true}),
+		).toBeVisible();
 		await expect(page.getByText('blur()', {exact: true})).toBeVisible();
 		const scrollTopAfter = await inspector.evaluate(
 			(element) => element.scrollTop,

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -27,6 +27,11 @@ import {Plus} from '../icons/plus';
 import {SetSelectedModalContext} from '../state/modals';
 import {Transform3DModeStateContext} from '../state/transform-3d-mode';
 import {AssetFileIcon} from './AssetFileIcon';
+import {
+	clearPendingEffectsInspectorExpansion,
+	hasPendingEffectsInspectorExpansion,
+	subscribeToEffectsInspectorExpansionRequests,
+} from './effect-inspector-expansion';
 import {InlineAction} from './InlineAction';
 import {InlineCaptionInspector} from './InlineCaptionInspector';
 import {CollapsibleInspectorSectionHeader} from './InspectorPanel/CollapsibleInspectorSectionHeader';
@@ -605,6 +610,33 @@ export const InspectorSequenceSection: React.FC<{
 	);
 	const captionsExpanded = isAdditionalSectionExpanded('captions');
 	const effectsExpanded = isAdditionalSectionExpanded('effects');
+	const expandEffectsInspectorIfRequested = useCallback(() => {
+		const subscriptionKey = nodePathInfo.sequenceSubscriptionKey;
+		if (!hasPendingEffectsInspectorExpansion(subscriptionKey)) {
+			return;
+		}
+
+		const expansionKey = getInspectorSectionExpansionKey({
+			nodePathInfo,
+			sectionId: 'effects',
+		});
+		setSectionExpansionOverrides((overrides) => {
+			clearPendingEffectsInspectorExpansion(subscriptionKey);
+			if (overrides[expansionKey] === true) {
+				return overrides;
+			}
+
+			const next = {...overrides, [expansionKey]: true};
+			persistInspectorSectionExpansionOverrides(next);
+			return next;
+		});
+	}, [nodePathInfo]);
+	useEffect(() => {
+		expandEffectsInspectorIfRequested();
+		return subscribeToEffectsInspectorExpansionRequests(
+			expandEffectsInspectorIfRequested,
+		);
+	}, [expandEffectsInspectorIfRequested]);
 	const visibleControlRows = controlGroups.flatMap((group) => {
 		return isControlGroupExpanded(group) ? group.rows : [];
 	});

--- a/packages/studio/src/components/effect-drag-and-drop.ts
+++ b/packages/studio/src/components/effect-drag-and-drop.ts
@@ -6,6 +6,7 @@ import {getRequiredPackageForEffectImportPath} from '@remotion/studio-shared';
 import type {SequencePropsSubscriptionKey} from 'remotion';
 import {getBrowserStudioEffectOperations} from '../helpers/browser-studio-operations';
 import {installRequiredPackages} from '../helpers/install-required-package';
+import {requestEffectsInspectorExpansion} from './effect-inspector-expansion';
 import {addEffect} from './effect-operations-api';
 import {showNotification} from './Notifications/NotificationCenter';
 
@@ -78,7 +79,10 @@ export const addEffectToSequence = async ({
 
 		if (!result.success) {
 			showNotification(result.reason, 4000);
+			return;
 		}
+
+		requestEffectsInspectorExpansion(nodePath);
 	} catch (err) {
 		showNotification((err as Error).message, 4000);
 	}

--- a/packages/studio/src/components/effect-inspector-expansion.ts
+++ b/packages/studio/src/components/effect-inspector-expansion.ts
@@ -1,0 +1,38 @@
+import type {SequencePropsSubscriptionKey} from 'remotion';
+
+const pendingExpansionKeys = new Set<string>();
+const listeners = new Set<() => void>();
+
+const getExpansionRequestKey = (nodePath: SequencePropsSubscriptionKey) => {
+	return JSON.stringify([nodePath.absolutePath, nodePath.nodePath]);
+};
+
+export const requestEffectsInspectorExpansion = (
+	nodePath: SequencePropsSubscriptionKey,
+) => {
+	pendingExpansionKeys.add(getExpansionRequestKey(nodePath));
+	for (const listener of listeners) {
+		listener();
+	}
+};
+
+export const hasPendingEffectsInspectorExpansion = (
+	nodePath: SequencePropsSubscriptionKey,
+) => {
+	return pendingExpansionKeys.has(getExpansionRequestKey(nodePath));
+};
+
+export const clearPendingEffectsInspectorExpansion = (
+	nodePath: SequencePropsSubscriptionKey,
+) => {
+	pendingExpansionKeys.delete(getExpansionRequestKey(nodePath));
+};
+
+export const subscribeToEffectsInspectorExpansionRequests = (
+	listener: () => void,
+) => {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+};


### PR DESCRIPTION
## Summary

- expand the Effects inspector section after successfully adding an effect
- retain the expansion request across the source refresh for the targeted sequence
- cover the collapsed-panel workflow in the existing Studio end-to-end test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test e2e/studio.test.mts --grep "should expand Effects and preserve"`

Closes #10849
