### PR TITLE
Elements: Keep installed Elements visible at the playhead

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -242,6 +242,15 @@ export const MyComponent = () => {
 		await decoyStudioPage.mouse.click(500, 300);
 
 		await studioPage.bringToFront();
+		await studioPage.keyboard.press('g');
+		const currentFrameInput = studioPage.locator('input:focus');
+		await expect(currentFrameInput).toBeVisible();
+		await currentFrameInput.fill('45');
+		await currentFrameInput.press('Enter');
+		await expect(
+			studioPage.getByRole('button', {name: '45', exact: true}),
+		).toBeVisible();
+
 		await studioPage.locator('[data-sidebar-toggle="right"]').click();
 		const browseElements = studioPage.getByRole('button', {
 			name: 'Browse Elements',
@@ -332,6 +341,9 @@ export const MyComponent = () => {
 		);
 		expect(compositionSource).toContain('ProtocolElement');
 		expect(compositionSource).toContain('protocol-element.element');
+		expect(compositionSource).toMatch(
+			/<Sequence\b(?=[^>]*\bfrom=\{45\})(?=[^>]*\bdurationInFrames=\{30\})[^>]*>\s*<ProtocolElement\s*\/>\s*<\/Sequence>/,
+		);
 
 		await studioPage.bringToFront();
 		await studioPage.mouse.click(500, 300);

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -842,8 +842,7 @@ export const Canvas: React.FC<{
 
 	useEffect(() => {
 		return subscribeToElementInstallRequests((request) => {
-			setPendingElementInstallRequests((requests) => [
-				...requests,
+			const requestWithFrom =
 				request.source.type === 'drag-and-drop' || request.from !== null
 					? request
 					: {
@@ -853,7 +852,10 @@ export const Canvas: React.FC<{
 								from: getCurrentFrame(),
 								preferCompositionStart: true,
 							}),
-						},
+						};
+			setPendingElementInstallRequests((requests) => [
+				...requests,
+				requestWithFrom,
 			]);
 		});
 	}, []);

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -72,6 +72,7 @@ import {
 import {ElementInstallConfirmation} from './ElementInstallConfirmation';
 import {handleDrop} from './handle-drop';
 import {
+	getFromForDrop,
 	hasSvgFile,
 	importAssets,
 	importFigmaClipboard,
@@ -835,16 +836,25 @@ export const Canvas: React.FC<{
 				return;
 			}
 
-			setPendingElementInstallRequests((requests) => [
-				...requests,
-				event.request,
-			]);
+			enqueueElementInstallRequest(event.request);
 		});
 	}, [previewServerClientId, subscribeToEvent]);
 
 	useEffect(() => {
 		return subscribeToElementInstallRequests((request) => {
-			setPendingElementInstallRequests((requests) => [...requests, request]);
+			setPendingElementInstallRequests((requests) => [
+				...requests,
+				request.source.type === 'drag-and-drop' || request.from !== null
+					? request
+					: {
+							...request,
+							from: getFromForDrop({
+								durationInFrames: request.element.durationInFrames,
+								from: getCurrentFrame(),
+								preferCompositionStart: true,
+							}),
+						},
+			]);
 		});
 	}, []);
 


### PR DESCRIPTION
## Summary

- Place installed Elements at the composition start when they cover the playhead, otherwise at the current playhead
- Apply the existing Canvas asset placement policy to Studio Protocol and Browser Studio Element installs
- Cover the embedded Element library installation flow with an end-to-end test

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test e2e/studio-protocol.test.mts`

Closes #10880
