### PR TITLE
Wait for pending audio resume before suspending

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -471,19 +471,22 @@ export const SharedAudioContextProvider: React.FC<{
 	}, []);
 
 	const suspend = useCallback(() => {
-		isResuming.current?.abortController.abort();
+		const resumeAttempt = isResuming.current;
 
 		if (!ctxAndGain) {
+			resumeAttempt?.abortController.abort();
 			return Promise.resolve();
 		}
 
 		if (!audioContextIsPlayingEventually.current) {
+			resumeAttempt?.abortController.abort();
 			return Promise.resolve();
 		}
 
 		audioContextIsPlayingEventually.current = false;
 
 		if (_experimentalKeepAudioContextAlive) {
+			resumeAttempt?.abortController.abort();
 			// Silence through the gain instead of suspending, so the context
 			// clock keeps running and the next resume() is instant. Audio that
 			// is already scheduled plays out silently; resume() ramps the gain
@@ -498,7 +501,26 @@ export const SharedAudioContextProvider: React.FC<{
 			return Promise.resolve();
 		}
 
-		return ctxAndGain.suspend();
+		if (ctxAndGain.getState() === 'running') {
+			resumeAttempt?.abortController.abort();
+			return ctxAndGain.suspend();
+		}
+
+		if (!resumeAttempt) {
+			return Promise.resolve();
+		}
+
+		return resumeAttempt.promise.then((result) => {
+			if (
+				result !== 'resumed' ||
+				audioContextIsPlayingEventually.current ||
+				ctxAndGain.getState() !== 'running'
+			) {
+				return;
+			}
+
+			return ctxAndGain.suspend();
+		});
 	}, [ctxAndGain, _experimentalKeepAudioContextAlive]);
 
 	// With _experimentalKeepAudioContextAlive, start the context as early as

--- a/packages/core/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/core/src/test/keep-audio-context-alive.test.tsx
@@ -22,6 +22,8 @@ const previewEnvironment = {
 };
 
 let nativeSuspendCalls = 0;
+let stallNativeResume = false;
+let finishNativeResume: (() => void) | null = null;
 let gainValues: number[] = [];
 
 class TrackedAudioContext {
@@ -30,6 +32,7 @@ class TrackedAudioContext {
 	public outputLatency = 0;
 	public currentTime = 0;
 	public destination = {};
+	private outputTime = 0;
 
 	addEventListener() {
 		return undefined;
@@ -59,12 +62,26 @@ class TrackedAudioContext {
 	}
 
 	resume() {
+		if (stallNativeResume) {
+			return new Promise<void>((resolve) => {
+				finishNativeResume = () => {
+					this.state = 'running';
+					resolve();
+				};
+			});
+		}
+
 		this.state = 'running';
 		return Promise.resolve();
 	}
 
 	getOutputTimestamp() {
-		return {contextTime: this.currentTime, performanceTime: 0};
+		if (this.state === 'running') {
+			this.currentTime += 0.01;
+			this.outputTime += 10;
+		}
+
+		return {contextTime: this.currentTime, performanceTime: this.outputTime};
 	}
 
 	createMediaElementSource() {
@@ -139,6 +156,8 @@ const withMockedAudioContext = async (fn: () => Promise<void>) => {
 	globalThis.AudioContext =
 		TrackedAudioContext as unknown as typeof AudioContext;
 	nativeSuspendCalls = 0;
+	stallNativeResume = false;
+	finishNativeResume = null;
 	gainValues = [];
 	try {
 		await fn();
@@ -161,6 +180,31 @@ test('suspend() suspends the AudioContext by default', async () => {
 			value.suspend();
 			await Promise.resolve();
 		});
+		expect(nativeSuspendCalls).toBe(1);
+	});
+});
+
+test('suspend() waits for a pending resume before suspending', async () => {
+	await withMockedAudioContext(async () => {
+		stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		nativeSuspendCalls = 0;
+
+		const pendingNativeResume = finishNativeResume;
+		expect(pendingNativeResume).not.toBeNull();
+		const suspendPromise = value.suspend();
+		expect(nativeSuspendCalls).toBe(0);
+
+		await act(async () => {
+			pendingNativeResume?.();
+			await suspendPromise;
+		});
+
 		expect(nativeSuspendCalls).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

When playback pauses while `AudioContext.resume()` is still pending, wait for that attempt to settle before deciding whether the native context needs to be suspended.

This preserves the latest playback intent:

- if the pending resume succeeds and playback is still paused, suspend the running context
- if playback resumed again, the old pause does not suspend it
- if the attempt failed or was cancelled, do not issue a redundant native suspend

The `_experimentalKeepAudioContextAlive` gain-silencing path keeps its current behavior.

## Problem

Calling native `suspend()` against a context whose `resume()` has not settled creates an ordering race. A delayed resume may complete after the pause and leave the context running, or browser implementations may handle the overlapping operations inconsistently.

## Tradeoff

`suspend()` can remain pending while a native resume attempt is pending. The existing resume attempt already has a one-second failure timeout, so the default autoplay path remains bounded.

## Testing

- `bun run test` in `packages/core` (673 tests)
- `bun run lint` in `packages/core` (one unrelated existing warning in `src/use-lazy-component.ts`)
- `bun run formatting` in `packages/core`
- `bunx turbo run make --filter=remotion --filter=@remotion/player`