### PR TITLE
`@remotion/studio`: Fix outline update loop in read-only mode

### DIFF
--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -796,20 +796,16 @@ const ActiveSelectedOutlineOverlayUnmemoized: React.FC<
 		],
 	);
 
-	const outlineTargetsRef =
-		useRef<readonly SelectedOutlineLayoutTarget[]>(outlineTargets);
-	const getOutlineTargets = useCallback(() => outlineTargetsRef.current, []);
 	useLayoutEffect(() => {
-		outlineTargetsRef.current = outlineTargets;
 		updateOutlinesRef.current();
-	}, [outlineTargets, scale, translationX, translationY]);
+	}, [scale, translationX, translationY]);
 	return (
 		<SelectedOutlineRenderer
 			compositionHeight={compositionHeight}
 			compositionWidth={compositionWidth}
 			dragging={draggingOutline}
 			getLatestOutlineTargetByKey={getLatestOutlineTargetByKey}
-			getOutlineTargets={getOutlineTargets}
+			outlineTargets={outlineTargets}
 			onDraggingChange={onDraggingChange}
 			onContextMenuOpenChange={onContextMenuOpenChange}
 			onSelect={onSelect}

--- a/packages/studio/src/components/SelectedOutlineOverlay.tsx
+++ b/packages/studio/src/components/SelectedOutlineOverlay.tsx
@@ -946,9 +946,6 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 			],
 		);
 
