### PR TITLE
`@remotion/studio`: Fix Explorer item hover states and actions

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1204,6 +1204,10 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 			contents: new TextEncoder().encode('hover test').buffer,
 			filePath: 'hover-test.txt',
 		});
+		await window.remotion_browserStudio.writeStaticFile({
+			contents: new TextEncoder().encode('folder action test').buffer,
+			filePath: 'hover-folder/inside.txt',
+		});
 	});
 
 	const addSolid = studio.getByRole('button', {name: 'Add Solid'});
@@ -1239,6 +1243,21 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 	const neutralArea = studio.locator('[data-sidebar-toggle="right"]');
 
 	await studio.getByRole('button', {name: 'Assets', exact: true}).click();
+	const assetFolder = studio.getByTitle('hover-folder', {exact: true});
+	await expect(assetFolder).toBeVisible();
+	await assetFolder.hover();
+	const folderActions = assetFolder.getByRole('button', {
+		name: 'More actions',
+	});
+	await expect(folderActions).toBeVisible();
+	await folderActions.click();
+	await expect(
+		studio.getByText('Copy folder path', {exact: true}),
+	).toBeVisible();
+	await expect(studio.getByText('Upload...', {exact: true})).toBeVisible();
+	await expect(studio.getByText(/^Show in /)).toHaveCount(0);
+	await page.keyboard.press('Escape');
+
 	const assetItem = studio.getByTitle('hover-test.txt', {exact: true});
 	await expect(assetItem).toBeVisible();
 	await assetItem.hover();

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1196,8 +1196,15 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 	await page.goto('/');
 	const studio = page.frameLocator('iframe');
 	await expect(studio.getByTitle('/project').getByText('MyComp')).toBeVisible();
+	await waitForBrowserStudioOperations(studio);
 	await studio.locator('[data-compname="MyComp"]').click();
 	await studio.locator('[data-sidebar-toggle="right"]').click();
+	await studio.locator('body').evaluate(async () => {
+		await window.remotion_browserStudio.writeStaticFile({
+			contents: new TextEncoder().encode('hover test').buffer,
+			filePath: 'hover-test.txt',
+		});
+	});
 
 	const addSolid = studio.getByRole('button', {name: 'Add Solid'});
 	await expect(addSolid).toBeVisible();
@@ -1229,7 +1236,33 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 		}
 	});
 
-	const neutralArea = studio.locator('.remotion-studio-composition-container');
+	const neutralArea = studio.locator('[data-sidebar-toggle="right"]');
+
+	await studio.getByRole('button', {name: 'Assets', exact: true}).click();
+	const assetItem = studio.getByTitle('hover-test.txt', {exact: true});
+	await expect(assetItem).toBeVisible();
+	await assetItem.hover();
+	await expect
+		.poll(() => getBackgroundColor(assetItem))
+		.toBe('rgba(255, 255, 255, 0.06)');
+	await neutralArea.hover();
+	await expect
+		.poll(() => getBackgroundColor(assetItem))
+		.toBe('rgba(0, 0, 0, 0)');
+
+	await assetItem.click();
+	await studio.getByRole('button', {name: 'Compositions', exact: true}).click();
+	const compositionItem = studio.locator('[data-compname="MyComp"]');
+	await compositionItem.hover();
+	await expect
+		.poll(() => getBackgroundColor(compositionItem))
+		.toBe('rgba(255, 255, 255, 0.06)');
+	await neutralArea.hover();
+	await expect
+		.poll(() => getBackgroundColor(compositionItem))
+		.toBe('rgba(0, 0, 0, 0)');
+	await compositionItem.click();
+	await expect(addSolid).toBeVisible();
 
 	await neutralArea.hover();
 	await expect

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1217,6 +1217,8 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 		locator.evaluate(
 			(element) => window.getComputedStyle(element).backgroundColor,
 		);
+	const getColor = (locator: ReturnType<typeof studio.locator>) =>
+		locator.evaluate((element) => window.getComputedStyle(element).color);
 
 	await addSolid.hover();
 	await expect
@@ -1264,6 +1266,11 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 	await expect
 		.poll(() => getBackgroundColor(assetItem))
 		.toBe('rgba(255, 255, 255, 0.06)');
+	const assetActions = assetItem.getByRole('button', {name: 'More actions'});
+	await assetActions.hover();
+	await expect.poll(() => getColor(assetActions)).toBe('rgb(255, 255, 255)');
+	await assetItem.hover({position: {x: 10, y: 10}});
+	await expect.poll(() => getColor(assetActions)).toBe('rgb(166, 167, 169)');
 	await neutralArea.hover();
 	await expect
 		.poll(() => getBackgroundColor(assetItem))
@@ -1276,6 +1283,15 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 	await expect
 		.poll(() => getBackgroundColor(compositionItem))
 		.toBe('rgba(255, 255, 255, 0.06)');
+	const compositionActions = compositionItem.locator('button').first();
+	await compositionActions.hover();
+	await expect
+		.poll(() => getColor(compositionActions))
+		.toBe('rgb(255, 255, 255)');
+	await compositionItem.hover({position: {x: 10, y: 10}});
+	await expect
+		.poll(() => getColor(compositionActions))
+		.toBe('rgb(166, 167, 169)');
 	await neutralArea.hover();
 	await expect
 		.poll(() => getBackgroundColor(compositionItem))

