### PR TITLE
`@remotion/studio`: Fix connected compositions after Fast Refresh

### DIFF
--- a/packages/browser-studio/src/react-refresh-runtime.d.ts
+++ b/packages/browser-studio/src/react-refresh-runtime.d.ts
@@ -1,6 +1,7 @@
 declare module 'react-refresh/runtime' {
 	type ReactRefreshRuntime = {
 		createSignatureFunctionForTransform: (...args: unknown[]) => unknown;
+		getFamilyByType: (type: unknown) => unknown;
 		injectIntoGlobalHook: (globalObject: typeof globalThis) => void;
 		register: (type: unknown, id: string) => void;
 	};

--- a/packages/browser-studio/src/virtual-files.ts
+++ b/packages/browser-studio/src/virtual-files.ts
@@ -39,7 +39,12 @@ const getInjectedReactRefreshFiles = () => {
 };
 
 const setupSequenceStackTraces = `import React from 'react';
+import * as RefreshRuntime from 'react-refresh/runtime';
 import {Internals} from 'remotion';
+
+Internals.setComponentIdentityResolver((component) => {
+  return RefreshRuntime.getFamilyByType(component) ?? component;
+});
 
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
 const sequenceComponent = Internals.getSequenceComponent();

--- a/packages/bundler/src/setup-sequence-stack-traces.ts
+++ b/packages/bundler/src/setup-sequence-stack-traces.ts
@@ -3,6 +3,16 @@ import JsxRuntimeDev from 'react/jsx-dev-runtime';
 import JsxRuntime from 'react/jsx-runtime';
 import {Internals} from 'remotion';
 
+type ReactRefreshRuntime = {
+	getFamilyByType: (component: unknown) => unknown;
+};
+
+const RefreshRuntime = require('react-refresh/runtime') as ReactRefreshRuntime;
+
+Internals.setComponentIdentityResolver((component) => {
+	return RefreshRuntime.getFamilyByType(component) ?? component;
+});
+
 const componentsToAddStacksTo = Internals.getComponentsToAddStacksTo();
 const sequenceComponent = Internals.getSequenceComponent();
 const internalStackProp = Internals.REMOTION_INTERNAL_STACK_PROP;

--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -12,6 +12,7 @@ import {CompositionRenderErrorContext} from './composition-render-error-context.
 import {CompositionErrorBoundary} from './CompositionErrorBoundary.js';
 import type {TComposition} from './CompositionManager.js';
 import {CompositionSetters} from './CompositionManagerContext.js';
+import {resolveComponentIdentity} from './enable-sequence-stack-traces.js';
 import {FolderContext} from './Folder.js';
 import {serializeThenDeserializeInStudio} from './input-props-serialization.js';
 import {useIsPlayer} from './is-player.js';
@@ -185,7 +186,9 @@ const InnerComposition = <
 		(compProps as {readonly _remotionInternalStack?: string})
 			._remotionInternalStack ?? null;
 	const componentFromProps =
-		'component' in compProps ? compProps.component : null;
+		'component' in compProps
+			? resolveComponentIdentity(compProps.component)
+			: null;
 
 	useEffect(() => {
 		// Ensure it's a URL safe id

--- a/packages/core/src/enable-sequence-stack-traces.ts
+++ b/packages/core/src/enable-sequence-stack-traces.ts
@@ -4,6 +4,10 @@ import type {SequenceControls} from './CompositionManager.js';
 const componentsToAddStacksTo: unknown[] = [];
 let sequenceComponent: unknown = null;
 const stacksByControls = new WeakMap<SequenceControls, string>();
+type ComponentIdentityResolver = (component: unknown) => unknown;
+// Studio installs a resolver that maps refreshed component implementations to
+// the stable family object maintained by React Refresh.
+let componentIdentityResolver: ComponentIdentityResolver | null = null;
 
 export const REMOTION_INTERNAL_STACK_PROP = '_remotionInternalStack';
 
@@ -18,6 +22,16 @@ export const setSequenceComponent = (component: unknown) => {
 };
 
 export const getSequenceComponent = () => sequenceComponent;
+
+export const setComponentIdentityResolver = (
+	resolver: ComponentIdentityResolver | null,
+) => {
+	componentIdentityResolver = resolver;
+};
+
+export const resolveComponentIdentity = (component: unknown): unknown => {
+	return componentIdentityResolver?.(component) ?? component;
+};
 
 export const setStackForControls = (
 	controls: SequenceControls,
@@ -52,5 +66,5 @@ export const getSingleChildComponent = (children: React.ReactNode): unknown => {
 		return null;
 	}
 
-	return child.type;
+	return resolveComponentIdentity(child.type);
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -73,6 +73,7 @@ import {
 	getSingleChildComponent,
 	getStackForControls,
 	REMOTION_INTERNAL_STACK_PROP,
+	setComponentIdentityResolver,
 } from './enable-sequence-stack-traces.js';
 import {findPropsToDelete} from './find-props-to-delete.js';
 import {
@@ -412,6 +413,7 @@ export const Internals = {
 	getSingleChildComponent,
 	getStackForControls,
 	REMOTION_INTERNAL_STACK_PROP,
+	setComponentIdentityResolver,
 	CurrentScaleContext,
 	PixelDensityContext,
 	PreviewSizeContext,

--- a/packages/core/src/test/single-child-component.test.tsx
+++ b/packages/core/src/test/single-child-component.test.tsx
@@ -1,6 +1,9 @@
 import {expect, test} from 'bun:test';
 import React from 'react';
-import {getSingleChildComponent} from '../enable-sequence-stack-traces';
+import {
+	getSingleChildComponent,
+	setComponentIdentityResolver,
+} from '../enable-sequence-stack-traces';
 
 const Child: React.FC = () => null;
 const OtherChild: React.FC = () => null;
@@ -25,4 +28,25 @@ test('does not detect host elements or multiple mounted children', () => {
 	expect(
 		getSingleChildComponent([<Child key="a" />, <OtherChild key="b" />]),
 	).toBe(null);
+});
+
+test('uses a stable component identity supplied by Fast Refresh', () => {
+	const family = {};
+	const PreviousChild: React.FC = () => null;
+	const RefreshedChild: React.FC = () => null;
+
+	setComponentIdentityResolver((component) => {
+		if (component === PreviousChild || component === RefreshedChild) {
+			return family;
+		}
+
+		return component;
+	});
+
+	try {
+		expect(getSingleChildComponent(<PreviousChild />)).toBe(family);
+		expect(getSingleChildComponent(<RefreshedChild />)).toBe(family);
+	} finally {
+		setComponentIdentityResolver(null);
+	}
 });

--- a/packages/core/src/test/still-stack.test.tsx
+++ b/packages/core/src/test/still-stack.test.tsx
@@ -6,10 +6,14 @@ import {
 	CompositionSetters,
 	type CompositionManagerSetters,
 } from '../CompositionManagerContext.js';
+import {setComponentIdentityResolver} from '../enable-sequence-stack-traces.js';
 import {Internals} from '../internals.js';
 import {Still} from '../Still.js';
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	setComponentIdentityResolver(null);
+});
 
 const AnyComp: React.FC = () => null;
 
@@ -55,5 +59,32 @@ test('Still forwards its stack to the registered composition', async () => {
 
 	await waitFor(() => {
 		expect(registeredCompositions[0]?.stack).toBe(stillStack);
+	});
+});
+
+test('Still registers the stable component identity', async () => {
+	const family = {};
+	const registeredCompositions: AnyComposition[] = [];
+	setComponentIdentityResolver((component) => {
+		return component === AnyComp ? family : component;
+	});
+
+	render(
+		<CompositionSetters.Provider
+			value={makeCompositionSetters((composition) => {
+				registeredCompositions.push(composition);
+			})}
+		>
+			<Still
+				id="still-component-identity-test"
+				component={AnyComp}
+				width={100}
+				height={100}
+			/>
+		</CompositionSetters.Provider>,
+	);
+
+	await waitFor(() => {
+		expect(registeredCompositions[0]?.componentFromProps).toBe(family);
 	});
 });


### PR DESCRIPTION
## Summary

- preserve connected-composition identity across Fast Refresh by resolving component implementations to their React Refresh family
- install the resolver in both regular Studio and Browser Studio development runtimes
- add regression coverage for sequence children and composition registration

## Testing

- `bun run build`
- `bun run stylecheck`
- affected package tests

Closes #10858
