### PR TITLE
`@remotion/studio`: Avoid `/events` request in read-only Studio

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3457,11 +3457,6 @@ test.describe('visual mode', () => {
 	});
 
 	test('should seek in read-only Studio', async ({page}) => {
-		const requestedPaths: string[] = [];
-		page.on('request', (request) => {
-			requestedPaths.push(new URL(request.url()).pathname);
-		});
-
 		await page.addInitScript(() => {
 			Object.defineProperty(window, 'remotion_isReadOnlyStudio', {
 				configurable: false,
@@ -3481,7 +3476,6 @@ test.describe('visual mode', () => {
 		await page.locator('[data-timeline-scrubber]').click();
 
 		await expect(currentTime).not.toHaveAttribute('aria-label', '0');
-		expect(requestedPaths).not.toContain('/events');
 	});
 
 	test('should preview and place Canvas drops at the playhead', async ({

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3457,6 +3457,11 @@ test.describe('visual mode', () => {
 	});
 
 	test('should seek in read-only Studio', async ({page}) => {
+		const requestedPaths: string[] = [];
+		page.on('request', (request) => {
+			requestedPaths.push(new URL(request.url()).pathname);
+		});
+
 		await page.addInitScript(() => {
 			Object.defineProperty(window, 'remotion_isReadOnlyStudio', {
 				configurable: false,
@@ -3476,6 +3481,7 @@ test.describe('visual mode', () => {
 		await page.locator('[data-timeline-scrubber]').click();
 
 		await expect(currentTime).not.toHaveAttribute('aria-label', '0');
+		expect(requestedPaths).not.toContain('/events');
 	});
 
 	test('should preview and place Canvas drops at the playhead', async ({

--- a/packages/studio/src/helpers/preview-server-events.ts
+++ b/packages/studio/src/helpers/preview-server-events.ts
@@ -132,6 +132,10 @@ export const ensurePreviewServerEventSource = () => {
 		return;
 	}
 
+	if (window.remotion_isReadOnlyStudio) {
+		return;
+	}
+
 	if (typeof EventSource === 'undefined') {
 		return;
 	}


### PR DESCRIPTION
## Summary

- prevent read-only Studio from opening the preview server `/events` stream
- keep Browser Studio's in-memory event subscription behavior unchanged
- extend the read-only Studio browser workflow with regression coverage

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun run test:e2e studio.test.mts --grep "should seek in read-only Studio"`
