### PR TITLE
`@remotion/studio`: Keep Effects section expanded

### DIFF
--- a/packages/example/e2e/inspector-section-collapse.test.mts
+++ b/packages/example/e2e/inspector-section-collapse.test.mts
@@ -456,13 +456,11 @@ test.describe('inspector section collapse', () => {
 		).toBeVisible();
 		await expect(
 			page.getByRole('button', {name: 'Collapse Effects', exact: true}),
-		).toBeVisible();
-		await page
-			.getByRole('button', {name: 'Collapse Effects', exact: true})
-			.click();
+		).toHaveCount(0);
 		await expect(
 			page.getByRole('button', {name: 'Expand Effects', exact: true}),
-		).toBeVisible();
+		).toHaveCount(0);
+		await expect(page.getByTitle('Add effect', {exact: true})).toBeVisible();
 
 		await page
 			.getByRole('button', {name: 'Expand Border radius', exact: true})

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -504,7 +504,7 @@ test.describe('visual mode', () => {
 		}
 	});
 
-	test('should preserve the sequence inspector scroll position when adding an effect', async ({
+	test('should keep Effects expanded and preserve the inspector scroll position when adding an effect', async ({
 		page,
 	}) => {
 		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
@@ -518,6 +518,10 @@ test.describe('visual mode', () => {
 			await page.getByTitle('Scale precision', {exact: true}).first().click();
 			await expect(addEffectButton).toBeVisible({timeout: 1000});
 		}).toPass({timeout: 15_000});
+		await expect(page.getByText('wave()', {exact: true})).toBeVisible();
+		await expect(
+			page.getByRole('button', {name: 'Collapse Effects', exact: true}),
+		).toHaveCount(0);
 		const inspector = page
 			.locator('.__remotion-vertical-scrollbar')
 			.filter({has: addEffectButton});

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -35,6 +35,7 @@ import {
 	getInspectorSectionActivity,
 	isSmartCollapsibleInspectorGroup,
 } from './InspectorPanel/inspector-section-collapse';
+import {sectionHeaderRow, sectionHeaderTitle} from './InspectorPanel/styles';
 import {getAssetSearchQueryForComponent} from './QuickSwitcher/asset-search';
 import {
 	BORDER_RADIUS_SHORTHAND_KEY,
@@ -87,6 +88,11 @@ const emptyState: React.CSSProperties = {
 const plusIcon: React.CSSProperties = {
 	width: 15,
 	height: 15,
+};
+
+const effectsHeaderTitle: React.CSSProperties = {
+	...sectionHeaderTitle,
+	flexShrink: 1,
 };
 
 const borderRadiusToggleIcon: React.CSSProperties = {
@@ -201,7 +207,7 @@ const persistInspectorCollapsedKeys = (keys: ReadonlySet<string>): void => {
 };
 
 type InspectorSectionExpansionOverrides = Readonly<Record<string, boolean>>;
-type AdditionalInspectorSectionId = 'captions' | 'effects';
+type AdditionalInspectorSectionId = 'captions';
 
 const loadInspectorSectionExpansionOverrides =
 	(): InspectorSectionExpansionOverrides => {
@@ -604,7 +610,6 @@ export const InspectorSequenceSection: React.FC<{
 		[isAdditionalSectionExpanded, nodePathInfo],
 	);
 	const captionsExpanded = isAdditionalSectionExpanded('captions');
-	const effectsExpanded = isAdditionalSectionExpanded('effects');
 	const visibleControlRows = controlGroups.flatMap((group) => {
 		return isControlGroupExpanded(group) ? group.rows : [];
 	});
@@ -747,20 +752,16 @@ export const InspectorSequenceSection: React.FC<{
 	);
 
 	const effectsHeader = (
-		<CollapsibleInspectorSectionHeader
-			action={
-				<InlineAction
-					variant={null}
-					disabled={!canAddEffect}
-					onClick={onAddEffect}
-					title={canAddEffect ? 'Add effect' : undefined}
-					renderAction={(color) => <Plus color={color} style={plusIcon} />}
-				/>
-			}
-			expanded={effectsExpanded}
-			label="Effects"
-			onToggle={() => toggleAdditionalSection('effects')}
-		/>
+		<div style={sectionHeaderRow}>
+			<div style={effectsHeaderTitle}>Effects</div>
+			<InlineAction
+				variant={null}
+				disabled={!canAddEffect}
+				onClick={onAddEffect}
+				title={canAddEffect ? 'Add effect' : undefined}
+				renderAction={(color) => <Plus color={color} style={plusIcon} />}
+			/>
+		</div>
 	);
 
 	const renderRow = ({node, depth}: FlatTreeRow) => {
@@ -859,7 +860,7 @@ export const InspectorSequenceSection: React.FC<{
 				) : null}
 				{showEffectsSection ? (
 					<InspectorSection header={effectsHeader}>
-						{effectsExpanded && effectRows.length > 0 ? (
+						{effectRows.length > 0 ? (
 							<TimelineSelectionOrderProvider items={effectSelectableItems}>
 								{effectRows.map(renderRow)}
 							</TimelineSelectionOrderProvider>


### PR DESCRIPTION
## Summary

- keep the Effects inspector section permanently expanded
- remove Effects from persisted inspector section-collapse state
- update end-to-end coverage for existing and newly added effects

## Testing

- `bun run build`
- `bun run stylecheck`
- focused Playwright coverage for inspector section collapsing and adding effects

Closes #10849