-	const calculateOutlineTargetsRef = useRef(
-		calculateOutlineTargetsForCurrentState,
-	);
 	const getSelectableOutlinesRef = useRef(getSelectableOutlines);
 	const selectableOutlinesCacheRef = useRef<{
 		readonly getSelectableOutlines: typeof getSelectableOutlines;
@@ -958,9 +955,8 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 		readonly timelinePosition: number;
 	} | null>(null);
 	useLayoutEffect(() => {
-		calculateOutlineTargetsRef.current = calculateOutlineTargetsForCurrentState;
 		getSelectableOutlinesRef.current = getSelectableOutlines;
-	}, [calculateOutlineTargetsForCurrentState, getSelectableOutlines]);
+	}, [getSelectableOutlines]);
 	const getSelectableOutlinesAtFrame = useCallback(
 		(timelinePosition: number) => {
 			const currentGetSelectableOutlines = getSelectableOutlinesRef.current;
@@ -985,7 +981,7 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 	const getLatestOutlineTargetByKey = useCallback(
 		(key: string) => {
 			const timelinePosition = getCurrentFrame();
-			const target = calculateOutlineTargetsRef.current({
+			const target = calculateOutlineTargetsForCurrentState({
 				mode: 'controls',
 				runtimeValuesByStore: new Map(),
 				selectableOutlines: getSelectableOutlinesAtFrame(timelinePosition),
@@ -994,7 +990,11 @@ const SelectedOutlineOverlayUnmemoized: React.FC<
 			})[0];
 			return target as SelectedOutlineTarget | undefined;
 		},
-		[getCurrentFrame, getSelectableOutlinesAtFrame],
+		[
+			calculateOutlineTargetsForCurrentState,
+			getCurrentFrame,
+			getSelectableOutlinesAtFrame,
+		],
 	);
 	const getCurrentSelectableOutlines = useCallback(
 		() => getSelectableOutlinesAtFrame(getCurrentFrame()),

--- a/packages/studio/src/components/SelectedOutlineRenderer.tsx
+++ b/packages/studio/src/components/SelectedOutlineRenderer.tsx
@@ -47,16 +47,6 @@ const outlineContainer: React.CSSProperties = {
 	overflow: 'visible',
 };
 
-type SelectedOutlineRenderState = {
-	readonly outlines: readonly SelectedOutline[];
-	readonly targets: readonly SelectedOutlineLayoutTarget[];
-};
-
-const emptyRenderState: SelectedOutlineRenderState = {
-	outlines: [],
-	targets: [],
-};
-
 const SelectedOutlineRendererUnmemoized: React.FC<{
 	readonly compositionHeight: number;
 	readonly compositionWidth: number;
@@ -64,7 +54,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	readonly getLatestOutlineTargetByKey: (
 		key: string,
 	) => SelectedOutlineTarget | undefined;
-	readonly getOutlineTargets: () => readonly SelectedOutlineLayoutTarget[];
+	readonly outlineTargets: readonly SelectedOutlineLayoutTarget[];
 	readonly onDraggingChange: (dragging: boolean) => void;
 	readonly onContextMenuOpenChange: (open: boolean) => void;
 	readonly onSelect: (
@@ -81,7 +71,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	compositionWidth,
 	dragging,
 	getLatestOutlineTargetByKey,
-	getOutlineTargets,
+	outlineTargets,
 	onDraggingChange,
 	onContextMenuOpenChange,
 	onSelect,
@@ -89,8 +79,9 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	sequences,
 	updateOutlinesRef,
 }) => {
-	const [renderState, setRenderState] =
-		useState<SelectedOutlineRenderState>(emptyRenderState);
+	// Targets are derived props and can receive a new identity on every render.
+	// Keep only measured geometry in state to avoid layout-effect update loops.
+	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
 	const overlayRef = useRef<SVGSVGElement>(null);
 	const resizeObserverRef = useRef<ResizeObserver | null>(null);
 	const resizeObserverAnimationFrameRef = useRef<number | null>(null);
@@ -137,30 +128,24 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 		hoveredSequence?.source === 'timeline' ? hoveredNodePathKey : null;
 
 	const updateOutlines = useCallback(() => {
-		const targets = getOutlineTargets();
-		if (overlayRef.current === null || targets.length === 0) {
-			setRenderState((prevState) =>
-				prevState.targets.length === 0 ? prevState : emptyRenderState,
+		if (overlayRef.current === null || outlineTargets.length === 0) {
+			setOutlines((previousOutlines) =>
+				previousOutlines.length === 0 ? previousOutlines : [],
 			);
 			return;
 		}
 
 		const nextOutlines = measureOutlines(
 			overlayRef.current,
-			targets,
+			outlineTargets,
 			hoveredTimelineNodePathKey,
 		);
-		setRenderState((prevState) => {
-			const outlines = outlinesAreEqual(prevState.outlines, nextOutlines)
-				? prevState.outlines
-				: nextOutlines;
-			if (prevState.targets === targets && prevState.outlines === outlines) {
-				return prevState;
-			}
-
-			return {outlines, targets};
-		});
-	}, [getOutlineTargets, hoveredTimelineNodePathKey]);
+		setOutlines((previousOutlines) =>
+			outlinesAreEqual(previousOutlines, nextOutlines)
+				? previousOutlines
+				: nextOutlines,
+		);
+	}, [hoveredTimelineNodePathKey, outlineTargets]);
 
 	useLayoutEffect(() => {
 		updateOutlinesRef.current = updateOutlines;
@@ -212,7 +197,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 			nextObservedElements.add(overlayRef.current);
 		}
 
-		for (const target of renderState.targets) {
+		for (const target of outlineTargets) {
 			if (target.ref.current !== null) {
 				nextObservedElements.add(target.ref.current);
 			}
@@ -231,27 +216,27 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 		}
 
 		observedOutlineElementsRef.current = nextObservedElements;
-	}, [renderState.targets]);
+	}, [outlineTargets]);
 
 	const targetsByKey = useMemo(() => {
-		return new Map(renderState.targets.map((target) => [target.key, target]));
-	}, [renderState.targets]);
+		return new Map(outlineTargets.map((target) => [target.key, target]));
+	}, [outlineTargets]);
 	useEffect(() => {
 		if (
 			hoveredSequence?.source === 'canvas' &&
-			!renderState.targets.some((target) => target.key === hoveredSequence.key)
+			!outlineTargets.some((target) => target.key === hoveredSequence.key)
 		) {
 			setHoveredSequence((currentHover) =>
 				currentHover?.source === 'canvas' ? null : currentHover,
 			);
 		}
-	}, [hoveredSequence, renderState.targets, setHoveredSequence]);
+	}, [hoveredSequence, outlineTargets, setHoveredSequence]);
 	// Reordering a captured SVG target can cancel the active pointer session.
 	const outlineRenderingOrderRef = useRef<readonly string[]>([]);
 	const outlinesForRendering = useMemo(() => {
 		if (!dragging || outlineRenderingOrderRef.current.length === 0) {
 			const orderedOutlines = orderOutlinesForRendering({
-				outlines: renderState.outlines,
+				outlines,
 				sequences,
 				targetsByKey,
 			});
@@ -262,10 +247,10 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 		}
 
 		const currentOutlinesByKey = new Map(
-			renderState.outlines.map((outline) => [outline.key, outline]),
+			outlines.map((outline) => [outline.key, outline]),
 		);
 		const frozenKeys = new Set(outlineRenderingOrderRef.current);
-		const newOutlines = renderState.outlines.filter(
+		const newOutlines = outlines.filter(
 			(outline) => !frozenKeys.has(outline.key),
 		);
 		outlineRenderingOrderRef.current = [
@@ -276,12 +261,10 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 			const outline = currentOutlinesByKey.get(key);
 			return outline === undefined ? [] : [outline];
 		});
-	}, [dragging, renderState.outlines, sequences, targetsByKey]);
+	}, [dragging, outlines, sequences, targetsByKey]);
 	const outlinesByKey = useMemo(() => {
-		return new Map(
-			renderState.outlines.map((outline) => [outline.key, outline]),
-		);
-	}, [renderState.outlines]);
+		return new Map(outlines.map((outline) => [outline.key, outline]));
+	}, [outlines]);
 	const {
 		outlinesForEditingHandles,
 		outlinesForTransformOrigin,
@@ -320,12 +303,12 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 			outlinesForUvHandles: uvHandles,
 		};
 	}, [hoveredNodePathKey, outlinesForRendering, targetsByKey]);
