### PR TITLE
Studio: add on-canvas border radius control

### DIFF
--- a/packages/studio/src/components/SelectedOutlineBorderRadiusHandle.tsx
+++ b/packages/studio/src/components/SelectedOutlineBorderRadiusHandle.tsx
@@ -1,0 +1,256 @@
+import React, {useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {BLUE, SELECTED_OUTLINE_DROP_SHADOW} from '../helpers/colors';
+import {startCapturedPointerSession} from '../helpers/pointer-session';
+import {
+	forceSpecificCursor,
+	stopForcingSpecificCursor,
+} from './ForceSpecificCursor';
+import {showNotification} from './Notifications/NotificationCenter';
+import {
+	clearSelectedOutlineBorderRadiusDragOverrides,
+	getSelectedOutlineBorderRadiusDragChanges,
+	getSelectedOutlineBorderRadiusDragStates,
+	isSelectedOutlineDragPastThreshold,
+} from './selected-outline-drag';
+import type {SelectedOutline} from './selected-outline-geometry';
+import {borderRadiusFieldKey} from './selected-outline-types';
+import type {SelectedOutlineBorderRadiusDragTarget} from './selected-outline-types';
+import {svgPointToClientPoint} from './svg-point-to-client-point';
+import {callAddKeyframes} from './Timeline/call-add-keyframe';
+import {getCurrentFrame} from './Timeline/imperative-state';
+import {saveSequenceProps} from './Timeline/save-sequence-prop';
+
+const MIN_RADIUS = 0;
+
+export const SelectedOutlineBorderRadiusHandle: React.FC<{
+	readonly handlePoint: {readonly x: number; readonly y: number};
+	readonly onDraggingChange: (dragging: boolean) => void;
+	readonly outline: SelectedOutline;
+	readonly radius: number;
+	readonly target: SelectedOutlineBorderRadiusDragTarget | null;
+}> = ({handlePoint, onDraggingChange, outline, radius, target}) => {
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
+		Internals.VisualModeSettersContext,
+	);
+
+	const borderRadiusDrag = target ?? null;
+
+	const handlePosition = useMemo(() => {
+		const points = outline.uncroppedPoints ?? outline.points;
+		// The handle sits just inside the top-left corner; distance from the
+		// pointer to the top-left corner maps to the radius.
+		return points[0];
+	}, [outline.uncroppedPoints, outline.points]);
+
+	const onPointerDown = React.useCallback(
+		(event: React.PointerEvent<SVGGElement>) => {
+			if (event.button !== 0 || borderRadiusDrag === null) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const svg = event.currentTarget.ownerSVGElement;
+			if (svg === null) {
+				return;
+			}
+
+			const corner = svgPointToClientPoint(
+				handlePosition,
+				svg.getBoundingClientRect(),
+			);
+			const anchor = corner;
+
+			const dragStates = getSelectedOutlineBorderRadiusDragStates({
+				dragTargets: [borderRadiusDrag],
+				getDragOverrides,
+				timelinePosition: getCurrentFrame(),
+			});
+
+			let lastValue = new Map<string, number>();
+			let dragStarted = false;
+			let currentClientX = event.clientX;
+			let currentClientY = event.clientY;
+
+			const clampRadius = (value: number) => {
+				const max =
+					borderRadiusDrag.fieldSchema.max ?? Number.POSITIVE_INFINITY;
+				return Math.max(MIN_RADIUS, Math.min(value, max));
+			};
+
+			const updateBorderRadiusOverrides = () => {
+				const distance = Math.hypot(
+					currentClientX - anchor.x,
+					currentClientY - anchor.y,
+				);
+				const nextRadius = clampRadius(distance);
+				lastValue = new Map(
+					dragStates.map((dragState) => [dragState.key, nextRadius]),
+				);
+
+				forceSpecificCursor('ns-resize');
+
+				for (const dragState of dragStates) {
+					const value = lastValue.get(dragState.key);
+					if (value === undefined) {
+						continue;
+					}
+
+					if (dragState.target.propStatus.status === 'keyframed') {
+						setDragOverrides(
+							dragState.target.nodePath,
+							borderRadiusFieldKey,
+							Internals.makeKeyframedDragOverride({
+								status: dragState.target.propStatus,
+								frame: dragState.sourceFrame,
+								value,
+							}),
+						);
+					} else {
+						setDragOverrides(
+							dragState.target.nodePath,
+							borderRadiusFieldKey,
+							Internals.makeStaticDragOverride(value),
+						);
+					}
+				}
+			};
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				moveEvent.preventDefault();
+				const deltaX = moveEvent.clientX - event.clientX;
+				const deltaY = moveEvent.clientY - event.clientY;
+				if (!dragStarted) {
+					if (
+						!isSelectedOutlineDragPastThreshold({
+							deltaX,
+							deltaY,
+						})
+					) {
+						return;
+					}
+
+					dragStarted = true;
+					onDraggingChange(true);
+				}
+
+				currentClientX = moveEvent.clientX;
+				currentClientY = moveEvent.clientY;
+				updateBorderRadiusOverrides();
+			};
+
+			const onPointerUp = () => {
+				if (dragStarted) {
+					stopForcingSpecificCursor();
+					onDraggingChange(false);
+				}
+
+				const changes = getSelectedOutlineBorderRadiusDragChanges({
+					dragStates,
+					lastValues: lastValue,
+				});
+
+				if (changes.length === 0) {
+					clearSelectedOutlineBorderRadiusDragOverrides({
+						clearDragOverrides,
+						dragStates,
+					});
+					return;
+				}
+
+				const staticChanges = changes.filter(
+					(change): change is Extract<typeof change, {type: 'static'}> =>
+						change.type === 'static',
+				);
+				const keyframedChanges = changes.filter(
+					(change): change is Extract<typeof change, {type: 'keyframed'}> =>
+						change.type === 'keyframed',
+				);
+
+				Promise.all([
+					staticChanges.length > 0
+						? saveSequenceProps({
+								changes: staticChanges,
+								addedKeyframes: null,
+								movedKeyframes: null,
+								setPropStatuses,
+								clientId: borderRadiusDrag.clientId,
+								undoLabel: 'Change border radius',
+								redoLabel: 'Change border radius back',
+							})
+						: Promise.resolve(),
+					keyframedChanges.length > 0
+						? callAddKeyframes({
+								sequenceKeyframes: keyframedChanges,
+								effectKeyframes: [],
+								setPropStatuses,
+								clientId: borderRadiusDrag.clientId,
+							})
+						: Promise.resolve(),
+				])
+					.catch((err) => {
+						showNotification(
+							`Could not save border radius: ${
+								err instanceof Error ? err.message : String(err)
+							}`,
+							4000,
+						);
+					})
+					.finally(() => {
+						clearSelectedOutlineBorderRadiusDragOverrides({
+							clearDragOverrides,
+							dragStates,
+						});
+					});
+			};
+
+			startCapturedPointerSession({
+				event,
+				captureTarget: event.currentTarget,
+				onMove: onPointerMove,
+				onEnd: onPointerUp,
+			});
+		},
+		[
+			borderRadiusDrag,
+			clearDragOverrides,
+			getDragOverrides,
+			handlePosition,
+			onDraggingChange,
+			setDragOverrides,
+			setPropStatuses,
+		],
+	);
+
+	if (borderRadiusDrag === null) {
+		return null;
+	}
+
+	return (
+		<g
+			data-remotion-studio-border-radius-handle
+			pointerEvents="all"
+			cursor="ns-resize"
+			onPointerDown={onPointerDown}
+			aria-hidden="true"
+			style={{
+				filter: SELECTED_OUTLINE_DROP_SHADOW,
+			}}
+		>
+			<circle
+				cx={handlePoint.x}
+				cy={handlePoint.y}
+				r={radius / 2}
+				stroke={BLUE}
+				fill="none"
+				strokeWidth={2}
+				vectorEffect="non-scaling-stroke"
+			/>
+		</g>
+	);
+};

