### PR TITLE
Elements: Add audio waveform progress element

### DIFF
--- a/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
+++ b/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
@@ -92,7 +92,7 @@ const audioWaveformProgressSchema = {
 	showTimestamps: {
 		type: 'boolean',
 		default: true,
-		description: 'Show elapsed and remaining time',
+		description: 'Show elapsed and total time',
 		keyframable: false,
 	},
 	...Interactive.transformSchema,
@@ -156,14 +156,11 @@ const AudioWaveformProgressContent: React.FC<{
 		Math.floor(durationInSeconds),
 		Math.floor(progress * durationInSeconds),
 	);
-	const remainingWholeSeconds = Math.max(
-		0,
-		Math.floor(durationInSeconds) - elapsedWholeSeconds,
-	);
+	const totalWholeSeconds = Math.floor(durationInSeconds);
 	const elapsedMinutes = Math.floor(elapsedWholeSeconds / 60);
 	const elapsedSeconds = elapsedWholeSeconds % 60;
-	const remainingMinutes = Math.floor(remainingWholeSeconds / 60);
-	const remainingSeconds = remainingWholeSeconds % 60;
+	const totalMinutes = Math.floor(totalWholeSeconds / 60);
+	const totalSeconds = totalWholeSeconds % 60;
 	const resolvedBarGap = Math.max(0, Math.min(8, barGap));
 	const barWidth =
 		(884 - resolvedBarGap * (roundedNumberOfBars - 1)) / roundedNumberOfBars;
@@ -206,43 +203,29 @@ const AudioWaveformProgressContent: React.FC<{
 					);
 				})}
 				{showPlayhead ? (
-					<>
-						<line
-							x1={8 + progress * 884}
-							x2={8 + progress * 884}
-							y1={7}
-							y2={237}
-							stroke={playedColor}
-							strokeLinecap="round"
-							strokeWidth={3}
-						/>
-						<circle cx={8 + progress * 884} cy={7} fill={playedColor} r={7} />
-					</>
+					<line
+						x1={8 + progress * 884}
+						x2={8 + progress * 884}
+						y1={7}
+						y2={237}
+						stroke={playedColor}
+						strokeLinecap="round"
+						strokeWidth={3}
+					/>
 				) : null}
 				{showTimestamps ? (
-					<>
-						<text
-							x={8}
-							y={286}
-							fill={timestampColor}
-							fontFamily="Arial, sans-serif"
-							fontSize={28}
-							fontWeight={600}
-						>
-							{elapsedMinutes}:{elapsedSeconds.toString().padStart(2, '0')}
-						</text>
-						<text
-							x={892}
-							y={286}
-							fill={timestampColor}
-							fontFamily="Arial, sans-serif"
-							fontSize={28}
-							fontWeight={600}
-							textAnchor="end"
-						>
-							−{remainingMinutes}:{remainingSeconds.toString().padStart(2, '0')}
-						</text>
-					</>
+					<text
+						x={892}
+						y={286}
+						fill={timestampColor}
+						fontFamily="Arial, sans-serif"
+						fontSize={32}
+						fontWeight={500}
+						textAnchor="end"
+					>
+						{elapsedMinutes}:{elapsedSeconds.toString().padStart(2, '0')} /{' '}
+						{totalMinutes}:{totalSeconds.toString().padStart(2, '0')}
+					</text>
 				) : null}
 			</svg>
 		</>