-	const targetsRef = useRef(renderState.targets);
+	const targetsRef = useRef(outlineTargets);
 	const outlinesByKeyRef = useRef(outlinesByKey);
 	useLayoutEffect(() => {
-		targetsRef.current = renderState.targets;
+		targetsRef.current = outlineTargets;
 		outlinesByKeyRef.current = outlinesByKey;
-	}, [outlinesByKey, renderState.targets]);
+	}, [outlineTargets, outlinesByKey]);
 	const getAllDragTargets = useCallback(
 		() =>
 			targetsRef.current.flatMap((target) => {

--- a/packages/studio/src/components/SelectedOutlineRenderer.tsx
+++ b/packages/studio/src/components/SelectedOutlineRenderer.tsx
@@ -82,6 +82,7 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 	// Targets are derived props and can receive a new identity on every render.
 	// Keep only measured geometry in state to avoid layout-effect update loops.
 	const [outlines, setOutlines] = useState<readonly SelectedOutline[]>([]);
+	const outlinesRef = useRef<readonly SelectedOutline[]>(outlines);
 	const overlayRef = useRef<SVGSVGElement>(null);
 	const resizeObserverRef = useRef<ResizeObserver | null>(null);
 	const resizeObserverAnimationFrameRef = useRef<number | null>(null);
@@ -129,9 +130,12 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 
 	const updateOutlines = useCallback(() => {
 		if (overlayRef.current === null || outlineTargets.length === 0) {
-			setOutlines((previousOutlines) =>
-				previousOutlines.length === 0 ? previousOutlines : [],
-			);
+			if (outlinesRef.current.length === 0) {
+				return;
+			}
+
+			outlinesRef.current = [];
+			setOutlines(outlinesRef.current);
 			return;
 		}
 
@@ -140,11 +144,12 @@ const SelectedOutlineRendererUnmemoized: React.FC<{
 			outlineTargets,
 			hoveredTimelineNodePathKey,
 		);
-		setOutlines((previousOutlines) =>
-			outlinesAreEqual(previousOutlines, nextOutlines)
-				? previousOutlines
-				: nextOutlines,
-		);
+		if (outlinesAreEqual(outlinesRef.current, nextOutlines)) {
+			return;
+		}
+
+		outlinesRef.current = nextOutlines;
+		setOutlines(nextOutlines);
 	}, [hoveredTimelineNodePathKey, outlineTargets]);
 
 	useLayoutEffect(() => {


### PR DESCRIPTION
## Summary

- Fix the selected-outline update loop in read-only Studio.
- Keep derived outline targets out of measured geometry state.
- Compare measured geometry before dispatching state so unchanged outlines never enqueue a nested layout update.

Follow-up to #10903 and #10897.

## Testing

- `bun run build`
- `bun run stylecheck`
- `cd packages/studio && bun run test` (625 passing)
- `cd packages/example && bunx playwright test e2e/studio.test.mts --project=chromium --grep 'should keep selected canvas outlines visible outside the canvas'`
- Manually verified the read-only Studio Vercel preview
