### PR TITLE
`@remotion/studio-server`: Log busy ports during Studio startup

### DIFF
--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -87,16 +87,26 @@ export const startServer = async (options: {
 
 	const portConfig = RenderInternals.getPortConfig(options.forceIPv4);
 
-	const onPortUnavailable = options.forceNew
-		? undefined
-		: async (port: number): Promise<'continue' | 'stop'> => {
-				const detection = await detectRemotionServer({
-					port,
-					cwd: options.remotionRoot,
-					hostname: portConfig.hostsToTry[0],
-				});
-				return detection.type === 'match' ? 'stop' : 'continue';
-			};
+	const onPortUnavailable = async (
+		port: number,
+	): Promise<'continue' | 'stop'> => {
+		if (!options.forceNew) {
+			const detection = await detectRemotionServer({
+				port,
+				cwd: options.remotionRoot,
+				hostname: portConfig.hostsToTry[0],
+			});
+			if (detection.type === 'match') {
+				return 'stop';
+			}
+		}
+
+		RenderInternals.Log.info(
+			{indent: false, logLevel: options.logLevel},
+			RenderInternals.chalk.gray(`Port ${port} is busy, trying another.`),
+		);
+		return 'continue';
+	};
 
 	let portSelection = await RenderInternals.getDesiredPort({
 		desiredPort,


### PR DESCRIPTION
## Summary

- Log each busy port while Remotion Studio searches for an available port
- Render the retry message in gray so startup progress is visible without looking like an error
- Keep existing Studio reuse detection quiet when the running Studio matches the current project

## Testing

- `bun run build`
- `bun run stylecheck`
- Live Studio startup with ports 3000 through 3007 occupied
