### PR TITLE
`@remotion/renderer`: Report available memory instead of free pages

### DIFF
--- a/packages/renderer/src/memory/from-macos-memory-pressure.ts
+++ b/packages/renderer/src/memory/from-macos-memory-pressure.ts
@@ -1,0 +1,57 @@
+import {execFileSync} from 'node:child_process';
+import type {LogLevel} from '../log-level';
+import {Log} from '../logger';
+
+export const parseMacOSMemoryPressureOutput = (output: string) => {
+	const totalMemoryMatch = output.match(/The system has (\d+) /);
+	const freePercentageMatch = output.match(
+		/System-wide memory free percentage:\s*([\d.]+)%/,
+	);
+
+	if (totalMemoryMatch === null || freePercentageMatch === null) {
+		return null;
+	}
+
+	const totalMemory = Number(totalMemoryMatch[1]);
+	const freePercentage = Number(freePercentageMatch[1]);
+
+	if (
+		!Number.isFinite(totalMemory) ||
+		totalMemory <= 0 ||
+		!Number.isFinite(freePercentage) ||
+		freePercentage < 0 ||
+		freePercentage > 100
+	) {
+		return null;
+	}
+
+	return totalMemory * (freePercentage / 100);
+};
+
+export const getAvailableMemoryFromMacOS = (
+	logLevel: LogLevel,
+): number | null => {
+	if (process.platform !== 'darwin') {
+		return null;
+	}
+
+	try {
+		const output = execFileSync('/usr/bin/memory_pressure', [], {
+			encoding: 'utf8',
+		});
+		const availableMemory = parseMacOSMemoryPressureOutput(output);
+
+		if (availableMemory === null) {
+			throw new Error('Failed to parse memory_pressure output');
+		}
+
+		return availableMemory;
+	} catch (err) {
+		Log.verbose(
+			{indent: false, logLevel},
+			'Failed to get available memory from macOS memory_pressure, falling back to os.freemem():',
+		);
+		Log.verbose({indent: false, logLevel}, err);
+		return null;
+	}
+};

--- a/packages/renderer/src/memory/from-proc-meminfo.ts
+++ b/packages/renderer/src/memory/from-proc-meminfo.ts
@@ -2,7 +2,7 @@ import {existsSync, readFileSync} from 'node:fs';
 import type {LogLevel} from '../log-level';
 import {Log} from '../logger';
 
