### PR TITLE
Elements: Prevent Drag into Studio action flash

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -54,9 +54,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const [isSourceVisible, setIsSourceVisible] = useState(false);
 	const [isBrowserStudioActionVisible, setIsBrowserStudioActionVisible] =
 		useState(false);
-	const [isEmbeddedInStudio, setIsEmbeddedInStudio] = useState<boolean | null>(
-		null,
-	);
+	const [isEmbeddedInStudio, setIsEmbeddedInStudio] = useState(false);
 	const posterRef = useRef<HTMLImageElement>(null);
 	const sourceId = useId();
 	const {height: previewHeight, width: previewWidth} =


### PR DESCRIPTION
## Summary

- render the Drag into Studio action in the initial HTML for standalone Element pages
- continue hiding the action after detecting that the catalog is embedded in Studio

## Testing

- `bun run build`
- `bun run stylecheck`
