### PR TITLE
`@remotion/studio`: Split multiple selected clips

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -1274,6 +1274,7 @@ export const createBrowserStudioOperations = ({
 				mutate: () => nextProject,
 				nodePathMutationFiles: updates.map(({fileName, result}) => ({
 					absolutePath: fileName,
+					invalidatedNodePaths: [],
 					remappings: result.nodePathRemappings,
 					restoredNodePaths: [],
 				})),
@@ -1316,6 +1317,7 @@ export const createBrowserStudioOperations = ({
 				nodePathMutationFiles: [
 					{
 						absolutePath,
+						invalidatedNodePaths: [],
 						remappings: result.nodePathRemappings,
 						restoredNodePaths: [],
 					},
@@ -1356,6 +1358,7 @@ export const createBrowserStudioOperations = ({
 				[...itemsByAbsolutePath.entries()].map(
 					async ([absolutePath, fileItems]) => ({
 						absolutePath,
+						invalidatedNodePaths: fileItems.map(({nodePath}) => nodePath),
 						result: await splitJsxSequencesCodemod({
 							input: project.files[absolutePath],
 							splits: fileItems.map(({nodePath, sequenceKeys}) => ({
@@ -1376,11 +1379,14 @@ export const createBrowserStudioOperations = ({
 			const nodePathMutation = controller.applyMutation({
 				fileName: updates[0].absolutePath,
 				mutate: () => ({...project, files}),
-				nodePathMutationFiles: updates.map(({absolutePath, result}) => ({
-					absolutePath,
-					remappings: result.nodePathRemappings,
-					restoredNodePaths: [],
-				})),
+				nodePathMutationFiles: updates.map(
+					({absolutePath, invalidatedNodePaths, result}) => ({
+						absolutePath,
+						invalidatedNodePaths,
+						remappings: result.nodePathRemappings,
+						restoredNodePaths: [],
+					}),
+				),
 			});
 			if (nodePathMutation === null) {
 				throw new Error('Could not split JSX sequence');
@@ -1495,6 +1501,7 @@ export const createBrowserStudioOperations = ({
 				nodePathMutationFiles: [
 					{
 						absolutePath,
+						invalidatedNodePaths: [],
 						remappings: result.nodePathRemappings,
 						restoredNodePaths: [],
 					},
@@ -1868,6 +1875,7 @@ export const createBrowserStudioOperations = ({
 					nodePathMutationFiles: [
 						{
 							absolutePath,
+							invalidatedNodePaths: [],
 							remappings: result.nodePathRemappings,
 							restoredNodePaths: [],
 						},
@@ -1917,6 +1925,7 @@ export const createBrowserStudioOperations = ({
 				nodePathMutationFiles: [
 					{
 						absolutePath: result.filePath,
+						invalidatedNodePaths: [],
 						remappings: result.nodePathRemappings,
 						restoredNodePaths: [],
 					},
@@ -2101,6 +2110,7 @@ export const createBrowserStudioOperations = ({
 					nodePathMutationFiles: [
 						{
 							absolutePath: insertion.filePath,
+							invalidatedNodePaths: [],
 							remappings: insertion.nodePathRemappings,
 							restoredNodePaths: [],
 						},

--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -24,7 +24,7 @@ import {
 	reorderSequence as reorderSequenceCodemod,
 	resolveCompositionComponentWithFile,
 	simpleDiff,
-	splitJsxSequence as splitJsxSequenceCodemod,
+	splitJsxSequences as splitJsxSequencesCodemod,
 	splitVideoFromAudio as splitVideoFromAudioCodemod,
 	updateDefaultProps as updateDefaultPropsCodemod,
 	updateEffectProps as updateEffectPropsCodemod,
@@ -1332,37 +1332,55 @@ export const createBrowserStudioOperations = ({
 	};
 
 	const splitJsxSequence: BrowserStudioOperations['splitJsxSequence'] = async ({
-		fileName,
-		nodePath,
-		sequenceKeys,
+		sequences,
 		splitFrame,
 	}) => {
 		try {
+			if (sequences.length === 0) {
+				throw new Error('No JSX sequences were specified for splitting');
+			}
+
 			const project = getProject();
-			const absolutePath = findProjectFile({
-				filePath: fileName,
-				project,
-			});
-			const result = await splitJsxSequenceCodemod({
-				input: project.files[absolutePath],
-				nodePath,
-				sequenceKeys,
-				splitFrame,
-				formatFile: formatCodemodFile,
-			});
-			const nodePathMutation = controller.applyMutation({
-				fileName: absolutePath,
-				mutate: () => ({
-					...project,
-					files: {...project.files, [absolutePath]: result.output},
-				}),
-				nodePathMutationFiles: [
-					{
+			const itemsByAbsolutePath = new Map<string, typeof sequences>();
+			for (const sequence of sequences) {
+				const absolutePath = findProjectFile({
+					filePath: sequence.fileName,
+					project,
+				});
+				const fileItems = itemsByAbsolutePath.get(absolutePath) ?? [];
+				fileItems.push(sequence);
+				itemsByAbsolutePath.set(absolutePath, fileItems);
+			}
+
+			const updates = await Promise.all(
+				[...itemsByAbsolutePath.entries()].map(
+					async ([absolutePath, fileItems]) => ({
 						absolutePath,
-						remappings: result.nodePathRemappings,
-						restoredNodePaths: [],
-					},
-				],
+						result: await splitJsxSequencesCodemod({
+							input: project.files[absolutePath],
+							splits: fileItems.map(({nodePath, sequenceKeys}) => ({
+								nodePath,
+								sequenceKeys,
+							})),
+							splitFrame,
+							formatFile: formatCodemodFile,
+						}),
+					}),
+				),
+			);
+			const files = {...project.files};
+			for (const update of updates) {
+				files[update.absolutePath] = update.result.output;
+			}
+
+			const nodePathMutation = controller.applyMutation({
+				fileName: updates[0].absolutePath,
+				mutate: () => ({...project, files}),
+				nodePathMutationFiles: updates.map(({absolutePath, result}) => ({
+					absolutePath,
+					remappings: result.nodePathRemappings,
+					restoredNodePaths: [],
+				})),
 			});
 			if (nodePathMutation === null) {
 				throw new Error('Could not split JSX sequence');

--- a/packages/browser-studio/src/browser-studio-project-controller.ts
+++ b/packages/browser-studio/src/browser-studio-project-controller.ts
@@ -565,6 +565,15 @@ export const createBrowserStudioProjectController = ({
 		redoStack.push(entry);
 		const files = entry.nodePathMutationFiles?.map((file) => ({
 			absolutePath: file.absolutePath,
+			invalidatedNodePaths: file.invalidatedNodePaths.flatMap((nodePath) => {
+				const remapping = file.remappings.find(
+					(item) =>
+						JSON.stringify(item.oldNodePath) === JSON.stringify(nodePath),
+				);
+				return remapping?.newNodePath === null
+					? []
+					: [remapping?.newNodePath ?? nodePath];
+			}),
 			remappings: file.remappings.flatMap(
 				(remapping): SequenceNodePathRemapping[] =>
 					remapping.newNodePath === null

--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -758,9 +758,13 @@ registerRoot(Root);`,
 	}
 
 	const failure = await operations.splitJsxSequence({
-		fileName: 'src/Composition.tsx',
-		nodePath: subscription.nodePath.nodePath,
-		sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+		sequences: [
+			{
+				fileName: 'src/Composition.tsx',
+				nodePath: subscription.nodePath.nodePath,
+				sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+			},
+		],
 		splitFrame: 10,
 	});
 	expect(failure).toMatchObject({
@@ -771,9 +775,13 @@ registerRoot(Root);`,
 	expect(currentProject.files[fileName]).toBe(initialContents);
 
 	const splitResult = await operations.splitJsxSequence({
-		fileName: 'src/Composition.tsx',
-		nodePath: subscription.nodePath.nodePath,
-		sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+		sequences: [
+			{
+				fileName: 'src/Composition.tsx',
+				nodePath: subscription.nodePath.nodePath,
+				sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+			},
+		],
 		splitFrame: 15,
 	});
 	if (!splitResult.success) {

--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -288,6 +288,7 @@ export const Root = () => <Composition id="MyComp" component={Component} duratio
 	expect(result.nodePathMutation.files).toEqual([
 		{
 			absolutePath: fileName,
+			invalidatedNodePaths: [],
 			remappings: [
 				{
 					oldNodePath: subscription.nodePath.nodePath,
@@ -803,6 +804,7 @@ registerRoot(Root);`,
 	expect(splitResult.nodePathMutation.files).toEqual([
 		{
 			absolutePath: fileName,
+			invalidatedNodePaths: [subscription.nodePath.nodePath],
 			remappings: expect.any(Array),
 			restoredNodePaths: [],
 		},
@@ -903,6 +905,7 @@ registerRoot(Root);`,
 	expect(result.nodePathMutation.files).toEqual([
 		{
 			absolutePath: fileName,
+			invalidatedNodePaths: [],
 			remappings: expect.any(Array),
 			restoredNodePaths: [],
 		},
@@ -1468,6 +1471,7 @@ registerRoot(Root);`,
 	expect(result.nodePathMutation.files).toEqual([
 		{
 			absolutePath: fileName,
+			invalidatedNodePaths: [],
 			remappings: expect.any(Array),
 			restoredNodePaths: [],
 		},

--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -129,6 +129,7 @@ test('mutates virtual files, emits events, and preserves undo and redo history',
 	expect(deleteResult.nodePathMutation.files).toEqual([
 		{
 			absolutePath: '/project/src/Composition.tsx',
+			invalidatedNodePaths: [],
 			remappings: expect.arrayContaining([
 				{
 					oldNodePath: insertResult.insertedNodePath.nodePath,

--- a/packages/bundler/src/fast-refresh/notify-on-refresh.ts
+++ b/packages/bundler/src/fast-refresh/notify-on-refresh.ts
@@ -1,4 +1,7 @@
-import {REACT_REFRESH_FINISHED_EVENT} from '@remotion/studio-shared';
+import {
+	REACT_REFRESH_FINISHED_EVENT,
+	REACT_REFRESH_STARTED_EVENT,
+} from '@remotion/studio-shared';
 
 type ReactRefreshRuntime = {
 	performReactRefresh: () => unknown;
@@ -12,6 +15,7 @@ if (RefreshRuntime.__remotionReactRefreshWrapped === null) {
 	const originalPerformReactRefresh = RefreshRuntime.performReactRefresh;
 	RefreshRuntime.__remotionReactRefreshWrapped = true;
 	RefreshRuntime.performReactRefresh = () => {
+		window.dispatchEvent(new Event(REACT_REFRESH_STARTED_EVENT));
 		// The refresh integration calls this after applying the update. Emitting
 		// here gives Studio a boundary after React refreshed its roots.
 		const result = originalPerformReactRefresh();

--- a/packages/docs/docs/studio/interactivity.mdx
+++ b/packages/docs/docs/studio/interactivity.mdx
@@ -74,11 +74,12 @@ When editing exact Bezier-compatible helpers, Studio writes the easing back as a
 
 Other helpers such as `Easing.sin`, `Easing.circle`, `Easing.exp`, `Easing.bounce`, `Easing.elastic`, `Easing.poly(4)` and non-linear `Easing.inOut(...)` calls are shown as computed values because they cannot be represented exactly as a single cubic Bezier easing segment.
 
-## Deleting, resetting and duplicating
+## Deleting, resetting, duplicating and splitting
 
 - Press <kbd>Delete</kbd> or <kbd>Backspace</kbd> to delete selected keyframes, sequences, effects or all effects where supported.
 - Reset selected sequence or effect props to their defaults with <kbd>Delete</kbd> or <kbd>Backspace</kbd> when deletion does not apply.
 - Press <kbd>⌘/Ctrl</kbd> + <kbd>D</kbd> to duplicate selected sequences.
+- Press <kbd>⌘/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> to split selected sequences at the playhead. Sequences that cannot be split are skipped.
 
 ## See also
 

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -309,6 +309,16 @@ Pause and return to where playback started
     <td>
       <kbd>⌘/Ctrl</kbd>
       <div style={{width: 2, display: 'inline-block'}} />
+      <kbd>Shift</kbd>
+      <div style={{width: 2, display: 'inline-block'}} />
+      <kbd>D</kbd>
+    </td>
+    <td>Split selected sequences at the playhead</td>
+  </tr>
+  <tr>
+    <td>
+      <kbd>⌘/Ctrl</kbd>
+      <div style={{width: 2, display: 'inline-block'}} />
       <kbd>C</kbd>
     </td>
     <td>Copy selected effects or effect prop values</td>

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -22,6 +22,7 @@ const outlineSelectionCasesFile = path.join(
 	'VisualModeTests',
 	'OutlineSelectionCases.tsx',
 );
+const barChartFile = path.join(exampleDir, 'src', 'BarChart.tsx');
 
 const dropAssetOnCanvas = async ({
 	assetPath,
@@ -446,7 +447,6 @@ test.describe('visual mode', () => {
 	test('should commit a color drag before the picker closes', async ({
 		page,
 	}) => {
-		const barChartFile = path.join(exampleDir, 'src', 'BarChart.tsx');
 		const originalSource = fs.readFileSync(barChartFile, 'utf-8');
 
 		try {
@@ -500,6 +500,141 @@ test.describe('visual mode', () => {
 				.poll(() => fs.readFileSync(barChartFile, 'utf-8'))
 				.toBe(originalSource);
 			await expect(hexInput).toHaveValue('#000000');
+		} finally {
+			fs.writeFileSync(barChartFile, originalSource);
+		}
+	});
+
+	test('should settle every timeline clip after splitting multiple selections', async ({
+		page,
+	}) => {
+		const originalSource = fs.readFileSync(barChartFile, 'utf-8');
+
+		try {
+			await page.addInitScript(() => {
+				type RegisteredTool = {
+					readonly name: string;
+					readonly execute: (
+						input: Record<string, unknown>,
+					) => Promise<unknown>;
+				};
+				const tools = new Map<string, RegisteredTool>();
+				Object.defineProperty(window, '__remotion_webmcp_tools', {
+					value: tools,
+				});
+				Object.defineProperty(document, 'modelContext', {
+					value: {
+						registerTool: async (
+							tool: RegisteredTool,
+							options: {readonly signal: AbortSignal},
+						) => {
+							tools.set(tool.name, tool);
+							options.signal.addEventListener('abort', () => {
+								if (tools.get(tool.name) === tool) {
+									tools.delete(tool.name);
+								}
+							});
+						},
+					},
+				});
+			});
+			await page.goto(`${STUDIO_URL}/AnimatedBarChart`);
+			await expect(page).toHaveURL(/AnimatedBarChart/, {timeout: 15_000});
+
+			const ambientGlow = page.locator(
+				'[data-timeline-marquee-item][title="Ambient glow"]',
+			);
+			const eyebrow = page.locator(
+				'[data-timeline-marquee-item][title="Eyebrow"]',
+			);
+			await expect(ambientGlow).toHaveCount(1, {timeout: 15_000});
+			await expect(eyebrow).toHaveCount(1);
+			await page.keyboard.press('g');
+			const currentFrameInput = page.locator('input:focus');
+			await expect(currentFrameInput).toBeVisible();
+			await currentFrameInput.fill('38');
+			await currentFrameInput.press('Enter');
+			const getSelectionType = () =>
+				page.evaluate(async () => {
+					const tools = (
+						window as typeof window & {
+							readonly __remotion_webmcp_tools: Map<
+								string,
+								{readonly execute: () => Promise<unknown>}
+							>;
+						}
+					).__remotion_webmcp_tools;
+					const result = (await tools.get('get_selection')?.execute()) as {
+						readonly selectionType: string | null;
+					};
+					return result.selectionType;
+				});
+
+			await expect(async () => {
+				await ambientGlow.click();
+				expect(await getSelectionType()).toBe('sequence');
+			}).toPass({timeout: 30_000});
+			await eyebrow.dispatchEvent('pointerdown', {
+				bubbles: true,
+				button: 0,
+				ctrlKey: true,
+				isPrimary: true,
+				pointerId: 1,
+			});
+			await expect.poll(getSelectionType).toBe(null);
+			await page.keyboard.press(
+				process.platform === 'darwin' ? 'Meta+Shift+d' : 'Control+Shift+d',
+			);
+
+			await expect
+				.poll(() => {
+					const source = fs.readFileSync(barChartFile, 'utf-8');
+					return {
+						ambientGlow: source.match(/name="Ambient glow"/g)?.length ?? 0,
+						eyebrow: source.match(/name="Eyebrow"/g)?.length ?? 0,
+					};
+				})
+				.toEqual({ambientGlow: 2, eyebrow: 2});
+			await expect(ambientGlow).toHaveCount(2, {timeout: 30_000});
+			await expect(eyebrow).toHaveCount(2);
+			await expect
+				.poll(async () => {
+					const result = await page.evaluate(async () => {
+						const tools = (
+							window as typeof window & {
+								readonly __remotion_webmcp_tools: Map<
+									string,
+									{readonly execute: () => Promise<unknown>}
+								>;
+							}
+						).__remotion_webmcp_tools;
+						return tools.get('get_sequences')?.execute();
+					});
+					return (
+						result as {
+							readonly sequences: readonly {
+								readonly durationInFrames: number;
+								readonly name: string;
+								readonly startFrame: number;
+							}[];
+						}
+					).sequences
+						.filter(
+							(sequence) =>
+								sequence.name === 'Ambient glow' || sequence.name === 'Eyebrow',
+						)
+						.map(({durationInFrames, name, startFrame}) => ({
+							durationInFrames,
+							name,
+							startFrame,
+						}));
+				})
+				.toEqual([
+					{durationInFrames: 38, name: 'Ambient glow', startFrame: 0},
+					{durationInFrames: 142, name: 'Ambient glow', startFrame: 38},
+					{durationInFrames: 38, name: 'Eyebrow', startFrame: 0},
+					{durationInFrames: 142, name: 'Eyebrow', startFrame: 38},
+				]);
 		} finally {
 			fs.writeFileSync(barChartFile, originalSource);
 		}

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -505,7 +505,7 @@ test.describe('visual mode', () => {
 		}
 	});
 
-	test('should settle every timeline clip after splitting multiple selections', async ({
+	test('should settle timeline clips after splitting and undoing multiple selections', async ({
 		page,
 	}) => {
 		const originalSource = fs.readFileSync(barChartFile, 'utf-8');
@@ -569,6 +569,34 @@ test.describe('visual mode', () => {
 					};
 					return result.selectionType;
 				});
+			const getSplitSequences = () =>
+				page.evaluate(async () => {
+					const tools = (
+						window as typeof window & {
+							readonly __remotion_webmcp_tools: Map<
+								string,
+								{readonly execute: () => Promise<unknown>}
+							>;
+						}
+					).__remotion_webmcp_tools;
+					const result = (await tools.get('get_sequences')?.execute()) as {
+						readonly sequences: readonly {
+							readonly durationInFrames: number;
+							readonly name: string;
+							readonly startFrame: number;
+						}[];
+					};
+					return result.sequences
+						.filter(
+							(sequence) =>
+								sequence.name === 'Ambient glow' || sequence.name === 'Eyebrow',
+						)
+						.map(({durationInFrames, name, startFrame}) => ({
+							durationInFrames,
+							name,
+							startFrame,
+						}));
+				});
 
 			await expect(async () => {
 				await ambientGlow.click();
@@ -597,44 +625,23 @@ test.describe('visual mode', () => {
 				.toEqual({ambientGlow: 2, eyebrow: 2});
 			await expect(ambientGlow).toHaveCount(2, {timeout: 30_000});
 			await expect(eyebrow).toHaveCount(2);
+			await expect.poll(getSplitSequences).toEqual([
+				{durationInFrames: 38, name: 'Ambient glow', startFrame: 0},
+				{durationInFrames: 142, name: 'Ambient glow', startFrame: 38},
+				{durationInFrames: 38, name: 'Eyebrow', startFrame: 0},
+				{durationInFrames: 142, name: 'Eyebrow', startFrame: 38},
+			]);
+
+			await page.reload();
+			await expect(ambientGlow).toHaveCount(2, {timeout: 30_000});
+			await page.keyboard.press('ControlOrMeta+z');
 			await expect
-				.poll(async () => {
-					const result = await page.evaluate(async () => {
-						const tools = (
-							window as typeof window & {
-								readonly __remotion_webmcp_tools: Map<
-									string,
-									{readonly execute: () => Promise<unknown>}
-								>;
-							}
-						).__remotion_webmcp_tools;
-						return tools.get('get_sequences')?.execute();
-					});
-					return (
-						result as {
-							readonly sequences: readonly {
-								readonly durationInFrames: number;
-								readonly name: string;
-								readonly startFrame: number;
-							}[];
-						}
-					).sequences
-						.filter(
-							(sequence) =>
-								sequence.name === 'Ambient glow' || sequence.name === 'Eyebrow',
-						)
-						.map(({durationInFrames, name, startFrame}) => ({
-							durationInFrames,
-							name,
-							startFrame,
-						}));
-				})
-				.toEqual([
-					{durationInFrames: 38, name: 'Ambient glow', startFrame: 0},
-					{durationInFrames: 142, name: 'Ambient glow', startFrame: 38},
-					{durationInFrames: 38, name: 'Eyebrow', startFrame: 0},
-					{durationInFrames: 142, name: 'Eyebrow', startFrame: 38},
-				]);
+				.poll(() => fs.readFileSync(barChartFile, 'utf-8'))
+				.toBe(originalSource);
+			await expect.poll(getSplitSequences).toEqual([
+				{durationInFrames: 180, name: 'Ambient glow', startFrame: 0},
+				{durationInFrames: 180, name: 'Eyebrow', startFrame: 0},
+			]);
 		} finally {
 			fs.writeFileSync(barChartFile, originalSource);
 		}

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -67,7 +67,7 @@ export {
 export {JsxElementIdentityMismatchError} from './sequence-props/jsx-component-identity';
 export {JsxElementNotFoundAtLocationError} from './sequence-props/jsx-element-not-found-at-location-error';
 export {simpleDiff} from './simple-diff';
-export {splitJsxSequence} from './split-jsx-sequence';
+export {splitJsxSequence, splitJsxSequences} from './split-jsx-sequence';
 export {splitVideoFromAudio} from './split-video-from-audio';
 export {
 	formatInlineContentWithFormatter,

--- a/packages/studio-codemods/src/split-jsx-sequence.ts
+++ b/packages/studio-codemods/src/split-jsx-sequence.ts
@@ -8,6 +8,7 @@ import type {
 	JSXIdentifier,
 	JSXMemberExpression,
 	JSXNamespacedName,
+	JSXOpeningElement,
 	Node,
 	ReturnStatement,
 } from '@babel/types';
@@ -354,6 +355,7 @@ export const splitJsxSequences = async ({
 	nodeLabels: string[];
 	logLines: number[];
 	nodePathRemappings: SequenceNodePathRemapping[];
+	invalidatedNodePathsAfterMutation: SequenceNodePath[];
 }> => {
 	if (splits.length === 0) {
 		throw new Error('No JSX sequences were specified for splitting');
@@ -396,8 +398,13 @@ export const splitJsxSequences = async ({
 		return {jsxElement, jsxPath, timing, finiteEnd};
 	});
 
+	const splitNodesAfterMutation: JSXOpeningElement[] = [];
 	for (const {jsxElement, jsxPath, timing, finiteEnd} of pathsToSplit) {
 		const right = cloneJsxElement(jsxElement);
+		splitNodesAfterMutation.push(
+			jsxElement.openingElement,
+			right.openingElement,
+		);
 		const leftDuration = splitFrame - timing.from;
 		const rightDuration =
 			timing.durationInFrames === Infinity ? Infinity : finiteEnd - splitFrame;
@@ -445,15 +452,26 @@ export const splitJsxSequences = async ({
 		contents: finalFile,
 		prettierConfigOverride: prettierConfigOverride ?? null,
 	});
-	const {nodePathRemappings} = getNodePathRemappings({
+	const {finalNodePathByNode, nodePathRemappings} = getNodePathRemappings({
 		ast,
 		captured: capturedNodePaths,
 		output,
 	});
+	const invalidatedNodePathsAfterMutation = splitNodesAfterMutation.map(
+		(node) => {
+			const nodePath = finalNodePathByNode.get(node);
+			if (!nodePath) {
+				throw new Error('Could not determine a split sequence node path');
+			}
+
+			return nodePath;
+		},
+	);
 
 	return {
 		output,
 		formatted,
+		invalidatedNodePathsAfterMutation,
 		nodeLabels: pathsToSplit.map(({jsxElement}) =>
 			getJsxElementTagLabel(jsxElement),
 		),
@@ -490,15 +508,22 @@ export const splitJsxSequence = async ({
 	nodeLabel: string;
 	logLine: number;
 	nodePathRemappings: SequenceNodePathRemapping[];
+	invalidatedNodePathsAfterMutation: SequenceNodePath[];
 }> => {
-	const {output, formatted, nodeLabels, logLines, nodePathRemappings} =
-		await splitJsxSequences({
-			input,
-			splits: [{nodePath, sequenceKeys}],
-			splitFrame,
-			formatFile,
-			prettierConfigOverride,
-		});
+	const {
+		output,
+		formatted,
+		nodeLabels,
+		logLines,
+		nodePathRemappings,
+		invalidatedNodePathsAfterMutation,
+	} = await splitJsxSequences({
+		input,
+		splits: [{nodePath, sequenceKeys}],
+		splitFrame,
+		formatFile,
+		prettierConfigOverride,
+	});
 
 	return {
 		output,
@@ -506,5 +531,6 @@ export const splitJsxSequence = async ({
 		nodeLabel: nodeLabels[0],
 		logLine: logLines[0],
 		nodePathRemappings,
+		invalidatedNodePathsAfterMutation,
 	};
 };

--- a/packages/studio-codemods/src/split-jsx-sequence.ts
+++ b/packages/studio-codemods/src/split-jsx-sequence.ts
@@ -330,6 +330,143 @@ const insertAfter = (
 	return false;
 };
 
+export const splitJsxSequences = async ({
+	input,
+	splits,
+	splitFrame,
+	formatFile,
+	prettierConfigOverride,
+}: {
+	input: string;
+	splits: Array<{
+		nodePath: SequenceNodePath;
+		sequenceKeys: string[];
+	}>;
+	splitFrame: number;
+	formatFile: (input: {
+		contents: string;
+		prettierConfigOverride: Record<string, unknown> | null;
+	}) => Promise<{output: string; formatted: boolean}>;
+	prettierConfigOverride?: Record<string, unknown> | null;
+}): Promise<{
+	output: string;
+	formatted: boolean;
+	nodeLabels: string[];
+	logLines: number[];
+	nodePathRemappings: SequenceNodePathRemapping[];
+}> => {
+	if (splits.length === 0) {
+		throw new Error('No JSX sequences were specified for splitting');
+	}
+
+	if (!Number.isInteger(splitFrame)) {
+		throw new Error('Split frame must be an integer');
+	}
+
+	const ast = parseAst(input);
+	const capturedNodePaths = captureJsxNodePaths(ast);
+	const pathsToSplit = splits.map(({nodePath, sequenceKeys}) => {
+		const jsxPath = findJsxElementPathForDeletion(ast, nodePath);
+		if (!jsxPath) {
+			throw new Error(
+				'Could not find a JSX sequence at the specified location to split',
+			);
+		}
+
+		const jsxElement = jsxPath.node as JSXElement;
+		const tagName = getSplittableSequenceTagName(jsxElement);
+		if (!hasSequenceTimingTraits(sequenceKeys)) {
+			throw new Error(`<${tagName}> cannot be split`);
+		}
+
+		const timing = readSequenceTiming(jsxElement);
+		const finiteEnd =
+			timing.durationInFrames === Infinity
+				? Infinity
+				: timing.from + timing.durationInFrames;
+
+		if (splitFrame <= timing.from) {
+			throw new Error('Cannot split at or before the sequence start');
+		}
+
+		if (splitFrame >= finiteEnd) {
+			throw new Error('Cannot split at or after the sequence end');
+		}
+
+		return {jsxElement, jsxPath, timing, finiteEnd};
+	});
+
+	for (const {jsxElement, jsxPath, timing, finiteEnd} of pathsToSplit) {
+		const right = cloneJsxElement(jsxElement);
+		const leftDuration = splitFrame - timing.from;
+		const rightDuration =
+			timing.durationInFrames === Infinity ? Infinity : finiteEnd - splitFrame;
+		const rightTrimBefore = timing.trimBefore + leftDuration;
+
+		setNumericAttribute({
+			element: jsxElement,
+			name: 'durationInFrames',
+			value: leftDuration,
+			omitIfMissing: false,
+		});
+		setNumericAttribute({
+			element: right,
+			name: 'from',
+			value: splitFrame,
+			omitIfMissing: false,
+		});
+		setNumericAttribute({
+			element: right,
+			name: 'durationInFrames',
+			value: rightDuration === Infinity ? null : rightDuration,
+			omitIfMissing: !timing.hasDurationInFrames,
+		});
+		setNumericAttribute({
+			element: right,
+			name: 'trimBefore',
+			value: rightTrimBefore === 0 ? null : rightTrimBefore,
+			omitIfMissing: !timing.hasTrimBefore && rightTrimBefore === 0,
+		});
+		orderTimingAttributes(jsxElement);
+		orderTimingAttributes(right);
+
+		const {parentPath} = jsxPath;
+		if (!parentPath) {
+			throw new Error('Cannot split JSX sequence with no parent');
+		}
+
+		if (!insertAfter(parentPath.node, jsxElement, right)) {
+			jsxPath.replace(makeFragment(jsxElement, right));
+		}
+	}
+
+	const finalFile = serializeAst(ast);
+	const {output, formatted} = await formatFile({
+		contents: finalFile,
+		prettierConfigOverride: prettierConfigOverride ?? null,
+	});
+	const {nodePathRemappings} = getNodePathRemappings({
+		ast,
+		captured: capturedNodePaths,
+		output,
+	});
+
+	return {
+		output,
+		formatted,
+		nodeLabels: pathsToSplit.map(({jsxElement}) =>
+			getJsxElementTagLabel(jsxElement),
+		),
+		logLines: pathsToSplit.map(
+			({jsxElement}) =>
+				jsxElement.openingElement.loc?.start.line ??
+				jsxElement.loc?.start.line ??
+				1,
+		),
+		nodePathRemappings,
+	};
+};
+
 export const splitJsxSequence = async ({
 	input,
 	nodePath,
@@ -354,100 +491,20 @@ export const splitJsxSequence = async ({
 	logLine: number;
 	nodePathRemappings: SequenceNodePathRemapping[];
 }> => {
-	if (!Number.isInteger(splitFrame)) {
-		throw new Error('Split frame must be an integer');
-	}
-
-	const ast = parseAst(input);
-	const capturedNodePaths = captureJsxNodePaths(ast);
-	const jsxPath = findJsxElementPathForDeletion(ast, nodePath);
-	if (!jsxPath) {
-		throw new Error(
-			'Could not find a JSX sequence at the specified location to split',
-		);
-	}
-
-	const jsxElement = jsxPath.node as JSXElement;
-	const tagName = getSplittableSequenceTagName(jsxElement);
-	if (!hasSequenceTimingTraits(sequenceKeys)) {
-		throw new Error(`<${tagName}> cannot be split`);
-	}
-
-	const timing = readSequenceTiming(jsxElement);
-	const finiteEnd =
-		timing.durationInFrames === Infinity
-			? Infinity
-			: timing.from + timing.durationInFrames;
-
-	if (splitFrame <= timing.from) {
-		throw new Error('Cannot split at or before the sequence start');
-	}
-
-	if (splitFrame >= finiteEnd) {
-		throw new Error('Cannot split at or after the sequence end');
-	}
-
-	const right = cloneJsxElement(jsxElement);
-	const leftDuration = splitFrame - timing.from;
-	const rightDuration =
-		timing.durationInFrames === Infinity ? Infinity : finiteEnd - splitFrame;
-	const rightTrimBefore = timing.trimBefore + leftDuration;
-
-	setNumericAttribute({
-		element: jsxElement,
-		name: 'durationInFrames',
-		value: leftDuration,
-		omitIfMissing: false,
-	});
-	setNumericAttribute({
-		element: right,
-		name: 'from',
-		value: splitFrame,
-		omitIfMissing: false,
-	});
-	setNumericAttribute({
-		element: right,
-		name: 'durationInFrames',
-		value: rightDuration === Infinity ? null : rightDuration,
-		omitIfMissing: !timing.hasDurationInFrames,
-	});
-	setNumericAttribute({
-		element: right,
-		name: 'trimBefore',
-		value: rightTrimBefore === 0 ? null : rightTrimBefore,
-		omitIfMissing: !timing.hasTrimBefore && rightTrimBefore === 0,
-	});
-	orderTimingAttributes(jsxElement);
-	orderTimingAttributes(right);
-
-	const {parentPath} = jsxPath;
-	if (!parentPath) {
-		throw new Error('Cannot split JSX sequence with no parent');
-	}
-
-	if (!insertAfter(parentPath.node, jsxElement, right)) {
-		jsxPath.replace(makeFragment(jsxElement, right));
-	}
-
-	const finalFile = serializeAst(ast);
-	const {output, formatted} = await formatFile({
-		contents: finalFile,
-		prettierConfigOverride: prettierConfigOverride ?? null,
-	});
-	const {nodePathRemappings} = getNodePathRemappings({
-		ast,
-		captured: capturedNodePaths,
-		output,
-	});
+	const {output, formatted, nodeLabels, logLines, nodePathRemappings} =
+		await splitJsxSequences({
+			input,
+			splits: [{nodePath, sequenceKeys}],
+			splitFrame,
+			formatFile,
+			prettierConfigOverride,
+		});
 
 	return {
 		output,
 		formatted,
-		nodeLabel: getJsxElementTagLabel(jsxElement),
-		logLine:
-			jsxElement.openingElement.loc?.start.line ??
-			jsxElement.loc?.start.line ??
-			1,
+		nodeLabel: nodeLabels[0],
+		logLine: logLines[0],
 		nodePathRemappings,
 	};
 };

--- a/packages/studio-server/src/codemods/split-jsx-sequence.ts
+++ b/packages/studio-server/src/codemods/split-jsx-sequence.ts
@@ -1,4 +1,7 @@
-import {splitJsxSequence as splitJsxSequenceCodemod} from '@remotion/studio-codemods';
+import {
+	splitJsxSequence as splitJsxSequenceCodemod,
+	splitJsxSequences as splitJsxSequencesCodemod,
+} from '@remotion/studio-codemods';
 import type {SequenceNodePath} from 'remotion';
 import {formatFileContent} from './format-file-content';
 
@@ -19,6 +22,32 @@ export const splitJsxSequence = ({
 		input,
 		nodePath,
 		sequenceKeys,
+		splitFrame,
+		formatFile: ({contents, prettierConfigOverride: override}) =>
+			formatFileContent({
+				input: contents,
+				prettierConfigOverride: override,
+			}),
+		prettierConfigOverride,
+	});
+
+export const splitJsxSequences = ({
+	input,
+	splits,
+	splitFrame,
+	prettierConfigOverride,
+}: {
+	input: string;
+	splits: Array<{
+		nodePath: SequenceNodePath;
+		sequenceKeys: string[];
+	}>;
+	splitFrame: number;
+	prettierConfigOverride?: Record<string, unknown> | null;
+}) =>
+	splitJsxSequencesCodemod({
+		input,
+		splits,
 		splitFrame,
 		formatFile: ({contents, prettierConfigOverride: override}) =>
 			formatFileContent({

--- a/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect-keyframe.ts
@@ -98,6 +98,7 @@ export const addEffectKeyframeHandler: ApiHandler<
 			},
 			entryType: 'effect-props',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/add-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/add-effect.ts
@@ -72,6 +72,7 @@ export const addEffectHandler: ApiHandler<
 				},
 				entryType: 'add-effect',
 				suppressHmrOnFileRestore: false,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			});
 			suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/add-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/add-keyframes.ts
@@ -264,6 +264,7 @@ export const addKeyframes = async ({
 	pushTransactionToUndoStack({
 		snapshots: snapshots.map((snapshot) => ({
 			...snapshot,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		})),
 		logLevel,

--- a/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
+++ b/packages/studio-server/src/preview-server/routes/add-sequence-keyframe.ts
@@ -84,6 +84,7 @@ export const addSequenceKeyframeHandler: ApiHandler<
 			},
 			entryType: 'sequence-props',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/apply-codemod.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-codemod.ts
@@ -268,6 +268,7 @@ export const applyCodemodHandler: ApiHandler<
 				>[0]['snapshots'] = [
 					{
 						filePath,
+						invalidatedNodePaths: [],
 						oldContents: input,
 						newContents: null,
 						logLine,
@@ -286,6 +287,7 @@ export const applyCodemodHandler: ApiHandler<
 					componentFileContents = await formatNewCompositionFile(codemod);
 					snapshots.push({
 						filePath: componentFilePath,
+						invalidatedNodePaths: [],
 						oldContents: null,
 						newContents: componentFileContents,
 						logLine: 1,
@@ -305,6 +307,7 @@ export const applyCodemodHandler: ApiHandler<
 				} else {
 					pushToUndoStack({
 						filePath,
+						invalidatedNodePaths: [],
 						oldContents: input,
 						newContents: null,
 						logLevel,

--- a/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
+++ b/packages/studio-server/src/preview-server/routes/apply-visual-control-change.ts
@@ -118,6 +118,7 @@ export const applyVisualControlHandler: ApiHandler<
 			},
 			entryType: 'visual-control',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/batch-update-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/batch-update-keyframe-settings.ts
@@ -217,6 +217,7 @@ export const batchUpdateKeyframeSettings = async ({
 	pushTransactionToUndoStack({
 		snapshots: snapshots.map((snapshot) => ({
 			...snapshot,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		})),
 		logLevel,

--- a/packages/studio-server/src/preview-server/routes/delete-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-effect.ts
@@ -107,6 +107,7 @@ export const deleteEffectHandler: ApiHandler<
 					},
 					entryType: 'delete-effect',
 					suppressHmrOnFileRestore: false,
+					invalidatedNodePaths: [],
 					nodePathRemappings: null,
 				});
 				suppressUndoStackInvalidation(update.absolutePath);

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -92,6 +92,7 @@ export const deleteJsxNodeHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation(
 				updates.map((update) => ({
 					absolutePath: update.absolutePath,
+					invalidatedNodePaths: [],
 					remappings: update.nodePathRemappings,
 					restoredNodePaths: [],
 				})),

--- a/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-jsx-node.ts
@@ -116,6 +116,7 @@ export const deleteJsxNodeHandler: ApiHandler<
 					},
 					entryType: 'delete-jsx-node',
 					suppressHmrOnFileRestore: false,
+					invalidatedNodePaths: [],
 					nodePathRemappings: update.nodePathRemappings,
 				});
 				suppressUndoStackInvalidation(update.absolutePath);

--- a/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/delete-keyframes.ts
@@ -278,6 +278,7 @@ export const deleteKeyframes = async ({
 	pushTransactionToUndoStack({
 		snapshots: snapshots.map((snapshot) => ({
 			...snapshot,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		})),
 		logLevel,

--- a/packages/studio-server/src/preview-server/routes/duplicate-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-effect.ts
@@ -99,6 +99,7 @@ export const duplicateEffectHandler: ApiHandler<
 					},
 					entryType: 'duplicate-effect',
 					suppressHmrOnFileRestore: false,
+					invalidatedNodePaths: [],
 					nodePathRemappings: null,
 				});
 				suppressUndoStackInvalidation(update.absolutePath);

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -44,6 +44,7 @@ export const duplicateJsxNodeHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath,
+					invalidatedNodePaths: [],
 					remappings: nodePathRemappings,
 					restoredNodePaths: [],
 				},

--- a/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
+++ b/packages/studio-server/src/preview-server/routes/duplicate-jsx-node.ts
@@ -63,6 +63,7 @@ export const duplicateJsxNodeHandler: ApiHandler<
 				},
 				entryType: 'duplicate-jsx-node',
 				suppressHmrOnFileRestore: false,
+				invalidatedNodePaths: [],
 				nodePathRemappings,
 			});
 			suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -206,6 +206,7 @@ export const insertElementHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath: inserted.fileName,
+					invalidatedNodePaths: [],
 					remappings: inserted.nodePathRemappings,
 					restoredNodePaths: [],
 				},

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -218,6 +218,7 @@ export const insertElementHandler: ApiHandler<
 						? [
 								{
 									filePath: plan.elementFileName,
+									invalidatedNodePaths: [],
 									oldContents: plan.existingElementSource,
 									newContents: element.sourceCode,
 									logLine: 1,
@@ -227,6 +228,7 @@ export const insertElementHandler: ApiHandler<
 						: []),
 					{
 						filePath: inserted.fileName,
+						invalidatedNodePaths: [],
 						oldContents: inserted.oldContents,
 						newContents: inserted.output,
 						logLine: inserted.logLine,

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -277,6 +277,7 @@ export const insertJsxElementHandler: ApiHandler<
 
 			pushToUndoStack({
 				filePath: fileName,
+				invalidatedNodePaths: [],
 				oldContents,
 				newContents: output,
 				logLevel,

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -263,6 +263,7 @@ export const insertJsxElementHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath: fileName,
+					invalidatedNodePaths: [],
 					remappings: nodePathRemappings,
 					restoredNodePaths: [],
 				},

--- a/packages/studio-server/src/preview-server/routes/move-keyframes.ts
+++ b/packages/studio-server/src/preview-server/routes/move-keyframes.ts
@@ -290,6 +290,7 @@ export const moveKeyframes = async ({
 	pushTransactionToUndoStack({
 		snapshots: snapshots.map((snapshot) => ({
 			...snapshot,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		})),
 		logLevel,

--- a/packages/studio-server/src/preview-server/routes/paste-effects.ts
+++ b/packages/studio-server/src/preview-server/routes/paste-effects.ts
@@ -86,6 +86,7 @@ export const pasteEffectsHandler: ApiHandler<
 				},
 				entryType: 'paste-effects',
 				suppressHmrOnFileRestore: false,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			});
 			suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/reorder-effect.ts
+++ b/packages/studio-server/src/preview-server/routes/reorder-effect.ts
@@ -63,6 +63,7 @@ export const reorderEffectHandler: ApiHandler<
 				},
 				entryType: 'reorder-effect',
 				suppressHmrOnFileRestore: false,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			});
 			suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
@@ -73,6 +73,7 @@ export const reorderSequenceHandler: ApiHandler<
 				},
 				entryType: 'reorder-sequence',
 				suppressHmrOnFileRestore: false,
+				invalidatedNodePaths: [],
 				nodePathRemappings,
 			});
 			suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/reorder-sequence.ts
@@ -54,6 +54,7 @@ export const reorderSequenceHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath,
+					invalidatedNodePaths: [],
 					remappings: nodePathRemappings,
 					restoredNodePaths: [],
 				},

--- a/packages/studio-server/src/preview-server/routes/save-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-effect-props.ts
@@ -136,6 +136,7 @@ export const saveEffectPropsHandler: ApiHandler<
 			},
 			entryType: 'effect-props',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/save-multiple-effect-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-multiple-effect-props.ts
@@ -152,6 +152,7 @@ export const saveMultipleEffectPropsHandler: ApiHandler<
 		pushTransactionToUndoStack({
 			snapshots: snapshots.map((snapshot) => ({
 				...snapshot,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			})),
 			logLevel,

--- a/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
+++ b/packages/studio-server/src/preview-server/routes/save-sequence-props.ts
@@ -618,6 +618,7 @@ export const saveSequencePropsHandler: ApiHandler<
 		pushTransactionToUndoStack({
 			snapshots: snapshots.map((snapshot) => ({
 				...snapshot,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			})),
 			logLevel,

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -51,15 +51,21 @@ export const splitJsxSequenceHandler: ApiHandler<
 						action: 'modify',
 					});
 					const fileContents = readFileSync(absolutePath, 'utf-8');
-					const {output, formatted, nodeLabels, logLines, nodePathRemappings} =
-						await splitJsxSequences({
-							input: fileContents,
-							splits: fileItems.map(({nodePath, sequenceKeys}) => ({
-								nodePath,
-								sequenceKeys,
-							})),
-							splitFrame,
-						});
+					const {
+						output,
+						formatted,
+						nodeLabels,
+						logLines,
+						nodePathRemappings,
+						invalidatedNodePathsAfterMutation,
+					} = await splitJsxSequences({
+						input: fileContents,
+						splits: fileItems.map(({nodePath, sequenceKeys}) => ({
+							nodePath,
+							sequenceKeys,
+						})),
+						splitFrame,
+					});
 
 					return {
 						absolutePath,
@@ -67,6 +73,7 @@ export const splitJsxSequenceHandler: ApiHandler<
 						fileRelativeToRoot,
 						formatted,
 						invalidatedNodePaths: fileItems.map(({nodePath}) => nodePath),
+						invalidatedNodePathsAfterMutation,
 						logLine: Math.min(...logLines),
 						nodeLabels,
 						nodePathRemappings,
@@ -103,6 +110,9 @@ export const splitJsxSequenceHandler: ApiHandler<
 					},
 					entryType: 'split-jsx-sequence',
 					suppressHmrOnFileRestore: false,
+					invalidatedNodePaths: update.invalidatedNodePaths,
+					invalidatedNodePathsAfterMutation:
+						update.invalidatedNodePathsAfterMutation,
 					nodePathRemappings: update.nodePathRemappings,
 				});
 				suppressUndoStackInvalidation(update.absolutePath);

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -4,7 +4,7 @@ import type {
 	SplitJsxSequenceRequest,
 	SplitJsxSequenceResponse,
 } from '@remotion/studio-shared';
-import {splitJsxSequence} from '../../codemods/split-jsx-sequence';
+import {splitJsxSequences} from '../../codemods/split-jsx-sequence';
 import {writeFileAndNotifyFileWatchers} from '../../file-watcher';
 import {resolveFileInsideProject} from '../../helpers/resolve-file-inside-project';
 import type {ApiHandler} from '../api-types';
@@ -24,84 +24,113 @@ import {
 export const splitJsxSequenceHandler: ApiHandler<
 	SplitJsxSequenceRequest,
 	SplitJsxSequenceResponse
-> = ({
-	input: {fileName, nodePath, sequenceKeys, splitFrame},
-	remotionRoot,
-	logLevel,
-}) =>
+> = ({input: {sequences, splitFrame}, remotionRoot, logLevel}) =>
 	withSourceFileWriteQueue(async () => {
 		try {
+			if (sequences.length === 0) {
+				throw new Error('No JSX sequences were specified for splitting');
+			}
+
 			RenderInternals.Log.trace(
 				{indent: false, logLevel},
-				`[split-jsx-sequence] Received request for fileName="${fileName}" at frame ${splitFrame}`,
+				`[split-jsx-sequence] Received request to split ${sequences.length} sequence${sequences.length === 1 ? '' : 's'} at frame ${splitFrame}`,
 			);
-			const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
-				remotionRoot,
-				fileName,
-				action: 'modify',
-			});
 
-			const fileContents = readFileSync(absolutePath, 'utf-8');
+			const itemsByFileName = new Map<string, typeof sequences>();
+			for (const sequence of sequences) {
+				const fileItems = itemsByFileName.get(sequence.fileName) ?? [];
+				fileItems.push(sequence);
+				itemsByFileName.set(sequence.fileName, fileItems);
+			}
 
-			const {output, formatted, nodeLabel, logLine, nodePathRemappings} =
-				await splitJsxSequence({
-					input: fileContents,
-					nodePath,
-					sequenceKeys,
-					splitFrame,
-				});
-			const nodePathMutation = broadcastSequenceNodePathMutation([
-				{
+			const updates = await Promise.all(
+				[...itemsByFileName.entries()].map(async ([fileName, fileItems]) => {
+					const {absolutePath, fileRelativeToRoot} = resolveFileInsideProject({
+						remotionRoot,
+						fileName,
+						action: 'modify',
+					});
+					const fileContents = readFileSync(absolutePath, 'utf-8');
+					const {output, formatted, nodeLabels, logLines, nodePathRemappings} =
+						await splitJsxSequences({
+							input: fileContents,
+							splits: fileItems.map(({nodePath, sequenceKeys}) => ({
+								nodePath,
+								sequenceKeys,
+							})),
+							splitFrame,
+						});
+
+					return {
+						absolutePath,
+						fileContents,
+						fileRelativeToRoot,
+						formatted,
+						logLine: Math.min(...logLines),
+						nodeLabels,
+						nodePathRemappings,
+						output,
+					};
+				}),
+			);
+			const nodePathMutation = broadcastSequenceNodePathMutation(
+				updates.map(({absolutePath, nodePathRemappings}) => ({
 					absolutePath,
 					remappings: nodePathRemappings,
 					restoredNodePaths: [],
-				},
-			]);
-
-			pushToUndoStack({
-				filePath: absolutePath,
-				oldContents: fileContents,
-				newContents: null,
-				logLevel,
-				remotionRoot,
-				logLine,
-				description: {
-					undoMessage: `↩️  Split of ${nodeLabel}`,
-					redoMessage: `↪️  Split of ${nodeLabel}`,
-				},
-				entryType: 'split-jsx-sequence',
-				suppressHmrOnFileRestore: false,
-				nodePathRemappings,
-			});
-			suppressUndoStackInvalidation(absolutePath);
-			writeFileAndNotifyFileWatchers({
-				file: absolutePath,
-				content: output,
-				originatorClientId: undefined,
-				metadata: {skipSequencePropsUpdate: true},
-			});
-
-			const locationLabel = formatLogFileLocation({
-				remotionRoot,
-				absolutePath,
-				line: logLine,
-			});
-			RenderInternals.Log.info(
-				{indent: false, logLevel},
-				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(
-					`${locationLabel}`,
-				)} Split ${nodeLabel}`,
+				})),
 			);
-			if (!formatted) {
-				warnAboutPrettierOnce(logLevel);
+
+			for (const update of updates) {
+				const nodeDescription =
+					update.nodeLabels.length === 1
+						? update.nodeLabels[0]
+						: `${update.nodeLabels.length} clips`;
+				pushToUndoStack({
+					filePath: update.absolutePath,
+					oldContents: update.fileContents,
+					newContents: null,
+					logLevel,
+					remotionRoot,
+					logLine: update.logLine,
+					description: {
+						undoMessage: `↩️  Split of ${nodeDescription}`,
+						redoMessage: `↪️  Split of ${nodeDescription}`,
+					},
+					entryType: 'split-jsx-sequence',
+					suppressHmrOnFileRestore: false,
+					nodePathRemappings: update.nodePathRemappings,
+				});
+				suppressUndoStackInvalidation(update.absolutePath);
+				writeFileAndNotifyFileWatchers({
+					file: update.absolutePath,
+					content: update.output,
+					originatorClientId: undefined,
+					metadata: {skipSequencePropsUpdate: true},
+				});
+
+				const locationLabel = formatLogFileLocation({
+					remotionRoot,
+					absolutePath: update.absolutePath,
+					line: update.logLine,
+				});
+				RenderInternals.Log.info(
+					{indent: false, logLevel},
+					`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(
+						`${locationLabel}`,
+					)} Split ${nodeDescription}`,
+				);
+				if (!update.formatted) {
+					warnAboutPrettierOnce(logLevel);
+				}
+
+				RenderInternals.Log.verbose(
+					{indent: false, logLevel},
+					`[split-jsx-sequence] Wrote ${update.fileRelativeToRoot}${
+						update.formatted ? ' (formatted)' : ''
+					}`,
+				);
 			}
-
-			RenderInternals.Log.verbose(
-				{indent: false, logLevel},
-				`[split-jsx-sequence] Wrote ${fileRelativeToRoot}${
-					formatted ? ' (formatted)' : ''
-				}`,
-			);
 
 			printUndoHint(logLevel);
 

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -66,6 +66,7 @@ export const splitJsxSequenceHandler: ApiHandler<
 						fileContents,
 						fileRelativeToRoot,
 						formatted,
+						invalidatedNodePaths: fileItems.map(({nodePath}) => nodePath),
 						logLine: Math.min(...logLines),
 						nodeLabels,
 						nodePathRemappings,
@@ -74,11 +75,14 @@ export const splitJsxSequenceHandler: ApiHandler<
 				}),
 			);
 			const nodePathMutation = broadcastSequenceNodePathMutation(
-				updates.map(({absolutePath, nodePathRemappings}) => ({
-					absolutePath,
-					remappings: nodePathRemappings,
-					restoredNodePaths: [],
-				})),
+				updates.map(
+					({absolutePath, invalidatedNodePaths, nodePathRemappings}) => ({
+						absolutePath,
+						invalidatedNodePaths,
+						remappings: nodePathRemappings,
+						restoredNodePaths: [],
+					}),
+				),
 			);
 
 			for (const update of updates) {

--- a/packages/studio-server/src/preview-server/routes/split-video-from-audio.ts
+++ b/packages/studio-server/src/preview-server/routes/split-video-from-audio.ts
@@ -47,6 +47,7 @@ export const splitVideoFromAudioHandler: ApiHandler<
 			const nodePathMutation = broadcastSequenceNodePathMutation([
 				{
 					absolutePath,
+					invalidatedNodePaths: [],
 					remappings: nodePathRemappings,
 					restoredNodePaths: [],
 				},

--- a/packages/studio-server/src/preview-server/routes/split-video-from-audio.ts
+++ b/packages/studio-server/src/preview-server/routes/split-video-from-audio.ts
@@ -55,6 +55,7 @@ export const splitVideoFromAudioHandler: ApiHandler<
 
 			pushToUndoStack({
 				filePath: absolutePath,
+				invalidatedNodePaths: [],
 				oldContents: fileContents,
 				newContents: null,
 				logLevel,

--- a/packages/studio-server/src/preview-server/routes/update-default-props.ts
+++ b/packages/studio-server/src/preview-server/routes/update-default-props.ts
@@ -72,6 +72,7 @@ export const updateDefaultPropsHandler: ApiHandler<
 				},
 				entryType: 'default-props',
 				suppressHmrOnFileRestore: true,
+				invalidatedNodePaths: [],
 				nodePathRemappings: null,
 			});
 			suppressUndoStackInvalidation(projectInfo.rootFile);

--- a/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-effect-keyframe-settings.ts
@@ -100,6 +100,7 @@ export const updateEffectKeyframeSettingsHandler: ApiHandler<
 			},
 			entryType: 'effect-props',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
+++ b/packages/studio-server/src/preview-server/routes/update-sequence-keyframe-settings.ts
@@ -87,6 +87,7 @@ export const updateSequenceKeyframeSettingsHandler: ApiHandler<
 			},
 			entryType: 'sequence-props',
 			suppressHmrOnFileRestore: true,
+			invalidatedNodePaths: [],
 			nodePathRemappings: null,
 		});
 		suppressUndoStackInvalidation(absolutePath);

--- a/packages/studio-server/src/preview-server/sequence-node-path-mutation.ts
+++ b/packages/studio-server/src/preview-server/sequence-node-path-mutation.ts
@@ -12,6 +12,7 @@ let mutationCounter = 0;
 export const broadcastSequenceNodePathMutation = (
 	files: Array<{
 		absolutePath: string;
+		invalidatedNodePaths: SequenceNodePath[];
 		remappings: SequenceNodePathRemapping[];
 		restoredNodePaths: SequenceNodePath[];
 	}>,

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -445,6 +445,7 @@ export function popUndo(): UndoResponse {
 		return [
 			{
 				absolutePath: snapshot.filePath,
+				invalidatedNodePaths: [],
 				remappings: snapshot.nodePathRemappings.flatMap(
 					(remapping): SequenceNodePathRemapping[] => {
 						if (remapping.newNodePath === null) {
@@ -554,6 +555,7 @@ export function popRedo(): RedoResponse {
 		return [
 			{
 				absolutePath: snapshot.filePath,
+				invalidatedNodePaths: [],
 				remappings: snapshot.nodePathRemappings,
 				restoredNodePaths: [],
 			},

--- a/packages/studio-server/src/preview-server/undo-stack.ts
+++ b/packages/studio-server/src/preview-server/undo-stack.ts
@@ -55,6 +55,8 @@ type UndoEntryType =
 
 type UndoEntrySnapshot = {
 	filePath: string;
+	invalidatedNodePaths: SequenceNodePath[];
+	invalidatedNodePathsAfterMutation: SequenceNodePath[];
 	oldContents: string | null;
 	newContents: string | null;
 	/** 1-based source line for terminal/IDE file links (e.g. path:line). */
@@ -141,6 +143,8 @@ export function pushToUndoStack({
 	entryType,
 	suppressHmrOnFileRestore,
 	nodePathRemappings,
+	invalidatedNodePaths,
+	invalidatedNodePathsAfterMutation = [],
 }: {
 	filePath: string;
 	oldContents: string;
@@ -152,11 +156,15 @@ export function pushToUndoStack({
 	entryType: UndoEntryType;
 	suppressHmrOnFileRestore: boolean;
 	nodePathRemappings: SequenceNodePathRemapping[] | null;
+	invalidatedNodePaths: SequenceNodePath[];
+	invalidatedNodePathsAfterMutation?: SequenceNodePath[];
 }) {
 	pushTransactionToUndoStack({
 		snapshots: [
 			{
 				filePath,
+				invalidatedNodePaths,
+				invalidatedNodePathsAfterMutation,
 				oldContents,
 				newContents,
 				logLine,
@@ -185,6 +193,8 @@ export function pushTransactionToUndoStack({
 		newContents: string | null;
 		logLine: number;
 		nodePathRemappings: SequenceNodePathRemapping[] | null;
+		invalidatedNodePaths: SequenceNodePath[];
+		invalidatedNodePathsAfterMutation?: SequenceNodePath[];
 	}>;
 	logLevel: LogLevel;
 	remotionRoot: string;
@@ -196,7 +206,11 @@ export function pushTransactionToUndoStack({
 	storedRemotionRoot = remotionRoot;
 
 	const entry = makeUndoEntry({
-		snapshots,
+		snapshots: snapshots.map((snapshot) => ({
+			...snapshot,
+			invalidatedNodePathsAfterMutation:
+				snapshot.invalidatedNodePathsAfterMutation ?? [],
+		})),
 		description,
 		entryType,
 		suppressHmrOnFileRestore,
@@ -254,6 +268,8 @@ export function pushToRedoStack({
 		snapshots: [
 			{
 				filePath,
+				invalidatedNodePaths: [],
+				invalidatedNodePathsAfterMutation: [],
 				oldContents,
 				newContents,
 				logLine,
@@ -445,7 +461,7 @@ export function popUndo(): UndoResponse {
 		return [
 			{
 				absolutePath: snapshot.filePath,
-				invalidatedNodePaths: [],
+				invalidatedNodePaths: snapshot.invalidatedNodePathsAfterMutation,
 				remappings: snapshot.nodePathRemappings.flatMap(
 					(remapping): SequenceNodePathRemapping[] => {
 						if (remapping.newNodePath === null) {
@@ -555,7 +571,7 @@ export function popRedo(): RedoResponse {
 		return [
 			{
 				absolutePath: snapshot.filePath,
-				invalidatedNodePaths: [],
+				invalidatedNodePaths: snapshot.invalidatedNodePaths,
 				remappings: snapshot.nodePathRemappings,
 				restoredNodePaths: [],
 			},

--- a/packages/studio-server/src/test/delete-jsx-node.test.ts
+++ b/packages/studio-server/src/test/delete-jsx-node.test.ts
@@ -431,6 +431,7 @@ test('deleting a JSX node broadcasts node path mutations for all clients', async
 		expect(response.nodePathMutation.files).toEqual([
 			{
 				absolutePath: filePath,
+				invalidatedNodePaths: [],
 				remappings: [
 					{
 						oldNodePath: lineColumnToNodePath(interactiveSiblings, 6),
@@ -474,6 +475,7 @@ test('deleting a JSX node broadcasts node path mutations for all clients', async
 		expect(undoResponse.nodePathMutation.files).toEqual([
 			{
 				absolutePath: filePath,
+				invalidatedNodePaths: [],
 				remappings: [
 					{
 						oldNodePath: lineColumnToNodePath(output, 6),

--- a/packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts
+++ b/packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts
@@ -154,9 +154,13 @@ test('JSX structure routes broadcast and return node path mutations before writi
 		const splitResponse = await splitJsxSequenceHandler({
 			...handlerContext,
 			input: {
-				fileName,
-				nodePath: lineContainingToNodePath(before, 'name="c"'),
-				sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+				sequences: [
+					{
+						fileName,
+						nodePath: lineContainingToNodePath(before, 'name="c"'),
+						sequenceKeys: ['from', 'durationInFrames', 'trimBefore'],
+					},
+				],
 				splitFrame: 30,
 			},
 		});

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -239,15 +239,26 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 	try {
 		clearUndoStack();
 		const entryPoint = path.join(remotionRoot, 'Root.tsx');
-		const input = wrap('<AbsoluteFill from={0} durationInFrames={50} />');
+		const input = wrap(
+			'<AbsoluteFill name="first" from={0} durationInFrames={50} />\n\t\t\t<AbsoluteFill name="second" from={10} durationInFrames={40} />',
+		);
 		writeFileSync(entryPoint, input);
 
 		const success = await splitJsxSequenceHandler(
 			getHandlerOptions({
 				input: {
-					fileName: entryPoint,
-					nodePath: lineColumnToNodePath(input, sequenceLine),
-					sequenceKeys: sequenceTimingKeys,
+					sequences: [
+						{
+							fileName: entryPoint,
+							nodePath: lineContainingToNodePath(input, 'name="first"'),
+							sequenceKeys: sequenceTimingKeys,
+						},
+						{
+							fileName: entryPoint,
+							nodePath: lineContainingToNodePath(input, 'name="second"'),
+							sequenceKeys: sequenceTimingKeys,
+						},
+					],
 					splitFrame: 30,
 				},
 				entryPoint,
@@ -256,17 +267,25 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 		);
 
 		expect(success.success).toBe(true);
-		expect(readFileSync(entryPoint, 'utf-8')).toContain(
-			'<AbsoluteFill from={30} durationInFrames={20} trimBefore={30} />',
+		const output = readFileSync(entryPoint, 'utf-8');
+		expect(output).toMatch(
+			/<AbsoluteFill\s+name="first"\s+from=\{30\}\s+durationInFrames=\{20\}\s+trimBefore=\{30\}/,
+		);
+		expect(output).toMatch(
+			/<AbsoluteFill\s+name="second"\s+from=\{30\}\s+durationInFrames=\{20\}\s+trimBefore=\{20\}/,
 		);
 		expect(getUndoStack().length).toBe(1);
 
 		const failure = await splitJsxSequenceHandler(
 			getHandlerOptions({
 				input: {
-					fileName: entryPoint,
-					nodePath: lineColumnToNodePath(input, sequenceLine),
-					sequenceKeys: sequenceTimingKeys,
+					sequences: [
+						{
+							fileName: entryPoint,
+							nodePath: lineContainingToNodePath(output, 'name="first"'),
+							sequenceKeys: sequenceTimingKeys,
+						},
+					],
 					splitFrame: 0,
 				},
 				entryPoint,

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -243,6 +243,8 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 			'<AbsoluteFill name="first" from={0} durationInFrames={50} />\n\t\t\t<AbsoluteFill name="second" from={10} durationInFrames={40} />',
 		);
 		writeFileSync(entryPoint, input);
+		const firstNodePath = lineContainingToNodePath(input, 'name="first"');
+		const secondNodePath = lineContainingToNodePath(input, 'name="second"');
 
 		const success = await splitJsxSequenceHandler(
 			getHandlerOptions({
@@ -250,12 +252,12 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 					sequences: [
 						{
 							fileName: entryPoint,
-							nodePath: lineContainingToNodePath(input, 'name="first"'),
+							nodePath: firstNodePath,
 							sequenceKeys: sequenceTimingKeys,
 						},
 						{
 							fileName: entryPoint,
-							nodePath: lineContainingToNodePath(input, 'name="second"'),
+							nodePath: secondNodePath,
 							sequenceKeys: sequenceTimingKeys,
 						},
 					],
@@ -266,7 +268,17 @@ test('splitJsxSequenceHandler writes success and failure responses', async () =>
 			}),
 		);
 
-		expect(success.success).toBe(true);
+		expect(success).toMatchObject({
+			success: true,
+			nodePathMutation: {
+				files: [
+					{
+						absolutePath: entryPoint,
+						invalidatedNodePaths: [firstNodePath, secondNodePath],
+					},
+				],
+			},
+		});
 		const output = readFileSync(entryPoint, 'utf-8');
 		expect(output).toMatch(
 			/<AbsoluteFill\s+name="first"\s+from=\{30\}\s+durationInFrames=\{20\}\s+trimBefore=\{30\}/,

--- a/packages/studio-server/src/test/undo-stack.test.ts
+++ b/packages/studio-server/src/test/undo-stack.test.ts
@@ -40,6 +40,7 @@ test('undo and redo restore every file in a transaction', () => {
 					oldContents: 'old first',
 					newContents: 'new first',
 					logLine: 1,
+					invalidatedNodePaths: [],
 					nodePathRemappings: null,
 				},
 				{
@@ -47,6 +48,7 @@ test('undo and redo restore every file in a transaction', () => {
 					oldContents: 'old second',
 					newContents: 'new second',
 					logLine: 1,
+					invalidatedNodePaths: [],
 					nodePathRemappings: null,
 				},
 			],

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -818,10 +818,14 @@ export type DuplicateJsxNodeResponse =
 			stack: string;
 	  };
 
-export type SplitJsxSequenceRequest = {
+export type SplitJsxSequenceRequestItem = {
 	fileName: string;
 	nodePath: SequenceNodePath;
 	sequenceKeys: string[];
+};
+
+export type SplitJsxSequenceRequest = {
+	sequences: SplitJsxSequenceRequestItem[];
 	splitFrame: number;
 };
 

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -122,6 +122,7 @@ export {
 	SaveSequencePropsResult,
 	SimpleDiff,
 	SplitJsxSequenceRequest,
+	SplitJsxSequenceRequestItem,
 	SplitJsxSequenceResponse,
 	SplitVideoFromAudioRequest,
 	SplitVideoFromAudioResponse,

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -181,7 +181,10 @@ export type {
 } from './sequence-node-path-mutation';
 export type {ApplyVisualControlCodemod, RecastCodemod} from './codemods';
 export {compositionDragDataToSymbolicatedStack} from './composition-drag-data';
-export {REACT_REFRESH_FINISHED_EVENT} from './react-refresh-event';
+export {
+	REACT_REFRESH_FINISHED_EVENT,
+	REACT_REFRESH_STARTED_EVENT,
+} from './react-refresh-event';
 export {hasSequenceTimingTraits} from './has-sequence-timing-traits';
 export {
 	getConfigFileChangeMessage,

--- a/packages/studio-shared/src/react-refresh-event.ts
+++ b/packages/studio-shared/src/react-refresh-event.ts
@@ -1,1 +1,2 @@
+export const REACT_REFRESH_STARTED_EVENT = 'remotion-react-refresh-started';
 export const REACT_REFRESH_FINISHED_EVENT = 'remotion-react-refresh-finished';

--- a/packages/studio-shared/src/sequence-node-path-mutation.ts
+++ b/packages/studio-shared/src/sequence-node-path-mutation.ts
@@ -9,6 +9,7 @@ export type SequenceNodePathMutation = {
 	mutationId: string;
 	files: Array<{
 		absolutePath: string;
+		invalidatedNodePaths: SequenceNodePath[];
 		remappings: SequenceNodePathRemapping[];
 		restoredNodePaths: SequenceNodePath[];
 	}>;

--- a/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
+++ b/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
@@ -1,5 +1,9 @@
-import {type EventSourceEvent} from '@remotion/studio-shared';
+import {
+	REACT_REFRESH_STARTED_EVENT,
+	type EventSourceEvent,
+} from '@remotion/studio-shared';
 import {useContext, useEffect, useLayoutEffect, useRef} from 'react';
+import {flushSync} from 'react-dom';
 import type {
 	SequencePropsStatusRemapping,
 	SequencePropsSubscriptionKey,
@@ -30,6 +34,9 @@ export const SequencePropsObserver = () => {
 	const {migrateExpandedTracksForSubscriptionKey} = useContext(
 		ExpandedTracksSetterContext,
 	);
+	const pendingPropStatusInvalidations = useRef<SequencePropsStatusRemapping[]>(
+		[],
+	);
 	useEffect(() => {
 		const handleEvent = (event: EventSourceEvent) => {
 			if (event.type === 'sequence-props-updated') {
@@ -41,7 +48,6 @@ export const SequencePropsObserver = () => {
 				return;
 			}
 
-			const invalidations: SequencePropsStatusRemapping[] = [];
 			for (const previousNodePath of Object.values(
 				overrideIdToNodePathMappingsRef.current,
 			)) {
@@ -56,17 +62,28 @@ export const SequencePropsObserver = () => {
 						),
 				);
 				if (sourceNodeWasInvalidated) {
-					invalidations.push({
+					pendingPropStatusInvalidations.current.push({
 						previousNodePath,
 						nodePath: previousNodePath,
 						result: null,
 					});
 				}
 			}
+		};
 
-			if (invalidations.length > 0) {
-				remapPropStatuses(invalidations);
+		const handleReactRefreshStarted = () => {
+			const invalidations = pendingPropStatusInvalidations.current;
+			pendingPropStatusInvalidations.current = [];
+			if (invalidations.length === 0) {
+				return;
 			}
+
+			// Invalidate immediately before React applies the refreshed modules. Both
+			// updates happen in the same browser task, so the old timeline remains
+			// visible until it can be replaced by the authoritative server result.
+			flushSync(() => {
+				remapPropStatuses(invalidations);
+			});
 		};
 
 		const unsubscribe = subscribeToEvent('sequence-props-updated', handleEvent);
@@ -74,10 +91,18 @@ export const SequencePropsObserver = () => {
 			'sequence-node-paths-remapped',
 			handleEvent,
 		);
+		window.addEventListener(
+			REACT_REFRESH_STARTED_EVENT,
+			handleReactRefreshStarted,
+		);
 
 		return () => {
 			unsubscribe();
 			unsubscribeFromNodePathMutations();
+			window.removeEventListener(
+				REACT_REFRESH_STARTED_EVENT,
+				handleReactRefreshStarted,
+			);
 		};
 	}, [remapPropStatuses, setPropStatuses, subscribeToEvent]);
 

--- a/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
+++ b/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
@@ -32,19 +32,54 @@ export const SequencePropsObserver = () => {
 	);
 	useEffect(() => {
 		const handleEvent = (event: EventSourceEvent) => {
-			if (event.type !== 'sequence-props-updated') {
+			if (event.type === 'sequence-props-updated') {
+				setPropStatuses(event.nodePath, () => event.result);
 				return;
 			}
 
-			setPropStatuses(event.nodePath, () => event.result);
+			if (event.type !== 'sequence-node-paths-remapped') {
+				return;
+			}
+
+			const invalidations: SequencePropsStatusRemapping[] = [];
+			for (const previousNodePath of Object.values(
+				overrideIdToNodePathMappingsRef.current,
+			)) {
+				const previousNodePathString = JSON.stringify(
+					previousNodePath.nodePath,
+				);
+				const sourceNodeWasInvalidated = event.mutation.files.some(
+					(file) =>
+						file.absolutePath === previousNodePath.absolutePath &&
+						file.invalidatedNodePaths.some(
+							(nodePath) => JSON.stringify(nodePath) === previousNodePathString,
+						),
+				);
+				if (sourceNodeWasInvalidated) {
+					invalidations.push({
+						previousNodePath,
+						nodePath: previousNodePath,
+						result: null,
+					});
+				}
+			}
+
+			if (invalidations.length > 0) {
+				remapPropStatuses(invalidations);
+			}
 		};
 
 		const unsubscribe = subscribeToEvent('sequence-props-updated', handleEvent);
+		const unsubscribeFromNodePathMutations = subscribeToEvent(
+			'sequence-node-paths-remapped',
+			handleEvent,
+		);
 
 		return () => {
 			unsubscribe();
+			unsubscribeFromNodePathMutations();
 		};
-	}, [setPropStatuses, subscribeToEvent]);
+	}, [remapPropStatuses, setPropStatuses, subscribeToEvent]);
 
 	useLayoutEffect(() => {
 		const mutations = takePendingSequenceNodePathMutations();
@@ -64,6 +99,7 @@ export const SequencePropsObserver = () => {
 			let {nodePath} = previousNodePath;
 			let wasRemapped = false;
 			let wasDeleted = false;
+			let sourceNodeWasInvalidated = false;
 			let runtimeNodePathExists = true;
 			const previousNodePathString = JSON.stringify(previousNodePath.nodePath);
 
@@ -71,6 +107,16 @@ export const SequencePropsObserver = () => {
 				for (const file of mutation.files) {
 					if (file.absolutePath !== previousNodePath.absolutePath) {
 						continue;
+					}
+
+					if (
+						file.invalidatedNodePaths.some(
+							(invalidatedNodePath) =>
+								JSON.stringify(invalidatedNodePath) ===
+								JSON.stringify(nodePath),
+						)
+					) {
+						sourceNodeWasInvalidated = true;
 					}
 
 					// Prop statuses follow source nodes to their new paths. Override IDs,
@@ -139,7 +185,9 @@ export const SequencePropsObserver = () => {
 			statusRemappings.push({
 				previousNodePath,
 				nodePath: nextNodePath,
-				result: propStatusesRef.current[previousStatusKey] ?? null,
+				result: sourceNodeWasInvalidated
+					? null
+					: (propStatusesRef.current[previousStatusKey] ?? null),
 			});
 
 			overrideUpdates.push({

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -205,6 +205,9 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 					overrideIdsToNodePaths: overrideIdToNodePathMappings,
 					propStatuses: propStatusesRef.current,
 					splitFrame: getCurrentFrame(),
+					onSplit: (selections) => {
+						currentSelection.current.selectItems(selections);
+					},
 				});
 
 				if (splitPromise === null) {

--- a/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/split-selected-timeline-item.ts
@@ -1,4 +1,7 @@
-import {hasSequenceTimingTraits} from '@remotion/studio-shared';
+import {
+	hasSequenceTimingTraits,
+	type SequenceNodePathMutation,
+} from '@remotion/studio-shared';
 import type {
 	CanUpdateSequencePropStatus,
 	OverrideIdToNodePaths,
@@ -144,34 +147,43 @@ export const getTimelineSequenceSplitEligibility = ({
 	};
 };
 
+export const splitTimelineSequencesFromSource = ({
+	nodePathInfos,
+	splitFrame,
+}: {
+	nodePathInfos: SequenceNodePathInfo[];
+	splitFrame: number;
+}): Promise<SequenceNodePathMutation | null> => {
+	return splitJsxSequence({
+		sequences: nodePathInfos.map(({sequenceSubscriptionKey}) => ({
+			fileName: sequenceSubscriptionKey.absolutePath,
+			nodePath: sequenceSubscriptionKey.nodePath,
+			sequenceKeys: sequenceSubscriptionKey.sequenceKeys,
+		})),
+		splitFrame,
+	})
+		.then((result) => {
+			if (result.success) {
+				return result.nodePathMutation;
+			}
+
+			showNotification(result.reason, 4000);
+			return null;
+		})
+		.catch((err) => {
+			showNotification((err as Error).message, 4000);
+			return null;
+		});
+};
+
 export const splitTimelineSequenceFromSource = ({
 	nodePathInfo,
 	splitFrame,
 }: {
 	nodePathInfo: SequenceNodePathInfo;
 	splitFrame: number;
-}): Promise<boolean> => {
-	const nodePath = nodePathInfo.sequenceSubscriptionKey;
-
-	return splitJsxSequence({
-		fileName: nodePath.absolutePath,
-		nodePath: nodePath.nodePath,
-		sequenceKeys: nodePath.sequenceKeys,
-		splitFrame,
-	})
-		.then((result) => {
-			if (result.success) {
-				return true;
-			}
-
-			showNotification(result.reason, 4000);
-			return false;
-		})
-		.catch((err) => {
-			showNotification((err as Error).message, 4000);
-			return false;
-		});
-};
+}): Promise<SequenceNodePathMutation | null> =>
+	splitTimelineSequencesFromSource({nodePathInfos: [nodePathInfo], splitFrame});
 
 export const shouldHandleTimelineDuplicateShortcut = ({
 	shiftKey,
@@ -191,52 +203,126 @@ export const splitSelectedTimelineItems = ({
 	overrideIdsToNodePaths,
 	propStatuses,
 	splitFrame,
-	splitSequence = splitTimelineSequenceFromSource,
+	splitSequences = splitTimelineSequencesFromSource,
+	notify = showNotification,
+	onSplit = () => undefined,
 }: {
 	selections: readonly TimelineSelection[];
 	sequences: TSequence[];
 	overrideIdsToNodePaths: OverrideIdToNodePaths;
 	propStatuses: PropStatuses | undefined;
 	splitFrame: number;
-	splitSequence?: (options: {
-		nodePathInfo: SequenceNodePathInfo;
+	splitSequences?: (options: {
+		nodePathInfos: SequenceNodePathInfo[];
 		splitFrame: number;
-	}) => Promise<boolean>;
+	}) => Promise<SequenceNodePathMutation | null>;
+	notify?: (content: string, durationInMs: number) => unknown;
+	onSplit?: (selections: readonly TimelineSelection[]) => void;
 }): Promise<boolean> | null => {
-	if (selections.length !== 1) {
+	if (selections.length === 0) {
 		return null;
 	}
 
-	const [selection] = selections;
-	if (selection.type !== 'sequence') {
+	const sequenceSelections = selections.filter(
+		(selection): selection is Extract<TimelineSelection, {type: 'sequence'}> =>
+			selection.type === 'sequence',
+	);
+	if (sequenceSelections.length === 0) {
 		return null;
 	}
 
-	const track = findTrackForNodePathInfo({
-		sequences,
-		overrideIdsToNodePaths,
-		nodePathInfo: selection.nodePathInfo,
-	});
-	const sequencePropStatuses = propStatuses
-		? Internals.getPropStatusesCtx(
-				propStatuses,
-				selection.nodePathInfo.sequenceSubscriptionKey,
-			)
-		: undefined;
-	const eligibility = getTimelineSequenceSplitEligibility({
-		selection,
-		sequence: track?.sequence ?? null,
-		splitFrame,
-		propStatuses: sequencePropStatuses,
-	});
+	const eligible: SequenceNodePathInfo[] = [];
+	const skippedReasons: string[] = [];
+	for (const selection of sequenceSelections) {
+		const track = findTrackForNodePathInfo({
+			sequences,
+			overrideIdsToNodePaths,
+			nodePathInfo: selection.nodePathInfo,
+		});
+		const sequencePropStatuses = propStatuses
+			? Internals.getPropStatusesCtx(
+					propStatuses,
+					selection.nodePathInfo.sequenceSubscriptionKey,
+				)
+			: undefined;
+		const eligibility = getTimelineSequenceSplitEligibility({
+			selection,
+			sequence: track?.sequence ?? null,
+			splitFrame,
+			propStatuses: sequencePropStatuses,
+		});
 
-	if (!eligibility.canSplit) {
-		showNotification(eligibility.reason, 4000);
+		if (eligibility.canSplit) {
+			eligible.push(eligibility.nodePathInfo);
+		} else {
+			skippedReasons.push(eligibility.reason);
+		}
+	}
+
+	if (eligible.length === 0) {
+		const uniqueReasons = [...new Set(skippedReasons)];
+		notify(
+			uniqueReasons.length === 1
+				? uniqueReasons[0]
+				: `Could not split ${skippedReasons.length} selected clips`,
+			4000,
+		);
 		return Promise.resolve(false);
 	}
 
-	return splitSequence({
-		nodePathInfo: eligibility.nodePathInfo,
-		splitFrame,
-	});
+	if (skippedReasons.length > 0) {
+		notify(
+			`Skipped ${skippedReasons.length} selected clip${skippedReasons.length === 1 ? '' : 's'} that cannot be split`,
+			4000,
+		);
+	}
+
+	return splitSequences({nodePathInfos: eligible, splitFrame}).then(
+		(mutation) => {
+			if (mutation === null) {
+				return false;
+			}
+
+			const remappedSelections = selections.flatMap(
+				(selection): TimelineSelection[] => {
+					if (selection.type !== 'sequence') {
+						return [selection];
+					}
+
+					const {sequenceSubscriptionKey} = selection.nodePathInfo;
+					const fileMutation = mutation.files.find(
+						(file) =>
+							file.absolutePath === sequenceSubscriptionKey.absolutePath,
+					);
+					const remapping = fileMutation?.remappings.find(
+						(item) =>
+							JSON.stringify(item.oldNodePath) ===
+							JSON.stringify(sequenceSubscriptionKey.nodePath),
+					);
+					if (!remapping) {
+						return [selection];
+					}
+
+					if (remapping.newNodePath === null) {
+						return [];
+					}
+
+					return [
+						{
+							...selection,
+							nodePathInfo: {
+								...selection.nodePathInfo,
+								sequenceSubscriptionKey: {
+									...sequenceSubscriptionKey,
+									nodePath: remapping.newNodePath,
+								},
+							},
+						},
+					];
+				},
+			);
+			onSplit(remappedSelections);
+			return true;
+		},
+	);
 };

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -125,6 +125,10 @@ export const keyboardShortcutGroups: readonly KeyboardShortcutGroup[] = [
 				chords: [[cmdOrCtrlCharacter, 'D']],
 			},
 			{
+				action: 'Split sequences at playhead',
+				chords: [[cmdOrCtrlCharacter, 'Shift', 'D']],
+			},
+			{
 				action: 'Copy effects / values',
 				chords: [[cmdOrCtrlCharacter, 'C']],
 			},

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -315,6 +315,10 @@ test('splitSelectedTimelineItems batches eligible clips and skips ineligible cli
 				files: [
 					{
 						absolutePath: '/tmp/Comp.tsx',
+						invalidatedNodePaths: [
+							first.sequenceSubscriptionKey.nodePath,
+							second.sequenceSubscriptionKey.nodePath,
+						],
 						remappings: [
 							{oldNodePath: ['body', 1], newNodePath: ['body', 2]},
 							{oldNodePath: ['body', 2], newNodePath: ['body', 4]},

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -13,6 +13,7 @@ import {
 	shouldHandleTimelineSplitShortcut,
 	splitSelectedTimelineItems,
 } from '../components/Timeline/split-selected-timeline-item';
+import type {TimelineSelection} from '../components/Timeline/TimelineSelection';
 import type {SequenceNodePathInfo} from '../helpers/get-timeline-sequence-sort-key';
 import {makeRuntimeValueStore} from './make-runtime-value-store';
 
@@ -231,8 +232,10 @@ test('splitSelectedTimelineItems splits the selected sequence at the playhead', 
 			effects: [],
 		},
 	} satisfies PropStatuses;
-	const splitCalls: {nodePathInfo: SequenceNodePathInfo; splitFrame: number}[] =
-		[];
+	const splitCalls: {
+		nodePathInfos: SequenceNodePathInfo[];
+		splitFrame: number;
+	}[] = [];
 
 	const result = await splitSelectedTimelineItems({
 		selections: [{type: 'sequence', nodePathInfo}],
@@ -242,12 +245,113 @@ test('splitSelectedTimelineItems splits the selected sequence at the playhead', 
 		},
 		propStatuses,
 		splitFrame: 30,
-		splitSequence: (options) => {
+		splitSequences: (options) => {
 			splitCalls.push(options);
-			return Promise.resolve(true);
+			return Promise.resolve({mutationId: 'test', files: []});
 		},
 	});
 
 	expect(result).toBe(true);
-	expect(splitCalls).toEqual([{nodePathInfo, splitFrame: 30}]);
+	expect(splitCalls).toEqual([{nodePathInfos: [nodePathInfo], splitFrame: 30}]);
+});
+
+test('splitSelectedTimelineItems batches eligible clips and skips ineligible clips', async () => {
+	const first = makeNodePathInfo(['body', 0]);
+	const second = makeNodePathInfo(['body', 1]);
+	const third = makeNodePathInfo(['body', 2]);
+	const propStatuses = Object.fromEntries(
+		[first, second, third].map((nodePathInfo) => [
+			Internals.makeSequencePropsSubscriptionKey(
+				nodePathInfo.sequenceSubscriptionKey,
+			),
+			{
+				canUpdate: true,
+				props: {
+					from: staticNumber(10),
+					durationInFrames: staticNumber(50),
+					trimBefore: staticNumber(0),
+				},
+				effects: [],
+			},
+		]),
+	) as PropStatuses;
+	const makeControls = (overrideId: string) => ({
+		schema: {},
+		runtimeValues: makeRuntimeValueStore({}),
+		overrideId,
+		supportsEffects: true,
+		componentIdentity: null,
+		componentName: 'Sequence',
+	});
+	const splitCalls: SequenceNodePathInfo[][] = [];
+	const notifications: string[] = [];
+	const selectedAfterSplit: (readonly TimelineSelection[])[] = [];
+
+	const result = await splitSelectedTimelineItems({
+		selections: [first, second, third].map((nodePathInfo) => ({
+			type: 'sequence' as const,
+			nodePathInfo,
+		})),
+		sequences: [
+			makeSequence({controls: makeControls('first')}),
+			makeSequence({controls: makeControls('second')}),
+			makeSequence({
+				from: 40,
+				duration: 20,
+				controls: makeControls('third'),
+			}),
+		],
+		overrideIdsToNodePaths: {
+			first: first.sequenceSubscriptionKey,
+			second: second.sequenceSubscriptionKey,
+			third: third.sequenceSubscriptionKey,
+		},
+		propStatuses,
+		splitFrame: 30,
+		splitSequences: ({nodePathInfos}) => {
+			splitCalls.push(nodePathInfos);
+			return Promise.resolve({
+				mutationId: 'test',
+				files: [
+					{
+						absolutePath: '/tmp/Comp.tsx',
+						remappings: [
+							{oldNodePath: ['body', 1], newNodePath: ['body', 2]},
+							{oldNodePath: ['body', 2], newNodePath: ['body', 4]},
+						],
+						restoredNodePaths: [],
+					},
+				],
+			});
+		},
+		notify: (content) => notifications.push(content),
+		onSplit: (selections) => selectedAfterSplit.push(selections),
+	});
+
+	expect(result).toBe(true);
+	expect(splitCalls).toEqual([[first, second]]);
+	expect(notifications).toEqual([
+		'Skipped 1 selected clip that cannot be split',
+	]);
+	expect(
+		selectedAfterSplit[0].map(
+			(selection) => selection.type === 'sequence' && selection.nodePathInfo,
+		),
+	).toEqual([
+		first,
+		{
+			...second,
+			sequenceSubscriptionKey: {
+				...second.sequenceSubscriptionKey,
+				nodePath: ['body', 2],
+			},
+		},
+		{
+			...third,
+			sequenceSubscriptionKey: {
+				...third.sequenceSubscriptionKey,
+				nodePath: ['body', 4],
+			},
+		},
+	]);
 });


### PR DESCRIPTION
## Summary

- split all eligible selected Studio clips at the playhead
- batch source mutations by file so sibling clips remain stable and undo together
- preserve timeline selection through node path remappings and notify when clips are skipped
- document the Cmd/Ctrl + Shift + D shortcut

## Validation

- `bun test packages/studio/src/test/split-selected-timeline-item.test.ts packages/studio-server/src/test/split-jsx-sequence.test.ts packages/studio-server/src/test/jsx-node-path-mutation-routes.test.ts packages/browser-studio/src/test/browser-studio-operations.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #8707

## Preview

- [Studio shortcuts](https://remotion-git-codex-split-multiple-studio-clips-remotion.vercel.app/docs/studio/shortcuts)
- [Studio interactivity](https://remotion-git-codex-split-multiple-studio-clips-remotion.vercel.app/docs/studio/interactivity)
