### PR TITLE
Internal: Run Twoslash prewarming inside the docs build

### DIFF
--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -114,6 +114,13 @@ const docusaurusEnv = {
 		: null),
 };
 
+const twoslashEnv = lowMemoryBuild
+	? {
+			TWOSLASH_WORKER_COUNT: process.env.TWOSLASH_WORKER_COUNT ?? '2',
+			TWOSLASH_RECYCLE_LIMIT_BYTES:
+				process.env.TWOSLASH_RECYCLE_LIMIT_BYTES ?? String(1024 * 1024 * 1024),
+		}
+	: {};
 const docusaurusBuild = lowMemoryBuild
 	? {
 			command: 'node',
@@ -129,6 +136,7 @@ await run('fetch prompt submissions', 'bun', ['fetch-prompt-submissions.ts']);
 await run('prepare Browser Studio workspace', 'bun', [
 	'prepare-browser-studio-workspace.ts',
 ]);
+await run('prewarm twoslash', 'bun', ['prewarm-twoslash.ts'], twoslashEnv);
 await run(
 	'Docusaurus build',
 	docusaurusBuild.command,

--- a/packages/docs/docs/static-file-relative-paths.mdx
+++ b/packages/docs/docs/static-file-relative-paths.mdx
@@ -15,6 +15,7 @@ staticFile() does not support relative paths. Instead, pass the name of a file t
 You have tried to pass a relative path to `staticFile()`:
 
 ```tsx twoslash title="❌ Relative path"
+// Temporary Vercel Twoslash cache probe.
 import { staticFile } from "remotion";
 staticFile("../public/image.png");
 ```

--- a/packages/docs/docs/static-file-relative-paths.mdx
+++ b/packages/docs/docs/static-file-relative-paths.mdx
@@ -15,7 +15,6 @@ staticFile() does not support relative paths. Instead, pass the name of a file t
 You have tried to pass a relative path to `staticFile()`:
 
 ```tsx twoslash title="❌ Relative path"
-// Temporary Vercel Twoslash cache probe.
 import { staticFile } from "remotion";
 staticFile("../public/image.png");
 ```

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,6 @@
 		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && bun prepare-browser-studio-workspace.ts && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0",
 		"build-docs": "bun build-docs.ts",
 		"build-browser-studio": "bun prepare-browser-studio-workspace.ts && bun build-browser-studio-standalone.ts",
-		"prewarm-twoslash": "bun prewarm-twoslash.ts",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"serve": "docusaurus serve",

--- a/turbo.json
+++ b/turbo.json
@@ -103,26 +103,15 @@
 			"outputs": [],
 			"outputLogs": "new-only"
 		},
-		"prewarm-twoslash": {
-			"dependsOn": ["^make"],
-			"inputs": [
-				"$TURBO_ROOT$/bun.lock",
-				"$TURBO_ROOT$/package.json",
-				"$TURBO_ROOT$/packages/**/package.json",
-				"$TURBO_ROOT$/packages/**/*.d.ts",
-				"$TURBO_ROOT$/packages/**/*.d.mts",
-				"$TURBO_ROOT$/packages/**/*.d.cts",
-				"docs/**",
-				"blog/**",
-				"learn/**",
-				"new-docs/**",
-				"elements/**",
-				"plugins/element-source-utils.js",
-				"prewarm-twoslash.ts",
-				"twoslash-worker.mjs",
-				"package.json"
+		"build-docs": {
+			"dependsOn": [
+				"^make",
+				"make",
+				"@remotion/convert#build-spa",
+				"@remotion/brand#bundle",
+				"@remotion/example#bundle-testbed"
 			],
-			"outputs": ["node_modules/.cache/twoslash/**"],
+			"outputs": [".docusaurus", "build", "node_modules/.cache/twoslash"],
 			"env": [
 				"REMOTION_DOCS_DISABLE_TWOSLASH",
 				"REMOTION_DOCS_ENABLE_TWOSLASH"
@@ -138,22 +127,6 @@
 				"TWOSLASH_STALL_TIMEOUT_MS",
 				"TWOSLASH_WORKER_COUNT",
 				"VERCEL"
-			],
-			"outputLogs": "new-only"
-		},
-		"build-docs": {
-			"dependsOn": [
-				"^make",
-				"make",
-				"prewarm-twoslash",
-				"@remotion/convert#build-spa",
-				"@remotion/brand#bundle",
-				"@remotion/example#bundle-testbed"
-			],
-			"outputs": [".docusaurus", "build"],
-			"env": [
-				"REMOTION_DOCS_DISABLE_TWOSLASH",
-				"REMOTION_DOCS_ENABLE_TWOSLASH"
 			],
 			"outputLogs": "new-only"
 		},


### PR DESCRIPTION
## Summary

- Run Twoslash prewarming from `packages/docs/build-docs.ts` before the Docusaurus build, retaining the low-memory worker-count and recycle-limit overrides.
- Remove the dedicated `prewarm-twoslash` Turbo task and package script, and include `node_modules/.cache/twoslash` in the `build-docs` outputs again.
- Preserve the Twoslash environment passthrough on `build-docs`, the current Browser Studio/docs build steps, and the existing worker and cache-key implementation.

## Rationale

The analysis covered 5,000 Vercel deployments and phase logs from an evenly sampled 120 production deployments.

- Before #9157, deployments averaged 6.62m with a 6.57m median. The period from #9157 to #9183 stayed at 6.68m average / 6.71m median, so #9157 did not itself cause the immediate spike.
- #9183 introduced broad declaration-sensitive Twoslash invalidation. The next period averaged 9.40m with a 10.13m median.
- After #9825, deployments averaged 12.41m with a 10.76m median. In the 24 sampled post-#9825 production builds, the dedicated prewarm Turbo task hit 0 times. Nine of those 24 showed Docusaurus client compilation rising from about 1.9m to about 9.3m and total deployments near 18m. This is an observed association; an A/B Vercel preview is needed to prove the mechanism.
- #10173 helped: the post-#10173 period averaged 8.53m with an 8.32m median by reducing median prewarming from roughly 1,500 blocks / 216s to 316 blocks / 80s. This change retains its workspace-dependency-scoped cache keys and does not modify the worker or cache implementation.
- The remaining median delta versus the old baseline is roughly +60s from Twoslash partial invalidation and +35s from Docusaurus growth.

This removes the low-value dedicated Turbo cache layer while retaining granular per-snippet caching. It provides a surgical Vercel A/B candidate without attributing the deployment-time changes to the task architecture before that comparison is run.

## Vercel cache probe

A temporary comment was added to one existing Twoslash block, deployed, and then reverted:

- The changed-snippet deployment made `docs#build-docs` miss as expected, but prewarming invalidated only that snippet: 1 block completed in 4.0s with 0 errors, and 82 of 83 Turbo tasks were cached.
- The revert deployment restored the prior input state. `docs#build-docs` hit its cache, all 83 Turbo tasks were cached, Turbo completed in 38.7s, and the Vercel build completed in 55s.
- Both exact `remotion` deployments reached `READY`, and the final PR diff contains only the three intended production-build files.

This validates Vercel invalidation and restoration behavior for the new task shape, but it is not the architecture A/B needed to prove the historical performance mechanism.

## Verification

- `bunx oxfmt packages/docs/build-docs.ts packages/docs/package.json turbo.json --write`
- `bun run build`
- `bun run stylecheck`
- `bunx turbo run build-docs --filter=docs --dry=json --no-update-notifier` — confirmed `docs#build-docs` has no dedicated prewarm dependency, includes the Twoslash cache output, and retains the Twoslash environment passthrough.
