### PR TITLE
Retry stalled keep-alive audio resumes

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -19,6 +19,7 @@ import type {RemotionAudioContextState} from './use-audio-context.js';
 import {useSingletonAudioContext} from './use-audio-context.js';
 import {
 	type AudioContextResumeResult,
+	waitUntilAudioContextRunning,
 	waitUntilActuallyResumed,
 } from './wait-until-actually-resumed.js';
 
@@ -398,7 +399,20 @@ export const SharedAudioContextProvider: React.FC<{
 		}
 
 		if (audioContextIsPlayingEventually.current) {
-			return Promise.resolve();
+			if (
+				!_experimentalKeepAudioContextAlive ||
+				ctxAndGain.getState() === 'running'
+			) {
+				return Promise.resolve();
+			}
+
+			return ctxAndGain.resume().catch((err) => {
+				Log.warn(
+					{logLevel, tag: 'audio'},
+					'AudioContext resume rejected; keeping playback buffered until the next resume attempt',
+					err,
+				);
+			});
 		}
 
 		audioContextIsPlayingEventually.current = true;
@@ -435,17 +449,31 @@ export const SharedAudioContextProvider: React.FC<{
 		const resumeAttemptId = nextResumeAttemptId.current++;
 
 		const waitPromise = new Promise<AudioContextResumeResult>((resolve) => {
-			waitUntilActuallyResumed(
-				ctxAndGain.audioContext,
-				logLevel,
-				abortController.signal,
-			).then(resolve);
+			if (_experimentalKeepAudioContextAlive) {
+				waitUntilAudioContextRunning(
+					ctxAndGain.audioContext,
+					abortController.signal,
+				).then(resolve);
+			} else {
+				waitUntilActuallyResumed(
+					ctxAndGain.audioContext,
+					logLevel,
+					abortController.signal,
+				).then(resolve);
+			}
+
 			resumePromise.catch((err) => {
 				Log.warn(
 					{logLevel, tag: 'audio'},
-					'AudioContext resume rejected, muting playback and continuing without audio',
+					_experimentalKeepAudioContextAlive
+						? 'AudioContext resume rejected; keeping playback buffered until the next resume attempt'
+						: 'AudioContext resume rejected, muting playback and continuing without audio',
 					err,
 				);
+				if (_experimentalKeepAudioContextAlive) {
+					return;
+				}
+
 				abortController.abort();
 				resolve('failed');
 			});

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -4,6 +4,45 @@ const RESUME_WAIT_TIMEOUT = 1000;
 
 export type AudioContextResumeResult = 'resumed' | 'cancelled' | 'failed';
 
+export const waitUntilAudioContextRunning = (
+	audioContext: AudioContext,
+	signal: AbortSignal,
+): Promise<AudioContextResumeResult> => {
+	return new Promise((resolve) => {
+		let settled = false;
+		let onStateChange: () => void = () => undefined;
+		let onAbort: () => void = () => undefined;
+
+		const finish = (result: AudioContextResumeResult) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			audioContext.removeEventListener('statechange', onStateChange);
+			signal.removeEventListener('abort', onAbort);
+			resolve(result);
+		};
+
+		onStateChange = () => {
+			if (audioContext.state === 'running') {
+				finish('resumed');
+			}
+		};
+
+		onAbort = () => finish('cancelled');
+
+		if (signal.aborted) {
+			finish('cancelled');
+			return;
+		}
+
+		audioContext.addEventListener('statechange', onStateChange);
+		signal.addEventListener('abort', onAbort, {once: true});
+		onStateChange();
+	});
+};
+
 export const waitUntilActuallyResumed = (
 	audioContext: AudioContext,
 	logLevel: LogLevel,

--- a/packages/core/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/core/src/test/keep-audio-context-alive.test.tsx
@@ -22,6 +22,8 @@ const previewEnvironment = {
 };
 
 let nativeSuspendCalls = 0;
+let nativeResumeCalls = 0;
+let stallNativeResume = false;
 let gainValues: number[] = [];
 
 class TrackedAudioContext {
@@ -30,13 +32,18 @@ class TrackedAudioContext {
 	public outputLatency = 0;
 	public currentTime = 0;
 	public destination = {};
+	private readonly stateChangeListeners = new Set<EventListener>();
 
-	addEventListener() {
-		return undefined;
+	addEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.add(listener);
+		}
 	}
 
-	removeEventListener() {
-		return undefined;
+	removeEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.delete(listener);
+		}
 	}
 
 	createGain() {
@@ -59,7 +66,16 @@ class TrackedAudioContext {
 	}
 
 	resume() {
+		nativeResumeCalls++;
+		if (stallNativeResume) {
+			return new Promise<void>(() => undefined);
+		}
+
 		this.state = 'running';
+		for (const listener of this.stateChangeListeners) {
+			listener(new Event('statechange'));
+		}
+
 		return Promise.resolve();
 	}
 
@@ -139,6 +155,8 @@ const withMockedAudioContext = async (fn: () => Promise<void>) => {
 	globalThis.AudioContext =
 		TrackedAudioContext as unknown as typeof AudioContext;
 	nativeSuspendCalls = 0;
+	nativeResumeCalls = 0;
+	stallNativeResume = false;
 	gainValues = [];
 	try {
 		await fn();
@@ -214,5 +232,30 @@ test('_experimentalKeepAudioContextAlive queues nodes scheduled while silenced',
 			await Promise.resolve();
 		});
 		expect(startedWhileSilenced).toEqual([2]);
+	});
+});
+
+test('_experimentalKeepAudioContextAlive retries a stalled resume', async () => {
+	await withMockedAudioContext(async () => {
+		stallNativeResume = true;
+		const value = renderProvider(true);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+
+		const pendingResume = value.getIsResumingAudioContext();
+		expect(pendingResume).not.toBeNull();
+		const callsBeforeRetry = nativeResumeCalls;
+
+		stallNativeResume = false;
+		await act(async () => {
+			await value.resume();
+		});
+
+		expect(nativeResumeCalls).toBeGreaterThan(callsBeforeRetry);
+		expect(await pendingResume).toBe('resumed');
+		expect(value.getIsResumingAudioContext()).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- keep one pending resume attempt while `_experimentalKeepAudioContextAlive` waits for the native context to become `running`
- retry `AudioContext.resume()` when a later play or user gesture arrives
- resolve the existing Player resume wait from the native `statechange` event

The default autoplay path keeps its current output-progress check, timeout, and mute-on-failure behavior.

## Problem

A browser can leave `AudioContext.resume()` pending while the context remains suspended. The keep-alive path records playback intent before that call, so later resume calls currently return early and the Player eventually treats the first attempt as an autoplay failure.

Keep-alive mode is intended for editors and DAW-like playback, where a later gesture should retry the native resume without replacing the Player promise that is already parking the visual clock.

## Tradeoff

With the experimental flag enabled, a rejected or stalled native resume remains pending until a later attempt reaches `running` or playback suspends and aborts the attempt. The default Player behavior is unchanged.

## Testing

- `bun run test` in `packages/core` (673 tests)
- `bun run lint` in `packages/core` (one unrelated existing warning in `src/use-lazy-component.ts`)
- `bun run formatting` in `packages/core`
- `bunx turbo run make --filter=remotion --filter=@remotion/player`