--- a/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
+++ b/packages/studio/src/components/SelectedOutlineEditingHandles.tsx
@@ -8,6 +8,7 @@ import type {
 	SelectedOutlineScaleDragTarget,
 	SelectedOutlineTarget,
 } from './selected-outline-types';
+import {SelectedOutlineBorderRadiusHandle} from './SelectedOutlineBorderRadiusHandle';
 import {SelectedOutlineCropControls} from './SelectedOutlineCropControls';
 import {SelectedOutlineRotationCornerHandle} from './SelectedOutlineRotationCornerHandle';
 import {SelectedOutlineScaleEdgeLine} from './SelectedOutlineScaleEdgeLine';
@@ -109,6 +110,26 @@ export const SelectedOutlineEditingHandles: React.FC<{
 							target={controlTarget}
 						/>
 					))
+				: null}
+			{controlTarget?.borderRadiusDrag === null &&
+			(layoutTarget?.containsSelection || hovered)
+				? (() => {
+						const handle = controlLayout.borderRadiusHandle;
+						if (handle === undefined) {
+							return null;
+						}
+
+						return (
+							<SelectedOutlineBorderRadiusHandle
+								key="border-radius"
+								handlePoint={handle}
+								onDraggingChange={onDraggingChange}
+								outline={outline}
+								radius={controlLayout.borderRadiusHandleRadius}
+								target={controlTarget?.borderRadiusDrag}
+							/>
+						);
+					})()
 				: null}
 		</>
 	);

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -45,6 +45,7 @@ import {
 	cropFieldKeys,
 	rotateFieldKey,
 	scaleFieldKey,
+	borderRadiusFieldKey,
 	transformOriginFieldKey,
 	translateFieldKey,
 	type SelectedOutlineCropDragTarget,
@@ -369,6 +370,8 @@ const calculateOutlineTargets = ({
 		const scalePropStatus = nodePropStatuses?.[scaleFieldKey];
 		const rotationFieldSchema = activeSchema?.[rotateFieldKey];
 		const rotationPropStatus = nodePropStatuses?.[rotateFieldKey];
+		const borderRadiusFieldSchema = activeSchema?.[borderRadiusFieldKey];
+		const borderRadiusPropStatus = nodePropStatuses?.[borderRadiusFieldKey];
 		const transformOriginFieldSchema = activeSchema?.[transformOriginFieldKey];
 		const transformOriginPropStatus =
 			nodePropStatuses?.[transformOriginFieldKey];
@@ -443,6 +446,15 @@ const calculateOutlineTargets = ({
 			controls !== null &&
 			rotationFieldSchema?.type === 'rotation-css' &&
 			canRotationDragStatus;
+		const canBorderRadiusDragStatus =
+			borderRadiusPropStatus?.status === 'static' ||
+			(borderRadiusPropStatus?.status === 'keyframed' &&
+				borderRadiusPropStatus.interpolationFunction === 'interpolate');
+		const canBorderRadiusDrag =
+			previewInteractive &&
+			controls !== null &&
+			borderRadiusFieldSchema?.type === 'number' &&
+			canBorderRadiusDragStatus;
 		const transform3DMode =
 			manuallyEnabled3DTransformSequenceKeys.has(key) ||
 			[
@@ -571,6 +583,24 @@ const calculateOutlineTargets = ({
 							schema: controls.schema,
 							transform3DMode,
 							transformOriginValue: transformOriginValueForRotation,
+						}
+					: null,
+				borderRadiusDrag: canBorderRadiusDrag
+					? {
+							propStatus: borderRadiusPropStatus,
+							clientId: connectedClientId,
+							fieldDefault: borderRadiusFieldSchema.default,
+							fieldSchema: borderRadiusFieldSchema,
+							keyframeDisplayOffset: getKeyframeDisplayOffset({
+								propStatus: borderRadiusPropStatus,
+								keyframeDisplayOffset,
+							}),
+							nodePath,
+							schema: controls.schema,
+							value:
+								typeof borderRadiusFieldSchema.default === 'number'
+									? borderRadiusFieldSchema.default
+									: 0,
 						}
 					: null,
 				transformOriginDrag: canTransformOriginDrag

--- a/packages/studio/src/components/selected-outline-control-layout.ts
+++ b/packages/studio/src/components/selected-outline-control-layout.ts
@@ -109,7 +109,17 @@ export const getSelectedOutlineControlLayout = (
 		}),
 	}));
 
+	// Place the border-radius handle just inside the top-left corner so it does
+	// not collide with the rotation handle, which sits outside the same corner.
+	const [topLeftPoint] = points;
+	const borderRadiusHandle: OutlinePoint = {
+		x: topLeftPoint.x + rotationHandleRadius,
+		y: topLeftPoint.y + rotationHandleRadius,
+	};
+
 	return {
+		borderRadiusHandle,
+		borderRadiusHandleRadius: rotationHandleRadius,
 		rotationCorners: isTinyX || isTinyY ? [] : rotationCorners,
 		rotationHandleRadius,
 		scaleEdges,

--- a/packages/studio/src/components/selected-outline-drag.ts
+++ b/packages/studio/src/components/selected-outline-drag.ts
@@ -18,6 +18,7 @@ import {
 	vectorLength,
 } from './selected-outline-measurement';
 import type {
+	SelectedOutlineBorderRadiusDragTarget,
 	SelectedOutlineCropDragTarget,
 	SelectedOutlineCropFieldKey,
 	SelectedOutlineCropHandle,
@@ -31,6 +32,7 @@ import type {
 	SelectedOutlineTransformOriginDragTarget,
 } from './selected-outline-types';
 import {
+	borderRadiusFieldKey,
 	cropFieldKeys,
 	rotateFieldKey,
 	scaleFieldKey,
@@ -1272,4 +1274,124 @@ export const snapSelectedOutlineTransformOriginUv = ({
 	}
 
 	return best?.uv ?? uv;
+};
+
+type SelectedOutlineBorderRadiusDragState = {
+	readonly defaultValue: string | null;
+	readonly key: string;
+	readonly sourceFrame: number;
+	readonly startValue: number;
+	readonly target: SelectedOutlineBorderRadiusDragTarget;
+};
+
+export const getSelectedOutlineBorderRadiusDragStates = ({
+	dragTargets,
+	getDragOverrides,
+	timelinePosition,
+}: {
+	readonly dragTargets: readonly SelectedOutlineBorderRadiusDragTarget[];
+	readonly getDragOverrides: GetDragOverrides;
+	readonly timelinePosition: number;
+}): SelectedOutlineBorderRadiusDragState[] => {
+	return dragTargets.map((target) => {
+		const dragOverrideValue = (getDragOverrides(target.nodePath) ?? {})[
+			borderRadiusFieldKey
+		];
+		const sourceFrame = timelinePosition - target.keyframeDisplayOffset;
+		const effectiveValue = Internals.getEffectiveVisualModeValue({
+			propStatus: target.propStatus,
+			dragOverrideValue,
+			defaultValue: target.fieldDefault,
+			frame: sourceFrame,
+			shouldResortToDefaultValueIfUndefined: true,
+		});
+		const startValue =
+			typeof effectiveValue === 'number' && Number.isFinite(effectiveValue)
+				? effectiveValue
+				: target.value;
+
+		return {
+			defaultValue:
+				target.fieldDefault !== undefined
+					? JSON.stringify(target.fieldDefault)
+					: null,
+			key: Internals.makeSequencePropsSubscriptionKey(target.nodePath),
+			sourceFrame,
+			startValue,
+			target,
+		};
+	});
+};
+
+export const getSelectedOutlineBorderRadiusDragChanges = ({
+	dragStates,
+	lastValues,
+}: {
+	readonly dragStates: readonly SelectedOutlineBorderRadiusDragState[];
+	readonly lastValues: ReadonlyMap<string, number>;
+}): SelectedOutlineDragChange[] => {
+	const changes: SelectedOutlineDragChange[] = [];
+
+	for (const dragState of dragStates) {
+		const value = lastValues.get(dragState.key);
+		if (value === undefined) {
+			continue;
+		}
+
+		if (dragState.target.propStatus.status === 'keyframed') {
+			const startValue = dragState.startValue;
+			if (value === startValue) {
+				continue;
+			}
+
+			changes.push({
+				type: 'keyframed',
+				fileName: dragState.target.nodePath.absolutePath,
+				nodePath: dragState.target.nodePath,
+				fieldKey: borderRadiusFieldKey,
+				sourceFrame: dragState.sourceFrame,
+				value,
+				schema: dragState.target.schema,
+				clientId: dragState.target.clientId,
+			});
+			continue;
+		}
+
+		const stringifiedValue = JSON.stringify(value);
+		const shouldSave =
+			stringifiedValue !==
+				JSON.stringify(dragState.target.propStatus.codeValue) &&
+			!(
+				dragState.defaultValue === stringifiedValue &&
+				dragState.target.propStatus.codeValue === undefined
+			);
+
+		if (!shouldSave) {
+			continue;
+		}
+
+		changes.push({
+			type: 'static',
+			fileName: dragState.target.nodePath.absolutePath,
+			nodePath: dragState.target.nodePath,
+			fieldKey: borderRadiusFieldKey,
+			value,
+			defaultValue: dragState.defaultValue,
+			schema: dragState.target.schema,
+		});
+	}
+
+	return changes;
+};
+
+export const clearSelectedOutlineBorderRadiusDragOverrides = ({
+	clearDragOverrides,
+	dragStates,
+}: {
+	readonly clearDragOverrides: (nodePath: SequencePropsSubscriptionKey) => void;
+	readonly dragStates: readonly SelectedOutlineBorderRadiusDragState[];
+}): void => {
+	for (const dragState of dragStates) {
+		clearDragOverrides(dragState.target.nodePath);
+	}
 };

--- a/packages/studio/src/components/selected-outline-types.ts
+++ b/packages/studio/src/components/selected-outline-types.ts
@@ -1,4 +1,5 @@
 import type {CanvasOutlineTarget} from '@remotion/canvas';
+import {BORDER_RADIUS_SHORTHAND_KEY} from '@remotion/studio-shared';
 import type {
 	CanUpdateSequencePropStatus,
 	CanUpdateSequencePropStatusKeyframed,
@@ -43,6 +44,7 @@ export type SelectedOutlineTarget = SelectedOutlineLayoutTarget & {
 	readonly scaleDrag: SelectedOutlineScaleDragTarget | null;
 	readonly rotationDrag: SelectedOutlineRotationDragTarget | null;
 	readonly transformOriginDrag: SelectedOutlineTransformOriginDragTarget | null;
+	readonly borderRadiusDrag: SelectedOutlineBorderRadiusDragTarget | null;
 };
 
 export const cropFieldKeys = {
@@ -188,6 +190,24 @@ export type SelectedOutlineRotationDragTarget = {
 	readonly transformOriginValue: string;
 };
 
+export type BorderRadiusFieldSchema = Extract<
+	InteractivitySchemaField,
+	{type: 'number'}
+>;
+
+export type SelectedOutlineBorderRadiusDragTarget = {
+	readonly propStatus:
+		| CanUpdateSequencePropStatusStatic
+		| CanUpdateSequencePropStatusKeyframed;
+	readonly clientId: string;
+	readonly fieldDefault: number | string | null | undefined;
+	readonly fieldSchema: BorderRadiusFieldSchema;
+	readonly keyframeDisplayOffset: number;
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly schema: InteractivitySchema;
+	readonly value: number;
+};
+
 export type SelectedOutlineDragState = {
 	readonly defaultValue: string | null;
 	readonly key: string;
@@ -222,6 +242,7 @@ export const translateFieldKey = 'style.translate';
 export const scaleFieldKey = 'style.scale';
 export const rotateFieldKey = 'style.rotate';
 export const transformOriginFieldKey = 'style.transformOrigin';
+export const borderRadiusFieldKey = BORDER_RADIUS_SHORTHAND_KEY;
 export const selectedOutlineDragThresholdPx = 4;
 
 export const outlineContainer: React.CSSProperties = {


### PR DESCRIPTION
Implements remotion-dev/remotion#10606 (v1): a Figma-style draggable handle inside the top-left corner of a selected sequence that edits the element's border radius directly on the canvas.

## What it does
- Shows a draggable handle when the selected element exposes a numeric `style.borderRadius` (static or keyframed).
- Dragging maps the pointer distance from the top-left corner to the radius, clamps to the schema `min`/`max`, and writes through the existing Visual Mode drag-override path (`setDragOverrides` → `saveSequenceProps`), so the Inspector stays in sync and undo grouping works.
- Updates optimistically while dragging; commits a static or keyframed change on release.

## Implementation
- `SelectedOutlineBorderRadiusDragTarget` + drag-state builders (`getSelectedOutlineBorderRadiusDragStates`/`...DragChanges`/`clear...Overrides`) in `selected-outline-drag.ts`, mirroring the rotation/scale plumbing.
- `borderRadiusDrag` is produced in `SelectedOutlineOverlay` (gated on a numeric `style.borderRadius` schema field and static/keyframed status).
- `selected-outline-control-layout.ts` positions the handle; `SelectedOutlineEditingHandles` renders `SelectedOutlineBorderRadiusHandle`.

## Scope (per the issue's v1)
Uniform radius only; the data model (`border-radius-representation.ts`) already supports per-corner follow-up. No E2E interaction test added yet — the repo's visual-controls E2E covers the rotation handle pattern; I can add a border-radius E2E once the approach is approved.

## Validation
- `tsgo` typecheck clean for the changed files (`packages/studio`).
- All 619 existing studio unit tests pass.
- `oxfmt` clean.

Note: this is a proposed implementation of the open #10606 — happy to adjust the interaction/handle placement to maintainer preference before merge.