-export const getFreeMemoryFromProcMeminfo = (
+export const getAvailableMemoryFromProcMeminfo = (
 	logLevel: LogLevel,
 ): number | null => {
 	if (!existsSync('/proc/meminfo')) {
@@ -11,7 +11,8 @@ export const getFreeMemoryFromProcMeminfo = (
 
 	try {
 		const data = readFileSync('/proc/meminfo', 'utf-8');
-		// Split the file by lines and find the line with MemFree
+		// MemAvailable includes reclaimable memory and is a better estimate than MemFree
+		// of how much memory can be allocated without swapping.
 		const lines = data.split('\n');
 		const memAvailableLine = lines.find((line) =>
 			line.startsWith('MemAvailable'),

--- a/packages/renderer/src/memory/get-available-memory.ts
+++ b/packages/renderer/src/memory/get-available-memory.ts
@@ -3,45 +3,41 @@ import type {LogLevel} from '../log-level';
 import {Log} from '../logger';
 import {getAvailableMemoryFromCgroup} from './from-docker-cgroup';
 import {getMaxLambdaMemory} from './from-lambda-env';
-import {getFreeMemoryFromProcMeminfo} from './from-proc-meminfo';
+import {getAvailableMemoryFromMacOS} from './from-macos-memory-pressure';
+import {getAvailableMemoryFromProcMeminfo} from './from-proc-meminfo';
+
+type MemoryEstimate = {
+	bytes: number;
+	source: string;
+};
 
 export const getAvailableMemory = (logLevel: LogLevel) => {
-	// If we are in Lambda, the most reliable way is to read the environment variable
-	// This is also pretty much free
-	const maxMemory = getMaxLambdaMemory();
+	const procInfo = getAvailableMemoryFromProcMeminfo(logLevel);
+	const macOSMemory = getAvailableMemoryFromMacOS(logLevel);
+	const hostEstimate: MemoryEstimate =
+		procInfo !== null
+			? {bytes: procInfo, source: '/proc/meminfo MemAvailable'}
+			: macOSMemory !== null
+				? {bytes: macOSMemory, source: 'macOS memory_pressure'}
+				: {bytes: freemem(), source: 'os.freemem()'};
 
-	if (maxMemory !== null) {
-		const nodeMemory = freemem();
-		return Math.min(nodeMemory, maxMemory);
-	}
-
-	// If cgroup memory data is available, we are in Docker, and we should respect it
+	const estimates = [hostEstimate];
 	const cgroupMemory = getAvailableMemoryFromCgroup();
-	if (cgroupMemory !== null) {
+	if (cgroupMemory !== null && Number.isFinite(cgroupMemory)) {
 		// There are 2 Docker memory configurations:
 		// 1. --memory=[num]
 		// 2. Global Docker memory limit
 
 		// If cgroup limit is higher than global memory, the global memory limit still applies
-		const nodeMemory = freemem();
-		const _procInfo = getFreeMemoryFromProcMeminfo(logLevel);
-
-		if (cgroupMemory > nodeMemory * 1.25 && Number.isFinite(cgroupMemory)) {
+		if (cgroupMemory > hostEstimate.bytes * 1.25) {
 			Log.warn({indent: false, logLevel}, 'Detected differing memory amounts:');
 			Log.warn(
 				{indent: false, logLevel},
 				`Memory reported by CGroup: ${(cgroupMemory / 1024 / 1024).toFixed(2)} MB`,
 			);
-			if (_procInfo !== null) {
-				Log.warn(
-					{indent: false, logLevel},
-					`Memory reported by /proc/meminfo: ${(_procInfo / 1024 / 1024).toFixed(2)} MB`,
-				);
-			}
-
 			Log.warn(
 				{indent: false, logLevel},
-				`Memory reported by Node: ${(nodeMemory / 1024 / 1024).toFixed(2)} MB`,
+				`Host available memory reported by ${hostEstimate.source}: ${(hostEstimate.bytes / 1024 / 1024).toFixed(2)} MB`,
 			);
 			Log.warn(
 				{indent: false, logLevel},
@@ -53,14 +49,28 @@ export const getAvailableMemory = (logLevel: LogLevel) => {
 			);
 		}
 
-		return Math.min(nodeMemory, cgroupMemory);
+		estimates.push({
+			bytes: Math.max(0, cgroupMemory),
+			source: 'remaining CGroup allocation',
+		});
 	}
 
-	const procInfo = getFreeMemoryFromProcMeminfo(logLevel);
-
-	if (procInfo !== null) {
-		return Math.min(freemem(), procInfo);
+	const maxLambdaMemory = getMaxLambdaMemory();
+	if (maxLambdaMemory !== null && Number.isFinite(maxLambdaMemory)) {
+		estimates.push({
+			bytes: Math.max(0, maxLambdaMemory),
+			source: 'AWS Lambda memory limit',
+		});
 	}
 
-	return freemem();
+	const selected = estimates.reduce((lowest, estimate) =>
+		estimate.bytes < lowest.bytes ? estimate : lowest,
+	);
+
+	Log.verbose(
+		{indent: false, logLevel},
+		`Available memory for rendering: ${(selected.bytes / 1024 / 1024).toFixed(2)} MB (${selected.source}; lowest applicable host estimate or allocation limit).`,
+	);
+
+	return selected.bytes;
 };

--- a/packages/renderer/src/test/get-available-memory.test.ts
+++ b/packages/renderer/src/test/get-available-memory.test.ts
@@ -1,0 +1,155 @@
+import {afterEach, expect, mock, spyOn, test} from 'bun:test';
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+const gibibyte = 1024 * 1024 * 1024;
+const memoryPaths = new Set([
+	'/proc/meminfo',
+	'/sys/fs/cgroup/memory.max',
+	'/sys/fs/cgroup/memory.current',
+	'/sys/fs/cgroup/memory/memory.limit_in_bytes',
+	'/sys/fs/cgroup/memory/memory.usage_in_bytes',
+]);
+const originalPlatform = process.platform;
+const originalLambdaMemory = process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE;
+
+let nodeFreeMemory = 2 * gibibyte;
+let memoryPressureOutput: string | null = null;
+let files = new Map<string, string>();
+
+mock.module('node:os', () => ({
+	...os,
+	freemem: () => nodeFreeMemory,
+}));
+
+mock.module('node:fs', () => ({
+	...fs,
+	existsSync: (path: fs.PathLike) => {
+		const filePath = path.toString();
+		if (memoryPaths.has(filePath)) {
+			return files.has(filePath);
+		}
+
+		return fs.existsSync(path);
+	},
+	readFileSync: (path: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+		const filePath = path.toString();
+		if (memoryPaths.has(filePath)) {
+			const contents = files.get(filePath);
+			if (contents === undefined) {
+				throw new Error(`ENOENT: ${filePath}`);
+			}
+
+			return contents;
+		}
+
+		return Reflect.apply(fs.readFileSync, fs, [path, ...args]);
+	},
+}));
+
+mock.module('node:child_process', () => ({
+	...childProcess,
+	execFileSync: (file: string, ...args: unknown[]) => {
+		if (file === '/usr/bin/memory_pressure') {
+			if (memoryPressureOutput === null) {
+				throw new Error('memory_pressure unavailable');
+			}
+
+			return memoryPressureOutput;
+		}
+
+		return Reflect.apply(childProcess.execFileSync, childProcess, [
+			file,
+			...args,
+		]);
+	},
+}));
+
+const {getAvailableMemory} = require('../memory/get-available-memory');
+
+const setPlatform = (platform: string) => {
+	Object.defineProperty(process, 'platform', {value: platform});
+};
+
+const setProcAvailableMemory = (availableMemory: number) => {
+	files.set(
+		'/proc/meminfo',
+		`MemTotal: 16777216 kB\nMemFree: 1048576 kB\nMemAvailable: ${availableMemory / 1024} kB\n`,
+	);
+};
+
+afterEach(() => {
+	Object.defineProperty(process, 'platform', {value: originalPlatform});
+	nodeFreeMemory = 2 * gibibyte;
+	memoryPressureOutput = null;
+	files = new Map();
+
+	if (originalLambdaMemory === undefined) {
+		delete process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE;
+	} else {
+		process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = originalLambdaMemory;
+	}
+});
+
+test('uses Linux MemAvailable instead of immediately free pages', () => {
+	setPlatform('linux');
+	setProcAvailableMemory(8 * gibibyte);
+
+	expect(getAvailableMemory('error')).toBe(8 * gibibyte);
+});
+
+test('bounds Linux MemAvailable by the remaining finite CGroup allocation', () => {
+	setPlatform('linux');
+	setProcAvailableMemory(8 * gibibyte);
+	files.set('/sys/fs/cgroup/memory.max', String(6 * gibibyte));
+	files.set('/sys/fs/cgroup/memory.current', String(gibibyte));
+
+	expect(getAvailableMemory('error')).toBe(5 * gibibyte);
+});
+
+test('ignores an unlimited CGroup when selecting Linux MemAvailable', () => {
+	setPlatform('linux');
+	setProcAvailableMemory(8 * gibibyte);
+	files.set('/sys/fs/cgroup/memory.max', 'max');
+	files.set('/sys/fs/cgroup/memory.current', String(gibibyte));
+
+	expect(getAvailableMemory('error')).toBe(8 * gibibyte);
+});
+
+test('uses the pressure-aware macOS available-memory estimate', () => {
+	setPlatform('darwin');
+	const totalMemory = 24 * gibibyte;
+	memoryPressureOutput = `The system has ${totalMemory} (1572864 pages with a page size of 16384).\n\nSystem-wide memory free percentage: 79%\n`;
+
+	expect(getAvailableMemory('error')).toBe(totalMemory * 0.79);
+});
+
+test('falls back to os.freemem() when memory_pressure cannot be parsed', () => {
+	setPlatform('darwin');
+	memoryPressureOutput = 'Unexpected output';
+
+	expect(getAvailableMemory('error')).toBe(2 * gibibyte);
+});
+
+test('keeps the Lambda memory limit as a hard upper bound', () => {
+	setPlatform('linux');
+	setProcAvailableMemory(8 * gibibyte);
+	process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '4096';
+
+	expect(getAvailableMemory('error')).toBe(4 * gibibyte);
+});
+
+test('verbose logging identifies the selected memory source', () => {
+	setPlatform('darwin');
+	const totalMemory = 24 * gibibyte;
+	memoryPressureOutput = `The system has ${totalMemory} (1572864 pages with a page size of 16384).\n\nSystem-wide memory free percentage: 79%\n`;
+	const consoleSpy = spyOn(console, 'log').mockImplementation(() => undefined);
+
+	getAvailableMemory('verbose');
+
+	expect(consoleSpy.mock.calls.flat().join(' ')).toContain(
+		'Available memory for rendering: 19415.04 MB (macOS memory_pressure;',
+	);
+	consoleSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary

- use `/proc/meminfo`'s `MemAvailable` instead of immediately free pages on Linux
- use macOS `memory_pressure` as a pressure-aware host estimate with an `os.freemem()` fallback
- retain finite CGroup and Lambda limits as hard caps and identify the selected source in verbose logs
- add deterministic platform and bounding regression tests

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun run --cwd packages/renderer test` (356 tests passed)
- red/green regression verification against the previous Linux free-page selection

Closes #10654