--- a/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
+++ b/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
@@ -1,0 +1,324 @@
+import {Audio} from '@remotion/media';
+import {getWaveformPortion, useWindowedAudioData} from '@remotion/media-utils';
+import React, {
+	forwardRef,
+	useId,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+} from 'react';
+import {
+	Interactive,
+	Sequence,
+	useCurrentFrame,
+	useVideoConfig,
+	type InteractiveBaseProps,
+	type InteractiveTransformProps,
+	type InteractivitySchema,
+	type SequenceControls,
+} from 'remotion';
+
+type AudioWaveformProgressProps = InteractiveBaseProps &
+	InteractiveTransformProps & {
+		readonly amplitude?: number;
+		readonly audioSrc?: string;
+		readonly barGap?: number;
+		readonly numberOfBars?: number;
+		readonly playedColor?: string;
+		readonly showPlayhead?: boolean;
+		readonly showTimestamps?: boolean;
+		readonly timestampColor?: string;
+		readonly unplayedColor?: string;
+	};
+
+const audioWaveformProgressSchema = {
+	...Interactive.baseSchema,
+	audioSrc: {
+		type: 'asset',
+		default:
+			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
+		description: 'Audio source',
+	},
+	playedColor: {
+		type: 'color',
+		default: '#0b84f3',
+		description: 'Played color',
+	},
+	unplayedColor: {
+		type: 'color',
+		default: '#cbd5e1',
+		description: 'Unplayed color',
+	},
+	timestampColor: {
+		type: 'color',
+		default: '#475569',
+		description: 'Timestamp color',
+	},
+	numberOfBars: {
+		type: 'number',
+		min: 12,
+		max: 96,
+		step: 1,
+		default: 64,
+		description: 'Number of bars',
+		hiddenFromList: false,
+		keyframable: false,
+	},
+	barGap: {
+		type: 'number',
+		min: 0,
+		max: 8,
+		step: 1,
+		default: 5,
+		description: 'Gap between bars',
+		hiddenFromList: false,
+		keyframable: false,
+	},
+	amplitude: {
+		type: 'number',
+		min: 0.25,
+		max: 2,
+		step: 0.05,
+		default: 1,
+		description: 'Amplitude',
+		hiddenFromList: false,
+	},
+	showPlayhead: {
+		type: 'boolean',
+		default: true,
+		description: 'Show playhead',
+		keyframable: false,
+	},
+	showTimestamps: {
+		type: 'boolean',
+		default: true,
+		description: 'Show elapsed and remaining time',
+		keyframable: false,
+	},
+	...Interactive.transformSchema,
+} as const satisfies InteractivitySchema;
+
+const AudioWaveformProgressContent: React.FC<{
+	readonly amplitude: number;
+	readonly audioSrc: string;
+	readonly barGap: number;
+	readonly durationInFrames: number;
+	readonly numberOfBars: number;
+	readonly playedColor: string;
+	readonly showPlayhead: boolean;
+	readonly showTimestamps: boolean;
+	readonly timestampColor: string;
+	readonly unplayedColor: string;
+}> = ({
+	amplitude,
+	audioSrc,
+	barGap,
+	durationInFrames,
+	numberOfBars,
+	playedColor,
+	showPlayhead,
+	showTimestamps,
+	timestampColor,
+	unplayedColor,
+}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+	const durationInSeconds = durationInFrames / fps;
+	const {audioData, dataOffsetInSeconds} = useWindowedAudioData({
+		fps,
+		frame: 0,
+		src: audioSrc,
+		windowInSeconds: durationInSeconds,
+	});
+	const gradientId = `audio-waveform-progress-${useId().replaceAll(':', '')}`;
+	const roundedNumberOfBars = Math.max(
+		12,
+		Math.min(96, Math.round(numberOfBars)),
+	);
+	const waveform = useMemo(() => {
+		if (!audioData) {
+			return [];
+		}
+
+		return getWaveformPortion({
+			audioData,
+			dataOffsetInSeconds,
+			durationInSeconds,
+			numberOfSamples: roundedNumberOfBars,
+			startTimeInSeconds: 0,
+		});
+	}, [audioData, dataOffsetInSeconds, durationInSeconds, roundedNumberOfBars]);
+	const progress = Math.max(
+		0,
+		Math.min(1, frame / Math.max(1, durationInFrames - 1)),
+	);
+	const elapsedWholeSeconds = Math.min(
+		Math.floor(durationInSeconds),
+		Math.floor(progress * durationInSeconds),
+	);
+	const remainingWholeSeconds = Math.max(
+		0,
+		Math.floor(durationInSeconds) - elapsedWholeSeconds,
+	);
+	const elapsedMinutes = Math.floor(elapsedWholeSeconds / 60);
+	const elapsedSeconds = elapsedWholeSeconds % 60;
+	const remainingMinutes = Math.floor(remainingWholeSeconds / 60);
+	const remainingSeconds = remainingWholeSeconds % 60;
+	const resolvedBarGap = Math.max(0, Math.min(8, barGap));
+	const barWidth =
+		(884 - resolvedBarGap * (roundedNumberOfBars - 1)) / roundedNumberOfBars;
+
+	return (
+		<>
+			<Audio showInTimeline={false} src={audioSrc} />
+			<svg height={300} viewBox="0 0 900 300" width={900}>
+				<defs>
+					<linearGradient
+						id={gradientId}
+						gradientUnits="userSpaceOnUse"
+						x1={8}
+						x2={892}
+						y1={0}
+						y2={0}
+					>
+						<stop offset="0%" stopColor={playedColor} />
+						<stop offset={`${progress * 100}%`} stopColor={playedColor} />
+						<stop offset={`${progress * 100}%`} stopColor={unplayedColor} />
+						<stop offset="100%" stopColor={unplayedColor} />
+					</linearGradient>
+				</defs>
+				{waveform.map((sample, index) => {
+					const barHeight = Math.max(
+						10,
+						Math.min(210, Math.sqrt(sample.amplitude) * 210 * amplitude),
+					);
+
+					return (
+						<rect
+							key={sample.index}
+							fill={`url(#${gradientId})`}
+							height={barHeight}
+							rx={Math.min(barWidth / 2, barHeight / 2)}
+							width={barWidth}
+							x={8 + index * (barWidth + resolvedBarGap)}
+							y={122 - barHeight / 2}
+						/>
+					);
+				})}
+				{showPlayhead ? (
+					<>
+						<line
+							x1={8 + progress * 884}
+							x2={8 + progress * 884}
+							y1={7}
+							y2={237}
+							stroke={playedColor}
+							strokeLinecap="round"
+							strokeWidth={3}
+						/>
+						<circle cx={8 + progress * 884} cy={7} fill={playedColor} r={7} />
+					</>
+				) : null}
+				{showTimestamps ? (
+					<>
+						<text
+							x={8}
+							y={286}
+							fill={timestampColor}
+							fontFamily="Arial, sans-serif"
+							fontSize={28}
+							fontWeight={600}
+						>
+							{elapsedMinutes}:{elapsedSeconds.toString().padStart(2, '0')}
+						</text>
+						<text
+							x={892}
+							y={286}
+							fill={timestampColor}
+							fontFamily="Arial, sans-serif"
+							fontSize={28}
+							fontWeight={600}
+							textAnchor="end"
+						>
+							−{remainingMinutes}:{remainingSeconds.toString().padStart(2, '0')}
+						</text>
+					</>
+				) : null}
+			</svg>
+		</>
+	);
+};
+
+const AudioWaveformProgressInner = forwardRef<
+	HTMLDivElement,
+	AudioWaveformProgressProps & {
+		readonly controls: SequenceControls | undefined;
+	}
+>(
+	(
+		{
+			amplitude = 1,
+			audioSrc = 'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
+			barGap = 5,
+			controls,
+			durationInFrames = 271,
+			name,
+			numberOfBars = 64,
+			playedColor = '#0b84f3',
+			showPlayhead = true,
+			showTimestamps = true,
+			style,
+			timestampColor = '#475569',
+			unplayedColor = '#cbd5e1',
+			...sequenceProps
+		},
+		ref,
+	) => {
+		const outlineRef = useRef<HTMLDivElement>(null);
+
+		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
+
+		return (
+			<Sequence
+				layout="none"
+				{...sequenceProps}
+				controls={controls}
+				durationInFrames={durationInFrames}
+				name={name ?? 'Audio waveform progress'}
+				outlineRef={outlineRef}
+			>
+				<div
+					ref={outlineRef}
+					style={{
+						boxSizing: 'border-box',
+						height: 300,
+						width: 900,
+						...style,
+					}}
+				>
+					<AudioWaveformProgressContent
+						key={`${audioSrc}-${durationInFrames}`}
+						amplitude={amplitude}
+						audioSrc={audioSrc}
+						barGap={barGap}
+						durationInFrames={durationInFrames}
+						numberOfBars={numberOfBars}
+						playedColor={playedColor}
+						showPlayhead={showPlayhead}
+						showTimestamps={showTimestamps}
+						timestampColor={timestampColor}
+						unplayedColor={unplayedColor}
+					/>
+				</div>
+			</Sequence>
+		);
+	},
+);
+
+export const AudioWaveformProgress = Interactive.withSchema({
+	Component: AudioWaveformProgressInner,
+	componentName: '<AudioWaveformProgress>',
+	componentIdentity: null,
+	schema: audioWaveformProgressSchema,
+	supportsEffects: false,
+}) as React.FC<AudioWaveformProgressProps>;

