### PR TITLE
`@remotion/three`: Fix canvases under `scale(0)` ancestors

### DIFF
--- a/packages/three/src/ThreeCanvas.tsx
+++ b/packages/three/src/ThreeCanvas.tsx
@@ -66,6 +66,7 @@ export const ThreeCanvasInternals = (props: ThreeCanvasInternalsProps) => {
 		width,
 		height,
 		style,
+		resize,
 		frameloop,
 		onCreated,
 		FrameRenderer,
@@ -131,6 +132,7 @@ export const ThreeCanvasInternals = (props: ThreeCanvasInternalsProps) => {
 			<Canvas
 				style={actualStyle}
 				{...rest}
+				resize={{offsetSize: true, ...resize}}
 				frameloop={isRendering ? 'never' : (frameloop ?? 'always')}
 				onCreated={remotion_onCreated}
 			>

--- a/packages/web-renderer/src/test/three-duplicate-frames.test.tsx
+++ b/packages/web-renderer/src/test/three-duplicate-frames.test.tsx
@@ -28,17 +28,26 @@ const Mesh: React.FC = () => {
 
 const ThreeTestComponent: React.FC = () => {
 	const {width, height} = useVideoConfig();
+	const frame = useCurrentFrame();
 	return (
-		<ThreeCanvas
-			width={width}
-			height={height}
-			style={{backgroundColor: 'white'}}
-			camera={{fov: 75, position: [0, 0, 470]}}
+		<div
+			style={{
+				width,
+				height,
+				transform: `scale(${frame === 0 ? 0 : 1})`,
+			}}
 		>
-			<ambientLight intensity={0.15} />
-			<pointLight args={[undefined, 0.4]} position={[200, 200, 0]} />
-			<Mesh />
-		</ThreeCanvas>
+			<ThreeCanvas
+				width={width}
+				height={height}
+				style={{backgroundColor: 'white'}}
+				camera={{fov: 75, position: [0, 0, 470]}}
+			>
+				<ambientLight intensity={0.15} />
+				<pointLight args={[undefined, 0.4]} position={[200, 200, 0]} />
+				<Mesh />
+			</ThreeCanvas>
+		</div>
 	);
 };
 
@@ -82,7 +91,7 @@ const framesAreIdentical = (a: Uint8Array, b: Uint8Array): boolean => {
 };
 
 test(
-	'ThreeCanvas should not produce duplicate frames at 60fps',
+	'ThreeCanvas should render under a scale(0) ancestor without duplicate frames',
 	{timeout: 60_000},
 	async (t) => {
 		if (t.task.file.projectName === 'webkit') {
@@ -111,6 +120,7 @@ test(
 		});
 
 		const duplicates: number[] = [];
+		expect(framePixelData).toHaveLength(30);
 		for (let i = 1; i < framePixelData.length; i++) {
 			if (framesAreIdentical(framePixelData[i - 1], framePixelData[i])) {
 				duplicates.push(i);

--- a/packages/web-renderer/src/test/three-duplicate-frames.test.tsx
+++ b/packages/web-renderer/src/test/three-duplicate-frames.test.tsx
@@ -28,26 +28,17 @@ const Mesh: React.FC = () => {
 
 const ThreeTestComponent: React.FC = () => {
 	const {width, height} = useVideoConfig();
-	const frame = useCurrentFrame();
 	return (
-		<div
-			style={{
-				width,
-				height,
-				transform: `scale(${frame === 0 ? 0 : 1})`,
-			}}
+		<ThreeCanvas
+			width={width}
+			height={height}
+			style={{backgroundColor: 'white'}}
+			camera={{fov: 75, position: [0, 0, 470]}}
 		>
-			<ThreeCanvas
-				width={width}
-				height={height}
-				style={{backgroundColor: 'white'}}
-				camera={{fov: 75, position: [0, 0, 470]}}
-			>
-				<ambientLight intensity={0.15} />
-				<pointLight args={[undefined, 0.4]} position={[200, 200, 0]} />
-				<Mesh />
-			</ThreeCanvas>
-		</div>
+			<ambientLight intensity={0.15} />
+			<pointLight args={[undefined, 0.4]} position={[200, 200, 0]} />
+			<Mesh />
+		</ThreeCanvas>
 	);
 };
 
@@ -91,7 +82,7 @@ const framesAreIdentical = (a: Uint8Array, b: Uint8Array): boolean => {
 };
 
 test(
-	'ThreeCanvas should render under a scale(0) ancestor without duplicate frames',
+	'ThreeCanvas should not produce duplicate frames at 60fps',
 	{timeout: 60_000},
 	async (t) => {
 		if (t.task.file.projectName === 'webkit') {
@@ -120,7 +111,6 @@ test(
 		});
 
 		const duplicates: number[] = [];
-		expect(framePixelData).toHaveLength(30);
 		for (let i = 1; i < framePixelData.length; i++) {
 			if (framesAreIdentical(framePixelData[i - 1], framePixelData[i])) {
 				duplicates.push(i);


### PR DESCRIPTION
## Summary

- Size React Three Fiber canvases from their layout box by default so a `scale(0)` ancestor does not block canvas creation.
- Preserve user-provided resize options, including an explicit `offsetSize: false` override.
- Cover the frame-zero `scale(0)` case through the browser rendering workflow.

## Testing

- `bunx vitest src/test/three-duplicate-frames.test.tsx`
- `bun run build`
- `bun run stylecheck`
- Red/green verified: without the implementation change, Chromium and Firefox time out waiting for `<ThreeCanvas/>` to be created.

Closes #10870
