### PR TITLE
`@remotion/studio`: Add inspector section titles

### DIFF
--- a/packages/studio/src/components/CurrentAsset.tsx
+++ b/packages/studio/src/components/CurrentAsset.tsx
@@ -25,6 +25,7 @@ import {
 	InspectorQuickActionsSection,
 	InspectorQuickAction,
 	InspectorSection,
+	InspectorSectionHeader,
 } from './InspectorPanel/common';
 import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from './InspectorPanelLayout';
 import {COMPACT_CONTROL_ROW_HEIGHT} from './layout';
@@ -333,6 +334,7 @@ export const AssetInfo: React.FC<{
 					)}
 				</InspectorSection>
 			) : null}
+			<InspectorSectionHeader>Actions</InspectorSectionHeader>
 			<InspectorQuickActionsSection>
 				{src ? (
 					<InspectorQuickAction

--- a/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionInspector.tsx
@@ -155,53 +155,56 @@ const CompositionActions: React.FC = () => {
 	}
 
 	return (
-		<InspectorQuickActionsSection>
-			{canShowInsertSolid ? (
-				<InspectorQuickAction
-					disabled={!canInsertSolid}
-					onClick={insertSolid}
-					renderIcon={(color) => (
-						<SolidIcon color={color} style={actionIconStyle} />
-					)}
-				>
-					Add Solid
-				</InspectorQuickAction>
-			) : null}
-			{canShowInsertAsset ? (
-				<InspectorQuickAction
-					disabled={!canInsertAsset}
-					onClick={insertAsset}
-					renderIcon={(color) => (
-						<PicIcon color={color} style={actionIconStyle} />
-					)}
-				>
-					Add asset...
-				</InspectorQuickAction>
-			) : null}
-			{canShowInsertComposition ? (
-				<InspectorQuickAction
-					disabled={!canInsertComposition}
-					onClick={insertComposition}
-					renderIcon={(color) => (
-						<FilmIcon color={color} style={actionIconStyle} />
-					)}
-				>
-					Add composition...
-				</InspectorQuickAction>
-			) : null}
-			{canShowInsertAsset ? <ElementLibraryButton /> : null}
-			{downloadProject ? (
-				<InspectorQuickAction
-					disabled={false}
-					onClick={onDownloadProject}
-					renderIcon={(color) => (
-						<CloudDownloadIcon color={color} style={actionIconStyle} />
-					)}
-				>
-					Download project
-				</InspectorQuickAction>
-			) : null}
-		</InspectorQuickActionsSection>
+		<>
+			<InspectorSectionHeader>Actions</InspectorSectionHeader>
+			<InspectorQuickActionsSection>
+				{canShowInsertSolid ? (
+					<InspectorQuickAction
+						disabled={!canInsertSolid}
+						onClick={insertSolid}
+						renderIcon={(color) => (
+							<SolidIcon color={color} style={actionIconStyle} />
+						)}
+					>
+						Add Solid
+					</InspectorQuickAction>
+				) : null}
+				{canShowInsertAsset ? (
+					<InspectorQuickAction
+						disabled={!canInsertAsset}
+						onClick={insertAsset}
+						renderIcon={(color) => (
+							<PicIcon color={color} style={actionIconStyle} />
+						)}
+					>
+						Add asset...
+					</InspectorQuickAction>
+				) : null}
+				{canShowInsertComposition ? (
+					<InspectorQuickAction
+						disabled={!canInsertComposition}
+						onClick={insertComposition}
+						renderIcon={(color) => (
+							<FilmIcon color={color} style={actionIconStyle} />
+						)}
+					>
+						Add composition...
+					</InspectorQuickAction>
+				) : null}
+				{canShowInsertAsset ? <ElementLibraryButton /> : null}
+				{downloadProject ? (
+					<InspectorQuickAction
+						disabled={false}
+						onClick={onDownloadProject}
+						renderIcon={(color) => (
+							<CloudDownloadIcon color={color} style={actionIconStyle} />
+						)}
+					>
+						Download project
+					</InspectorQuickAction>
+				) : null}
+			</InspectorQuickActionsSection>
+		</>
 	);
 };
 
@@ -353,6 +356,7 @@ export const CompositionInspector: React.FC<{
 		<div style={scrollableContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<div style={inspectorOverviewSection}>
 				<CompositionInspectorHeader />
+				<InspectorSectionHeader>Metadata</InspectorSectionHeader>
 				<CompositionMetadata
 					compositionId={composition.id}
 					disabled={readOnlyStudio || previewServerState.type !== 'connected'}

--- a/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
+++ b/packages/studio/src/components/InspectorPanel/ConnectedCompositionsSection.tsx
@@ -12,7 +12,7 @@ import {ContextMenu} from '../ContextMenu';
 import {useSelectComposition} from '../InitialCompositionLoader';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
 import {useEditorOpening} from '../use-default-editor-info';
-import {InspectorQuickAction} from './common';
+import {InspectorQuickAction, InspectorSectionHeader} from './common';
 
 const compositionIconStyle: React.CSSProperties = {
 	height: 18,
@@ -49,14 +49,17 @@ export const ConnectedCompositionsSection: React.FC<{
 	readonly connectedCompositions: readonly _InternalTypes['AnyComposition'][];
 }> = ({connectedCompositions}) => {
 	return (
-		<div style={compositionListStyle}>
-			{connectedCompositions.map((composition) => (
-				<ConnectedCompositionRow
-					key={composition.id}
-					composition={composition}
-				/>
-			))}
-		</div>
+		<>
+			<InspectorSectionHeader>Connected compositions</InspectorSectionHeader>
+			<div style={compositionListStyle}>
+				{connectedCompositions.map((composition) => (
+					<ConnectedCompositionRow
+						key={composition.id}
+						composition={composition}
+					/>
+				))}
+			</div>
+		</>
 	);
 };
 

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -33,6 +33,7 @@ import {
 	InspectorQuickActionsSection,
 	InspectorQuickAction,
 	InspectorMessage,
+	InspectorSectionHeader,
 } from './common';
 import {
 	ConnectedCompositionsSection,
@@ -335,6 +336,7 @@ const SequenceExpandedInspector: React.FC<{
 						keyframeDisplayOffset={track.keyframeDisplayOffset}
 						renderTransformControls={() => <AlignmentControls track={track} />}
 					/>
+					<InspectorSectionHeader>Actions</InspectorSectionHeader>
 					<InspectorQuickActionsSection>
 						<SplitSequenceQuickAction
 							selection={sequenceSelection}


### PR DESCRIPTION
## Summary

- add a section title for connected compositions
- add a metadata section title to the composition inspector
- add action section titles to the composition, sequence, and asset inspectors

Closes #10852

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio' --no-update-notifier`
