### PR TITLE
`@remotion/canvas-capture-extension`: Redesign

### DIFF
--- a/packages/canvas-capture-extension/package.json
+++ b/packages/canvas-capture-extension/package.json
@@ -11,6 +11,7 @@
 		"make": "bunx --bun wxt build"
 	},
 	"dependencies": {
+		"@remotion/design": "workspace:*",
 		"mediabunny": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:"

--- a/packages/canvas-capture-extension/src/background.ts
+++ b/packages/canvas-capture-extension/src/background.ts
@@ -1,68 +1,6 @@
 import {browser} from 'wxt/browser';
-import {capturePopupTargetMessageType} from './messages';
 
 export const startBackground = () => {
-	const captureWindowStorageKey = 'remotion-canvas-capture-window-id';
-	let windowAction = Promise.resolve();
-
-	const showCaptureWindow = async (tabId: number) => {
-		const stored = await browser.storage.session.get(captureWindowStorageKey);
-		const storedWindowId = stored[captureWindowStorageKey];
-		if (typeof storedWindowId === 'number') {
-			try {
-				await browser.windows.update(storedWindowId, {focused: true});
-				await browser.runtime.sendMessage({
-					type: capturePopupTargetMessageType,
-					tabId,
-				});
-				return;
-			} catch {
-				await browser.storage.session.remove(captureWindowStorageKey);
-			}
-		}
-
-		const url = new URL(browser.runtime.getURL('/recorder.html'));
-		url.searchParams.set('tabId', String(tabId));
-		const captureWindow = await browser.windows.create({
-			url: url.toString(),
-			type: 'popup',
-			width: 380,
-			height: 560,
-			focused: true,
-		});
-		if (!captureWindow) {
-			throw new Error('Could not open the Canvas Capture window.');
-		}
-
-		if (captureWindow.id !== undefined) {
-			await browser.storage.session.set({
-				[captureWindowStorageKey]: captureWindow.id,
-			});
-		}
-	};
-
-	browser.action.onClicked.addListener((tab) => {
-		if (tab.id === undefined) {
-			return;
-		}
-
-		const tabId = tab.id;
-		windowAction = windowAction
-			.then(() => showCaptureWindow(tabId))
-			.catch(() => undefined);
-	});
-
-	browser.windows.onRemoved.addListener((windowId) => {
-		const clearStoredWindow = async () => {
-			const stored = await browser.storage.session.get(captureWindowStorageKey);
-			if (stored[captureWindowStorageKey] === windowId) {
-				await browser.storage.session.remove(captureWindowStorageKey);
-			}
-		};
-
-		clearStoredWindow().catch(() => undefined);
-	});
-
 	browser.runtime.onMessage.addListener((message) => {
 		if (
 			typeof message !== 'object' ||

--- a/packages/canvas-capture-extension/src/content.ts
+++ b/packages/canvas-capture-extension/src/content.ts
@@ -72,22 +72,20 @@ export const startContent = () => {
 			position: fixed;
 			inset: 0;
 			display: none;
-			background: rgba(0,0,0,.08);
+			background: transparent;
 			cursor: crosshair;
 			pointer-events: auto;
 		}
 		.selection-box {
 			position: fixed;
 			display: none;
-			border: 2px solid #4d8dff;
-			background: rgba(77,141,255,.16);
-			box-shadow: 0 0 0 1px rgba(255,255,255,.65) inset;
+			border: 1px solid #0b84f3;
+			background: transparent;
 		}
 		.highlight {
 			position: fixed;
 			display: none;
-			border: 2px solid #4d8dff;
-			box-shadow: 0 0 0 1px rgba(255,255,255,.8), 0 0 0 99999px rgba(77,141,255,.035);
+			border: 1px solid #0b84f3;
 			pointer-events: none;
 		}
 	`;
@@ -103,6 +101,7 @@ export const startContent = () => {
 
 		let selectedTarget: SelectedTarget | null = null;
 		let capture: PageCapture | null = null;
+		let completedRecording: File | null = null;
 		let finalizing = false;
 		let selecting = false;
 		let scale = Math.max(1, window.devicePixelRatio);
@@ -150,7 +149,14 @@ export const startContent = () => {
 
 		const refreshEncoderSupport = async () => {
 			const checkId = ++encoderSupportCheckId;
-			if (!supported || !selectedTarget || capture || finalizing || selecting) {
+			if (
+				!supported ||
+				!selectedTarget ||
+				capture ||
+				completedRecording ||
+				finalizing ||
+				selecting
+			) {
 				if (!selectedTarget) {
 					encoderSupport = 'unavailable';
 					encoderSupportKey = null;
@@ -280,6 +286,7 @@ export const startContent = () => {
 			outputSize,
 			recording: capture !== null,
 			finalizing,
+			hasCompletedRecording: completedRecording !== null,
 			scale,
 			format,
 			status,
@@ -387,7 +394,7 @@ export const startContent = () => {
 			return true;
 		};
 
-		const finishRecording = async (destination: 'convert' | 'download') => {
+		const finishRecording = async () => {
 			if (!capture || finalizing) {
 				return;
 			}
@@ -397,23 +404,46 @@ export const startContent = () => {
 			setStatus(`Finalizing ${getContainerLabel(recordingFormat)}…`);
 			const currentCapture = capture;
 			try {
-				const file = await currentCapture.stop();
-				if (destination === 'convert') {
-					setStatus('Opening recording in Remotion Convert…');
-					await openCaptureInConvert(file);
-					setStatus('Recording opened. Ready to record again.');
-				} else {
-					downloadFile(file);
-					setStatus(
-						`${getContainerLabel(recordingFormat)} downloaded. Ready to record again.`,
-					);
-				}
+				completedRecording = await currentCapture.stop();
+				setStatus(
+					`${getContainerLabel(recordingFormat)} ready. Open it in Convert or download it.`,
+				);
 			} catch (error) {
 				setStatus(error instanceof Error ? error.message : String(error), true);
 			} finally {
 				capture = null;
 				finalizing = false;
 				updateHighlight();
+			}
+		};
+
+		const consumeCompletedRecording = async (
+			destination: 'convert' | 'download',
+		) => {
+			if (!completedRecording || finalizing) {
+				return;
+			}
+
+			const file = completedRecording;
+			finalizing = true;
+			try {
+				if (destination === 'convert') {
+					setStatus('Opening recording in Remotion Convert…');
+					await openCaptureInConvert(file);
+					completedRecording = null;
+					setStatus('Recording opened. Ready to record again.');
+					return;
+				}
+
+				downloadFile(file);
+				completedRecording = null;
+				setStatus(
+					`${getContainerLabel(format)} downloaded. Ready to record again.`,
+				);
+			} catch (error) {
+				setStatus(error instanceof Error ? error.message : String(error), true);
+			} finally {
+				finalizing = false;
 			}
 		};
 
@@ -425,7 +455,7 @@ export const startContent = () => {
 				}
 
 				if (request.command === 'set-options') {
-					if (!capture && !finalizing) {
+					if (!capture && !completedRecording && !finalizing) {
 						if (setOptions(request.scale)) {
 							await refreshEncoderSupport();
 						}
@@ -435,7 +465,7 @@ export const startContent = () => {
 				}
 
 				if (request.command === 'select-area') {
-					if (!capture && !finalizing) {
+					if (!capture && !completedRecording && !finalizing) {
 						encoderSupportCheckId++;
 						encoderSupportKey = null;
 						selecting = true;
@@ -459,7 +489,7 @@ export const startContent = () => {
 				}
 
 				if (request.command === 'select-whole-page') {
-					if (!capture && !finalizing) {
+					if (!capture && !completedRecording && !finalizing) {
 						if (selecting) {
 							cancelSelection();
 						}
@@ -474,7 +504,7 @@ export const startContent = () => {
 				}
 
 				if (request.command === 'start-recording') {
-					if (capture || finalizing || selecting) {
+					if (capture || completedRecording || finalizing || selecting) {
 						return getState();
 					}
 
@@ -516,7 +546,14 @@ export const startContent = () => {
 					return getState();
 				}
 
-				await finishRecording(request.destination);
+				if (request.command === 'stop-recording') {
+					await finishRecording();
+					return getState();
+				}
+
+				await consumeCompletedRecording(
+					request.command === 'open-in-convert' ? 'convert' : 'download',
+				);
 				return getState();
 			},
 		};

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
@@ -1,8 +1,8 @@
+import {Button, Card, Input} from '@remotion/design';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {browser} from 'wxt/browser';
 import {
 	captureControllerMessageType,
-	isCapturePopupTargetMessage,
 	type CaptureControllerRequest,
 	type CaptureControllerState,
 } from '../../messages';
@@ -137,29 +137,21 @@ export const App: React.FC = () => {
 	}, [state]);
 
 	useEffect(() => {
-		const onMessage = (message: unknown) => {
-			if (!isCapturePopupTargetMessage(message)) {
-				return;
-			}
+		browser.tabs
+			.query({active: true, currentWindow: true})
+			.then(([tab]) => {
+				if (tab?.id === undefined) {
+					renderDisconnected('No active tab is available.');
+					return;
+				}
 
-			connectToTab(message.tabId).catch(() => undefined);
-		};
-
-		browser.runtime.onMessage.addListener(onMessage);
-		return () => browser.runtime.onMessage.removeListener(onMessage);
-	}, [connectToTab]);
-
-	useEffect(() => {
-		const initialTabId = Number(
-			new URL(window.location.href).searchParams.get('tabId'),
-		);
-		if (Number.isInteger(initialTabId) && initialTabId >= 0) {
-			connectToTab(initialTabId).catch(() => undefined);
-		} else {
-			renderDisconnected(
-				'No target tab was provided. Click the extension icon on the page you want to capture.',
-			);
-		}
+				return connectToTab(tab.id);
+			})
+			.catch((error) => {
+				renderDisconnected(
+					error instanceof Error ? error.message : String(error),
+				);
+			});
 	}, [connectToTab, renderDisconnected]);
 
 	useEffect(() => {
@@ -181,21 +173,7 @@ export const App: React.FC = () => {
 						return;
 					}
 
-					const selectionFinished =
-						currentState.current?.selecting && !nextState.selecting;
 					applyState(nextState);
-					if (selectionFinished) {
-						browser.windows
-							.getCurrent()
-							.then((recorderWindow) => {
-								if (recorderWindow.id !== undefined) {
-									return browser.windows.update(recorderWindow.id, {
-										focused: true,
-									});
-								}
-							})
-							.catch(() => undefined);
-					}
 				})
 				.catch((error) => {
 					if (activeTabId.current === tabId) {
@@ -213,6 +191,7 @@ export const App: React.FC = () => {
 	}, [applyState, renderDisconnected]);
 
 	const controlsDisabled = busy || !state || state.finalizing;
+	const setupDisabled = controlsDisabled || state?.hasCompletedRecording;
 	const targetLabel = state?.targetLabel
 		? `${state.targetLabel}${
 				state.outputSize
@@ -247,7 +226,7 @@ export const App: React.FC = () => {
 				</div>
 			</header>
 
-			<section className="panel settings-panel">
+			<Card className="panel settings-panel">
 				<div className="field">
 					<label>Format</label>
 					<div className="format-value">
@@ -258,12 +237,12 @@ export const App: React.FC = () => {
 				<div className="field">
 					<label htmlFor="scale">Scale</label>
 					<div className="scale-control">
-						<input
+						<Input
 							id="scale"
 							type="number"
 							min="0.1"
 							step="0.1"
-							disabled={controlsDisabled || state?.recording}
+							disabled={setupDisabled || state?.recording}
 							value={scaleInput}
 							onChange={(event) => setScaleInput(event.currentTarget.value)}
 							onBlur={() => updateOptions(Number(scaleInput))}
@@ -276,15 +255,14 @@ export const App: React.FC = () => {
 						<span>×</span>
 					</div>
 				</div>
-			</section>
+			</Card>
 
 			<section className="capture-section">
 				<div className="section-label">Capture target</div>
 				<div className="button-row">
-					<button
+					<Button
 						className="secondary-button"
-						type="button"
-						disabled={controlsDisabled || state?.recording}
+						disabled={setupDisabled || state?.recording}
 						onClick={() => {
 							const command = state?.selecting
 								? 'cancel-selection'
@@ -295,33 +273,17 @@ export const App: React.FC = () => {
 										return;
 									}
 
-									const tabId = activeTabId.current;
-									if (tabId === null) {
-										return;
-									}
-
-									browser.tabs
-										.get(tabId)
-										.then(async (tab) => {
-											await browser.tabs.update(tabId, {active: true});
-											if (tab.windowId !== undefined) {
-												await browser.windows.update(tab.windowId, {
-													focused: true,
-												});
-											}
-										})
-										.catch(() => undefined);
+									window.close();
 								})
 								.catch(() => undefined);
 						}}
 					>
 						<span className="selection-icon" aria-hidden="true" />
 						{state?.selecting ? 'Cancel selection' : 'Select area'}
-					</button>
-					<button
+					</Button>
+					<Button
 						className="secondary-button"
-						type="button"
-						disabled={controlsDisabled || state?.recording}
+						disabled={setupDisabled || state?.recording}
 						onClick={() =>
 							runCommand({
 								type: captureControllerMessageType,
@@ -331,56 +293,70 @@ export const App: React.FC = () => {
 					>
 						<span className="page-icon" aria-hidden="true" />
 						Whole page
-					</button>
+					</Button>
 				</div>
-				<div className={`target-card${state?.hasTarget ? ' selected' : ''}`}>
+				<Card className={`target-card${state?.hasTarget ? ' selected' : ''}`}>
 					<span className="target-dot" />
 					<span>{targetLabel}</span>
-				</div>
+				</Card>
 			</section>
 
 			<div className="actions">
-				<button
-					className={`record-button${state?.recording ? ' recording' : ''}`}
-					type="button"
-					disabled={recordDisabled}
-					title={state?.encoderSupport === 'unsupported' ? state.status : ''}
-					onClick={() => {
-						if (state?.recording) {
-							runCommand({
-								type: captureControllerMessageType,
-								command: 'stop-recording',
-								destination: 'convert',
-							}).catch(() => undefined);
-							return;
-						}
+				{state?.hasCompletedRecording ? (
+					<div className="completed-recording">
+						<div className="completed-title">Recording ready</div>
+						<div className="completed-actions">
+							<Button
+								className="convert-button"
+								disabled={controlsDisabled}
+								onClick={() =>
+									runCommand({
+										type: captureControllerMessageType,
+										command: 'open-in-convert',
+									}).catch(() => undefined)
+								}
+							>
+								Open in Convert
+							</Button>
+							<Button
+								className="download-button"
+								disabled={controlsDisabled}
+								onClick={() =>
+									runCommand({
+										type: captureControllerMessageType,
+										command: 'download-recording',
+									}).catch(() => undefined)
+								}
+							>
+								Download {state.format === 'mp4' ? 'MP4' : 'WebM'}
+							</Button>
+						</div>
+					</div>
+				) : (
+					<Button
+						className={`record-button${state?.recording ? ' recording' : ''}`}
+						disabled={recordDisabled}
+						title={state?.encoderSupport === 'unsupported' ? state.status : ''}
+						onClick={() => {
+							if (state?.recording) {
+								runCommand({
+									type: captureControllerMessageType,
+									command: 'stop-recording',
+								}).catch(() => undefined);
+								return;
+							}
 
-						runCommand({
-							type: captureControllerMessageType,
-							command: 'start-recording',
-							scale: state?.scale ?? 1,
-						}).catch(() => undefined);
-					}}
-				>
-					<span className="record-icon" aria-hidden="true" />
-					{state?.recording ? 'Stop & open in Convert' : 'Start recording'}
-				</button>
-				{state?.recording ? (
-					<button
-						className="download-button"
-						type="button"
-						disabled={controlsDisabled}
-						onClick={() =>
 							runCommand({
 								type: captureControllerMessageType,
-								command: 'stop-recording',
-								destination: 'download',
-							}).catch(() => undefined)
-						}
+								command: 'start-recording',
+								scale: state?.scale ?? 1,
+							}).catch(() => undefined);
+						}}
 					>
-						Download {state.format === 'mp4' ? 'MP4' : 'WebM'}
-					</button>
-				) : null}
+						<span className="record-icon" aria-hidden="true" />
+						{state?.recording ? 'Stop recording' : 'Start recording'}
+					</Button>
+				)}
 			</div>
 
 			<footer className={`status${statusIsError ? ' error' : ''}`}>

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/App.tsx
@@ -1,4 +1,4 @@
-import {Button, Card, Input} from '@remotion/design';
+import {Button, Slider} from '@remotion/design';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {browser} from 'wxt/browser';
 import {
@@ -36,7 +36,7 @@ export const App: React.FC = () => {
 	const [connectionMessage, setConnectionMessage] = useState(
 		'Connecting to the selected tab…',
 	);
-	const [scaleInput, setScaleInput] = useState('1');
+	const [scaleInput, setScaleInput] = useState(1);
 
 	const applyState = useCallback((nextState: CaptureControllerState) => {
 		currentState.current = nextState;
@@ -132,7 +132,7 @@ export const App: React.FC = () => {
 
 	useEffect(() => {
 		if (state && document.activeElement?.id !== 'scale') {
-			setScaleInput(String(state.scale));
+			setScaleInput(state.scale);
 		}
 	}, [state]);
 
@@ -220,42 +220,8 @@ export const App: React.FC = () => {
 		<main className="app-shell">
 			<header className="header">
 				<img className="logo" src="/logo.svg" alt="" />
-				<div>
-					<h1>Canvas Capture</h1>
-					<p>High-resolution recording for the web</p>
-				</div>
+				<h1>Canvas Capture</h1>
 			</header>
-
-			<Card className="panel settings-panel">
-				<div className="field">
-					<label>Format</label>
-					<div className="format-value">
-						{state?.format === 'webm' ? 'WebM · VP9' : 'MP4 · H.264'}
-					</div>
-				</div>
-
-				<div className="field">
-					<label htmlFor="scale">Scale</label>
-					<div className="scale-control">
-						<Input
-							id="scale"
-							type="number"
-							min="0.1"
-							step="0.1"
-							disabled={setupDisabled || state?.recording}
-							value={scaleInput}
-							onChange={(event) => setScaleInput(event.currentTarget.value)}
-							onBlur={() => updateOptions(Number(scaleInput))}
-							onKeyDown={(event) => {
-								if (event.key === 'Enter') {
-									event.currentTarget.blur();
-								}
-							}}
-						/>
-						<span>×</span>
-					</div>
-				</div>
-			</Card>
 
 			<section className="capture-section">
 				<div className="section-label">Capture target</div>
@@ -278,7 +244,6 @@ export const App: React.FC = () => {
 								.catch(() => undefined);
 						}}
 					>
-						<span className="selection-icon" aria-hidden="true" />
 						{state?.selecting ? 'Cancel selection' : 'Select area'}
 					</Button>
 					<Button
@@ -291,14 +256,40 @@ export const App: React.FC = () => {
 							}).catch(() => undefined)
 						}
 					>
-						<span className="page-icon" aria-hidden="true" />
 						Whole page
 					</Button>
 				</div>
-				<Card className={`target-card${state?.hasTarget ? ' selected' : ''}`}>
-					<span className="target-dot" />
-					<span>{targetLabel}</span>
-				</Card>
+			</section>
+
+			<section className="settings-panel">
+				<div className="field">
+					<label>Format</label>
+					<div className="format-value">
+						{state?.format === 'webm' ? 'WebM · VP9' : 'MP4 · H.264'}
+					</div>
+				</div>
+
+				<div className="field">
+					<label htmlFor="scale">Scale</label>
+					<div className="scale-control">
+						<Slider
+							id="scale"
+							min="0.1"
+							max="4"
+							step="0.1"
+							disabled={setupDisabled || state?.recording}
+							value={scaleInput}
+							onChange={setScaleInput}
+							onPointerUp={(event) =>
+								updateOptions(Number(event.currentTarget.value))
+							}
+							onKeyUp={(event) =>
+								updateOptions(Number(event.currentTarget.value))
+							}
+						/>
+						<output htmlFor="scale">{Number(scaleInput.toFixed(1))}×</output>
+					</div>
+				</div>
 			</section>
 
 			<div className="actions">
@@ -353,10 +344,12 @@ export const App: React.FC = () => {
 							}).catch(() => undefined);
 						}}
 					>
-						<span className="record-icon" aria-hidden="true" />
 						{state?.recording ? 'Stop recording' : 'Start recording'}
 					</Button>
 				)}
+				<div className={`target-summary${state?.hasTarget ? ' selected' : ''}`}>
+					{targetLabel}
+				</div>
 			</div>
 
 			<footer className={`status${statusIsError ? ' error' : ''}`}>

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/index.html
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta name="theme-color" content="#1f2428" />
+		<meta name="theme-color" content="#f5f7f9" />
 		<title>Remotion Canvas Capture</title>
 	</head>
 	<body>

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/main.tsx
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/main.tsx
@@ -1,5 +1,6 @@
 import {createRoot} from 'react-dom/client';
 import {App} from './App';
+import '@remotion/design/tailwind.css';
 import './style.css';
 
 const root = document.getElementById('root');

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
@@ -55,8 +55,7 @@ input:focus-visible {
 	height: 36px;
 }
 
-h1,
-p {
+h1 {
 	margin: 0;
 }
 
@@ -66,24 +65,10 @@ h1 {
 	letter-spacing: -0.02em;
 }
 
-.header p {
-	margin-top: 1px;
-	color: #555b61;
-	font-size: 12px;
-}
-
-.panel,
-.target-card {
-	border: 2px solid #000;
-	border-bottom-width: 4px;
-	border-radius: 8px;
-	background: #fff;
-	color: #000;
-}
-
 .settings-panel {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 1fr;
+	gap: 8px;
 }
 
 .field {
@@ -91,11 +76,6 @@ h1 {
 	min-width: 0;
 	flex-direction: column;
 	gap: 7px;
-	padding: 11px;
-}
-
-.field + .field {
-	border-left: 2px solid #000;
 }
 
 .field label,
@@ -103,11 +83,8 @@ h1 {
 	color: #555b61;
 	font-size: 11px;
 	font-weight: 700;
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
 }
 
-input,
 .format-value {
 	width: 100%;
 	height: 36px;
@@ -124,25 +101,25 @@ input,
 	padding: 0 9px;
 }
 
-input {
-	padding: 0 8px;
-	font-size: 13px;
-}
-
-input:disabled {
-	cursor: default;
-	opacity: 0.5;
-}
-
 .scale-control {
 	display: flex;
 	align-items: center;
-	gap: 7px;
+	gap: 10px;
+	height: 36px;
+	padding: 0 4px;
 }
 
-.scale-control span {
+.scale-control .remotion-design-slider {
+	min-width: 0;
+	width: auto;
+	flex: 1;
+}
+
+.scale-control output {
+	min-width: 28px;
 	color: #555b61;
 	font-weight: 700;
+	text-align: right;
 }
 
 .capture-section {
@@ -164,7 +141,6 @@ input:disabled {
 .record-button {
 	width: 100%;
 	height: 40px;
-	gap: 8px;
 	border: 2px solid #000;
 	border-bottom-width: 4px;
 	border-radius: 8px;
@@ -180,46 +156,22 @@ input:disabled {
 	background: #eef1f4;
 }
 
-.selection-icon {
-	width: 13px;
-	height: 13px;
-	border: 1px dashed currentColor;
-	border-radius: 2px;
-}
-
-.page-icon {
-	width: 11px;
-	height: 14px;
-	border: 1px solid currentColor;
-	border-radius: 1px;
-}
-
-.target-card {
-	display: flex;
-	min-height: 42px;
-	align-items: center;
-	gap: 9px;
-	padding: 9px 11px;
+.target-summary {
 	color: #6b7177;
+	font-size: 12px;
 	overflow-wrap: anywhere;
 }
 
-.target-card.selected {
+.target-summary.selected {
 	color: #000;
 }
 
-.target-dot,
 .status-dot {
 	width: 7px;
 	height: 7px;
 	flex: 0 0 auto;
 	border-radius: 50%;
 	background: #9aa0a6;
-}
-
-.target-card.selected .target-dot {
-	background: #0b84f3;
-	box-shadow: 0 0 0 3px rgba(11, 132, 243, 0.16);
 }
 
 .actions {
@@ -248,27 +200,10 @@ input:disabled {
 	background: #ff4b4b;
 }
 
-.record-icon {
-	width: 10px;
-	height: 10px;
-	border: 2px solid currentColor;
-	border-radius: 50%;
-}
-
-.recording .record-icon {
-	border-radius: 2px;
-	background: currentColor;
-}
-
 .completed-recording {
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
-	padding: 12px;
-	border: 2px solid #000;
-	border-bottom-width: 4px;
-	border-radius: 8px;
-	background: #e9f4ff;
 }
 
 .completed-title {

--- a/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
+++ b/packages/canvas-capture-extension/src/entrypoints/recorder/style.css
@@ -1,15 +1,15 @@
 :root {
-	color-scheme: dark;
+	color-scheme: light;
 	font-family:
-		Inter,
+		GTPlanar,
 		ui-sans-serif,
 		system-ui,
 		-apple-system,
 		BlinkMacSystemFont,
 		'Segoe UI',
 		sans-serif;
-	background: #1f2428;
-	color: #fff;
+	background: #f5f7f9;
+	color: #000;
 	font-synthesis: none;
 	-webkit-font-smoothing: antialiased;
 }
@@ -19,9 +19,9 @@
 }
 
 body {
-	min-width: 360px;
+	width: 380px;
 	margin: 0;
-	background: #1f2428;
+	background: #f5f7f9;
 	font-size: 13px;
 	line-height: 1.4;
 }
@@ -31,22 +31,17 @@ input {
 	font: inherit;
 }
 
-button {
-	cursor: pointer;
-}
-
-button:disabled,
-input:disabled {
-	cursor: default;
-	opacity: 0.48;
+button:focus-visible,
+input:focus-visible {
+	outline: 2px solid #0b84f3;
+	outline-offset: 2px;
 }
 
 .app-shell {
 	display: flex;
-	min-height: 100vh;
 	flex-direction: column;
-	gap: 18px;
-	padding: 20px;
+	gap: 16px;
+	padding: 18px;
 }
 
 .header {
@@ -66,21 +61,24 @@ p {
 }
 
 h1 {
-	font-size: 17px;
-	font-weight: 650;
-	letter-spacing: -0.01em;
+	font-size: 18px;
+	font-weight: 700;
+	letter-spacing: -0.02em;
 }
 
 .header p {
-	margin-top: 2px;
-	color: #a6a7a9;
+	margin-top: 1px;
+	color: #555b61;
 	font-size: 12px;
 }
 
-.panel {
-	border: 1px solid rgba(255, 255, 255, 0.1);
+.panel,
+.target-card {
+	border: 2px solid #000;
+	border-bottom-width: 4px;
 	border-radius: 8px;
-	background: rgba(255, 255, 255, 0.035);
+	background: #fff;
+	color: #000;
 }
 
 .settings-panel {
@@ -93,18 +91,18 @@ h1 {
 	min-width: 0;
 	flex-direction: column;
 	gap: 7px;
-	padding: 12px;
+	padding: 11px;
 }
 
 .field + .field {
-	border-left: 1px solid rgba(255, 255, 255, 0.1);
+	border-left: 2px solid #000;
 }
 
 .field label,
 .section-label {
-	color: #a6a7a9;
+	color: #555b61;
 	font-size: 11px;
-	font-weight: 600;
+	font-weight: 700;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
 }
@@ -112,12 +110,12 @@ h1 {
 input,
 .format-value {
 	width: 100%;
-	height: 34px;
-	border: 1px solid rgba(255, 255, 255, 0.12);
-	border-radius: 5px;
-	outline: none;
-	background: #2f363d;
-	color: #fff;
+	height: 36px;
+	border: 2px solid #000;
+	border-bottom-width: 4px;
+	border-radius: 8px;
+	background: #fff;
+	color: #000;
 }
 
 .format-value {
@@ -128,12 +126,12 @@ input,
 
 input {
 	padding: 0 8px;
+	font-size: 13px;
 }
 
-input:focus,
-button:focus-visible {
-	border-color: #0b84f3;
-	box-shadow: 0 0 0 2px rgba(11, 132, 243, 0.25);
+input:disabled {
+	cursor: default;
+	opacity: 0.5;
 }
 
 .scale-control {
@@ -143,7 +141,8 @@ button:focus-visible {
 }
 
 .scale-control span {
-	color: #a6a7a9;
+	color: #555b61;
+	font-weight: 700;
 }
 
 .capture-section {
@@ -152,60 +151,61 @@ button:focus-visible {
 	gap: 9px;
 }
 
-.button-row {
+.button-row,
+.completed-actions {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: 8px;
 }
 
 .secondary-button,
-.download-button {
-	display: flex;
-	min-height: 38px;
-	align-items: center;
-	justify-content: center;
+.download-button,
+.convert-button,
+.record-button {
+	width: 100%;
+	height: 40px;
 	gap: 8px;
-	border: 1px solid rgba(255, 255, 255, 0.12);
-	border-radius: 6px;
-	background: #2f363d;
-	color: #fff;
-	font-weight: 550;
+	border: 2px solid #000;
+	border-bottom-width: 4px;
+	border-radius: 8px;
+	background: #fff;
+	color: #000;
+	font-size: 13px;
+	font-weight: 700;
+	padding: 0 10px;
 }
 
 .secondary-button:hover:not(:disabled),
 .download-button:hover:not(:disabled) {
-	background: #39424a;
+	background: #eef1f4;
 }
 
 .selection-icon {
 	width: 13px;
 	height: 13px;
-	border: 1px dashed #a6a7a9;
+	border: 1px dashed currentColor;
 	border-radius: 2px;
 }
 
 .page-icon {
 	width: 11px;
 	height: 14px;
-	border: 1px solid #a6a7a9;
+	border: 1px solid currentColor;
 	border-radius: 1px;
 }
 
 .target-card {
 	display: flex;
-	min-height: 40px;
+	min-height: 42px;
 	align-items: center;
 	gap: 9px;
 	padding: 9px 11px;
-	border: 1px solid rgba(255, 255, 255, 0.08);
-	border-radius: 6px;
-	background: #191d20;
-	color: #a6a7a9;
+	color: #6b7177;
 	overflow-wrap: anywhere;
 }
 
 .target-card.selected {
-	color: #ddd;
+	color: #000;
 }
 
 .target-dot,
@@ -214,7 +214,7 @@ button:focus-visible {
 	height: 7px;
 	flex: 0 0 auto;
 	border-radius: 50%;
-	background: #6d747a;
+	background: #9aa0a6;
 }
 
 .target-card.selected .target-dot {
@@ -228,27 +228,24 @@ button:focus-visible {
 	gap: 8px;
 }
 
-.record-button {
-	display: flex;
-	min-height: 44px;
-	align-items: center;
-	justify-content: center;
-	gap: 9px;
-	border: 1px solid #0b84f3;
-	border-radius: 6px;
+.record-button,
+.convert-button {
+	height: 46px;
 	background: #0b84f3;
 	color: #fff;
-	font-weight: 650;
 }
 
-.record-button:hover:not(:disabled) {
-	border-color: #2290f5;
+.record-button:hover:not(:disabled),
+.convert-button:hover:not(:disabled) {
 	background: #2290f5;
 }
 
 .record-button.recording {
-	border-color: #e74c3c;
-	background: #e74c3c;
+	background: #ff3232;
+}
+
+.record-button.recording:hover:not(:disabled) {
+	background: #ff4b4b;
 }
 
 .record-icon {
@@ -263,12 +260,33 @@ button:focus-visible {
 	background: currentColor;
 }
 
+.completed-recording {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding: 12px;
+	border: 2px solid #000;
+	border-bottom-width: 4px;
+	border-radius: 8px;
+	background: #e9f4ff;
+}
+
+.completed-title {
+	font-size: 14px;
+	font-weight: 700;
+}
+
+.completed-actions .convert-button,
+.completed-actions .download-button {
+	height: 42px;
+}
+
 .status {
 	display: flex;
 	min-height: 18px;
 	align-items: flex-start;
 	gap: 8px;
-	color: #a6a7a9;
+	color: #555b61;
 	font-size: 12px;
 	overflow-wrap: anywhere;
 }
@@ -279,7 +297,7 @@ button:focus-visible {
 }
 
 .status.error {
-	color: #ff7777;
+	color: #c5221f;
 }
 
 .status.error .status-dot {

--- a/packages/canvas-capture-extension/src/messages.ts
+++ b/packages/canvas-capture-extension/src/messages.ts
@@ -1,27 +1,7 @@
 export const captureControllerMessageType =
 	'remotion-canvas-capture-controller';
-export const capturePopupTargetMessageType =
-	'remotion-canvas-capture-popup-target';
 
 export type CaptureFormat = 'mp4' | 'webm';
-
-export type CapturePopupTargetMessage = {
-	readonly type: typeof capturePopupTargetMessageType;
-	readonly tabId: number;
-};
-
-export const isCapturePopupTargetMessage = (
-	message: unknown,
-): message is CapturePopupTargetMessage => {
-	return (
-		typeof message === 'object' &&
-		message !== null &&
-		'type' in message &&
-		message.type === capturePopupTargetMessageType &&
-		'tabId' in message &&
-		typeof message.tabId === 'number'
-	);
-};
 
 export type CaptureControllerState = {
 	readonly supported: boolean;
@@ -36,6 +16,7 @@ export type CaptureControllerState = {
 	readonly outputSize: {readonly width: number; readonly height: number} | null;
 	readonly recording: boolean;
 	readonly finalizing: boolean;
+	readonly hasCompletedRecording: boolean;
 	readonly scale: number;
 	readonly format: CaptureFormat;
 	readonly status: string;
@@ -72,7 +53,14 @@ export type CaptureControllerRequest =
 	| {
 			readonly type: typeof captureControllerMessageType;
 			readonly command: 'stop-recording';
-			readonly destination: 'convert' | 'download';
+	  }
+	| {
+			readonly type: typeof captureControllerMessageType;
+			readonly command: 'open-in-convert';
+	  }
+	| {
+			readonly type: typeof captureControllerMessageType;
+			readonly command: 'download-recording';
 	  };
 
 export const isCaptureControllerRequest = (

--- a/packages/canvas-capture-extension/wxt.config.ts
+++ b/packages/canvas-capture-extension/wxt.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
 		permissions: ['activeTab', 'scripting', 'storage', 'unlimitedStorage'],
 		action: {
 			default_title: 'Open Remotion Canvas Capture',
+			default_popup: 'recorder.html',
 		},
 	},
 	webExt: {


### PR DESCRIPTION
## Summary

- replace the separate Canvas Capture window with Chrome's toolbar-anchored action popup
- stop and finalize recordings before presenting Convert and Download choices
- use `@remotion/design` controls and a single 1px Remotion-blue capture outline

## Testing

- `bun run build`
- `bun run stylecheck`