--- a/packages/studio/src/components/AssetSelector.tsx
+++ b/packages/studio/src/components/AssetSelector.tsx
@@ -3,7 +3,7 @@ import {copyRenderOutputToAsset} from '../api/copy-render-output-to-asset';
 import {writeStaticFile} from '../api/write-static-file';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
-import {BACKGROUND, WHITE_ALPHA_06, LIGHT_TEXT} from '../helpers/colors';
+import {BACKGROUND, LIGHT_TEXT, WHITE_ALPHA_06} from '../helpers/colors';
 import {buildAssetFolderStructure} from '../helpers/create-folder-tree';
 import {toggleBooleanMapKey} from '../helpers/persist-boolean-map';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
@@ -191,29 +191,33 @@ export const AssetSelector: React.FC<{
 		},
 		[dropLocation, writeFilesToPublicFolder],
 	);
-	const uploadAssets = useCallback(async () => {
-		try {
-			const files = await pickFilesToImport();
-			if (files.length === 0) {
-				return;
-			}
+	const uploadAssets = useCallback(
+		async (assetPath: string | null) => {
+			try {
+				const files = await pickFilesToImport();
+				if (files.length === 0) {
+					return;
+				}
 
-			const wereWritten = await writeFilesToPublicFolder({
-				files,
-				assetPath: null,
-			});
-			if (wereWritten) {
-				showNotification(
-					files.length === 1
-						? `Uploaded ${files[0].name} to public folder`
-						: `Uploaded ${files.length} assets to public folder`,
-					3000,
-				);
+				const wereWritten = await writeFilesToPublicFolder({
+					files,
+					assetPath,
+				});
+				if (wereWritten) {
+					const destination = assetPath ? `'${assetPath}'` : 'public folder';
+					showNotification(
+						files.length === 1
+							? `Uploaded ${files[0].name} to ${destination}`
+							: `Uploaded ${files.length} assets to ${destination}`,
+						3000,
+					);
+				}
+			} catch (error) {
+				showNotification(`Error during upload: ${error}`, 3000);
 			}
-		} catch (error) {
-			showNotification(`Error during upload: ${error}`, 3000);
-		}
-	}, [writeFilesToPublicFolder]);
+		},
+		[writeFilesToPublicFolder],
+	);
 	const getAssetActions = useCallback((): ComboboxValue[] => {
 		return [
 			{
@@ -221,7 +225,7 @@ export const AssetSelector: React.FC<{
 				keyHint: null,
 				label: 'Upload...',
 				leftItem: null,
-				onClick: uploadAssets,
+				onClick: () => uploadAssets(null),
 				quickSwitcherLabel: 'Upload assets...',
 				subMenu: null,
 				type: 'item',
@@ -282,6 +286,7 @@ export const AssetSelector: React.FC<{
 						dropLocation={dropLocation}
 						setDropLocation={setDropLocation}
 						readOnlyStudio={readOnlyStudio}
+						uploadAssets={uploadAssets}
 					/>
 				</div>
 			)}

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -25,7 +25,11 @@ import {getFileManagerName} from '../helpers/get-file-manager-name';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {
 	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	HOVER_GROUP_CLASS_NAME,
+	HOVER_GROUP_REVEAL_CLASS_NAME,
 	NO_HOVER_BACKGROUND_STYLE,
+	hoverableStyle,
 } from '../helpers/hoverable';
 import {openInRemotionConvert} from '../helpers/open-in-remotion-convert';
 import {
@@ -61,7 +65,6 @@ const iconStyle: React.CSSProperties = {
 };
 
 const itemStyle: React.CSSProperties = {
-	paddingRight: 10,
 	paddingTop: 5,
 	paddingBottom: 5,
 	fontSize: 13,
@@ -76,7 +79,6 @@ const itemStyle: React.CSSProperties = {
 	borderRadius: 4,
 	width: 'calc(100% - 4px)',
 	textAlign: 'left',
-	backgroundColor: BACKGROUND,
 	height: COMPACT_CONTROL_ROW_HEIGHT,
 	userSelect: 'none',
 	WebkitUserSelect: 'none',
@@ -103,6 +105,11 @@ const ellipsisIconStyle: React.SVGProps<SVGSVGElement> = {
 	},
 };
 
+const inlineActionsStyle: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+};
+
 export const getAssetActionAvailability = ({
 	browserStudioCanMutateAssets,
 	readOnlyStudio,
@@ -119,6 +126,7 @@ export const getAssetActionAvailability = ({
 			browserStudioCanMutateAssets !== true &&
 			(readOnlyStudio || connectionStatus !== 'connected'),
 		fileExplorerDisabled:
+			browserStudioCanMutateAssets !== null ||
 			publicFolderExists === null ||
 			readOnlyStudio ||
 			connectionStatus !== 'connected',
@@ -288,7 +296,6 @@ const AssetFolderItem: React.FC<{
 	setDropLocation,
 	readOnlyStudio,
 }) => {
-	const [hovered, setHovered] = useState(false);
 	const openFolderTimerRef = useRef<number | null>(null);
 
 	const {isDropDiv, onDragEnter, onDragLeave} = useAssetDragEvents({
@@ -298,28 +305,18 @@ const AssetFolderItem: React.FC<{
 		setDropLocation,
 	});
 
-	const onPointerEnter = useCallback(() => {
-		setHovered(true);
-	}, []);
-
-	const onPointerLeave = useCallback(() => {
-		setHovered(false);
-	}, []);
-
 	const folderStyle: React.CSSProperties = useMemo(() => {
 		return {
 			...itemStyle,
 			paddingLeft: 4 + level * 8,
-			backgroundColor: hovered ? WHITE_ALPHA_06 : TRANSPARENT,
+			...hoverableStyle({
+				idleBackground: TRANSPARENT,
+				hoverBackground: WHITE_ALPHA_06,
+				idleColor: LIGHT_TEXT,
+				hoverColor: WHITE,
+			}),
 		};
-	}, [hovered, level]);
-
-	const label = useMemo(() => {
-		return {
-			...labelStyle,
-			color: hovered ? WHITE : LIGHT_TEXT,
-		};
-	}, [hovered]);
+	}, [level]);
 
 	const onClick = useCallback(() => {
 		toggleFolder(item.name, parentFolder);
@@ -337,8 +334,7 @@ const AssetFolderItem: React.FC<{
 		>
 			<div
 				style={folderStyle}
-				onPointerEnter={onPointerEnter}
-				onPointerLeave={onPointerLeave}
+				className={HOVERABLE_CLASS_NAME}
 				tabIndex={tabIndex}
 				title={item.name}
 				onClick={onClick}
@@ -364,9 +360,9 @@ const AssetFolderItem: React.FC<{
 				}}
 			>
 				<Row>
-					<Icon style={iconStyle} color={hovered ? WHITE : LIGHT_TEXT} />
+					<Icon style={iconStyle} color={CURRENT_COLOR} />
 					<Spacing x={1} />
-					<div style={label}>{item.name}</div>
+					<div style={labelStyle}>{item.name}</div>
 				</Row>
 			</div>
 
@@ -458,15 +454,10 @@ const AssetSelectorItem: React.FC<{
 	const fileManagerName = getFileManagerName(
 		window.remotion_fileSystemPlatform,
 	);
-	const [hovered, setHovered] = useState(false);
 	const [isDragging, setIsDragging] = useState(false);
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const connectionStatus = useContext(StudioServerConnectionCtx)
 		.previewServerState.type;
-	const onPointerEnter = useCallback(() => {
-		setHovered(true);
-	}, []);
-
 	const {setCanvasContent} = useContext(Internals.CompositionSetters);
 	const {canvasContent} = useContext(Internals.CompositionManager);
 
@@ -488,10 +479,6 @@ const AssetSelectorItem: React.FC<{
 	const canDragAsset = useMemo(() => {
 		return getCanDragAsset({readOnlyStudio, relativePath});
 	}, [readOnlyStudio, relativePath]);
-
-	const onPointerLeave = useCallback(() => {
-		setHovered(false);
-	}, []);
 
 	const rowRef = useRef<HTMLDivElement>(null);
 	useLayoutEffect(() => {
@@ -559,18 +546,15 @@ const AssetSelectorItem: React.FC<{
 	const style: React.CSSProperties = useMemo(() => {
 		return {
 			...itemStyle,
-			color: hovered || selected ? WHITE : LIGHT_TEXT,
-			backgroundColor: hovered || selected ? WHITE_ALPHA_06 : TRANSPARENT,
+			...hoverableStyle({
+				idleBackground: selected ? WHITE_ALPHA_06 : TRANSPARENT,
+				hoverBackground: WHITE_ALPHA_06,
+				idleColor: selected ? WHITE : LIGHT_TEXT,
+				hoverColor: WHITE,
+			}),
 			paddingLeft: 12 + level * 8,
 		};
-	}, [hovered, level, selected]);
-
-	const label = useMemo(() => {
-		return {
-			...labelStyle,
-			color: hovered || selected ? WHITE : LIGHT_TEXT,
-		};
-	}, [hovered, selected]);
+	}, [level, selected]);
 
 	const renderFileExplorerAction: RenderInlineAction = useCallback((color) => {
 		return <ExpandedFolderIcon style={revealIconStyle} color={color} />;
@@ -695,8 +679,7 @@ const AssetSelectorItem: React.FC<{
 				<div
 					ref={rowRef}
 					style={style}
-					onPointerEnter={onPointerEnter}
-					onPointerLeave={onPointerLeave}
+					className={`${HOVERABLE_CLASS_NAME} ${HOVER_GROUP_CLASS_NAME}`}
 					onClick={onClick}
 					draggable={canDragAsset}
 					onDragStart={onDragStart}
@@ -707,12 +690,15 @@ const AssetSelectorItem: React.FC<{
 					<AssetFileIcon
 						fileType={previewFileType}
 						style={iconStyle}
-						color={hovered || selected ? WHITE : LIGHT_TEXT}
+						color={CURRENT_COLOR}
 					/>
 					<Spacing x={1} />
-					<div style={label}>{item.name}</div>
-					{hovered && !isDragging ? (
-						<>
+					<div style={labelStyle}>{item.name}</div>
+					{!isDragging ? (
+						<div
+							className={HOVER_GROUP_REVEAL_CLASS_NAME}
+							style={inlineActionsStyle}
+						>
 							<Spacing x={0.5} />
 							<InlineDropdown
 								variant={null}
@@ -735,7 +721,7 @@ const AssetSelectorItem: React.FC<{
 									/>
 								</>
 							)}
-						</>
+						</div>
 					) : null}
 				</div>
 			</Row>

--- a/packages/studio/src/components/AssetSelectorItem.tsx
+++ b/packages/studio/src/components/AssetSelectorItem.tsx
@@ -13,11 +13,11 @@ import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	BACKGROUND,
-	WHITE_ALPHA_06,
 	CURRENT_COLOR,
 	LIGHT_TEXT,
 	TRANSPARENT,
 	WHITE,
+	WHITE_ALPHA_06,
 } from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
 import type {AssetFolder, AssetStructure} from '../helpers/create-folder-tree';
@@ -108,6 +108,10 @@ const ellipsisIconStyle: React.SVGProps<SVGSVGElement> = {
 const inlineActionsStyle: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
+};
+
+const renderContextMenuAction: RenderInlineAction = (color) => {
+	return <EllipsisIcon svgProps={ellipsisIconStyle} fill={color} />;
 };
 
 export const getAssetActionAvailability = ({
@@ -274,6 +278,87 @@ export const getAssetContextMenuItems = ({
 	return items.filter(NoReactInternals.truthy);
 };
 
+export const getAssetFolderContextMenuItems = ({
+	folderPath,
+	fileManagerName,
+	copyFolderPath,
+	copyAbsolutePath,
+	openFolderInExplorer,
+	uploadAssets,
+	fileExplorerAvailable,
+	fileExplorerDisabled,
+	mutationsDisabled,
+}: {
+	folderPath: string;
+	fileManagerName: string;
+	copyFolderPath: () => void;
+	copyAbsolutePath: (() => void) | null;
+	openFolderInExplorer: () => void;
+	uploadAssets: () => void;
+	fileExplorerAvailable: boolean;
+	fileExplorerDisabled: boolean;
+	mutationsDisabled: boolean;
+}): ComboboxValue[] => {
+	const items: (ComboboxValue | null)[] = [
+		fileExplorerAvailable
+			? {
+					id: 'open-asset-folder-in-explorer',
+					keyHint: null,
+					label: `Show in ${fileManagerName}`,
+					leftItem: null,
+					onClick: openFolderInExplorer,
+					quickSwitcherLabel: `Show asset folder in ${fileManagerName}`,
+					subMenu: null,
+					type: 'item',
+					value: 'open-asset-folder-in-explorer',
+					disabled: fileExplorerDisabled,
+				}
+			: null,
+		{
+			id: 'copy-asset-folder-path',
+			keyHint: null,
+			label: 'Copy folder path',
+			leftItem: null,
+			onClick: copyFolderPath,
+			quickSwitcherLabel: 'Copy asset folder path',
+			subMenu: null,
+			type: 'item',
+			value: 'copy-asset-folder-path',
+		},
+		copyAbsolutePath
+			? {
+					id: 'copy-asset-folder-absolute-path',
+					keyHint: null,
+					label: 'Copy absolute path',
+					leftItem: null,
+					onClick: copyAbsolutePath,
+					quickSwitcherLabel: 'Copy asset folder absolute path',
+					subMenu: null,
+					type: 'item',
+					value: 'copy-asset-folder-absolute-path',
+				}
+			: null,
+		{
+			type: 'divider',
+			id: 'asset-folder-upload-divider',
+		},
+		{
+			id: 'upload-assets-to-folder',
+			keyHint: null,
+			label: 'Upload...',
+			leftItem: null,
+			onClick: uploadAssets,
+			quickSwitcherLabel: `Upload assets to ${folderPath}...`,
+			subMenu: null,
+			type: 'item',
+			value: 'upload-assets-to-folder',
+			disabled: mutationsDisabled,
+		},
+	];
+
+	return items.filter(NoReactInternals.truthy);
+};
+
 const AssetFolderItem: React.FC<{
 	readonly item: AssetFolder;
 	readonly tabIndex: number;
@@ -286,6 +371,7 @@ const AssetFolderItem: React.FC<{
 	readonly dropLocation: string | null;
 	readonly setDropLocation: React.Dispatch<React.SetStateAction<string | null>>;
 	readonly readOnlyStudio: boolean;
+	readonly uploadAssets: (assetPath: string | null) => void;
 }> = ({
 	tabIndex,
 	item,
@@ -295,8 +381,17 @@ const AssetFolderItem: React.FC<{
 	dropLocation,
 	setDropLocation,
 	readOnlyStudio,
+	uploadAssets,
 }) => {
 	const openFolderTimerRef = useRef<number | null>(null);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
+	const fileManagerName = getFileManagerName(
+		window.remotion_fileSystemPlatform,
+	);
+	const folderPath = useMemo(() => {
+		return parentFolder ? `${parentFolder}/${item.name}` : item.name;
+	}, [item.name, parentFolder]);
 
 	const {isDropDiv, onDragEnter, onDragLeave} = useAssetDragEvents({
 		name: item.name,
@@ -322,6 +417,80 @@ const AssetFolderItem: React.FC<{
 		toggleFolder(item.name, parentFolder);
 	}, [item.name, parentFolder, toggleFolder]);
 
+	const copyFolderPath = useCallback(() => {
+		copyText(folderPath)
+			.then(() => {
+				showNotification(`Copied '${folderPath}' to clipboard`, 1000);
+			})
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [folderPath]);
+
+	const copyAbsolutePath = useCallback(() => {
+		if (window.remotion_publicFolderExists === null) {
+			return;
+		}
+
+		const content = `${window.remotion_publicFolderExists}/${folderPath}`;
+		copyText(content)
+			.then(() => {
+				showNotification(`Copied '${content}' to clipboard`, 1000);
+			})
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [folderPath]);
+
+	const openFolderInExplorer = useCallback(() => {
+		if (!window.remotion_publicFolderExists) {
+			showNotification('Could not find the public folder', 2000);
+			return;
+		}
+
+		openInFileExplorer({
+			directory: `${window.remotion_publicFolderExists}/${folderPath}`,
+		}).catch((err) => {
+			showNotification(`Could not open folder: ${err.message}`, 2000);
+		});
+	}, [folderPath]);
+
+	const uploadAssetsToFolder = useCallback(() => {
+		uploadAssets(folderPath);
+	}, [folderPath, uploadAssets]);
+
+	const {mutationsDisabled, fileExplorerDisabled} = getAssetActionAvailability({
+		browserStudioCanMutateAssets:
+			getBrowserStudioOperations() === null ? null : true,
+		readOnlyStudio,
+		connectionStatus,
+		publicFolderExists: window.remotion_publicFolderExists,
+	});
+
+	const getContextMenuItems = useCallback((): ComboboxValue[] => {
+		return getAssetFolderContextMenuItems({
+			folderPath,
+			fileManagerName,
+			copyFolderPath,
+			copyAbsolutePath:
+				window.remotion_publicFolderExists === null ? null : copyAbsolutePath,
+			openFolderInExplorer,
+			uploadAssets: uploadAssetsToFolder,
+			fileExplorerAvailable: getBrowserStudioOperations() === null,
+			fileExplorerDisabled,
+			mutationsDisabled,
+		});
+	}, [
+		copyAbsolutePath,
+		copyFolderPath,
+		fileExplorerDisabled,
+		fileManagerName,
+		folderPath,
+		mutationsDisabled,
+		openFolderInExplorer,
+		uploadAssetsToFolder,
+	]);
+
 	const Icon = item.expanded ? ExpandedFolderIcon : CollapsedFolderIcon;
 
 	return (
@@ -332,39 +501,55 @@ const AssetFolderItem: React.FC<{
 				backgroundColor: isDropDiv ? WHITE_ALPHA_06 : BACKGROUND,
 			}}
 		>
-			<div
-				style={folderStyle}
-				className={HOVERABLE_CLASS_NAME}
-				tabIndex={tabIndex}
-				title={item.name}
-				onClick={onClick}
-				onDragEnter={(event) => {
-					if (!isAssetUploadDragEvent(event)) {
-						return;
-					}
+			<ContextMenu getItems={getContextMenuItems}>
+				<Row align="center">
+					<div
+						style={folderStyle}
+						className={`${HOVERABLE_CLASS_NAME} ${HOVER_GROUP_CLASS_NAME}`}
+						tabIndex={tabIndex}
+						title={item.name}
+						onClick={onClick}
+						onDragEnter={(event) => {
+							if (!isAssetUploadDragEvent(event)) {
+								return;
+							}
 
-					if (!item.expanded) {
-						openFolderTimerRef.current = window.setTimeout(() => {
-							toggleFolder(item.name, parentFolder);
-						}, 1000);
-					}
-				}}
-				onDragLeave={(event) => {
-					if (!isAssetUploadDragEvent(event)) {
-						return;
-					}
+							if (!item.expanded) {
+								openFolderTimerRef.current = window.setTimeout(() => {
+									toggleFolder(item.name, parentFolder);
+								}, 1000);
+							}
+						}}
+						onDragLeave={(event) => {
+							if (!isAssetUploadDragEvent(event)) {
+								return;
+							}
 
-					if (openFolderTimerRef.current) {
-						clearTimeout(openFolderTimerRef.current);
-					}
-				}}
-			>
-				<Row>
-					<Icon style={iconStyle} color={CURRENT_COLOR} />
-					<Spacing x={1} />
-					<div style={labelStyle}>{item.name}</div>
+							if (openFolderTimerRef.current) {
+								clearTimeout(openFolderTimerRef.current);
+							}
+						}}
+					>
+						<Icon style={iconStyle} color={CURRENT_COLOR} />
+						<Spacing x={1} />
+						<div style={labelStyle}>{item.name}</div>
+						<div
+							className={HOVER_GROUP_REVEAL_CLASS_NAME}
+							style={inlineActionsStyle}
+						>
+							<Spacing x={0.5} />
+							<InlineDropdown
+								variant={null}
+								title="More actions"
+								renderAction={renderContextMenuAction}
+								getItems={getContextMenuItems}
+								style={NO_HOVER_BACKGROUND_STYLE}
+								className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
+							/>
+						</div>
+					</div>
 				</Row>
-			</div>
+			</ContextMenu>
 
 			{item.expanded ? (
 				<AssetFolderTree
@@ -378,6 +563,7 @@ const AssetFolderItem: React.FC<{
 					dropLocation={dropLocation}
 					setDropLocation={setDropLocation}
 					readOnlyStudio={readOnlyStudio}
+					uploadAssets={uploadAssets}
 				/>
 			) : null}
 		</div>
@@ -397,6 +583,7 @@ export const AssetFolderTree: React.FC<{
 	readonly dropLocation: string | null;
 	readonly setDropLocation: React.Dispatch<React.SetStateAction<string | null>>;
 	readonly readOnlyStudio: boolean;
+	readonly uploadAssets: (assetPath: string | null) => void;
 }> = ({
 	item,
 	level,
@@ -407,6 +594,7 @@ export const AssetFolderTree: React.FC<{
 	dropLocation,
 	setDropLocation,
 	readOnlyStudio,
+	uploadAssets,
 }) => {
 	const combinedParents = useMemo(() => {
 		return [parentFolder, name].filter(NoReactInternals.truthy).join('/');
@@ -425,6 +613,7 @@ export const AssetFolderTree: React.FC<{
 						dropLocation={dropLocation}
 						setDropLocation={setDropLocation}
 						readOnlyStudio={readOnlyStudio}
+						uploadAssets={uploadAssets}
 					/>
 				);
 			})}
@@ -558,10 +747,6 @@ const AssetSelectorItem: React.FC<{
 
 	const renderFileExplorerAction: RenderInlineAction = useCallback((color) => {
 		return <ExpandedFolderIcon style={revealIconStyle} color={color} />;
-	}, []);
-
-	const renderContextMenuAction: RenderInlineAction = useCallback((color) => {
-		return <EllipsisIcon svgProps={ellipsisIconStyle} fill={color} />;
 	}, []);
 
 	const copyFileName = useCallback(() => {

--- a/packages/studio/src/components/CompositionContextButton.tsx
+++ b/packages/studio/src/components/CompositionContextButton.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVER_GROUP_REVEAL_CLASS_NAME,
 	NO_HOVER_BACKGROUND_STYLE,
 } from '../helpers/hoverable';
 import {EllipsisIcon} from '../icons/ellipsis';
@@ -10,10 +11,15 @@ import type {RenderInlineAction} from './InlineAction';
 import {InlineDropdown} from './InlineDropdown';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 
+const revealStyle: React.CSSProperties = {
+	display: 'flex',
+};
+
 export const CompositionContextButton: React.FC<{
 	readonly visible: boolean;
 	readonly getItems: () => ComboboxValue[];
-}> = ({visible, getItems}) => {
+	readonly readOnlyStudio: boolean;
+}> = ({visible, getItems, readOnlyStudio}) => {
 	const iconStyle: SVGProps<SVGSVGElement> = useMemo(() => {
 		return {
 			style: {
@@ -32,17 +38,19 @@ export const CompositionContextButton: React.FC<{
 		[iconStyle],
 	);
 
-	if (!visible || connectionStatus !== 'connected') {
+	if (!visible || (connectionStatus !== 'connected' && !readOnlyStudio)) {
 		return null;
 	}
 
 	return (
-		<InlineDropdown
-			renderAction={renderAction}
-			getItems={getItems}
-			variant={null}
-			style={NO_HOVER_BACKGROUND_STYLE}
-			className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
-		/>
+		<div className={HOVER_GROUP_REVEAL_CLASS_NAME} style={revealStyle}>
+			<InlineDropdown
+				renderAction={renderAction}
+				getItems={getItems}
+				variant={null}
+				style={NO_HOVER_BACKGROUND_STYLE}
+				className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
+			/>
+		</div>
 	);
 };

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -12,13 +12,18 @@ import React, {
 import {type _InternalTypes} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
-	BACKGROUND,
+	CURRENT_COLOR,
 	LIGHT_TEXT,
 	TRANSPARENT,
 	WHITE,
 	WHITE_ALPHA_06,
 	WHITE_ALPHA_12,
 } from '../helpers/colors';
+import {
+	HOVERABLE_CLASS_NAME,
+	HOVER_GROUP_CLASS_NAME,
+	hoverableStyle,
+} from '../helpers/hoverable';
 import {noop} from '../helpers/noop';
 import {
 	markCompositionSidebarScrollFromRowClick,
@@ -56,7 +61,6 @@ const itemStyle: React.CSSProperties = {
 	borderRadius: 4,
 	width: 'calc(100% - 12px)',
 	textAlign: 'left',
-	backgroundColor: BACKGROUND,
 	height: COMPACT_CONTROL_ROW_HEIGHT,
 	userSelect: 'none',
 };
@@ -123,14 +127,6 @@ export const CompositionSelectorItem: React.FC<{
 
 		return false;
 	}, [item, currentComposition]);
-	const [hovered, setHovered] = useState(false);
-	const onPointerEnter = useCallback(() => {
-		setHovered(true);
-	}, []);
-
-	const onPointerLeave = useCallback(() => {
-		setHovered(false);
-	}, []);
 	const [isDragging, setIsDragging] = useState(false);
 	const [dragHovered, setDragHovered] = useState(false);
 
@@ -150,23 +146,22 @@ export const CompositionSelectorItem: React.FC<{
 	}, [compositionId, selected]);
 
 	const style: React.CSSProperties = useMemo(() => {
+		const idleBackground = dragHovered
+			? WHITE_ALPHA_12
+			: selected
+				? WHITE_ALPHA_06
+				: TRANSPARENT;
 		return {
 			...itemStyle,
-			backgroundColor: dragHovered
-				? WHITE_ALPHA_12
-				: hovered || selected
-					? WHITE_ALPHA_06
-					: TRANSPARENT,
+			...hoverableStyle({
+				idleBackground,
+				hoverBackground: dragHovered ? WHITE_ALPHA_12 : WHITE_ALPHA_06,
+				idleColor: selected ? WHITE : LIGHT_TEXT,
+				hoverColor: WHITE,
+			}),
 			paddingLeft: 12 + level * 8,
 		};
-	}, [dragHovered, hovered, level, selected]);
-
-	const label = useMemo(() => {
-		return {
-			...labelStyle,
-			color: selected || hovered ? WHITE : LIGHT_TEXT,
-		};
-	}, [hovered, selected]);
+	}, [dragHovered, level, selected]);
 
 	const onClick = useCallback(
 		(evt: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
@@ -376,9 +371,7 @@ export const CompositionSelectorItem: React.FC<{
 					<Row align="center">
 						<div
 							style={style}
-							className="__remotion-composition-selector-item"
-							onPointerEnter={onPointerEnter}
-							onPointerLeave={onPointerLeave}
+							className={`__remotion-composition-selector-item ${HOVERABLE_CLASS_NAME} ${HOVER_GROUP_CLASS_NAME}`}
 							tabIndex={tabIndex}
 							onClick={onClick}
 							onKeyDown={onKeyDown}
@@ -389,22 +382,17 @@ export const CompositionSelectorItem: React.FC<{
 							role="button"
 						>
 							{item.expanded ? (
-								<ExpandedFolderIcon
-									style={iconStyle}
-									color={hovered || selected ? WHITE : LIGHT_TEXT}
-								/>
+								<ExpandedFolderIcon style={iconStyle} color={CURRENT_COLOR} />
 							) : (
-								<CollapsedFolderIcon
-									color={hovered || selected ? WHITE : LIGHT_TEXT}
-									style={iconStyle}
-								/>
+								<CollapsedFolderIcon color={CURRENT_COLOR} style={iconStyle} />
 							)}
 							<Spacing x={1} />
-							<div style={label}>{item.folderName}</div>
+							<div style={labelStyle}>{item.folderName}</div>
 							<Spacing x={0.5} />
 							<CompositionContextButton
 								getItems={getContextMenuItems}
-								visible={hovered}
+								visible
+								readOnlyStudio={window.remotion_isReadOnlyStudio}
 							/>
 						</div>
 					</Row>
@@ -437,8 +425,6 @@ export const CompositionSelectorItem: React.FC<{
 				<a
 					ref={compositionRowRef}
 					style={style}
-					onPointerEnter={onPointerEnter}
-					onPointerLeave={onPointerLeave}
 					tabIndex={tabIndex}
 					onClick={onClick}
 					onKeyDown={onKeyDown}
@@ -447,24 +433,26 @@ export const CompositionSelectorItem: React.FC<{
 					onDragEnd={onCompositionDragEnd}
 					type="button"
 					title={item.composition.id}
-					className="__remotion-composition __remotion-composition-selector-item"
+					className={`__remotion-composition __remotion-composition-selector-item ${HOVERABLE_CLASS_NAME} ${HOVER_GROUP_CLASS_NAME}`}
 					data-compname={item.composition.id}
 				>
 					<CompositionOrStillIcon
 						composition={item.composition}
-						color={hovered || selected ? WHITE : LIGHT_TEXT}
+						color={CURRENT_COLOR}
 						style={iconStyle}
 					/>
 					<Spacing x={1} />
-					<div style={label}>{item.composition.id}</div>
+					<div style={labelStyle}>{item.composition.id}</div>
 					<Spacing x={0.5} />
 					<CompositionContextButton
 						getItems={getContextMenuItems}
-						visible={hovered && !isDragging}
+						visible={!isDragging}
+						readOnlyStudio={window.remotion_isReadOnlyStudio}
 					/>
 					<SidebarRenderButton
-						visible={hovered && !isDragging}
+						visible={!isDragging}
 						composition={item.composition}
+						readOnlyStudio={window.remotion_isReadOnlyStudio}
 					/>
 				</a>
 			</Row>

--- a/packages/studio/src/components/SidebarRenderButton.tsx
+++ b/packages/studio/src/components/SidebarRenderButton.tsx
@@ -13,6 +13,7 @@ import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {
 	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVER_GROUP_REVEAL_CLASS_NAME,
 	NO_HOVER_BACKGROUND_STYLE,
 } from '../helpers/hoverable';
 import {ThinRenderIcon} from '../icons/render';
@@ -20,10 +21,15 @@ import {SetSelectedModalContext} from '../state/modals';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 
+const revealStyle: React.CSSProperties = {
+	display: 'flex',
+};
+
 export const SidebarRenderButton: React.FC<{
 	readonly composition: _InternalTypes['AnyCompMetadata'];
 	readonly visible: boolean;
-}> = ({composition, visible}) => {
+	readonly readOnlyStudio: boolean;
+}> = ({composition, visible, readOnlyStudio}) => {
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 
 	const iconStyle: SVGProps<SVGSVGElement> = useMemo(() => {
@@ -100,10 +106,16 @@ export const SidebarRenderButton: React.FC<{
 				initialMediaCacheSizeInBytes: defaults.mediaCacheSizeInBytes,
 				renderDefaults: defaults,
 				initialDarkMode: defaults.darkMode,
-				readOnlyStudio: false,
+				readOnlyStudio,
 			});
 		},
-		[composition.defaultProps, composition.id, props, setSelectedModal],
+		[
+			composition.defaultProps,
+			composition.id,
+			props,
+			readOnlyStudio,
+			setSelectedModal,
+		],
 	);
 
 	const renderAction: RenderInlineAction = useCallback(
@@ -113,17 +125,19 @@ export const SidebarRenderButton: React.FC<{
 		[iconStyle],
 	);
 
-	if (!visible || connectionStatus !== 'connected') {
+	if (!visible || (connectionStatus !== 'connected' && !readOnlyStudio)) {
 		return null;
 	}
 
 	return (
-		<InlineAction
-			renderAction={renderAction}
-			onClick={onClick}
-			variant={null}
-			style={NO_HOVER_BACKGROUND_STYLE}
-			className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
-		/>
+		<div className={HOVER_GROUP_REVEAL_CLASS_NAME} style={revealStyle}>
+			<InlineAction
+				renderAction={renderAction}
+				onClick={onClick}
+				variant={null}
+				style={NO_HOVER_BACKGROUND_STYLE}
+				className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
+			/>
+		</div>
 	);
 };

--- a/packages/studio/src/helpers/hoverable.ts
+++ b/packages/studio/src/helpers/hoverable.ts
@@ -64,16 +64,21 @@ export const makeHoverableCSS = () => `
   }
 
   @media (hover: hover) {
-    ${hoverable}:hover,
-    ${hoverGroup}:hover ${hoverable} {
+    ${hoverable}:hover {
       background-color: var(${HOVER_BG_VARIABLE}, var(${BG_VARIABLE}, ${TRANSPARENT}));
     }
 
     ${hoverable}:hover,
-    ${hoverable}:hover *,
-    ${hoverGroup}:hover ${hoverable},
-    ${hoverGroup}:hover ${hoverable} * {
+    ${hoverable}:hover * {
       color: var(${HOVER_COLOR_VARIABLE}, var(${COLOR_VARIABLE}, inherit));
+    }
+
+    /* An outer hoverable must not put a nested inline action into its hover
+       state. The nested action should only use its hover color when the
+       pointer is over the action itself. */
+    ${hoverable}:hover ${hoverable}:not(:hover),
+    ${hoverable}:hover ${hoverable}:not(:hover) * {
+      color: var(${COLOR_VARIABLE}, inherit);
     }
 
     ${hoverGroup} ${reveal} {

--- a/packages/studio/src/test/asset-context-menu.test.ts
+++ b/packages/studio/src/test/asset-context-menu.test.ts
@@ -1,8 +1,9 @@
 import {expect, test} from 'bun:test';
 import {
 	getAssetActionAvailability,
-	getCanDragAsset,
 	getAssetContextMenuItems,
+	getAssetFolderContextMenuItems,
+	getCanDragAsset,
 } from '../components/AssetSelectorItem';
 
 const noop = () => undefined;
@@ -72,6 +73,50 @@ test('hides file-manager asset actions in Browser Studio', () => {
 	expect(items.find((item) => item.id === 'copy-asset-absolute-path')).toBe(
 		undefined,
 	);
+});
+
+test('offers supported asset folder actions in Browser Studio', () => {
+	const items = getAssetFolderContextMenuItems({
+		folderPath: 'nested/assets',
+		fileManagerName: 'Finder',
+		copyFolderPath: noop,
+		copyAbsolutePath: null,
+		openFolderInExplorer: noop,
+		uploadAssets: noop,
+		fileExplorerAvailable: false,
+		fileExplorerDisabled: true,
+		mutationsDisabled: false,
+	});
+
+	expect(getItem(items, 'copy-asset-folder-path').disabled).not.toBe(true);
+	expect(getItem(items, 'upload-assets-to-folder').disabled).not.toBe(true);
+	expect(
+		items.find((item) => item.id === 'open-asset-folder-in-explorer'),
+	).toBeUndefined();
+	expect(
+		items.find((item) => item.id === 'copy-asset-folder-absolute-path'),
+	).toBeUndefined();
+});
+
+test('keeps non-mutating asset folder actions in read-only Studio', () => {
+	const items = getAssetFolderContextMenuItems({
+		folderPath: 'nested/assets',
+		fileManagerName: 'Finder',
+		copyFolderPath: noop,
+		copyAbsolutePath: noop,
+		openFolderInExplorer: noop,
+		uploadAssets: noop,
+		fileExplorerAvailable: true,
+		fileExplorerDisabled: true,
+		mutationsDisabled: true,
+	});
+
+	expect(getItem(items, 'copy-asset-folder-path').disabled).not.toBe(true);
+	expect(getItem(items, 'copy-asset-folder-absolute-path').disabled).not.toBe(
+		true,
+	);
+	expect(getItem(items, 'open-asset-folder-in-explorer').disabled).toBe(true);
+	expect(getItem(items, 'upload-assets-to-folder').disabled).toBe(true);
 });
 
 test('only offers Remotion Convert for audio and video assets', () => {

--- a/packages/studio/src/test/asset-context-menu.test.ts
+++ b/packages/studio/src/test/asset-context-menu.test.ts
@@ -137,6 +137,20 @@ test('enables supported Browser Studio asset mutations', () => {
 	});
 });
 
+test('disables file-manager actions in editable Browser Studio', () => {
+	const availability = getAssetActionAvailability({
+		browserStudioCanMutateAssets: true,
+		readOnlyStudio: false,
+		connectionStatus: 'connected',
+		publicFolderExists: '/public',
+	});
+
+	expect(availability).toEqual({
+		fileExplorerDisabled: true,
+		mutationsDisabled: false,
+	});
+});
+
 test('disables drag insertion in read-only Studio', () => {
 	expect(
 		getCanDragAsset({


### PR DESCRIPTION
## Summary

- align Asset selector row spacing and hide unsupported file-manager actions in Browser Studio
- add context menus and hover ellipsis actions to Asset folders, including upload-to-folder, path copying, and local file-manager reveal
- show Composition selector actions in read-only Studio
- use iframe-safe CSS hover states for Asset and Composition selector items
- keep nested inline action hover states independent from their parent Explorer rows

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/studio && bun test src`
- `cd packages/browser-studio && bun run testbrowserstudio --grep "clears hover backgrounds even if pointer leave events are lost"`

Closes #10883
