### PR TITLE
`@remotion/canvas`: Prevent outline controller update loops

### DIFF
--- a/packages/canvas/src/index.ts
+++ b/packages/canvas/src/index.ts
@@ -38,6 +38,7 @@ export type {CanvasOutlineOrderTarget} from './order-outlines-for-rendering';
 export type {
 	CanvasOutline,
 	CanvasOutlinePoint,
+	CanvasOutlineTargetsAreEqual,
 	CanvasOutlinesController,
 	CanvasOutlinesSnapshot,
 	CanvasOutlineTarget,

--- a/packages/canvas/src/outlines.ts
+++ b/packages/canvas/src/outlines.ts
@@ -60,6 +60,10 @@ export type CanvasOutlinesController<
 	readonly disconnect: () => void;
 };
 
+export type CanvasOutlineTargetsAreEqual<
+	Target extends CanvasOutlineTarget = CanvasOutlineTarget,
+> = (previous: readonly Target[], next: readonly Target[]) => boolean;
+
 const rectToPoints = (
 	elementRect: DOMRect,
 	containerRect: DOMRect,
@@ -487,7 +491,9 @@ export const canvasOutlinesAreEqual = (
 
 export const createCanvasOutlinesController = <
 	Target extends CanvasOutlineTarget = CanvasOutlineTarget,
->(): CanvasOutlinesController<Target> => {
+>(
+	areTargetsEqual: CanvasOutlineTargetsAreEqual<Target> = Object.is,
+): CanvasOutlinesController<Target> => {
 	let snapshot: CanvasOutlinesSnapshot<Target> = {outlines: [], targets: []};
 	let container: SVGSVGElement | null = null;
 	let targets: readonly Target[] = [];
@@ -602,7 +608,11 @@ export const createCanvasOutlinesController = <
 		update: (nextContainer, nextTargets) => {
 			const containerChanged = container !== nextContainer;
 			container = nextContainer;
-			targets = nextTargets;
+
+			if (!areTargetsEqual(targets, nextTargets)) {
+				targets = nextTargets;
+			}
+
 			updateObserver(containerChanged);
 			calculate();
 		},
@@ -617,8 +627,12 @@ export const createCanvasOutlinesController = <
 
 export const useCanvasOutlinesController = <
 	Target extends CanvasOutlineTarget = CanvasOutlineTarget,
->(): CanvasOutlinesController<Target> => {
-	const [controller] = useState(createCanvasOutlinesController<Target>);
+>(
+	areTargetsEqual: CanvasOutlineTargetsAreEqual<Target> = Object.is,
+): CanvasOutlinesController<Target> => {
+	const [controller] = useState(() =>
+		createCanvasOutlinesController(areTargetsEqual),
+	);
 	return controller;
 };
 

--- a/packages/canvas/src/test/outlines.test.ts
+++ b/packages/canvas/src/test/outlines.test.ts
@@ -22,7 +22,23 @@ test('projects outline UV coordinates in both directions', () => {
 });
 
 test('publishes cropped outline geometry and keeps unchanged snapshots stable', () => {
-	const controller = createCanvasOutlinesController();
+	type TestOutlineTarget = CanvasOutlineTarget & {readonly label: string};
+	const controller = createCanvasOutlinesController<TestOutlineTarget>(
+		(previous, next) =>
+			previous.length === next.length &&
+			previous.every(
+				(target, index) =>
+					target.key === next[index].key &&
+					target.label === next[index].label &&
+					target.ref === next[index].ref &&
+					target.includeOutsideContainer ===
+						next[index].includeOutsideContainer &&
+					target.crop.left === next[index].crop.left &&
+					target.crop.right === next[index].crop.right &&
+					target.crop.top === next[index].crop.top &&
+					target.crop.bottom === next[index].crop.bottom,
+			),
+	);
 	const container = document.createElementNS(
 		'http://www.w3.org/2000/svg',
 		'svg',
@@ -69,9 +85,10 @@ test('publishes cropped outline geometry and keeps unchanged snapshots stable', 
 		],
 	});
 
-	const targets: readonly CanvasOutlineTarget[] = [
+	const targets: readonly TestOutlineTarget[] = [
 		{
 			key: 'title',
+			label: 'Title',
 			ref: {current: element},
 			crop: {bottom: 0.1, left: 0.1, right: 0.1, top: 0.1},
 			includeOutsideContainer: false,
@@ -106,14 +123,27 @@ test('publishes cropped outline geometry and keeps unchanged snapshots stable', 
 
 	controller.update(container, targets);
 	expect(updates).toBe(1);
+	controller.update(container, [
+		{
+			...targets[0],
+			crop: {...targets[0].crop},
+		},
+	]);
+	expect(controller.getSnapshot().targets).toBe(targets);
+	expect(updates).toBe(1);
+
+	const renamedTargets = [{...targets[0], label: 'Renamed title'}];
+	controller.update(container, renamedTargets);
+	expect(controller.getSnapshot().targets).toBe(renamedTargets);
+	expect(updates).toBe(2);
 
 	left = 30;
-	controller.update(container, targets);
+	controller.update(container, renamedTargets);
 	expect(controller.getSnapshot().outlines[0].points[0].x).toBe(30);
-	expect(updates).toBe(2);
+	expect(updates).toBe(3);
 
 	controller.disconnect();
 	expect(controller.getSnapshot()).toEqual({outlines: [], targets: []});
-	expect(updates).toBe(3);
+	expect(updates).toBe(4);
 	unsubscribe();
 });

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -769,6 +769,35 @@ test.describe('visual mode', () => {
 		await expect(duplicateButton).toBeVisible();
 	});
 
+	test('should show nested canvas outlines without an update loop', async ({
+		page,
+	}) => {
+		const updateDepthErrors: string[] = [];
+		const recordUpdateDepthError = (message: string) => {
+			if (
+				message.includes('Maximum update depth exceeded') ||
+				message.includes('Minified React error #185')
+			) {
+				updateDepthErrors.push(message);
+			}
+		};
+		page.on('console', (message) => recordUpdateDepthError(message.text()));
+		page.on('pageerror', (error) => recordUpdateDepthError(error.message));
+
+		await page.goto(`${STUDIO_URL}/outline-selection-cases`);
+		await expect(page.getByText('Children are above parents')).toBeVisible({
+			timeout: 15_000,
+		});
+		const canvas = page.locator('.remotion-studio-composition-container');
+		const outlines = canvas.locator(
+			'> svg[aria-hidden="true"] polygon[stroke="#0b84f3"]',
+		);
+		await canvas.getByText('Child', {exact: true}).hover();
+		await expect(outlines).toHaveCount(2);
+		await expect(canvas.getByText('Parent', {exact: true})).toBeVisible();
+		expect(updateDepthErrors).toEqual([]);
+	});
+
 	test('should preserve property selection while dragging its outline', async ({
 		page,
 	}) => {

--- a/packages/studio/src/components/SelectedOutlineRenderer.tsx
+++ b/packages/studio/src/components/SelectedOutlineRenderer.tsx
@@ -46,6 +46,34 @@ const outlineContainer: React.CSSProperties = {
 	overflow: 'visible',
 };
 
+const selectedOutlineMeasurementTargetsAreEqual = (
+	previous: readonly SelectedOutlineLayoutTarget[],
+	next: readonly SelectedOutlineLayoutTarget[],
+): boolean => {
+	if (previous.length !== next.length) {
+		return false;
+	}
+
+	for (let i = 0; i < previous.length; i++) {
+		const previousTarget = previous[i];
+		const nextTarget = next[i];
+		if (
+			previousTarget.key !== nextTarget.key ||
+			previousTarget.ref !== nextTarget.ref ||
+			previousTarget.crop.left !== nextTarget.crop.left ||
+			previousTarget.crop.right !== nextTarget.crop.right ||
+			previousTarget.crop.top !== nextTarget.crop.top ||
+			previousTarget.crop.bottom !== nextTarget.crop.bottom ||
+			previousTarget.includeOutsideContainer !==
+				nextTarget.includeOutsideContainer
+		) {
+			return false;
+		}
+	}
+
+	return true;
+};
+
 const SelectedOutlineRendererUnmemoized: React.FC<{
 	readonly compositionHeight: number;
 	readonly compositionWidth: number;
@@ -79,7 +107,9 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	updateOutlinesRef,
 }) => {
 	const outlinesController =
-		useCanvasOutlinesController<SelectedOutlineLayoutTarget>();
+		useCanvasOutlinesController<SelectedOutlineLayoutTarget>(
+			selectedOutlineMeasurementTargetsAreEqual,
+		);
 	const renderState = useCanvasOutlines(outlinesController);
 	const overlayRef = useRef<SVGSVGElement>(null);
 	const contextMenuOpenHandlersRef = useRef(
@@ -140,18 +170,18 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	}, [outlinesController]);
 
 	const targetsByKey = useMemo(() => {
-		return new Map(renderState.targets.map((target) => [target.key, target]));
-	}, [renderState.targets]);
+		return new Map(outlineTargets.map((target) => [target.key, target]));
+	}, [outlineTargets]);
 	useEffect(() => {
 		if (
 			hoveredSequence?.source === 'canvas' &&
-			!renderState.targets.some((target) => target.key === hoveredSequence.key)
+			!outlineTargets.some((target) => target.key === hoveredSequence.key)
 		) {
 			setHoveredSequence((currentHover) =>
 				currentHover?.source === 'canvas' ? null : currentHover,
 			);
 		}
-	}, [hoveredSequence, renderState.targets, setHoveredSequence]);
+	}, [hoveredSequence, outlineTargets, setHoveredSequence]);
 	// Reordering a captured SVG target can cancel the active pointer session.
 	const outlineRenderingOrderRef = useRef<readonly string[]>([]);
 	const outlinesForRendering = useMemo(() => {
@@ -226,12 +256,12 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 			outlinesForUvHandles: uvHandles,
 		};
 	}, [hoveredNodePathKey, outlinesForRendering, targetsByKey]);
-	const targetsRef = useRef(renderState.targets);
+	const targetsRef = useRef(outlineTargets);
 	const outlinesByKeyRef = useRef(outlinesByKey);
 	useLayoutEffect(() => {
-		targetsRef.current = renderState.targets;
+		targetsRef.current = outlineTargets;
 		outlinesByKeyRef.current = outlinesByKey;
-	}, [outlinesByKey, renderState.targets]);
+	}, [outlineTargets, outlinesByKey]);
 	const getAllDragTargets = useCallback(
 		() =>
 			targetsRef.current.flatMap((target) => {


### PR DESCRIPTION
## Summary

- retain equivalent canvas outline targets without publishing a new external-store snapshot
- keep Studio outline metadata current while separating it from measurement identity
- cover nested-outline hovering with controller and browser regressions

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test` in `packages/canvas`
- `bunx playwright test e2e/studio.test.mts --grep "nested canvas outlines"` in `packages/example`

Closes #10897