--- a/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
+++ b/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
@@ -25,9 +25,6 @@ type AudioWaveformProgressProps = InteractiveBaseProps &
 		readonly barGap?: number;
 		readonly numberOfBars?: number;
 		readonly playedColor?: string;
-		readonly showPlayhead?: boolean;
-		readonly showTimestamps?: boolean;
-		readonly timestampColor?: string;
 		readonly unplayedColor?: string;
 	};
 
@@ -48,11 +45,6 @@ const audioWaveformProgressSchema = {
 		type: 'color',
 		default: '#cbd5e1',
 		description: 'Unplayed color',
-	},
-	timestampColor: {
-		type: 'color',
-		default: '#475569',
-		description: 'Timestamp color',
 	},
 	numberOfBars: {
 		type: 'number',
@@ -83,18 +75,6 @@ const audioWaveformProgressSchema = {
 		description: 'Amplitude',
 		hiddenFromList: false,
 	},
-	showPlayhead: {
-		type: 'boolean',
-		default: true,
-		description: 'Show playhead',
-		keyframable: false,
-	},
-	showTimestamps: {
-		type: 'boolean',
-		default: true,
-		description: 'Show elapsed and total time',
-		keyframable: false,
-	},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -105,9 +85,6 @@ const AudioWaveformProgressContent: React.FC<{
 	readonly durationInFrames: number;
 	readonly numberOfBars: number;
 	readonly playedColor: string;
-	readonly showPlayhead: boolean;
-	readonly showTimestamps: boolean;
-	readonly timestampColor: string;
 	readonly unplayedColor: string;
 }> = ({
 	amplitude,
@@ -116,9 +93,6 @@ const AudioWaveformProgressContent: React.FC<{
 	durationInFrames,
 	numberOfBars,
 	playedColor,
-	showPlayhead,
-	showTimestamps,
-	timestampColor,
 	unplayedColor,
 }) => {
 	const frame = useCurrentFrame();
@@ -152,15 +126,6 @@ const AudioWaveformProgressContent: React.FC<{
 		0,
 		Math.min(1, frame / Math.max(1, durationInFrames - 1)),
 	);
-	const elapsedWholeSeconds = Math.min(
-		Math.floor(durationInSeconds),
-		Math.floor(progress * durationInSeconds),
-	);
-	const totalWholeSeconds = Math.floor(durationInSeconds);
-	const elapsedMinutes = Math.floor(elapsedWholeSeconds / 60);
-	const elapsedSeconds = elapsedWholeSeconds % 60;
-	const totalMinutes = Math.floor(totalWholeSeconds / 60);
-	const totalSeconds = totalWholeSeconds % 60;
 	const resolvedBarGap = Math.max(0, Math.min(8, barGap));
 	const barWidth =
 		(884 - resolvedBarGap * (roundedNumberOfBars - 1)) / roundedNumberOfBars;
@@ -198,35 +163,10 @@ const AudioWaveformProgressContent: React.FC<{
 							rx={Math.min(barWidth / 2, barHeight / 2)}
 							width={barWidth}
 							x={8 + index * (barWidth + resolvedBarGap)}
-							y={122 - barHeight / 2}
+							y={150 - barHeight / 2}
 						/>
 					);
 				})}
