### PR TITLE
`@remotion/studio`: Fix media asset previews in Browser Studio

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -804,15 +804,6 @@ test('drops a local file into the virtual Assets folder', async ({page}) => {
 			composition: expect.not.stringContaining('logo.png'),
 			publicFileSize: expect.any(Number),
 		});
-
-	await dropLocalFile({
-		filePath: localVideoPath,
-		page,
-		target: assetSelector,
-	});
-	await expect(studio.getByText('framer.webm', {exact: true})).toBeVisible();
-	await assetSelector.getByText('framer.webm', {exact: true}).click();
-	await expect(studio.getByTestId('asset-media-preview')).toBeVisible();
 	expect(studioApiRequests).toEqual([]);
 });
 

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -804,6 +804,15 @@ test('drops a local file into the virtual Assets folder', async ({page}) => {
 			composition: expect.not.stringContaining('logo.png'),
 			publicFileSize: expect.any(Number),
 		});
+
+	await dropLocalFile({
+		filePath: localVideoPath,
+		page,
+		target: assetSelector,
+	});
+	await expect(studio.getByText('framer.webm', {exact: true})).toBeVisible();
+	await assetSelector.getByText('framer.webm', {exact: true}).click();
+	await expect(studio.getByTestId('asset-media-preview')).toBeVisible();
 	expect(studioApiRequests).toEqual([]);
 });
 

--- a/packages/studio/src/helpers/get-asset-metadata.ts
+++ b/packages/studio/src/helpers/get-asset-metadata.ts
@@ -143,7 +143,9 @@ export const getAssetMetadata = async (
 		const fetchedAt = Date.now();
 		const srcWithTime = addTime ? addAssetCacheBust({fetchedAt, src}) : src;
 
-		const fileType = getPreviewFileType(src);
+		const fileType = getPreviewFileType(
+			canvasContent.type === 'asset' ? canvasContent.asset : src,
+		);
 
 		if (fileType === 'video' || fileType === 'audio') {
 			const mediaMetadata = await getMediaMetadata(srcWithTime);


### PR DESCRIPTION
## Summary

- detect Browser Studio media assets from their original filename instead of their extensionless blob URL
- keep using the blob URL for Mediabunny metadata parsing and playback
- extend the Browser Studio asset import workflow to verify the custom media preview mounts

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx playwright test --project=chromium --grep "drops a local file into the virtual Assets folder"`
