### PR TITLE
`@remotion/studio`: Fix Browser Studio canvas state URLs

### DIFF
--- a/packages/browser-studio/e2e/app.tsx
+++ b/packages/browser-studio/e2e/app.tsx
@@ -51,7 +51,6 @@ registerRoot(RemotionRoot);
 					? ({name, version}) => (name === 'react' ? version : null)
 					: undefined
 			}
-			iframeSrc="/frame.html"
 			initialElement={
 				initialElementPayload === null
 					? null

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -471,9 +471,7 @@ export const Root = () => <Composition id="OpfsComp" component={OpfsComposition}
 	await expect(
 		studio.getByTitle('/project').getByText('OpfsComp'),
 	).toBeVisible();
-	await expect
-		.poll(() => new URL(page.url()).search)
-		.toBe('?/OpfsComp&github=1');
+	await expect.poll(() => new URL(page.url()).search).toBe('?/OpfsComp');
 	await studio.locator('[data-compname="OpfsComp"]').click();
 	await expect(
 		studio.locator('.remotion-studio-composition-container img'),
@@ -647,7 +645,7 @@ export const Root = () => <Composition id="OpfsComp" component={OpfsComposition}
 	await secondPage.close();
 
 	const previousDirectoryName = projectStorage.storage?.directoryName;
-	await page.reload();
+	await page.goto('/?github=1');
 	await expect(
 		studio.getByTitle('/project').getByText('OpfsComp'),
 	).toBeVisible();

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -194,9 +194,7 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			await expect(
 				studio.locator('.remotion-studio-composition-container'),
 			).toBeVisible();
-			await expect
-				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
-				.toBe('/MyComp');
+			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp');
 			await studio.locator('button:has(svg[viewBox="0 0 415 426"])').click();
 			const popupPromise = page.waitForEvent('popup');
 			await studio.getByText('About Remotion', {exact: true}).click();
@@ -330,13 +328,9 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			await expect(
 				studio.getByTitle('/project').getByText('MyComp1'),
 			).toBeVisible();
-			await expect
-				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
-				.toBe('/MyComp1');
+			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp1');
 			await page.goBack();
-			await expect
-				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
-				.toBe('/MyComp');
+			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp');
 			await studio.getByRole('button', {name: 'Render on web'}).click();
 			await expect(
 				studio.getByText('Render MyComp', {exact: true}),
@@ -477,6 +471,9 @@ export const Root = () => <Composition id="OpfsComp" component={OpfsComposition}
 	await expect(
 		studio.getByTitle('/project').getByText('OpfsComp'),
 	).toBeVisible();
+	await expect
+		.poll(() => new URL(page.url()).search)
+		.toBe('?/OpfsComp&github=1');
 	await studio.locator('[data-compname="OpfsComp"]').click();
 	await expect(
 		studio.locator('.remotion-studio-composition-container img'),

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -194,6 +194,9 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			await expect(
 				studio.locator('.remotion-studio-composition-container'),
 			).toBeVisible();
+			await expect
+				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
+				.toBe('/MyComp');
 			await studio.locator('button:has(svg[viewBox="0 0 415 426"])').click();
 			const popupPromise = page.waitForEvent('popup');
 			await studio.getByText('About Remotion', {exact: true}).click();
@@ -327,6 +330,18 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			await expect(
 				studio.getByTitle('/project').getByText('MyComp1'),
 			).toBeVisible();
+			await expect
+				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
+				.toBe('/MyComp1');
+			await page.goBack();
+			await expect
+				.poll(() => new URL(page.url()).searchParams.get('remotion-route'))
+				.toBe('/MyComp');
+			await studio.getByRole('button', {name: 'Render on web'}).click();
+			await expect(
+				studio.getByText('Render MyComp', {exact: true}),
+			).toBeVisible();
+			await studio.locator('body').press('Escape');
 			await expect
 				.poll(() =>
 					page.evaluate(() => {

--- a/packages/studio/src/components/InitialCompositionLoader.tsx
+++ b/packages/studio/src/components/InitialCompositionLoader.tsx
@@ -5,7 +5,7 @@ import {Internals} from 'remotion';
 import {getKeysToExpand} from '../helpers/create-folder-tree';
 import type {ExpandedFoldersState} from '../helpers/persist-open-folders';
 import {persistExpandedFolders} from '../helpers/persist-open-folders';
-import {getRoute, pushUrl} from '../helpers/url-state';
+import {getNavigationWindow, getRoute, pushUrl} from '../helpers/url-state';
 import {
 	CompositionListContext,
 	compositionListRenderedRef,
@@ -177,9 +177,10 @@ export const InitialCompositionLoader: React.FC = () => {
 			setCanvasContent(newCanvas);
 		};
 
-		window.addEventListener('popstate', onchange);
+		const navigationWindow = getNavigationWindow();
+		navigationWindow.addEventListener('popstate', onchange);
 
-		return () => window.removeEventListener('popstate', onchange);
+		return () => navigationWindow.removeEventListener('popstate', onchange);
 	}, [
 		compositions,
 		selectAsset,

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -1,27 +1,51 @@
-type UrlHandling = 'spa' | 'query-string';
+type UrlHandling = 'browser-studio' | 'query-string' | 'spa';
+
+const browserStudioRouteParameter = 'remotion-route';
 
 const getUrlHandlingType = (): UrlHandling => {
-	if (window.remotion_isReadOnlyStudio || window.remotion_browserStudio) {
+	if (window.remotion_browserStudio) {
+		return 'browser-studio';
+	}
+
+	if (window.remotion_isReadOnlyStudio) {
 		return 'query-string';
 	}
 
 	return 'spa';
 };
 
+export const getNavigationWindow = () => {
+	if (window.remotion_browserStudio && window.parent !== window) {
+		return window.parent;
+	}
+
+	return window;
+};
+
 export const getUrlForRoute = (route: string) => {
+	if (getUrlHandlingType() === 'browser-studio') {
+		const navigationWindow = getNavigationWindow();
+		const currentSearch = navigationWindow.location.search.substring(1);
+		const searchParams = currentSearch.startsWith('/')
+			? new URLSearchParams()
+			: new URLSearchParams(currentSearch);
+		searchParams.set(browserStudioRouteParameter, route);
+		return `${navigationWindow.location.pathname}?${searchParams.toString()}`;
+	}
+
 	if (getUrlHandlingType() === 'query-string') {
-		return `${window.location.pathname}?${route}`;
+		return `${getNavigationWindow().location.pathname}?${route}`;
 	}
 
 	return route;
 };
 
 export const pushUrl = (url: string) => {
-	window.history.pushState({}, 'Studio', getUrlForRoute(url));
+	getNavigationWindow().history.pushState({}, 'Studio', getUrlForRoute(url));
 };
 
 export const replaceUrl = (url: string) => {
-	window.history.replaceState({}, 'Studio', getUrlForRoute(url));
+	getNavigationWindow().history.replaceState({}, 'Studio', getUrlForRoute(url));
 };
 
 export const clearUrl = () => {
@@ -33,8 +57,18 @@ export const reloadUrl = () => {
 };
 
 export const getRoute = () => {
+	if (getUrlHandlingType() === 'browser-studio') {
+		const search = getNavigationWindow().location.search.substring(1);
+		const route = new URLSearchParams(search).get(browserStudioRouteParameter);
+		if (route !== null) {
+			return route.startsWith('/') ? route : '';
+		}
+
+		return search.startsWith('/') ? search : '';
+	}
+
 	if (getUrlHandlingType() === 'query-string') {
-		const route = window.location.search.substring(1);
+		const route = getNavigationWindow().location.search.substring(1);
 		return route.startsWith('/') ? route : '';
 	}
 

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -1,7 +1,5 @@
 type UrlHandling = 'browser-studio' | 'query-string' | 'spa';
 
-const browserStudioRouteParameter = 'remotion-route';
-
 const getUrlHandlingType = (): UrlHandling => {
 	if (window.remotion_browserStudio) {
 		return 'browser-studio';
@@ -26,11 +24,13 @@ export const getUrlForRoute = (route: string) => {
 	if (getUrlHandlingType() === 'browser-studio') {
 		const navigationWindow = getNavigationWindow();
 		const currentSearch = navigationWindow.location.search.substring(1);
-		const searchParams = currentSearch.startsWith('/')
-			? new URLSearchParams()
-			: new URLSearchParams(currentSearch);
-		searchParams.set(browserStudioRouteParameter, route);
-		return `${navigationWindow.location.pathname}?${searchParams.toString()}`;
+		const firstSeparator = currentSearch.indexOf('&');
+		const hostSearch = currentSearch.startsWith('/')
+			? firstSeparator === -1
+				? ''
+				: currentSearch.substring(firstSeparator + 1)
+			: currentSearch;
+		return `${navigationWindow.location.pathname}?${route}${hostSearch ? `&${hostSearch}` : ''}`;
 	}
 
 	if (getUrlHandlingType() === 'query-string') {
@@ -59,12 +59,10 @@ export const reloadUrl = () => {
 export const getRoute = () => {
 	if (getUrlHandlingType() === 'browser-studio') {
 		const search = getNavigationWindow().location.search.substring(1);
-		const route = new URLSearchParams(search).get(browserStudioRouteParameter);
-		if (route !== null) {
-			return route.startsWith('/') ? route : '';
-		}
-
-		return search.startsWith('/') ? search : '';
+		const firstSeparator = search.indexOf('&');
+		const route =
+			firstSeparator === -1 ? search : search.substring(0, firstSeparator);
+		return route.startsWith('/') ? route : '';
 	}
 
 	if (getUrlHandlingType() === 'query-string') {

--- a/packages/studio/src/helpers/url-state.ts
+++ b/packages/studio/src/helpers/url-state.ts
@@ -1,11 +1,7 @@
-type UrlHandling = 'browser-studio' | 'query-string' | 'spa';
+type UrlHandling = 'query-string' | 'spa';
 
 const getUrlHandlingType = (): UrlHandling => {
-	if (window.remotion_browserStudio) {
-		return 'browser-studio';
-	}
-
-	if (window.remotion_isReadOnlyStudio) {
+	if (window.remotion_isReadOnlyStudio || window.remotion_browserStudio) {
 		return 'query-string';
 	}
 
@@ -21,18 +17,6 @@ export const getNavigationWindow = () => {
 };
 
 export const getUrlForRoute = (route: string) => {
-	if (getUrlHandlingType() === 'browser-studio') {
-		const navigationWindow = getNavigationWindow();
-		const currentSearch = navigationWindow.location.search.substring(1);
-		const firstSeparator = currentSearch.indexOf('&');
-		const hostSearch = currentSearch.startsWith('/')
-			? firstSeparator === -1
-				? ''
-				: currentSearch.substring(firstSeparator + 1)
-			: currentSearch;
-		return `${navigationWindow.location.pathname}?${route}${hostSearch ? `&${hostSearch}` : ''}`;
-	}
-
 	if (getUrlHandlingType() === 'query-string') {
 		return `${getNavigationWindow().location.pathname}?${route}`;
 	}
@@ -57,14 +41,6 @@ export const reloadUrl = () => {
 };
 
 export const getRoute = () => {
-	if (getUrlHandlingType() === 'browser-studio') {
-		const search = getNavigationWindow().location.search.substring(1);
-		const firstSeparator = search.indexOf('&');
-		const route =
-			firstSeparator === -1 ? search : search.substring(0, firstSeparator);
-		return route.startsWith('/') ? route : '';
-	}
-
 	if (getUrlHandlingType() === 'query-string') {
 		const route = getNavigationWindow().location.search.substring(1);
 		return route.startsWith('/') ? route : '';

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -62,6 +62,6 @@ test('uses query-string routing in Browser Studio', () => {
 	expect(getRoute()).toBe('');
 	replaceUrl('/assets/other.mp4');
 	expect(replaceStateCalls).toEqual([
-		[{}, 'Studio', '/experimental_new?/assets/other.mp4&source=release'],
+		[{}, 'Studio', '/experimental_new?/assets/other.mp4'],
 	]);
 });

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -36,15 +36,22 @@ test('replaces the current Studio URL', () => {
 
 test('uses query-string routing in Browser Studio', () => {
 	const replaceStateCalls: unknown[][] = [];
+	const parentWindow = {
+		history: {
+			replaceState: (...args: unknown[]) => replaceStateCalls.push(args),
+		},
+		location: {
+			pathname: '/experimental_new',
+			search: '?source=release',
+		},
+	};
 
 	Object.defineProperty(globalThis, 'window', {
 		configurable: true,
 		value: {
-			history: {
-				replaceState: (...args: unknown[]) => replaceStateCalls.push(args),
-			},
+			parent: parentWindow,
 			location: {
-				pathname: '/experimental_new',
+				pathname: 'blank',
 				search: '?source=release',
 			},
 			remotion_browserStudio: {},
@@ -55,6 +62,10 @@ test('uses query-string routing in Browser Studio', () => {
 	expect(getRoute()).toBe('');
 	replaceUrl('/assets/other.mp4');
 	expect(replaceStateCalls).toEqual([
-		[{}, 'Studio', '/experimental_new?/assets/other.mp4'],
+		[
+			{},
+			'Studio',
+			'/experimental_new?source=release&remotion-route=%2Fassets%2Fother.mp4',
+		],
 	]);
 });

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -62,10 +62,6 @@ test('uses query-string routing in Browser Studio', () => {
 	expect(getRoute()).toBe('');
 	replaceUrl('/assets/other.mp4');
 	expect(replaceStateCalls).toEqual([
-		[
-			{},
-			'Studio',
-			'/experimental_new?source=release&remotion-route=%2Fassets%2Fother.mp4',
-		],
+		[{}, 'Studio', '/experimental_new?/assets/other.mp4&source=release'],
 	]);
 });


### PR DESCRIPTION
## Summary

- write Browser Studio canvas routes to the embedding page URL using the existing `?/Composition` convention
- consume Browser Studio bootstrap query parameters when the first canvas route is selected
- synchronize Back and Forward navigation with the selected canvas content
- run Browser Studio E2E coverage without the removed iframe shell

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/url-state.test.ts`
- `bun run testbrowserstudio`

Closes #10884