-				{showPlayhead ? (
-					<line
-						x1={8 + progress * 884}
-						x2={8 + progress * 884}
-						y1={7}
-						y2={237}
-						stroke={playedColor}
-						strokeLinecap="round"
-						strokeWidth={3}
-					/>
-				) : null}
-				{showTimestamps ? (
-					<text
-						x={892}
-						y={286}
-						fill={timestampColor}
-						fontFamily="Arial, sans-serif"
-						fontSize={32}
-						fontWeight={500}
-						textAnchor="end"
-					>
-						{elapsedMinutes}:{elapsedSeconds.toString().padStart(2, '0')} /{' '}
-						{totalMinutes}:{totalSeconds.toString().padStart(2, '0')}
-					</text>
-				) : null}
 			</svg>
 		</>
 	);
@@ -248,10 +188,7 @@ const AudioWaveformProgressInner = forwardRef<
 			name,
 			numberOfBars = 64,
 			playedColor = '#0b84f3',
-			showPlayhead = true,
-			showTimestamps = true,
 			style,
-			timestampColor = '#475569',
 			unplayedColor = '#cbd5e1',
 			...sequenceProps
 		},
@@ -287,9 +224,6 @@ const AudioWaveformProgressInner = forwardRef<
 						durationInFrames={durationInFrames}
 						numberOfBars={numberOfBars}
 						playedColor={playedColor}
