### PR TITLE
`@remotion/studio-server`: Fix Zed source files opening in new windows

### DIFF
--- a/packages/studio-server/src/helpers/open-in-editor.ts
+++ b/packages/studio-server/src/helpers/open-in-editor.ts
@@ -277,7 +277,7 @@ function getArgumentsForLineNumber(
 	const isFolder =
 		fs.existsSync(fileName) && fs.lstatSync(fileName).isDirectory();
 	if (isZedEditor) {
-		return [fileName + ':' + lineNumber + ':' + colNumber];
+		return ['--existing', fileName + ':' + lineNumber + ':' + colNumber];
 	}
 
 	switch (editorBasename) {

--- a/packages/studio-server/src/test/open-in-editor.test.ts
+++ b/packages/studio-server/src/test/open-in-editor.test.ts
@@ -1,5 +1,11 @@
-import {expect, test} from 'bun:test';
-import {findMacOsEditorsFromProcessOutput} from '../helpers/open-in-editor';
+import {expect, spyOn, test} from 'bun:test';
+import childProcess from 'node:child_process';
+import type {SpawnOptions} from 'node:child_process';
+import {EventEmitter} from 'node:events';
+import {
+	findMacOsEditorsFromProcessOutput,
+	launchEditor,
+} from '../helpers/open-in-editor';
 import {findSearchPosition} from '../preview-server/routes/find-in-file';
 
 test('detects current VS Code macOS processes', () => {
@@ -10,6 +16,44 @@ test('detects current VS Code macOS processes', () => {
 		command: 'code',
 		process: '/Applications/Visual Studio Code.app/Contents/MacOS/Code',
 	});
+});
+
+test('opens source locations in an existing Zed window', async () => {
+	const calls: {
+		command: string;
+		args: readonly string[];
+		options: SpawnOptions;
+	}[] = [];
+	const spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(((
+		command: string,
+		args: readonly string[],
+		options: SpawnOptions,
+	) => {
+		calls.push({command, args, options});
+		return new EventEmitter() as ReturnType<typeof childProcess.spawn>;
+	}) as typeof childProcess.spawn);
+	const sourceFile = __filename;
+
+	try {
+		await launchEditor({
+			colNumber: 4,
+			editor: {command: 'zed', process: 'zed'},
+			fileName: sourceFile,
+			lineNumber: 12,
+			logLevel: 'error',
+			vsCodeNewWindow: false,
+		});
+
+		expect(calls).toEqual([
+			{
+				args: ['--existing', `${sourceFile}:12:4`],
+				command: 'zed',
+				options: {stdio: 'inherit'},
+			},
+		]);
+	} finally {
+		spawnSpy.mockRestore();
+	}
 });
 
 test('finds a property after the component location', () => {

--- a/packages/studio-server/src/test/open-in-editor.test.ts
+++ b/packages/studio-server/src/test/open-in-editor.test.ts
@@ -44,13 +44,23 @@ test('opens source locations in an existing Zed window', async () => {
 			vsCodeNewWindow: false,
 		});
 
-		expect(calls).toEqual([
-			{
-				args: ['--existing', `${sourceFile}:12:4`],
-				command: 'zed',
-				options: {stdio: 'inherit'},
-			},
-		]);
+		expect(calls).toEqual(
+			process.platform === 'win32'
+				? [
+						{
+							args: ['/C', 'zed', '--existing', `${sourceFile}:12:4`],
+							command: 'cmd.exe',
+							options: {detached: true, stdio: 'inherit'},
+						},
+					]
+				: [
+						{
+							args: ['--existing', `${sourceFile}:12:4`],
+							command: 'zed',
+							options: {stdio: 'inherit'},
+						},
+					],
+		);
 	} finally {
 		spawnSpy.mockRestore();
 	}


### PR DESCRIPTION
## Summary

- pass Zed's `--existing` flag when Studio opens a source location
- keep source locations in the active Zed workspace regardless of the user's default CLI open behavior
- cover the spawned Zed CLI arguments

## Test plan

- `bun test packages/studio-server/src/test/open-in-editor.test.ts`
- `bun run build`
- `bun run stylecheck`
- manually compared Zed launches without a flag, with `--add`, and with `--existing`

Closes #9744
