### PR TITLE
`@remotion/studio`: Add translation while rotating

### DIFF
--- a/packages/example/e2e/rotation-keyframes.test.mts
+++ b/packages/example/e2e/rotation-keyframes.test.mts
@@ -31,6 +31,11 @@ const readRotationKeyframes = () => {
 	};
 };
 
+const readTranslate = () => {
+	const source = fs.readFileSync(rotationKeyframeFile, 'utf-8');
+	return /translate:\s*(['"])(.*?)\1/.exec(source)?.[2] ?? null;
+};
+
 test.describe('canvas rotation keyframes', () => {
 	let sourceBefore: string;
 
@@ -44,7 +49,9 @@ test.describe('canvas rotation keyframes', () => {
 		fs.writeFileSync(rotationKeyframeFile, sourceBefore);
 	});
 
-	test('inserts and replaces keyframes in keyframed mode', async ({page}) => {
+	test('edits rotation keyframes and temporarily translates', async ({
+		page,
+	}) => {
 		await page.goto(`${STUDIO_URL}/rotation-keyframe-e2e`);
 		await expect(page).toHaveURL(/rotation-keyframe-e2e/, {timeout: 15_000});
 		await page.waitForFunction(
@@ -73,8 +80,8 @@ test.describe('canvas rotation keyframes', () => {
 		await currentFrameInput.fill('10');
 		await currentFrameInput.press('Enter');
 
-		const dragRotationSurface = async (deltaX: number, deltaY: number) => {
-			const point = await rotationSurface.evaluate((surface) => {
+		const getRotationSurfacePoint = () => {
+			return rotationSurface.evaluate((surface) => {
 				const box = surface.getBoundingClientRect();
 				for (let yIndex = 1; yIndex < 10; yIndex++) {
 					for (let xIndex = 1; xIndex < 10; xIndex++) {
@@ -94,6 +101,9 @@ test.describe('canvas rotation keyframes', () => {
 
 				throw new Error('Rotation surface should have an interactive point');
 			});
+		};
+		const dragRotationSurface = async (deltaX: number, deltaY: number) => {
+			const point = await getRotationSurfacePoint();
 			await page.mouse.move(point.x, point.y);
 			await page.mouse.down();
 			await page.mouse.move(point.x + deltaX, point.y + deltaY, {steps: 5});
@@ -112,5 +122,79 @@ test.describe('canvas rotation keyframes', () => {
 			.poll(() => readRotationKeyframes().values[1])
 			.not.toBe(firstValueAtFrame10);
 		expect(readRotationKeyframes().frames).toEqual([0, 10, 30]);
+
+		const rotationBeforeTranslation = readRotationKeyframes();
+		const translateBefore = readTranslate();
+		expect(translateBefore).toBeNull();
+		const point = await getRotationSurfacePoint();
+		const snapDelta = await rotationSurface.evaluate((surface) => {
+			const surfaceBox = surface.getBoundingClientRect();
+			const canvasBox = surface.ownerSVGElement?.getBoundingClientRect();
+			if (canvasBox === undefined) {
+				throw new Error('Rotation surface should be inside the canvas overlay');
+			}
+
+			return {
+				x:
+					canvasBox.x +
+					canvasBox.width / 2 -
+					(surfaceBox.x + surfaceBox.width / 2) +
+					2,
+				y:
+					canvasBox.y +
+					canvasBox.height / 2 -
+					(surfaceBox.y + surfaceBox.height / 2) +
+					2,
+			};
+		});
+		const commandKey = await page.evaluate(() =>
+			navigator.platform.startsWith('Mac') ? 'Meta' : 'Control',
+		);
+		await page.mouse.move(point.x, point.y);
+		const rotationCursor = await rotationSurface.getAttribute('cursor');
+		expect(rotationCursor).not.toBe('default');
+		await page.keyboard.down(commandKey);
+		await expect(rotationSurface).toHaveAttribute('cursor', 'default');
+		await page.keyboard.up(commandKey);
+		await expect(rotationSurface).toHaveAttribute('cursor', rotationCursor!);
+
+		await page.keyboard.down(commandKey);
+		await expect(rotationSurface).toHaveAttribute('pointer-events', 'none');
+		await page.mouse.down();
+		await page.mouse.move(point.x + snapDelta.x, point.y + snapDelta.y, {
+			steps: 5,
+		});
+		await expect
+			.poll(() =>
+				rotationSurface.evaluate((surface) => {
+					const surfaceBox = surface.getBoundingClientRect();
+					const canvasBox = surface.ownerSVGElement?.getBoundingClientRect();
+					if (canvasBox === undefined) {
+						throw new Error(
+							'Rotation surface should be inside the canvas overlay',
+						);
+					}
+
+					return Math.max(
+						Math.abs(
+							canvasBox.x +
+								canvasBox.width / 2 -
+								(surfaceBox.x + surfaceBox.width / 2),
+						),
+						Math.abs(
+							canvasBox.y +
+								canvasBox.height / 2 -
+								(surfaceBox.y + surfaceBox.height / 2),
+						),
+					);
+				}),
+			)
+			.toBeLessThan(0.5);
+		await page.mouse.up();
+		await page.keyboard.up(commandKey);
+
+		await expect.poll(readTranslate).not.toBeNull();
+		expect(readTranslate()).not.toBe(translateBefore);
+		expect(readRotationKeyframes()).toEqual(rotationBeforeTranslation);
 	});
 });

--- a/packages/example/e2e/rotation-keyframes.test.mts
+++ b/packages/example/e2e/rotation-keyframes.test.mts
@@ -31,11 +31,6 @@ const readRotationKeyframes = () => {
 	};
 };
 
-const readTranslate = () => {
-	const source = fs.readFileSync(rotationKeyframeFile, 'utf-8');
-	return /translate:\s*(['"])(.*?)\1/.exec(source)?.[2] ?? null;
-};
-
 test.describe('canvas rotation keyframes', () => {
 	let sourceBefore: string;
 
@@ -49,9 +44,7 @@ test.describe('canvas rotation keyframes', () => {
 		fs.writeFileSync(rotationKeyframeFile, sourceBefore);
 	});
 
-	test('edits rotation keyframes and temporarily translates', async ({
-		page,
-	}) => {
+	test('inserts and replaces keyframes in keyframed mode', async ({page}) => {
 		await page.goto(`${STUDIO_URL}/rotation-keyframe-e2e`);
 		await expect(page).toHaveURL(/rotation-keyframe-e2e/, {timeout: 15_000});
 		await page.waitForFunction(
@@ -80,8 +73,8 @@ test.describe('canvas rotation keyframes', () => {
 		await currentFrameInput.fill('10');
 		await currentFrameInput.press('Enter');
 
-		const getRotationSurfacePoint = () => {
-			return rotationSurface.evaluate((surface) => {
+		const dragRotationSurface = async (deltaX: number, deltaY: number) => {
+			const point = await rotationSurface.evaluate((surface) => {
 				const box = surface.getBoundingClientRect();
 				for (let yIndex = 1; yIndex < 10; yIndex++) {
 					for (let xIndex = 1; xIndex < 10; xIndex++) {
@@ -101,9 +94,6 @@ test.describe('canvas rotation keyframes', () => {
 
 				throw new Error('Rotation surface should have an interactive point');
 			});
-		};
-		const dragRotationSurface = async (deltaX: number, deltaY: number) => {
-			const point = await getRotationSurfacePoint();
 			await page.mouse.move(point.x, point.y);
 			await page.mouse.down();
 			await page.mouse.move(point.x + deltaX, point.y + deltaY, {steps: 5});
@@ -122,79 +112,5 @@ test.describe('canvas rotation keyframes', () => {
 			.poll(() => readRotationKeyframes().values[1])
 			.not.toBe(firstValueAtFrame10);
 		expect(readRotationKeyframes().frames).toEqual([0, 10, 30]);
-
-		const rotationBeforeTranslation = readRotationKeyframes();
-		const translateBefore = readTranslate();
-		expect(translateBefore).toBeNull();
-		const point = await getRotationSurfacePoint();
-		const snapDelta = await rotationSurface.evaluate((surface) => {
-			const surfaceBox = surface.getBoundingClientRect();
-			const canvasBox = surface.ownerSVGElement?.getBoundingClientRect();
-			if (canvasBox === undefined) {
-				throw new Error('Rotation surface should be inside the canvas overlay');
-			}
-
-			return {
-				x:
-					canvasBox.x +
-					canvasBox.width / 2 -
-					(surfaceBox.x + surfaceBox.width / 2) +
-					2,
-				y:
-					canvasBox.y +
-					canvasBox.height / 2 -
-					(surfaceBox.y + surfaceBox.height / 2) +
-					2,
-			};
-		});
-		const commandKey = await page.evaluate(() =>
-			navigator.platform.startsWith('Mac') ? 'Meta' : 'Control',
-		);
-		await page.mouse.move(point.x, point.y);
-		const rotationCursor = await rotationSurface.getAttribute('cursor');
-		expect(rotationCursor).not.toBe('default');
-		await page.keyboard.down(commandKey);
-		await expect(rotationSurface).toHaveAttribute('cursor', 'default');
-		await page.keyboard.up(commandKey);
-		await expect(rotationSurface).toHaveAttribute('cursor', rotationCursor!);
-
-		await page.keyboard.down(commandKey);
-		await expect(rotationSurface).toHaveAttribute('pointer-events', 'none');
-		await page.mouse.down();
-		await page.mouse.move(point.x + snapDelta.x, point.y + snapDelta.y, {
-			steps: 5,
-		});
-		await expect
-			.poll(() =>
-				rotationSurface.evaluate((surface) => {
-					const surfaceBox = surface.getBoundingClientRect();
-					const canvasBox = surface.ownerSVGElement?.getBoundingClientRect();
-					if (canvasBox === undefined) {
-						throw new Error(
-							'Rotation surface should be inside the canvas overlay',
-						);
-					}
-
-					return Math.max(
-						Math.abs(
-							canvasBox.x +
-								canvasBox.width / 2 -
-								(surfaceBox.x + surfaceBox.width / 2),
-						),
-						Math.abs(
-							canvasBox.y +
-								canvasBox.height / 2 -
-								(surfaceBox.y + surfaceBox.height / 2),
-						),
-					);
-				}),
-			)
-			.toBeLessThan(0.5);
-		await page.mouse.up();
-		await page.keyboard.up(commandKey);
-
-		await expect.poll(readTranslate).not.toBeNull();
-		expect(readTranslate()).not.toBe(translateBefore);
-		expect(readRotationKeyframes()).toEqual(rotationBeforeTranslation);
 	});
 });

--- a/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
+++ b/packages/studio/src/components/SelectedOutlineCanvasRotation.tsx
@@ -1,6 +1,7 @@
 import React, {useContext} from 'react';
 import {Internals} from 'remotion';
 import {TRANSPARENT} from '../helpers/colors';
+import {isMac} from '../helpers/is-mac';
 import {startCapturedPointerSession} from '../helpers/pointer-session';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {canvasRotationCursor} from './canvas-rotation-cursor';
@@ -63,9 +64,39 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 		Internals.VisualModeSettersContext,
 	);
 	const {editorSnapping} = useContext(EditorSnappingContext);
+	const [commandKeyPressed, setCommandKeyPressed] = React.useState(false);
 	const cursor = transform3DMode
 		? canvasRotationCursor
 		: canvas2DRotationCursor;
+
+	React.useEffect(() => {
+		const commandKey = isMac ? 'Meta' : 'Control';
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === commandKey) {
+				setCommandKeyPressed(true);
+			}
+		};
+
+		const onKeyUp = (event: KeyboardEvent) => {
+			if (event.key === commandKey) {
+				setCommandKeyPressed(false);
+			}
+		};
+
+		const onBlur = () => {
+			setCommandKeyPressed(false);
+		};
+
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
+		window.addEventListener('blur', onBlur);
+
+		return () => {
+			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keyup', onKeyUp);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, []);
 
 	const onPointerDown = React.useCallback(
 		(event: React.PointerEvent<SVGPathElement>) => {
@@ -291,8 +322,8 @@ export const SelectedOutlineCanvasRotation: React.FC<{
 		<polygon
 			points={outline.points.map((point) => `${point.x},${point.y}`).join(' ')}
 			fill={TRANSPARENT}
-			pointerEvents="all"
-			cursor={cursor}
+			pointerEvents={commandKeyPressed ? 'none' : 'all'}
+			cursor={commandKeyPressed ? 'default' : cursor}
 			onPointerDown={onPointerDown}
 			data-remotion-studio-canvas-rotation
 		/>

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -478,6 +478,10 @@ const SelectedOutlineElementUnmemoized: React.FC<
 				onDoubleClickTarget={onDoubleClickTarget}
 				scale={scale}
 				showSelectedOutline={layoutTarget?.showSelectedOutline ?? false}
+				translateWithCommandKey={
+					layoutTarget?.selectedForRotation === true &&
+					Boolean(controlTarget?.rotationDrag)
+				}
 			/>
 			{layoutTarget?.selectedForRotation && controlTarget?.rotationDrag ? (
 				<SelectedOutlineCanvasRotation

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -8,6 +8,7 @@ import {
 } from '../helpers/colors';
 import {createDragAwareDoubleClickTracker} from '../helpers/drag-aware-double-click';
 import {isStudioInteractivityEnabled} from '../helpers/interactivity-enabled';
+import {isMac} from '../helpers/is-mac';
 import {
 	startCapturedPointerSession,
 	type PointerSessionEndReason,
@@ -93,6 +94,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	) => boolean;
 	readonly scale: number;
 	readonly showSelectedOutline: boolean;
+	readonly translateWithCommandKey: boolean;
 }> = ({
 	compositionHeight,
 	compositionWidth,
@@ -113,6 +115,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	onDoubleClickTarget,
 	scale,
 	showSelectedOutline,
+	translateWithCommandKey,
 }) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const dragAwareDoubleClick = useMemo(
@@ -168,7 +171,13 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			event.preventDefault();
 			event.stopPropagation();
 
-			const interaction = getOutlineSelectionInteraction(event);
+			const temporaryTranslate =
+				translateWithCommandKey &&
+				(selected || containsSelection) &&
+				(isMac ? event.metaKey : event.ctrlKey);
+			const interaction = temporaryTranslate
+				? {shiftKey: false, toggleKey: false}
+				: getOutlineSelectionInteraction(event);
 			const shouldUpdateSelection =
 				!selected || interaction.shiftKey || interaction.toggleKey;
 			const ownerSvg = polygonRef.current?.ownerSVGElement;
@@ -252,7 +261,8 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			let currentPointerY = startPointerY;
 			let axisLocked = false;
 			let dragStarted = false;
-			let snappingDisabled = event.metaKey || event.ctrlKey;
+			let snappingDisabled =
+				!temporaryTranslate && (event.metaKey || event.ctrlKey);
 			let snapTargets: ReturnType<typeof getSelectedOutlineSnapTargets> | null =
 				null;
 
@@ -357,7 +367,8 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 				currentPointerX = moveEvent.clientX;
 				currentPointerY = moveEvent.clientY;
 				axisLocked = moveEvent.shiftKey;
-				snappingDisabled = moveEvent.metaKey || moveEvent.ctrlKey;
+				snappingDisabled =
+					!temporaryTranslate && (moveEvent.metaKey || moveEvent.ctrlKey);
 				updateDragOverrides();
 			};
 
@@ -476,6 +487,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			scale,
 			setPropStatuses,
 			setDragOverrides,
+			translateWithCommandKey,
 		],
 	);
 


### PR DESCRIPTION
## Summary

- translate selected elements by holding Command on macOS or Control on other platforms while in rotation mode
- update the cursor immediately when the modifier is pressed or released
- keep Studio snapping active during temporary translation

## Testing

- `bun run build`
- focused Studio formatting and ESLint checks
- `bun test src` in `packages/studio`

Closes #10919