-						showPlayhead={showPlayhead}
-						showTimestamps={showTimestamps}
-						timestampColor={timestampColor}
 						unplayedColor={unplayedColor}
 					/>
 				</div>

--- a/packages/docs/elements/audio/waveform-progress/index.mdx
+++ b/packages/docs/elements/audio/waveform-progress/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Audio Waveform Progress
-description: A full-clip audio waveform with played progress, a playhead, and timestamps.
+description: A full-clip audio waveform with played progress.
 image: https://remotion.media/elements/audio-waveform-progress-preview.png
 ---
 

--- a/packages/docs/elements/audio/waveform-progress/index.mdx
+++ b/packages/docs/elements/audio/waveform-progress/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Audio Waveform Progress
+description: A full-clip audio waveform with played progress, a playhead, and timestamps.
+image: https://remotion.media/elements/audio-waveform-progress-preview.png
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {elementDefinitions} from '@site/src/components/Elements/element-definitions';
+
+# Audio Waveform Progress
+
+<ElementPage definition={elementDefinitions['audio/waveform-progress']} sourceFile="./audio-waveform-progress.tsx" />

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -109,8 +109,7 @@ const elementImplementations = {
 	'audio/waveform-progress': {
 		component: AudioWaveformProgress,
 		contributors: [{username: 'samohovets', contribution: 'Author'}],
-		description:
-			'A full-clip audio waveform with played progress, a playhead, and timestamps.',
+		description: 'A full-clip audio waveform with played progress.',
 		dependencies: [
 			{name: '@remotion/media', version: null},
 			{name: '@remotion/media-utils', version: null},

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -5,6 +5,7 @@ import type {
 import type {ComponentType} from 'react';
 import {MirroredAudioSpectrum} from '../../../elements/audio/mirrored-spectrum/mirrored-spectrum';
 import {AudioOscilloscope} from '../../../elements/audio/oscilloscope/audio-oscilloscope';
+import {AudioWaveformProgress} from '../../../elements/audio/waveform-progress/audio-waveform-progress';
 import {LiquidContours} from '../../../elements/backgrounds/liquid-contours/liquid-contours';
 import {NotebookPaper} from '../../../elements/backgrounds/notebook-paper/notebook-paper';
 import {PaperTexture} from '../../../elements/backgrounds/paper-texture/paper-texture';
@@ -100,6 +101,32 @@ const elementImplementations = {
 				'https://remotion.media/elements/audio-oscilloscope-preview.png',
 			videoUrl:
 				'https://remotion.media/elements/audio-oscilloscope-preview.mp4',
+		},
+		safeArea: 120,
+		installationMode: 'component-owned-sequence',
+		width: 1920,
+	},
+	'audio/waveform-progress': {
+		component: AudioWaveformProgress,
+		contributors: [{username: 'samohovets', contribution: 'Author'}],
+		description:
+			'A full-clip audio waveform with played progress, a playhead, and timestamps.',
+		dependencies: [
+			{name: '@remotion/media', version: null},
+			{name: '@remotion/media-utils', version: null},
+		],
+		durationInFrames: 271,
+		elementHeight: 300,
+		elementWidth: 900,
+		fps: 30,
+		height: 1080,
+		posterFrame: 105,
+		preview: {
+			previewLayout: 'composition',
+			posterUrl:
+				'https://remotion.media/elements/audio-waveform-progress-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/audio-waveform-progress-preview.mp4',
 		},
 		safeArea: 120,
 		installationMode: 'component-owned-sequence',

--- a/packages/docs/src/components/Elements/element-registry.ts
+++ b/packages/docs/src/components/Elements/element-registry.ts
@@ -18,6 +18,10 @@ export const elementRegistry = {
 		category: 'audio',
 		displayName: 'Audio Oscilloscope',
 	},
+	'audio/waveform-progress': {
+		category: 'audio',
+		displayName: 'Audio Waveform Progress',
+	},
 	'audio/mirrored-spectrum': {
 		category: 'audio',
 		displayName: 'Mirrored Audio Spectrum',

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -511,7 +511,11 @@ describe('Elements sidebar', () => {
 			{
 				category: 'audio',
 				label: 'Audio',
-				items: ['audio/oscilloscope/index', 'audio/mirrored-spectrum/index'],
+				items: [
+					'audio/oscilloscope/index',
+					'audio/waveform-progress/index',
+					'audio/mirrored-spectrum/index',
+				],
 			},
 			{
 				category: 'backgrounds',
@@ -688,6 +692,7 @@ describe('Element preview definitions', () => {
 	test('only Elements with one interactive timeline item own their Sequence', () => {
 		const componentOwnedSequenceSlugs = new Set([
 			'audio/oscilloscope',
+			'audio/waveform-progress',
 			'audio/mirrored-spectrum',
 			'captions/moving-pill-captions',
 			'captions/popping-word-captions',


### PR DESCRIPTION
## Summary

- add an Audio Waveform Progress Element showing the waveform for the full clip
- animate solid played and unplayed colors across the waveform as playback advances
- expose Studio controls for the audio source, colors, amplitude, bar count, and bar gap
- register the Element in the Audio gallery with component-owned Sequence installation

## Why

A full-clip waveform is useful across podcast audiograms, voice messages, music previews, interviews, and audio-player treatments. Unlike the existing live spectrum and oscilloscope Elements, it communicates both the overall shape of the clip and playback progress.

## Element preview

![Audio Waveform Progress](https://remotion.media/elements/audio-waveform-progress-preview.png)

[Watch the animated preview](https://remotion.media/elements/audio-waveform-progress-preview.mp4)

## Inspiration

- [Audio Waveform Visualization Effect](https://www.youtube.com/watch?v=xZaInjWInR0)
- [Podcast visualizer waveform](https://www.youtube.com/watch?v=D9Iu0fGWENA)

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun test src/test/elements.test.ts`
- `cd packages/docs && bun run render-element-previews --element=audio/waveform-progress`

## Preview

- [Audio Waveform Progress Element page](https://remotion-git-another-audio-element-remotion.vercel.app/elements/audio/waveform-progress)
