### PR TITLE
Draft: Audio resume coordination overview

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -499,19 +499,22 @@ export const SharedAudioContextProvider: React.FC<{
 	}, []);
 
 	const suspend = useCallback(() => {
-		isResuming.current?.abortController.abort();
+		const resumeAttempt = isResuming.current;
 
 		if (!ctxAndGain) {
+			resumeAttempt?.abortController.abort();
 			return Promise.resolve();
 		}
 
 		if (!audioContextIsPlayingEventually.current) {
+			resumeAttempt?.abortController.abort();
 			return Promise.resolve();
 		}
 
 		audioContextIsPlayingEventually.current = false;
 
 		if (_experimentalKeepAudioContextAlive) {
+			resumeAttempt?.abortController.abort();
 			// Silence through the gain instead of suspending, so the context
 			// clock keeps running and the next resume() is instant. Audio that
 			// is already scheduled plays out silently; resume() ramps the gain
@@ -526,7 +529,26 @@ export const SharedAudioContextProvider: React.FC<{
 			return Promise.resolve();
 		}
 
-		return ctxAndGain.suspend();
+		if (ctxAndGain.getState() === 'running') {
+			resumeAttempt?.abortController.abort();
+			return ctxAndGain.suspend();
+		}
+
+		if (!resumeAttempt) {
+			return Promise.resolve();
+		}
+
+		return resumeAttempt.promise.then((result) => {
+			if (
+				result !== 'resumed' ||
+				audioContextIsPlayingEventually.current ||
+				ctxAndGain.getState() !== 'running'
+			) {
+				return;
+			}
+
+			return ctxAndGain.suspend();
+		});
 	}, [ctxAndGain, _experimentalKeepAudioContextAlive]);
 
 	// With _experimentalKeepAudioContextAlive, start the context as early as

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -19,6 +19,7 @@ import type {RemotionAudioContextState} from './use-audio-context.js';
 import {useSingletonAudioContext} from './use-audio-context.js';
 import {
 	type AudioContextResumeResult,
+	waitUntilAudioContextRunning,
 	waitUntilActuallyResumed,
 } from './wait-until-actually-resumed.js';
 
@@ -398,7 +399,20 @@ export const SharedAudioContextProvider: React.FC<{
 		}
 
 		if (audioContextIsPlayingEventually.current) {
-			return Promise.resolve();
+			if (
+				!_experimentalKeepAudioContextAlive ||
+				ctxAndGain.getState() === 'running'
+			) {
+				return Promise.resolve();
+			}
+
+			return ctxAndGain.resume().catch((err) => {
+				Log.warn(
+					{logLevel, tag: 'audio'},
+					'AudioContext resume rejected; keeping playback buffered until the next resume attempt',
+					err,
+				);
+			});
 		}
 
 		audioContextIsPlayingEventually.current = true;
@@ -435,17 +449,31 @@ export const SharedAudioContextProvider: React.FC<{
 		const resumeAttemptId = nextResumeAttemptId.current++;
 
 		const waitPromise = new Promise<AudioContextResumeResult>((resolve) => {
-			waitUntilActuallyResumed(
-				ctxAndGain.audioContext,
-				logLevel,
-				abortController.signal,
-			).then(resolve);
+			if (_experimentalKeepAudioContextAlive) {
+				waitUntilAudioContextRunning(
+					ctxAndGain.audioContext,
+					abortController.signal,
+				).then(resolve);
+			} else {
+				waitUntilActuallyResumed(
+					ctxAndGain.audioContext,
+					logLevel,
+					abortController.signal,
+				).then(resolve);
+			}
+
 			resumePromise.catch((err) => {
 				Log.warn(
 					{logLevel, tag: 'audio'},
-					'AudioContext resume rejected, muting playback and continuing without audio',
+					_experimentalKeepAudioContextAlive
+						? 'AudioContext resume rejected; keeping playback buffered until the next resume attempt'
+						: 'AudioContext resume rejected, muting playback and continuing without audio',
 					err,
 				);
+				if (_experimentalKeepAudioContextAlive) {
+					return;
+				}
+
 				abortController.abort();
 				resolve('failed');
 			});

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -4,6 +4,45 @@ const RESUME_WAIT_TIMEOUT = 1000;
 
 export type AudioContextResumeResult = 'resumed' | 'cancelled' | 'failed';
 
+export const waitUntilAudioContextRunning = (
+	audioContext: AudioContext,
+	signal: AbortSignal,
+): Promise<AudioContextResumeResult> => {
+	return new Promise((resolve) => {
+		let settled = false;
+		let onStateChange: () => void = () => undefined;
+		let onAbort: () => void = () => undefined;
+
+		const finish = (result: AudioContextResumeResult) => {
+			if (settled) {
+				return;
+			}
+
+			settled = true;
+			audioContext.removeEventListener('statechange', onStateChange);
+			signal.removeEventListener('abort', onAbort);
+			resolve(result);
+		};
+
+		onStateChange = () => {
+			if (audioContext.state === 'running') {
+				finish('resumed');
+			}
+		};
+
+		onAbort = () => finish('cancelled');
+
+		if (signal.aborted) {
+			finish('cancelled');
+			return;
+		}
+
+		audioContext.addEventListener('statechange', onStateChange);
+		signal.addEventListener('abort', onAbort, {once: true});
+		onStateChange();
+	});
+};
+
 export const waitUntilActuallyResumed = (
 	audioContext: AudioContext,
 	logLevel: LogLevel,

--- a/packages/core/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/core/src/test/keep-audio-context-alive.test.tsx
@@ -22,6 +22,8 @@ const previewEnvironment = {
 };
 
 let nativeSuspendCalls = 0;
+let nativeResumeCalls = 0;
+let stallNativeResume = false;
 let gainValues: number[] = [];
 
 class TrackedAudioContext {
@@ -30,13 +32,18 @@ class TrackedAudioContext {
 	public outputLatency = 0;
 	public currentTime = 0;
 	public destination = {};
+	private readonly stateChangeListeners = new Set<EventListener>();
 
-	addEventListener() {
-		return undefined;
+	addEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.add(listener);
+		}
 	}
 
-	removeEventListener() {
-		return undefined;
+	removeEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.delete(listener);
+		}
 	}
 
 	createGain() {
@@ -59,7 +66,16 @@ class TrackedAudioContext {
 	}
 
 	resume() {
+		nativeResumeCalls++;
+		if (stallNativeResume) {
+			return new Promise<void>(() => undefined);
+		}
+
 		this.state = 'running';
+		for (const listener of this.stateChangeListeners) {
+			listener(new Event('statechange'));
+		}
+
 		return Promise.resolve();
 	}
 
@@ -139,6 +155,8 @@ const withMockedAudioContext = async (fn: () => Promise<void>) => {
 	globalThis.AudioContext =
 		TrackedAudioContext as unknown as typeof AudioContext;
 	nativeSuspendCalls = 0;
+	nativeResumeCalls = 0;
+	stallNativeResume = false;
 	gainValues = [];
 	try {
 		await fn();
@@ -214,5 +232,30 @@ test('_experimentalKeepAudioContextAlive queues nodes scheduled while silenced',
 			await Promise.resolve();
 		});
 		expect(startedWhileSilenced).toEqual([2]);
+	});
+});
+
+test('_experimentalKeepAudioContextAlive retries a stalled resume', async () => {
+	await withMockedAudioContext(async () => {
+		stallNativeResume = true;
+		const value = renderProvider(true);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+
+		const pendingResume = value.getIsResumingAudioContext();
+		expect(pendingResume).not.toBeNull();
+		const callsBeforeRetry = nativeResumeCalls;
+
+		stallNativeResume = false;
+		await act(async () => {
+			await value.resume();
+		});
+
+		expect(nativeResumeCalls).toBeGreaterThan(callsBeforeRetry);
+		expect(await pendingResume).toBe('resumed');
+		expect(value.getIsResumingAudioContext()).toBeNull();
 	});
 });

--- a/packages/core/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/core/src/test/keep-audio-context-alive.test.tsx
@@ -24,6 +24,7 @@ const previewEnvironment = {
 let nativeSuspendCalls = 0;
 let nativeResumeCalls = 0;
 let stallNativeResume = false;
+let finishNativeResume: (() => void) | null = null;
 let gainValues: number[] = [];
 
 class TrackedAudioContext {
@@ -33,6 +34,7 @@ class TrackedAudioContext {
 	public currentTime = 0;
 	public destination = {};
 	private readonly stateChangeListeners = new Set<EventListener>();
+	private outputTime = 0;
 
 	addEventListener(name: string, listener: EventListener) {
 		if (name === 'statechange') {
@@ -68,7 +70,16 @@ class TrackedAudioContext {
 	resume() {
 		nativeResumeCalls++;
 		if (stallNativeResume) {
-			return new Promise<void>(() => undefined);
+			return new Promise<void>((resolve) => {
+				finishNativeResume = () => {
+					this.state = 'running';
+					for (const listener of this.stateChangeListeners) {
+						listener(new Event('statechange'));
+					}
+
+					resolve();
+				};
+			});
 		}
 
 		this.state = 'running';
@@ -80,7 +91,12 @@ class TrackedAudioContext {
 	}
 
 	getOutputTimestamp() {
-		return {contextTime: this.currentTime, performanceTime: 0};
+		if (this.state === 'running') {
+			this.currentTime += 0.01;
+			this.outputTime += 10;
+		}
+
+		return {contextTime: this.currentTime, performanceTime: this.outputTime};
 	}
 
 	createMediaElementSource() {
@@ -157,6 +173,7 @@ const withMockedAudioContext = async (fn: () => Promise<void>) => {
 	nativeSuspendCalls = 0;
 	nativeResumeCalls = 0;
 	stallNativeResume = false;
+	finishNativeResume = null;
 	gainValues = [];
 	try {
 		await fn();
@@ -179,6 +196,31 @@ test('suspend() suspends the AudioContext by default', async () => {
 			value.suspend();
 			await Promise.resolve();
 		});
+		expect(nativeSuspendCalls).toBe(1);
+	});
+});
+
+test('suspend() waits for a pending resume before suspending', async () => {
+	await withMockedAudioContext(async () => {
+		stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		nativeSuspendCalls = 0;
+
+		const pendingNativeResume = finishNativeResume;
+		expect(pendingNativeResume).not.toBeNull();
+		const suspendPromise = value.suspend();
+		expect(nativeSuspendCalls).toBe(0);
+
+		await act(async () => {
+			pendingNativeResume?.();
+			await suspendPromise;
+		});
+
 		expect(nativeSuspendCalls).toBe(1);
 	});
 });

--- a/packages/player/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/player/src/test/keep-audio-context-alive.test.tsx
@@ -1,6 +1,6 @@
 import {afterEach, expect, test} from 'bun:test';
 import {createRef} from 'react';
-import {Html5Audio, Internals} from 'remotion';
+import {Html5Audio, Internals, useBufferState} from 'remotion';
 import type {PlayerRef} from '../player-methods.js';
 import {Player} from '../Player.js';
 import {act, cleanup, render} from './test-utils.js';
@@ -33,7 +33,9 @@ class TrackedAudioContext {
 			connect: () => undefined,
 			gain: {
 				cancelScheduledValues: () => undefined,
-				linearRampToValueAtTime: () => undefined,
+				linearRampToValueAtTime: (value: number) => {
+					gainValues.push(value);
+				},
 				setValueAtTime: (value: number) => {
 					gainValues.push(value);
 				},
@@ -71,7 +73,11 @@ const sequenceManager = {
 	sequences: [],
 };
 
+let startBuffering: (() => {unblock: () => void}) | null = null;
+
 const AudioComposition = () => {
+	startBuffering = useBufferState().delayPlayback;
+
 	return (
 		<Internals.SequenceManager.Provider value={sequenceManager}>
 			<Html5Audio src="audio.mp3" />
@@ -81,8 +87,10 @@ const AudioComposition = () => {
 
 const playAndPause = async ({
 	_experimentalKeepAudioContextAlive,
+	bufferAfterPlay = false,
 }: {
 	_experimentalKeepAudioContextAlive: boolean;
+	bufferAfterPlay?: boolean;
 }) => {
 	const originalAudioContext = globalThis.AudioContext;
 	const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -133,6 +141,41 @@ const playAndPause = async ({
 		});
 
 		const resumeCallsDuringPlay = nativeResumeCalls;
+		let gainValuesDuringBufferResume: number[] = [];
+		if (bufferAfterPlay) {
+			if (!startBuffering) {
+				throw new Error('Expected buffering controls');
+			}
+
+			const beginBuffering = startBuffering;
+			let unblock: () => void = () => undefined;
+			await act(async () => {
+				unblock = beginBuffering().unblock;
+				await Promise.resolve();
+			});
+
+			const queuedFrames = [...animationFrames.values()];
+			if (queuedFrames.length === 0) {
+				throw new Error('Expected a queued animation frame');
+			}
+
+			animationFrames.clear();
+			await act(async () => {
+				for (const frame of queuedFrames) {
+					frame(performance.now());
+				}
+
+				await Promise.resolve();
+			});
+
+			gainValues = [];
+			await act(async () => {
+				unblock();
+				await Promise.resolve();
+			});
+			gainValuesDuringBufferResume = gainValues;
+		}
+
 		gainValues = [];
 
 		await act(async () => {
@@ -144,8 +187,10 @@ const playAndPause = async ({
 			resumeCallsDuringPlay,
 			suspendCallsDuringPause: nativeSuspendCalls,
 			gainValuesDuringPause: gainValues,
+			gainValuesDuringBufferResume,
 		};
 	} finally {
+		startBuffering = null;
 		globalThis.AudioContext = originalAudioContext;
 		globalThis.requestAnimationFrame = originalRequestAnimationFrame;
 		globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
@@ -173,4 +218,13 @@ test('_experimentalKeepAudioContextAlive silences through the gain instead of su
 	expect(resumeCallsDuringPlay).toBe(0);
 	expect(suspendCallsDuringPause).toBe(0);
 	expect(gainValuesDuringPause).toContain(0);
+});
+
+test('_experimentalKeepAudioContextAlive resumes immediately after buffering', async () => {
+	const {gainValuesDuringBufferResume} = await playAndPause({
+		_experimentalKeepAudioContextAlive: true,
+		bufferAfterPlay: true,
+	});
+
+	expect(gainValuesDuringBufferResume).toContain(1);
 });

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -303,6 +303,14 @@ export const usePlayback = ({
 
 				const stopListening = context.listenForResume(() => {
 					stopListening.remove();
+					if (
+						!muted &&
+						!audioContextFailed &&
+						sharedAudioContext?._experimentalKeepAudioContextAlive
+					) {
+						sharedAudioContext.resume();
+					}
+
 					startedTime = performance.now();
 					framesAdvanced = 0;
 					queueNextFrame();


### PR DESCRIPTION
## Review overview only - do not merge

This draft combines the complete downstream audio-resume patch tree so the architecture and interactions can be reviewed in one diff. The independent leaf PRs remain the source of truth and the intended merge units.

## Leaf PRs

- #10904 retries a stalled native `AudioContext.resume()` while `_experimentalKeepAudioContextAlive` is enabled.
- #10905 makes default-mode suspension wait for an already-pending resume, without allowing an old pause to suspend newer playback.
- #10902 resumes keep-alive audio when buffering ends before restarting the Player frame queue.

## Combined flow

1. `SharedAudioContextProvider` owns native AudioContext resume state and exposes one pending resume barrier.
2. In keep-alive mode, later playback attempts may retry the native resume while all callers observe the same barrier until the context reaches `running`.
3. In default mode, `suspend()` orders itself after any pending resume and rechecks current playback intent before suspending.
4. At the Player boundary, recovery from buffering resumes the shared context before the frame queue starts advancing again.

The keep-alive retry and buffer-recovery behavior remain behind the existing experimental flag. The suspend ordering fix is independent default-mode race handling.

## Coverage

Together these PRs represent all remaining Remotion behavior in the downstream Bun patches. This combined branch adds no fourth implementation; it only composes the three leaf commits.

Focused combined checks:

- Core keep-alive tests: 5 passed
- Player keep-alive tests: 3 passed
- Core and Player formatting checks passed
- `git diff --check` passed

Please review architecture here, but leave implementation comments and approvals on the owning leaf PR.