### PR TITLE
remotion.dev/convert: Add caption and Whisper output downloads

### DIFF
--- a/packages/convert/app/components/transcribe/App.tsx
+++ b/packages/convert/app/components/transcribe/App.tsx
@@ -96,7 +96,11 @@ const Transcribe: React.FC<{
 				/>
 				{state.type === 'transcribing' ? <div className="h-4" /> : null}
 				{state.type === 'done' ? (
-					<Display result={state.result} time={playbackTime} />
+					<Display
+						result={state.result}
+						time={playbackTime}
+						whisperWebGpuOutput={state.whisperWebGpuOutput}
+					/>
 				) : null}
 			</div>
 		</>

--- a/packages/convert/app/components/transcribe/display.tsx
+++ b/packages/convert/app/components/transcribe/display.tsx
@@ -1,8 +1,22 @@
 /* eslint-disable react/no-array-index-key */
 import type {Caption} from '@remotion/captions';
-import {Switch} from '@remotion/design';
+import {Button, Button as RemotionButton, Switch} from '@remotion/design';
+import type {WhisperWebGpuTranscription} from '@remotion/whisper-webgpu';
+import {Download} from 'lucide-react';
 import {useEffect, useMemo, useRef, useState} from 'react';
+import {ClipboardIcon} from '../icons/ClipboardIcon';
 import {Card} from '../ui/card';
+
+const downloadJson = (value: unknown, filename: string) => {
+	const blob = new Blob([JSON.stringify(value, null, 2)], {
+		type: 'application/json',
+	});
+	const a = document.createElement('a');
+	a.href = URL.createObjectURL(blob);
+	a.download = filename;
+	a.click();
+	URL.revokeObjectURL(a.href);
+};
 
 const SingleToken: React.FC<{
 	readonly caption: Caption;
@@ -37,9 +51,11 @@ const SingleToken: React.FC<{
 export default function Display({
 	result: unfilteredResult,
 	time,
+	whisperWebGpuOutput,
 }: {
 	readonly result: Caption[];
 	readonly time: number;
+	readonly whisperWebGpuOutput: WhisperWebGpuTranscription;
 }) {
 	const [tokens, setTokens] = useState<boolean>(false);
 
@@ -62,51 +78,85 @@ export default function Display({
 		return result.findLastIndex((c) => time * 1000 >= c.startMs);
 	}, [result, time]);
 
-	if (result.length === 0) {
-		return null;
-	}
-
 	return (
 		<div>
-			<div className="flex flex-row items-center">
-				<div className="font-semibold tracking-tight text-ellipsis font-brand overflow-x-hidden text-xl">
-					Show tokens
-				</div>
-				<div className="flex-1" />
-				<Switch active={tokens} onToggle={() => setTokens((e) => !e)} />
+			{result.length > 0 ? (
+				<>
+					<div className="flex flex-row items-center">
+						<div className="font-semibold tracking-tight text-ellipsis font-brand overflow-x-hidden text-xl">
+							Show tokens
+						</div>
+						<div className="flex-1" />
+						<Switch active={tokens} onToggle={() => setTokens((e) => !e)} />
+					</div>
+					<div className="h-4" />
+					<Card className="max-h-[80vh] overflow-y-auto">
+						<div data-tokens={tokens} className="data-[tokens=false]:p-4">
+							{result.map((c, index) => {
+								if (tokens) {
+									if (c.text.trim() === '') {
+										return null;
+									}
+
+									return (
+										<SingleToken
+											key={`${c.text}-${c.startMs}-${index}`}
+											caption={c}
+											time={time}
+											lastActive={index === lastActiveIndex}
+										/>
+									);
+								}
+
+								return (
+									<span
+										key={`${c.text}-${c.startMs}-${index}`}
+										data-active={time * 1000 >= c.startMs}
+										data-last-active={index === lastActiveIndex}
+										className="data-[active=true]:font-bold data-[last-active=true]:text-brand"
+									>
+										{c.text}
+									</span>
+								);
+							})}
+						</div>
+					</Card>
+					<div className="h-4" />
+				</>
+			) : null}
+			<RemotionButton
+				className="block w-full"
+				onClick={() => downloadJson(unfilteredResult, 'captions.json')}
+			>
+				Download as Caption[]
+			</RemotionButton>
+			<div className="h-2" />
+			<div className="flex flex-row gap-2">
+				<Button
+					className="w-full flex-1 flex-row justify-start rounded-full text-sm h-10"
+					type="button"
+					onClick={() =>
+						downloadJson(whisperWebGpuOutput, 'whisper-output.json')
+					}
+					depth={0.2}
+				>
+					<Download className="size-4" />
+					<div className="w-2" />
+					Whisper output
+				</Button>
+				<Button
+					className="w-full flex-1 flex-row justify-start rounded-full text-sm h-10"
+					type="button"
+					onClick={() =>
+						navigator.clipboard.writeText(whisperWebGpuOutput.text)
+					}
+					depth={0.2}
+				>
+					<ClipboardIcon />
+					<div className="w-2" />
+					Copy text
+				</Button>
 			</div>
-			<div className="h-4" />
-			<Card className="max-h-[80vh] overflow-y-auto">
-				<div data-tokens={tokens} className="data-[tokens=false]:p-4">
-					{result.map((c, index) => {
-						if (tokens) {
-							if (c.text.trim() === '') {
-								return null;
-							}
-
-							return (
-								<SingleToken
-									key={`${c.text}-${c.startMs}-${index}`}
-									caption={c}
-									time={time}
-									lastActive={index === lastActiveIndex}
-								/>
-							);
-						}
-
-						return (
-							<span
-								key={`${c.text}-${c.startMs}-${index}`}
-								data-active={time * 1000 >= c.startMs}
-								data-last-active={index === lastActiveIndex}
-								className="data-[active=true]:font-bold data-[last-active=true]:text-brand"
-							>
-								{c.text}
-							</span>
-						);
-					})}
-				</div>
-			</Card>
 		</div>
 	);
 }

--- a/packages/convert/app/components/transcribe/state.ts
+++ b/packages/convert/app/components/transcribe/state.ts
@@ -1,5 +1,8 @@
 import type {Caption} from '@remotion/captions';
-import type {WhisperWebGpuModelLoadProgress} from '@remotion/whisper-webgpu';
+import type {
+	WhisperWebGpuModelLoadProgress,
+	WhisperWebGpuTranscription,
+} from '@remotion/whisper-webgpu';
 
 export type TranscriptionState =
 	| {
@@ -18,5 +21,6 @@ export type TranscriptionState =
 	| {
 			type: 'done';
 			result: Caption[];
+			whisperWebGpuOutput: WhisperWebGpuTranscription;
 	  }
 	| {type: 'error'; message: string};

--- a/packages/convert/app/components/transcribe/transcribeAudio.tsx
+++ b/packages/convert/app/components/transcribe/transcribeAudio.tsx
@@ -20,6 +20,17 @@ const sourceToBlob = (source: Source) => {
 	return fetch(source.url).then((r) => r.blob());
 };
 
+const downloadJson = (value: unknown, filename: string) => {
+	const blob = new Blob([JSON.stringify(value, null, 2)], {
+		type: 'application/json',
+	});
+	const a = document.createElement('a');
+	a.href = URL.createObjectURL(blob);
+	a.download = filename;
+	a.click();
+	URL.revokeObjectURL(a.href);
+};
+
 export default function TranscribeAudio({
 	source,
 	selectedModel,
@@ -64,6 +75,7 @@ export default function TranscribeAudio({
 			setState(() => ({
 				type: 'done',
 				result: toCaptions({whisperWebGpuOutput: transcription}).captions,
+				whisperWebGpuOutput: transcription,
 			}));
 		} catch (error) {
 			setState({
@@ -131,6 +143,26 @@ export default function TranscribeAudio({
 						Transcribed with WebGPU
 						{state.result.length === 0 ? ' · No speech detected' : null}
 					</Card>
+					<div className="h-2" />
+					<Button
+						type="button"
+						className="block w-full"
+						variant="brand"
+						onClick={() => downloadJson(state.result, 'captions.json')}
+					>
+						Download captions.json
+					</Button>
+					<div className="h-2" />
+					<Button
+						type="button"
+						className="block w-full"
+						variant="brandsecondary"
+						onClick={() =>
+							downloadJson(state.whisperWebGpuOutput, 'whisper-output.json')
+						}
+					>
+						Download raw Whisper output
+					</Button>
 					<div className="h-4" />
 				</>
 			) : null}

--- a/packages/convert/app/components/transcribe/transcribeAudio.tsx
+++ b/packages/convert/app/components/transcribe/transcribeAudio.tsx
@@ -20,17 +20,6 @@ const sourceToBlob = (source: Source) => {
 	return fetch(source.url).then((r) => r.blob());
 };
 
-const downloadJson = (value: unknown, filename: string) => {
-	const blob = new Blob([JSON.stringify(value, null, 2)], {
-		type: 'application/json',
-	});
-	const a = document.createElement('a');
-	a.href = URL.createObjectURL(blob);
-	a.download = filename;
-	a.click();
-	URL.revokeObjectURL(a.href);
-};
-
 export default function TranscribeAudio({
 	source,
 	selectedModel,
@@ -143,26 +132,6 @@ export default function TranscribeAudio({
 						Transcribed with WebGPU
 						{state.result.length === 0 ? ' · No speech detected' : null}
 					</Card>
-					<div className="h-2" />
-					<Button
-						type="button"
-						className="block w-full"
-						variant="brand"
-						onClick={() => downloadJson(state.result, 'captions.json')}
-					>
-						Download captions.json
-					</Button>
-					<div className="h-2" />
-					<Button
-						type="button"
-						className="block w-full"
-						variant="brandsecondary"
-						onClick={() =>
-							downloadJson(state.whisperWebGpuOutput, 'whisper-output.json')
-						}
-					>
-						Download raw Whisper output
-					</Button>
 					<div className="h-4" />
 				</>
 			) : null}

--- a/packages/convert/test/transcribe-webgpu.test.tsx
+++ b/packages/convert/test/transcribe-webgpu.test.tsx
@@ -1,7 +1,7 @@
 import {afterEach, expect, test} from 'bun:test';
 import {cleanup, fireEvent, render} from '@testing-library/react';
+import Display from '../app/components/transcribe/display';
 import ModelSelector from '../app/components/transcribe/modelSelector';
-import TranscribeAudio from '../app/components/transcribe/transcribeAudio';
 
 afterEach(() => cleanup());
 
@@ -20,13 +20,18 @@ test('offers WebGPU model downloads', () => {
 	expect(model.textContent).toContain('Downloaded');
 });
 
-test('downloads captions and raw Whisper output as JSON', async () => {
+test('offers transcription actions underneath the transcript', async () => {
 	const originalCreateObjectUrl = URL.createObjectURL;
 	const originalRevokeObjectUrl = URL.revokeObjectURL;
 	const originalAnchorClick = HTMLAnchorElement.prototype.click;
+	const originalClipboard = Object.getOwnPropertyDescriptor(
+		navigator,
+		'clipboard',
+	);
 	const blobs: Blob[] = [];
 	const revokedUrls: string[] = [];
 	const downloads: Array<{filename: string; url: string}> = [];
+	const copiedText: string[] = [];
 
 	URL.createObjectURL = (blob) => {
 		if (!(blob instanceof Blob)) {
@@ -40,6 +45,15 @@ test('downloads captions and raw Whisper output as JSON', async () => {
 	HTMLAnchorElement.prototype.click = function () {
 		downloads.push({filename: this.download, url: this.href});
 	};
+	Object.defineProperty(navigator, 'clipboard', {
+		configurable: true,
+		value: {
+			writeText: (text: string) => {
+				copiedText.push(text);
+				return Promise.resolve();
+			},
+		},
+	});
 
 	const captions = [
 		{
@@ -64,25 +78,25 @@ test('downloads captions and raw Whisper output as JSON', async () => {
 
 	try {
 		const rendered = render(
-			<TranscribeAudio
-				source={{type: 'file', file: new File([], 'audio.mp3')}}
-				selectedModel="tiny.en"
-				name="audio.mp3"
-				state={{
-					type: 'done',
-					result: captions,
-					whisperWebGpuOutput,
-				}}
-				setState={() => undefined}
+			<Display
+				result={captions}
+				time={0}
+				whisperWebGpuOutput={whisperWebGpuOutput}
 			/>,
 		);
 
-		fireEvent.click(
-			rendered.getByRole('button', {name: 'Download captions.json'}),
-		);
-		fireEvent.click(
-			rendered.getByRole('button', {name: 'Download raw Whisper output'}),
-		);
+		const downloadCaptions = rendered.getByRole('button', {
+			name: 'Download as Caption[]',
+		});
+		const transcript = rendered.getByText('Hello');
+		expect(
+			transcript.compareDocumentPosition(downloadCaptions) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+
+		fireEvent.click(downloadCaptions);
+		fireEvent.click(rendered.getByRole('button', {name: 'Whisper output'}));
+		fireEvent.click(rendered.getByRole('button', {name: 'Copy text'}));
 
 		expect(downloads).toEqual([
 			{filename: 'captions.json', url: 'blob:transcription-1'},
@@ -100,9 +114,15 @@ test('downloads captions and raw Whisper output as JSON', async () => {
 			'blob:transcription-1',
 			'blob:transcription-2',
 		]);
+		expect(copiedText).toEqual(['Hello']);
 	} finally {
 		URL.createObjectURL = originalCreateObjectUrl;
 		URL.revokeObjectURL = originalRevokeObjectUrl;
 		HTMLAnchorElement.prototype.click = originalAnchorClick;
+		if (originalClipboard) {
+			Object.defineProperty(navigator, 'clipboard', originalClipboard);
+		} else {
+			Reflect.deleteProperty(navigator, 'clipboard');
+		}
 	}
 });

--- a/packages/convert/test/transcribe-webgpu.test.tsx
+++ b/packages/convert/test/transcribe-webgpu.test.tsx
@@ -1,6 +1,7 @@
 import {afterEach, expect, test} from 'bun:test';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import ModelSelector from '../app/components/transcribe/modelSelector';
+import TranscribeAudio from '../app/components/transcribe/transcribeAudio';
 
 afterEach(() => cleanup());
 
@@ -17,4 +18,91 @@ test('offers WebGPU model downloads', () => {
 	const model = rendered.getByRole('combobox', {name: 'Whisper model'});
 	expect(model.textContent).toContain('119.7 MB WebGPU');
 	expect(model.textContent).toContain('Downloaded');
+});
+
+test('downloads captions and raw Whisper output as JSON', async () => {
+	const originalCreateObjectUrl = URL.createObjectURL;
+	const originalRevokeObjectUrl = URL.revokeObjectURL;
+	const originalAnchorClick = HTMLAnchorElement.prototype.click;
+	const blobs: Blob[] = [];
+	const revokedUrls: string[] = [];
+	const downloads: Array<{filename: string; url: string}> = [];
+
+	URL.createObjectURL = (blob) => {
+		if (!(blob instanceof Blob)) {
+			throw new Error('Expected a Blob');
+		}
+
+		blobs.push(blob);
+		return `blob:transcription-${blobs.length}`;
+	};
+	URL.revokeObjectURL = (url) => revokedUrls.push(url);
+	HTMLAnchorElement.prototype.click = function () {
+		downloads.push({filename: this.download, url: this.href});
+	};
+
+	const captions = [
+		{
+			text: 'Hello',
+			startMs: 0,
+			endMs: 500,
+			timestampMs: 250,
+			confidence: null,
+		},
+	];
+	const whisperWebGpuOutput = {
+		text: 'Hello',
+		words: [
+			{
+				text: 'Hello',
+				startInSeconds: 0,
+				endInSeconds: 0.5,
+			},
+		],
+		model: 'tiny.en' as const,
+	};
+
+	try {
+		const rendered = render(
+			<TranscribeAudio
+				source={{type: 'file', file: new File([], 'audio.mp3')}}
+				selectedModel="tiny.en"
+				name="audio.mp3"
+				state={{
+					type: 'done',
+					result: captions,
+					whisperWebGpuOutput,
+				}}
+				setState={() => undefined}
+			/>,
+		);
+
+		fireEvent.click(
+			rendered.getByRole('button', {name: 'Download captions.json'}),
+		);
+		fireEvent.click(
+			rendered.getByRole('button', {name: 'Download raw Whisper output'}),
+		);
+
+		expect(downloads).toEqual([
+			{filename: 'captions.json', url: 'blob:transcription-1'},
+			{filename: 'whisper-output.json', url: 'blob:transcription-2'},
+		]);
+		expect(blobs.map((blob) => blob.type)).toEqual([
+			'application/json',
+			'application/json',
+		]);
+		expect(await blobs[0]?.text()).toBe(JSON.stringify(captions, null, 2));
+		expect(await blobs[1]?.text()).toBe(
+			JSON.stringify(whisperWebGpuOutput, null, 2),
+		);
+		expect(revokedUrls).toEqual([
+			'blob:transcription-1',
+			'blob:transcription-2',
+		]);
+	} finally {
+		URL.createObjectURL = originalCreateObjectUrl;
+		URL.revokeObjectURL = originalRevokeObjectUrl;
+		HTMLAnchorElement.prototype.click = originalAnchorClick;
+	}
 });


### PR DESCRIPTION
## Summary

- add a `captions.json` download containing the generated `Caption[]`
- preserve and expose the raw Whisper WebGPU transcription as `whisper-output.json`
- add an action for copying the plain transcription text
- place the primary and secondary actions beneath the transcript, matching video downloads
- use the same object URL download flow as converted video downloads

## Testing

- `bun test test` in `packages/convert`
- `bun run build`
- `bun run stylecheck`

Closes #10825
