### PR TITLE
`@remotion/studio`: Redesign error overlay actions and stack frames

### DIFF
--- a/packages/example/e2e/error-overlay.test.mts
+++ b/packages/example/e2e/error-overlay.test.mts
@@ -44,13 +44,17 @@ test.describe('error overlay dismissal', () => {
 
 		const errorMessage = page.getByText('"radius" must be a finite number');
 		const openInEditorRequests: unknown[] = [];
+		const openInCodingAgentRequests: unknown[] = [];
 		await page.route('**/api/default-editor-info', async (route) => {
 			await route.fulfill({
 				json: {
 					success: true,
 					data: {
-						defaultEditor: null,
-						installedEditors: [{id: 'zed', name: 'Zed', nameWithType: 'Zed'}],
+						defaultEditor: 'zed',
+						installedEditors: [
+							{id: 'zed', name: 'Zed', nameWithType: 'Zed'},
+							{id: 'vscode', name: 'Code', nameWithType: 'VS Code'},
+						],
 					},
 				},
 			});
@@ -60,11 +64,25 @@ test.describe('error overlay dismissal', () => {
 				json: {
 					success: true,
 					data: {
-						defaultCodingAgent: null,
-						installedCodingAgents: [],
+						defaultCodingAgent: 'codex',
+						installedCodingAgents: [
+							{id: 'codex', name: 'Codex', nameWithType: 'Codex'},
+							{
+								id: 'claude-code',
+								name: 'Claude',
+								nameWithType: 'Claude Code',
+							},
+						],
+						installedGitClients: [],
 						installedTerminals: [],
 					},
 				},
+			});
+		});
+		await page.route('**/api/open-in-coding-agent', async (route) => {
+			openInCodingAgentRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {success: true, data: {success: true}},
 			});
 		});
 		await page.route('**/api/open-in-editor', async (route) => {
@@ -99,6 +117,9 @@ test.describe('error overlay dismissal', () => {
 		await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
 			origin: STUDIO_URL,
 		});
+		await page.addInitScript(() => {
+			Object.defineProperty(window.navigator, 'platform', {value: 'Win32'});
+		});
 		await page.goto(`${STUDIO_URL}/error-overlay-unsymbolicated-e2e`);
 		await expect(page.getByText('Expected defaults').first()).toBeVisible({
 			timeout: 15_000,
@@ -106,15 +127,106 @@ test.describe('error overlay dismissal', () => {
 		await expect(
 			page.getByText('Could not symbolicate the stack trace: Failed to fetch'),
 		).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Copy stack'})).toBeVisible();
 		await expect(
-			page.getByRole('button', {name: 'Copy Stacktrace'}),
+			page.getByRole('button', {
+				name: 'Search Issues Ctrl+G',
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByRole('button', {name: /Search GitHub Issues/}),
+			page.getByRole('button', {
+				name: 'Ask on Discord Ctrl+D',
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByRole('button', {name: /Ask on Discord/}),
+			page.getByRole('button', {name: 'Fix with Codex', exact: true}),
 		).toBeVisible();
+		await expect(
+			page.getByRole('button', {
+				name: 'Fix with another coding agent',
+			}),
+		).toBeVisible();
+		for (const buttonName of [
+			'Copy stack',
+			'Search Issues Ctrl+G',
+			'Ask on Discord Ctrl+D',
+			'Fix with Codex',
+		]) {
+			const button = page.getByRole('button', {name: buttonName});
+			await expect(button).toHaveCSS('border-style', 'none');
+			await expect(button).toHaveCSS('cursor', 'default');
+		}
+		await expect(
+			page.getByRole('button', {name: 'Retry', exact: true}),
+		).toHaveCount(0);
+		const errorMessageBounds = await page
+			.getByText('Expected defaults', {exact: true})
+			.first()
+			.boundingBox();
+		const fixWithAgentButton = page.getByRole('button', {
+			name: 'Fix with Codex',
+			exact: true,
+		});
+		const fixWithAgentButtonBounds = await fixWithAgentButton.boundingBox();
+		const copyButton = page.getByRole('button', {name: 'Copy stack'});
+		const copyButtonBounds = await copyButton.boundingBox();
+		const fixWithAgentIconLeft = await fixWithAgentButton
+			.locator('img')
+			.evaluate((element) => element.getBoundingClientRect().left);
+		const actionTypography = await Promise.all(
+			[fixWithAgentButton, copyButton].map((button) =>
+				button.evaluate((element) => {
+					const style = window.getComputedStyle(element);
+					return {fontFamily: style.fontFamily, fontSize: style.fontSize};
+				}),
+			),
+		);
+		if (!errorMessageBounds || !fixWithAgentButtonBounds || !copyButtonBounds) {
+			throw new Error(
+				'Expected the error message and action row to be visible',
+			);
+		}
+
+		expect(actionTypography[0]).toEqual(actionTypography[1]);
+		expect(
+			Math.abs(fixWithAgentButtonBounds.y - copyButtonBounds.y),
+		).toBeLessThan(1);
+		expect(
+			Math.abs(fixWithAgentButtonBounds.height - copyButtonBounds.height),
+		).toBeLessThan(1);
+		expect(Math.abs(fixWithAgentIconLeft - errorMessageBounds.x)).toBeLessThan(
+			1,
+		);
+		expect(
+			fixWithAgentButtonBounds.y -
+				(errorMessageBounds.y + errorMessageBounds.height),
+		).toBeLessThan(16);
+		await page
+			.getByRole('button', {name: 'Fix with Codex', exact: true})
+			.click();
+		await expect
+			.poll(() => openInCodingAgentRequests)
+			.toEqual([
+				expect.objectContaining({
+					codingAgentId: 'codex',
+					prompt: expect.stringMatching(
+						/TypeError: Expected defaults[\s\S]*webpack-internal:\/\/\/cannot-symbolicate\.js/,
+					),
+				}),
+			]);
+
+		const macPage = await context.newPage();
+		await macPage.addInitScript(() => {
+			Object.defineProperty(window.navigator, 'platform', {value: 'MacIntel'});
+		});
+		await macPage.goto(`${STUDIO_URL}/error-overlay-unsymbolicated-e2e`);
+		await expect(
+			macPage.getByRole('button', {name: 'Search Issues ⌘G'}),
+		).toBeVisible();
+		await expect(
+			macPage.getByRole('button', {name: 'Ask on Discord ⌘D'}),
+		).toBeVisible();
+		await macPage.close();
 
 		const rawStack = page.getByLabel('Unsymbolicated stack trace');
 		await expect(rawStack).toContainText(
@@ -135,7 +247,7 @@ test.describe('error overlay dismissal', () => {
 			),
 		).toBe(true);
 
-		await page.getByRole('button', {name: 'Copy Stacktrace'}).click();
+		await page.getByRole('button', {name: 'Copy stack'}).click();
 		await expect(page.getByRole('button', {name: 'Copied!'})).toBeVisible();
 		expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
 			'webpack-internal:///cannot-symbolicate.js',
@@ -150,10 +262,72 @@ test.describe('error overlay dismissal', () => {
 		// 1. Introduce the bug: remove the `radius: 24` argument.
 		await writeAndWaitForRebuild(buggyContent, 'introducing the bug');
 		await expect(errorMessage).toBeVisible({timeout: 15_000});
-		await page.getByRole('button', {name: 'Open in Zed', exact: true}).click();
+		await expect(
+			page.getByText('ErrorOverlayRepro', {exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByText('react_stack_bottom_frame', {exact: true}),
+		).toHaveCount(0);
+		await page.getByRole('button', {name: 'Copy stack'}).click();
+		const copiedSymbolicatedStack = await page.evaluate(() =>
+			navigator.clipboard.readText(),
+		);
+		expect(copiedSymbolicatedStack).toContain('ErrorOverlayRepro');
+		expect(copiedSymbolicatedStack).not.toContain('react_stack_bottom_frame');
+		const openInEditorButtonBounds = await page
+			.locator('#error-overlay-open-in-editor')
+			.boundingBox();
+		const symbolicatedFixButtonBounds = await page
+			.getByRole('button', {name: 'Fix with Codex', exact: true})
+			.boundingBox();
+		const symbolicatedCopyButtonBounds = await page
+			.getByRole('button', {name: 'Copy stack'})
+			.boundingBox();
+		if (
+			!openInEditorButtonBounds ||
+			!symbolicatedFixButtonBounds ||
+			!symbolicatedCopyButtonBounds
+		) {
+			throw new Error('Expected the symbolicated error actions to be visible');
+		}
+
+		expect(
+			Math.abs(openInEditorButtonBounds.y - symbolicatedFixButtonBounds.y),
+		).toBeLessThan(1);
+		expect(
+			Math.abs(openInEditorButtonBounds.y - symbolicatedCopyButtonBounds.y),
+		).toBeLessThan(1);
+		await page.locator('#error-overlay-open-in-editor').click();
 		await expect
 			.poll(() => openInEditorRequests)
 			.toEqual([expect.objectContaining({editorId: 'zed'})]);
+		const openInAnotherApp = page.locator('#error-overlay-open-in-another-app');
+		await openInAnotherApp.click();
+		await expect(
+			page.getByRole('button', {name: 'VS Code', exact: true}),
+		).toBeVisible();
+		await expect(
+			page.getByRole('button', {
+				name: 'Configure default apps...',
+				exact: true,
+			}),
+		).toBeVisible();
+		await page.getByRole('button', {name: 'VS Code', exact: true}).click();
+		await expect
+			.poll(() => openInEditorRequests)
+			.toEqual([
+				expect.objectContaining({editorId: 'zed'}),
+				expect.objectContaining({editorId: 'vscode'}),
+			]);
+		await openInAnotherApp.click();
+		await page
+			.getByRole('button', {
+				name: 'Configure default apps...',
+				exact: true,
+			})
+			.click();
+		await expect(page.getByText('Default editor', {exact: true})).toBeVisible();
+		await page.keyboard.press('Escape');
 
 		// 2. Fix the bug: restore the `radius: 24` argument. The error UI should
 		//    dismiss once HMR applies the fix.

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3162,7 +3162,7 @@ test.describe('visual mode', () => {
 			await timelineGridline.click({button: 'right'});
 			await page.getByRole('button', {name: 'Open in...', exact: true}).click();
 			await page
-				.getByRole('button', {name: 'Change default apps...', exact: true})
+				.getByRole('button', {name: 'Configure default apps...', exact: true})
 				.click();
 
 			const settings = page.getByRole('dialog');
@@ -3384,16 +3384,16 @@ test.describe('visual mode', () => {
 		const openInAnotherApp = page
 			.getByTitle(exampleDir)
 			.getByRole('button', {name: 'Open in another app'});
-		const changeDefaultApps = page.getByRole('button', {
-			name: 'Change default apps...',
+		const configureDefaultApps = page.getByRole('button', {
+			name: 'Configure default apps...',
 		});
 
 		await openInAnotherApp.click();
-		await expect(changeDefaultApps).toBeVisible();
+		await expect(configureDefaultApps).toBeVisible();
 		// The menu overlay intercepts pointerleave; clicking it closes the menu
 		// through the same outside-click path a user would take.
 		await page.mouse.click(10, 100);
-		await expect(changeDefaultApps).toBeHidden();
+		await expect(configureDefaultApps).toBeHidden();
 		await expect(openInAnotherApp).toHaveCSS(
 			'background-color',
 			'rgba(0, 0, 0, 0)',

--- a/packages/studio/src/components/AppLaunchButton.tsx
+++ b/packages/studio/src/components/AppLaunchButton.tsx
@@ -1,0 +1,129 @@
+import React, {useMemo} from 'react';
+import {LIGHT_TEXT} from '../helpers/colors';
+import {CaretDown} from '../icons/caret';
+import {getConfigureDefaultAppsMenuItems} from './get-open-in-menu-items';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
+
+const compactMainSegmentStyle: React.CSSProperties = {
+	fontFamily: 'inherit',
+	gap: 6,
+	padding: '0 9px',
+};
+
+const defaultMainSegmentStyle: React.CSSProperties = {
+	...compactMainSegmentStyle,
+	fontSize: 14,
+	lineHeight: '21px',
+};
+
+const dropdownSegmentStyle: React.CSSProperties = {
+	fontFamily: 'inherit',
+	padding: 0,
+	width: 20,
+};
+
+const dropdownIconStyle: React.CSSProperties = {
+	display: 'flex',
+	transform: 'translateY(-1px)',
+};
+
+export const AppLaunchButton: React.FC<{
+	readonly actionButtonId: string | null;
+	readonly ariaLabel: string;
+	readonly children: React.ReactNode;
+	readonly disabled: boolean;
+	readonly menuAriaLabel: string;
+	readonly menuButtonId: string | null;
+	readonly menuItems: ComboboxValue[];
+	readonly onConfigureApps: (() => void) | null;
+	readonly onClick: React.MouseEventHandler<HTMLButtonElement>;
+	readonly size: 'compact' | 'default';
+	readonly style: React.CSSProperties | null;
+	readonly title: string;
+}> = ({
+	actionButtonId,
+	ariaLabel,
+	children,
+	disabled,
+	menuAriaLabel,
+	menuButtonId,
+	menuItems,
+	onConfigureApps,
+	onClick,
+	size,
+	style,
+	title,
+}) => {
+	const items = useMemo(() => {
+		return [
+			...menuItems,
+			...getConfigureDefaultAppsMenuItems({
+				hasPreviousItems: menuItems.length > 0,
+				onConfigureApps,
+			}),
+		];
+	}, [menuItems, onConfigureApps]);
+	const segments = useMemo((): SegmentedButtonSegment[] => {
+		return [
+			{
+				ariaLabel,
+				buttonId: actionButtonId,
+				disabled,
+				idleColor: LIGHT_TEXT,
+				onClick,
+				onPointerDown: null,
+				renderContent: () => children,
+				segmentId: 'preferred-app',
+				style:
+					size === 'default'
+						? defaultMainSegmentStyle
+						: compactMainSegmentStyle,
+				title,
+				type: 'action',
+			},
+			...(items.length > 0
+				? [
+						{
+							ariaLabel: menuAriaLabel,
+							buttonId: menuButtonId,
+							disabled: false,
+							idleColor: LIGHT_TEXT,
+							leaveLeftSpace: true,
+							onOpenChange: null,
+							renderContent: (color: string) => (
+								<span style={dropdownIconStyle}>
+									<CaretDown color={color} />
+								</span>
+							),
+							segmentId: 'another-app',
+							selectedId: null,
+							style: dropdownSegmentStyle,
+							title: menuAriaLabel,
+							type: 'menu' as const,
+							values: items,
+						},
+					]
+				: []),
+		];
+	}, [
+		actionButtonId,
+		ariaLabel,
+		children,
+		disabled,
+		items,
+		menuAriaLabel,
+		menuButtonId,
+		onClick,
+		size,
+		title,
+	]);
+
+	return (
+		<SegmentedButton
+			segments={segments}
+			style={{...(size === 'default' ? {height: 41} : null), ...style}}
+			title={null}
+		/>
+	);
+};

--- a/packages/studio/src/components/Button.tsx
+++ b/packages/studio/src/components/Button.tsx
@@ -1,14 +1,26 @@
 import React, {forwardRef, useMemo} from 'react';
-import {INPUT_BACKGROUND, BLACK_ALPHA_60, WHITE} from '../helpers/colors';
+import {
+	LIGHT_TEXT,
+	TRANSPARENT,
+	WHITE,
+	getBackgroundFromHoverState,
+} from '../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../helpers/hoverable';
+
 const button: React.CSSProperties = {
-	border: `1px solid ${BLACK_ALPHA_60}`,
-	borderRadius: 4,
-	backgroundColor: INPUT_BACKGROUND,
 	appearance: 'none',
+	border: 'none',
+	borderRadius: 6,
+	cursor: 'default',
 	fontFamily: 'inherit',
 	fontSize: 14,
-	color: WHITE,
 	flexDirection: 'row',
+	margin: 0,
+	padding: 0,
 };
 
 export type ButtonProps = {
@@ -43,18 +55,30 @@ const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
 	ref,
 ) => {
 	const combined = useMemo(() => {
+		const idleBackground = style?.backgroundColor ?? TRANSPARENT;
+		const idleColor = style?.color ?? LIGHT_TEXT;
+
 		return {
 			...button,
+			...hoverableStyle({
+				idleBackground,
+				hoverBackground:
+					disabled || style?.backgroundColor
+						? idleBackground
+						: getBackgroundFromHoverState({hovered: true, selected: false}),
+				idleColor,
+				hoverColor: disabled || style?.color ? idleColor : WHITE,
+			}),
 			...(size === 'compact' ? {fontSize: 12} : null),
 			...(size === 'condensed' ? {fontSize: 11} : null),
 			...(style ?? {}),
 		};
-	}, [size, style]);
+	}, [disabled, size, style]);
 	const buttonContainer: React.CSSProperties = useMemo(() => {
 		return {
 			padding:
 				size === 'condensed' ? '2px 7px' : size === 'compact' ? '5px 8px' : 10,
-			cursor: disabled ? 'inherit' : 'pointer',
+			cursor: 'default',
 			fontSize: size === 'condensed' ? 11 : size === 'compact' ? 12 : 14,
 			lineHeight:
 				size === 'condensed' ? '14px' : size === 'compact' ? '14px' : undefined,
@@ -66,6 +90,7 @@ const ButtonRefForwardFunction: React.ForwardRefRenderFunction<
 	return (
 		<button
 			ref={ref}
+			className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 			id={id}
 			style={combined}
 			type="button"

--- a/packages/studio/src/components/CanvasOrLoading.tsx
+++ b/packages/studio/src/components/CanvasOrLoading.tsx
@@ -1,6 +1,7 @@
 import type {Size} from '@remotion/player';
 import React, {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
+import type {OnRetry} from '../error-overlay/remotion-overlay/ErrorDisplay';
 import {ErrorLoader} from '../error-overlay/remotion-overlay/ErrorLoader';
 import {BACKGROUND, WHITE} from '../helpers/colors';
 import {CompositionListContext} from '../state/composition-list';
@@ -58,7 +59,11 @@ export const CanvasOrLoading: React.FC<{
 
 	if (renderError) {
 		return (
-			<ErrorLoading error={renderError} calculateMetadataContext={false} />
+			<ErrorLoading
+				error={renderError}
+				calculateMetadataContext={false}
+				onRetry={null}
+			/>
 		);
 	}
 
@@ -106,7 +111,15 @@ export const CanvasOrLoading: React.FC<{
 	}
 
 	if (resolved.type === 'error') {
-		return <ErrorLoading error={resolved.error} calculateMetadataContext />;
+		return (
+			<ErrorLoading
+				error={resolved.error}
+				calculateMetadataContext
+				onRetry={() =>
+					Internals.resolveCompositionsRef.current?.reloadCurrentlySelectedComposition()
+				}
+			/>
+		);
 	}
 
 	return (
@@ -128,7 +141,8 @@ const loaderContainer: React.CSSProperties = {
 const ErrorLoading: React.FC<{
 	readonly error: Error;
 	readonly calculateMetadataContext: boolean;
-}> = ({error, calculateMetadataContext}) => {
+	readonly onRetry: OnRetry;
+}> = ({error, calculateMetadataContext, onRetry}) => {
 	return (
 		<div style={loaderContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 			<ErrorLoader
@@ -136,9 +150,7 @@ const ErrorLoading: React.FC<{
 				canHaveDismissButton={false}
 				keyboardShortcuts
 				error={error}
-				onRetry={() =>
-					Internals.resolveCompositionsRef.current?.reloadCurrentlySelectedComposition()
-				}
+				onRetry={onRetry}
 				calculateMetadata={calculateMetadataContext}
 			/>
 		</div>

--- a/packages/studio/src/components/CodingAgentButton.tsx
+++ b/packages/studio/src/components/CodingAgentButton.tsx
@@ -1,0 +1,100 @@
+import type {DefaultCodingAgent} from '@remotion/renderer';
+import React, {useCallback, useMemo} from 'react';
+import {openInCodingAgent} from '../helpers/open-in-editor';
+import {AppLaunchButton} from './AppLaunchButton';
+import {CodingAgentIcon} from './CodingAgentIcon';
+import type {ComboboxValue} from './NewComposition/ComboBox';
+import {showNotification} from './Notifications/NotificationCenter';
+import {useSettings} from './SettingsContext';
+import {useConfigureDefaultApps} from './use-configure-default-apps';
+
+const menuLabel: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: '16px',
+};
+
+export const CodingAgentButton: React.FC<{
+	readonly label: 'Fix with' | 'Open in';
+	readonly prompt: string;
+	readonly size: 'compact' | 'default';
+	readonly style: React.CSSProperties | null;
+}> = ({label, prompt, size, style}) => {
+	const {codingAgentInfo} = useSettings();
+	const configureDefaultApps = useConfigureDefaultApps();
+	const installedCodingAgents = codingAgentInfo?.installedCodingAgents ?? [];
+	const defaultCodingAgent =
+		installedCodingAgents.find(
+			(agent) => agent.id === codingAgentInfo?.defaultCodingAgent,
+		) ?? installedCodingAgents[0];
+	const alternativeCodingAgents = installedCodingAgents.filter(
+		(agent) => agent.id !== defaultCodingAgent?.id,
+	);
+
+	const openWithCodingAgent = useCallback(
+		async (codingAgentId: DefaultCodingAgent, codingAgentName: string) => {
+			try {
+				const response = await openInCodingAgent(
+					codingAgentId,
+					codingAgentId === 'copilot' ? null : prompt,
+				);
+				if (!response.success) {
+					showNotification(`Could not open ${codingAgentName}`, 2000);
+				}
+			} catch (err) {
+				showNotification((err as Error).message, 2000);
+			}
+		},
+		[prompt],
+	);
+
+	const agentMenuItems = useMemo((): ComboboxValue[] => {
+		return alternativeCodingAgents.map((codingAgent) => ({
+			id: `open-in-${codingAgent.id}`,
+			keyHint: null,
+			label: <span style={menuLabel}>{codingAgent.name}</span>,
+			leftItem: <CodingAgentIcon codingAgentId={codingAgent.id} size={18} />,
+			onClick: () => {
+				openWithCodingAgent(codingAgent.id, codingAgent.nameWithType).catch(
+					() => undefined,
+				);
+			},
+			quickSwitcherLabel: null,
+			subMenu: null,
+			type: 'item',
+			value: `coding-agent-${codingAgent.id}`,
+		}));
+	}, [alternativeCodingAgents, openWithCodingAgent]);
+
+	if (!defaultCodingAgent) {
+		return null;
+	}
+
+	return (
+		<AppLaunchButton
+			actionButtonId={null}
+			ariaLabel={`${label} ${defaultCodingAgent.nameWithType}`}
+			disabled={false}
+			menuAriaLabel={`${label} another coding agent`}
+			menuButtonId={null}
+			menuItems={agentMenuItems}
+			onConfigureApps={configureDefaultApps}
+			onClick={() => {
+				openWithCodingAgent(
+					defaultCodingAgent.id,
+					defaultCodingAgent.nameWithType,
+				).catch(() => undefined);
+			}}
+			size={size}
+			style={style}
+			title={`${label} ${defaultCodingAgent.nameWithType}`}
+		>
+			<CodingAgentIcon
+				codingAgentId={defaultCodingAgent.id}
+				size={size === 'default' ? 14 : 18}
+			/>
+			{label} {defaultCodingAgent.name}
+		</AppLaunchButton>
+	);
+};

--- a/packages/studio/src/components/FixComputedValueModal.tsx
+++ b/packages/studio/src/components/FixComputedValueModal.tsx
@@ -1,20 +1,15 @@
-import type {DefaultCodingAgent} from '@remotion/renderer';
 import React, {useCallback} from 'react';
 import {LIGHT_TEXT, SELECTED_BACKGROUND, WHITE} from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
-import {openInCodingAgent} from '../helpers/open-in-editor';
-import {CaretDown} from '../icons/caret';
 import {ClipboardIcon} from '../icons/clipboard';
 import type {ModalState} from '../state/modals';
-import {CodingAgentIcon} from './CodingAgentIcon';
+import {CodingAgentButton} from './CodingAgentButton';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {ModalFooterContainer} from './ModalFooter';
 import {ModalHeader} from './ModalHeader';
-import type {ComboboxValue} from './NewComposition/ComboBox';
 import {DismissableModal} from './NewComposition/DismissableModal';
 import {showNotification} from './Notifications/NotificationCenter';
-import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
 import {useSettings} from './SettingsContext';
 
 const panelStyle: React.CSSProperties = {
@@ -68,23 +63,6 @@ const footer: React.CSSProperties = {
 	justifyContent: 'flex-end',
 };
 
-const mainSegmentStyle: React.CSSProperties = {
-	gap: 6,
-	padding: '0 9px',
-};
-
-const dropdownSegmentStyle: React.CSSProperties = {
-	padding: 0,
-	width: 20,
-};
-
-const menuLabel: React.CSSProperties = {
-	color: 'inherit',
-	fontFamily: 'sans-serif',
-	fontSize: 13,
-	lineHeight: '16px',
-};
-
 type FixComputedValueModalState = Extract<
 	ModalState,
 	{type: 'fix-computed-value'}
@@ -96,14 +74,8 @@ export const FixComputedValueModal: React.FC<{
 	const {codingAgentInfo} = useSettings();
 	const prompt = `/remotion-interactivity ${state.context} make "${state.prop}" interactive`;
 	const installCommand = 'npx remotion skills add';
-	const installedCodingAgents = codingAgentInfo?.installedCodingAgents ?? [];
-	const defaultCodingAgent =
-		installedCodingAgents.find(
-			(agent) => agent.id === codingAgentInfo?.defaultCodingAgent,
-		) ?? installedCodingAgents[0];
-	const alternativeCodingAgents = installedCodingAgents.filter(
-		(agent) => agent.id !== defaultCodingAgent?.id,
-	);
+	const hasCodingAgent =
+		(codingAgentInfo?.installedCodingAgents.length ?? 0) > 0;
 
 	const onCopyPrompt = useCallback(() => {
 		copyText(prompt).catch((err) => {
@@ -120,97 +92,6 @@ export const FixComputedValueModal: React.FC<{
 	const renderCopyAction: RenderInlineAction = useCallback((color) => {
 		return <ClipboardIcon color={color} style={copyIcon} />;
 	}, []);
-
-	const openWithCodingAgent = useCallback(
-		async (codingAgentId: DefaultCodingAgent, codingAgentName: string) => {
-			try {
-				const response = await openInCodingAgent(
-					codingAgentId,
-					codingAgentId === 'copilot' ? null : prompt,
-				);
-				if (!response.success) {
-					showNotification(`Could not open ${codingAgentName}`, 2000);
-				}
-			} catch (err) {
-				showNotification((err as Error).message, 2000);
-			}
-		},
-		[prompt],
-	);
-
-	const agentMenuItems = React.useMemo((): ComboboxValue[] => {
-		return alternativeCodingAgents.map((codingAgent) => ({
-			id: `fix-computed-value-in-${codingAgent.id}`,
-			keyHint: null,
-			label: <span style={menuLabel}>{codingAgent.name}</span>,
-			leftItem: <CodingAgentIcon codingAgentId={codingAgent.id} size={18} />,
-			onClick: () => {
-				openWithCodingAgent(codingAgent.id, codingAgent.nameWithType).catch(
-					() => undefined,
-				);
-			},
-			quickSwitcherLabel: null,
-			subMenu: null,
-			type: 'item',
-			value: `coding-agent-${codingAgent.id}`,
-		}));
-	}, [alternativeCodingAgents, openWithCodingAgent]);
-
-	const segments = React.useMemo((): SegmentedButtonSegment[] => {
-		if (!defaultCodingAgent) {
-			return [];
-		}
-
-		return [
-			{
-				ariaLabel: `Open in ${defaultCodingAgent.nameWithType}`,
-				buttonId: null,
-				disabled: false,
-				idleColor: LIGHT_TEXT,
-				onClick: () => {
-					openWithCodingAgent(
-						defaultCodingAgent.id,
-						defaultCodingAgent.nameWithType,
-					).catch(() => undefined);
-				},
-				onPointerDown: null,
-				renderContent: () => (
-					<>
-						<CodingAgentIcon codingAgentId={defaultCodingAgent.id} size={18} />
-						Open in {defaultCodingAgent.name}
-					</>
-				),
-				segmentId: 'default-coding-agent',
-				style: mainSegmentStyle,
-				title: `Open in ${defaultCodingAgent.nameWithType}`,
-				type: 'action',
-			},
-			...(alternativeCodingAgents.length > 0
-				? [
-						{
-							ariaLabel: 'Open in another coding agent',
-							buttonId: null,
-							disabled: false,
-							idleColor: LIGHT_TEXT,
-							leaveLeftSpace: true,
-							onOpenChange: null,
-							renderContent: (color: string) => <CaretDown color={color} />,
-							segmentId: 'another-coding-agent',
-							selectedId: null,
-							style: dropdownSegmentStyle,
-							title: 'Open in another coding agent',
-							type: 'menu' as const,
-							values: agentMenuItems,
-						},
-					]
-				: []),
-		];
-	}, [
-		agentMenuItems,
-		alternativeCodingAgents.length,
-		defaultCodingAgent,
-		openWithCodingAgent,
-	]);
 
 	return (
 		<DismissableModal panelStyle={panelStyle}>
@@ -250,9 +131,14 @@ export const FixComputedValueModal: React.FC<{
 					/>
 				</div>
 			</div>
-			{defaultCodingAgent ? (
+			{hasCodingAgent ? (
 				<ModalFooterContainer style={footer}>
-					<SegmentedButton segments={segments} style={null} title={null} />
+					<CodingAgentButton
+						label="Open in"
+						prompt={prompt}
+						size="compact"
+						style={null}
+					/>
 				</ModalFooterContainer>
 			) : null}
 		</DismissableModal>

--- a/packages/studio/src/components/InspectorOpenInEditor.tsx
+++ b/packages/studio/src/components/InspectorOpenInEditor.tsx
@@ -18,12 +18,12 @@ import {
 import {CaretDown} from '../icons/caret';
 import {EditorIcon} from '../icons/editor';
 import {GitHubIcon} from '../icons/github';
-import {SetSelectedModalContext} from '../state/modals';
 import {getOpenInMenuItems} from './get-open-in-menu-items';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {showNotification} from './Notifications/NotificationCenter';
 import {openInFileExplorer} from './RenderQueue/actions';
 import {SegmentedButton, type SegmentedButtonSegment} from './SegmentedButton';
+import {useConfigureDefaultApps} from './use-configure-default-apps';
 import {
 	useDefaultCodingAgentInfo,
 	useEditorOpening,
@@ -50,7 +50,7 @@ export const InspectorOpenInEditor: React.FC<{
 	readonly locationType: 'file' | 'folder' | null;
 }> = ({contextForAgents = null, label, location, locationType}) => {
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
-	const {setSelectedModal} = useContext(SetSelectedModalContext);
+	const configureDefaultApps = useConfigureDefaultApps();
 	const {
 		canConfigureApps,
 		canOpenInEditor,
@@ -126,16 +126,7 @@ export const InspectorOpenInEditor: React.FC<{
 				!location?.source || previewServerState.type !== 'connected',
 			folder: locationType === 'folder',
 			location,
-			onConfigureApps: canConfigureApps
-				? () => {
-						setSelectedModal({
-							type: 'settings',
-							initialTab: 'apps',
-							initialPublicLicenseKey:
-								window.remotion_renderDefaults?.publicLicenseKey ?? null,
-						});
-					}
-				: null,
+			onConfigureApps: configureDefaultApps,
 			onOpenInCodingAgent: (codingAgentId, codingAgentName) => {
 				openWithCodingAgent(codingAgentId, codingAgentName).catch(
 					() => undefined,
@@ -192,8 +183,8 @@ export const InspectorOpenInEditor: React.FC<{
 			: items;
 	}, [
 		codingAgentInfo,
-		canConfigureApps,
 		canOpenInEditor,
+		configureDefaultApps,
 		defaultActionIsGitHub,
 		defaultEditorId,
 		editorInfo,
@@ -202,7 +193,6 @@ export const InspectorOpenInEditor: React.FC<{
 		openWithCodingAgent,
 		openWithEditor,
 		previewServerState.type,
-		setSelectedModal,
 	]);
 	const segments = useMemo((): SegmentedButtonSegment[] => {
 		const result: SegmentedButtonSegment[] = [

--- a/packages/studio/src/components/get-open-in-menu-items.tsx
+++ b/packages/studio/src/components/get-open-in-menu-items.tsx
@@ -25,6 +25,35 @@ const menuLabel: React.CSSProperties = {
 	lineHeight: '16px',
 };
 
+export const getConfigureDefaultAppsMenuItems = ({
+	hasPreviousItems,
+	onConfigureApps,
+}: {
+	readonly hasPreviousItems: boolean;
+	readonly onConfigureApps: (() => void) | null;
+}): ComboboxValue[] => {
+	if (!onConfigureApps) {
+		return [];
+	}
+
+	return [
+		...(hasPreviousItems
+			? [{type: 'divider' as const, id: 'open-in-settings-divider'}]
+			: []),
+		{
+			id: 'change-default-apps',
+			keyHint: null,
+			label: <span style={menuLabel}>Configure default apps...</span>,
+			leftItem: null,
+			onClick: onConfigureApps,
+			quickSwitcherLabel: null,
+			subMenu: null,
+			type: 'item' as const,
+			value: 'change-default-apps',
+		},
+	];
+};
+
 export const getOpenInMenuItems = ({
 	codingAgentInfo,
 	editorDisabled,
@@ -215,21 +244,9 @@ export const getOpenInMenuItems = ({
 					...systemApps,
 				]
 			: []),
-		...(onConfigureApps && (hasCategorizedApps || systemApps.length > 0)
-			? [{type: 'divider' as const, id: 'open-in-settings-divider'}]
-			: []),
-		onConfigureApps
-			? {
-					id: 'change-default-apps',
-					keyHint: null,
-					label: <span style={menuLabel}>Change default apps...</span>,
-					leftItem: null,
-					onClick: onConfigureApps,
-					quickSwitcherLabel: null,
-					subMenu: null,
-					type: 'item' as const,
-					value: 'change-default-apps',
-				}
-			: null,
+		...getConfigureDefaultAppsMenuItems({
+			hasPreviousItems: hasCategorizedApps || systemApps.length > 0,
+			onConfigureApps,
+		}),
 	].filter(NoReactInternals.truthy);
 };

--- a/packages/studio/src/components/use-configure-default-apps.ts
+++ b/packages/studio/src/components/use-configure-default-apps.ts
@@ -1,0 +1,21 @@
+import {useCallback, useContext} from 'react';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {SetSelectedModalContext} from '../state/modals';
+import {canUseEditorPicker} from './use-default-editor-info';
+
+export const useConfigureDefaultApps = (): (() => void) | null => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const {setSelectedModal} = useContext(SetSelectedModalContext);
+	const configureDefaultApps = useCallback(() => {
+		setSelectedModal({
+			type: 'settings',
+			initialTab: 'apps',
+			initialPublicLicenseKey:
+				window.remotion_renderDefaults?.publicLicenseKey ?? null,
+		});
+	}, [setSelectedModal]);
+
+	return canUseEditorPicker(previewServerState.type === 'connected')
+		? configureDefaultApps
+		: null;
+};

--- a/packages/studio/src/error-overlay/remotion-overlay/CodeFrame.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/CodeFrame.tsx
@@ -2,13 +2,11 @@ import type {ScriptLine} from '@remotion/studio-shared';
 import React from 'react';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../../components/Menu/is-menu-item';
 import {
-	BLACK,
-	BLUE,
 	ERROR_CODE_FRAME_BACKGROUND,
 	ERROR_CODE_FRAME_LINE_BACKGROUND,
 	TRANSPARENT,
 	WHITE,
-	WHITE_ALPHA_60,
+	WHITE_ALPHA_40,
 } from '../../helpers/colors';
 
 const container: React.CSSProperties = {
@@ -19,6 +17,7 @@ const container: React.CSSProperties = {
 
 const frame: React.CSSProperties = {
 	backgroundColor: ERROR_CODE_FRAME_BACKGROUND,
+	borderRadius: 6,
 	marginBottom: 20,
 	overflowY: 'auto',
 };
@@ -53,10 +52,8 @@ export const CodeFrame: React.FC<{
 						<div
 							style={{
 								...lineNumber,
-								backgroundColor: s.highlight
-									? WHITE
-									: ERROR_CODE_FRAME_LINE_BACKGROUND,
-								color: s.highlight ? BLACK : WHITE_ALPHA_60,
+								backgroundColor: ERROR_CODE_FRAME_LINE_BACKGROUND,
+								color: s.highlight ? WHITE : WHITE_ALPHA_40,
 							}}
 						>
 							{String(s.lineNumber).padStart(lineNumberWidth, ' ')}
@@ -66,8 +63,8 @@ export const CodeFrame: React.FC<{
 								fontFamily: 'monospace',
 								whiteSpace: 'pre',
 								tabSize: 2,
-								color: s.highlight ? WHITE : WHITE_ALPHA_60,
-								backgroundColor: s.highlight ? BLUE : TRANSPARENT,
+								color: s.highlight ? WHITE : WHITE_ALPHA_40,
+								backgroundColor: TRANSPARENT,
 								lineHeight: 1.7,
 								paddingRight: 12,
 								paddingLeft: 12,

--- a/packages/studio/src/error-overlay/remotion-overlay/CopyStackTrace.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/CopyStackTrace.tsx
@@ -30,7 +30,7 @@ export const CopyStackTrace: React.FC<{
 			return 'Failed!';
 		}
 
-		return 'Copy Stacktrace';
+		return 'Copy stack';
 	}, [copyState]);
 
 	return <Button onClick={handleCopyToClipboard}>{label}</Button>;

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import {getLocationFromBuildError} from '@remotion/studio-shared';
 import React, {useContext, useMemo} from 'react';
 import {MediaPlaybackError} from 'remotion';
+import {CodingAgentButton} from '../../components/CodingAgentButton';
 import {Spacing} from '../../components/layout';
 import {HORIZONTAL_SCROLLBAR_CLASSNAME} from '../../components/Menu/is-menu-item';
 import {useEditorOpening} from '../../components/use-default-editor-info';
@@ -25,12 +26,13 @@ import {StackElement} from './StackFrame';
 
 const stack: React.CSSProperties = {
 	marginTop: 17,
-	overflowX: 'scroll',
-	marginBottom: '10vh',
+	overflowX: 'hidden',
+	marginBottom: 14,
 };
 
 const rawStack: React.CSSProperties = {
 	backgroundColor: ERROR_CODE_FRAME_BACKGROUND,
+	borderRadius: 6,
 	boxSizing: 'border-box',
 	color: WHITE,
 	fontFamily: 'monospace',
@@ -49,13 +51,26 @@ const symbolicationFailureStyle: React.CSSProperties = {
 	fontFamily: 'SF Pro Text, sans-serif',
 	fontSize: 14,
 	lineHeight: 1.5,
-	marginBottom: '10vh',
+	marginBottom: 14,
 	marginTop: 24,
 };
 
 const spacer: React.CSSProperties = {
 	width: 5,
 	display: 'inline-block',
+};
+
+const actionRow: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
+	flexWrap: 'wrap',
+	marginLeft: 4,
+	marginTop: -10,
+};
+
+const codingAgentButton: React.CSSProperties = {
+	marginLeft: 1,
+	marginRight: 5,
 };
 
 export type OnRetry = null | (() => void);
@@ -78,9 +93,23 @@ export const ErrorDisplay: React.FC<{
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const {canOpenInEditor, defaultEditorId, defaultEditorName} =
 		useEditorOpening(previewServerState.type === 'connected');
+	const stackFrames = useMemo(() => {
+		const withoutReactInternals = display.stackFrames.filter((frame) => {
+			const fileName = `/${frame.originalFileName?.replaceAll('\\', '/') ?? ''}`;
+			return ![
+				'/node_modules/react/',
+				'/node_modules/react-dom/',
+				'/node_modules/scheduler/',
+			].some((packagePath) => fileName.includes(packagePath));
+		});
+
+		return withoutReactInternals.length > 0
+			? withoutReactInternals
+			: display.stackFrames.slice(0, 1);
+	}, [display.stackFrames]);
 	const highestLineNumber = Math.max(
 		0,
-		...display.stackFrames
+		...stackFrames
 			.map((s) => s.originalScriptCode)
 			.flat(1)
 			.map((s) => s?.lineNumber ?? 0),
@@ -106,8 +135,8 @@ export const ErrorDisplay: React.FC<{
 	const errorTextForCopy = useMemo(() => {
 		const header = `${display.error.name}: ${message}`;
 
-		if (display.stackFrames.length > 0) {
-			const stackLines = display.stackFrames
+		if (stackFrames.length > 0) {
+			const stackLines = stackFrames
 				.map(
 					(frame) =>
 						`at ${frame.originalFunctionName || '<anonymous>'} (${frame.originalFileName || 'unknown'}:${frame.originalLineNumber || '?'}:${frame.originalColumnNumber || '?'})`,
@@ -117,7 +146,8 @@ export const ErrorDisplay: React.FC<{
 		}
 
 		return display.error.stack || header;
-	}, [display.stackFrames, display.error, message]);
+	}, [display.error, message, stackFrames]);
+	const fixWithAgentPrompt = `Fix this error in my Remotion project:\n\n${errorTextForCopy}`;
 
 	return (
 		<div>
@@ -128,46 +158,54 @@ export const ErrorDisplay: React.FC<{
 				canHaveDismissButton={canHaveDismissButton}
 			/>
 
-			{helpLink ? (
-				<>
-					<HelpLink
-						link={helpLink}
-						canHaveKeyboardShortcuts={keyboardShortcuts}
-					/>
-					<div style={spacer} />
-				</>
-			) : null}
-			{display.stackFrames.length > 0 &&
-			canOpenInEditor &&
-			defaultEditorId &&
-			defaultEditorName ? (
-				<>
-					<OpenInEditor
-						canHaveKeyboardShortcuts={keyboardShortcuts}
-						editorId={defaultEditorId}
-						editorName={defaultEditorName}
-						stack={display.stackFrames[0]}
-					/>
-					<div style={spacer} />
-				</>
-			) : null}
-			<CopyStackTrace errorText={errorTextForCopy} />
-			<div style={spacer} />
-			<SearchGithubIssues
-				canHaveKeyboardShortcuts={keyboardShortcuts}
-				message={display.error.message}
-			/>
-			<div style={spacer} />
-			<AskOnDiscord canHaveKeyboardShortcuts={keyboardShortcuts} />
-			{onRetry ? (
-				<>
-					<div style={spacer} />
-					<RetryButton
-						onClick={onRetry}
-						label={calculateMetadata ? 'Retry calculateMetadata()' : 'Retry'}
-					/>
-				</>
-			) : null}
+			<div style={actionRow}>
+				{helpLink ? (
+					<>
+						<HelpLink
+							link={helpLink}
+							canHaveKeyboardShortcuts={keyboardShortcuts}
+						/>
+						<div style={spacer} />
+					</>
+				) : null}
+				{stackFrames.length > 0 &&
+				canOpenInEditor &&
+				defaultEditorId &&
+				defaultEditorName ? (
+					<>
+						<OpenInEditor
+							canHaveKeyboardShortcuts={keyboardShortcuts}
+							editorId={defaultEditorId}
+							editorName={defaultEditorName}
+							stack={stackFrames[0]}
+						/>
+						<div style={spacer} />
+					</>
+				) : null}
+				<CodingAgentButton
+					label="Fix with"
+					prompt={fixWithAgentPrompt}
+					size="default"
+					style={codingAgentButton}
+				/>
+				<CopyStackTrace errorText={errorTextForCopy} />
+				<div style={spacer} />
+				<SearchGithubIssues
+					canHaveKeyboardShortcuts={keyboardShortcuts}
+					message={display.error.message}
+				/>
+				<div style={spacer} />
+				<AskOnDiscord canHaveKeyboardShortcuts={keyboardShortcuts} />
+				{onRetry ? (
+					<>
+						<div style={spacer} />
+						<RetryButton
+							onClick={onRetry}
+							label={calculateMetadata ? 'Retry calculateMetadata()' : 'Retry'}
+						/>
+					</>
+				) : null}
+			</div>
 			{calculateMetadata ? (
 				<>
 					<br />
@@ -182,9 +220,9 @@ export const ErrorDisplay: React.FC<{
 					<MediaPlaybackErrorExplainer src={display.error.src} />
 				</>
 			) : null}
-			{display.stackFrames.length > 0 ? (
+			{stackFrames.length > 0 ? (
 				<div style={stack} className={HORIZONTAL_SCROLLBAR_CLASSNAME}>
-					{display.stackFrames.map((s, i) => {
+					{stackFrames.map((s, i) => {
 						return (
 							<StackElement
 								// eslint-disable-next-line react/no-array-index-key

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorLoader.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorLoader.tsx
@@ -16,7 +16,7 @@ const container: React.CSSProperties = {
 	marginLeft: 'auto',
 	marginRight: 'auto',
 	fontFamily: 'SF Pro Text, sans-serif',
-	paddingTop: '5vh',
+	paddingTop: 14,
 	boxSizing: 'border-box',
 };
 

--- a/packages/studio/src/error-overlay/remotion-overlay/ErrorTitle.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ErrorTitle.tsx
@@ -14,6 +14,7 @@ const title: React.CSSProperties = {
 
 const left: React.CSSProperties = {
 	flex: 1,
+	paddingLeft: 14,
 	paddingRight: 14,
 	fontWeight: 'bold',
 	maxWidth: '100%',
@@ -44,15 +45,16 @@ export const ErrorTitle: React.FC<{
 	return (
 		<div style={title} className="css-reset">
 			<div style={left}>
-				<span style={errName}>{name}</span>
-				<br />
 				<div style={row}>
+					<span style={errName}>{name}</span>
 					{symbolicating ? (
 						<>
-							<Symbolicating />
 							<div style={spacer} />
+							<Symbolicating />
 						</>
 					) : null}
+				</div>
+				<div style={row}>
 					<ErrorMessage message={message} />
 				</div>
 			</div>

--- a/packages/studio/src/error-overlay/remotion-overlay/OpenInEditor.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/OpenInEditor.tsx
@@ -1,76 +1,23 @@
-/* eslint-disable no-console */
 import type {
 	EditorPickerId,
 	SymbolicatedStackFrame,
 } from '@remotion/studio-shared';
-import React, {
-	useCallback,
-	useEffect,
-	useMemo,
-	useReducer,
-	useRef,
-} from 'react';
-import {Button} from '../../components/Button';
+import React, {useCallback, useEffect, useMemo} from 'react';
+import {AppLaunchButton} from '../../components/AppLaunchButton';
+import type {ComboboxValue} from '../../components/NewComposition/ComboBox';
+import {showNotification} from '../../components/Notifications/NotificationCenter';
+import {useSettings} from '../../components/SettingsContext';
+import {useConfigureDefaultApps} from '../../components/use-configure-default-apps';
 import {openInEditor} from '../../helpers/open-in-editor';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {EditorIcon} from '../../icons/editor';
 import {ShortcutHint} from './ShortcutHint';
 
-type State =
-	| {
-			type: 'idle';
-	  }
-	| {
-			type: 'success';
-	  }
-	| {
-			type: 'load';
-	  }
-	| {
-			type: 'error';
-	  };
-
-const initialState: State = {type: 'idle'};
-
-type Action =
-	| {
-			type: 'start';
-	  }
-	| {
-			type: 'succeed';
-	  }
-	| {
-			type: 'fail';
-	  }
-	| {
-			type: 'reset';
-	  };
-
-const reducer = (state: State, action: Action): State => {
-	if (action.type === 'start') {
-		return {
-			type: 'load',
-		};
-	}
-
-	if (action.type === 'fail') {
-		return {
-			type: 'error',
-		};
-	}
-
-	if (action.type === 'reset') {
-		return {
-			type: 'idle',
-		};
-	}
-
-	if (action.type === 'succeed') {
-		return {
-			type: 'success',
-		};
-	}
-
-	return state;
+const menuLabel: React.CSSProperties = {
+	color: 'inherit',
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	lineHeight: '16px',
 };
 
 export const OpenInEditor: React.FC<{
@@ -79,82 +26,85 @@ export const OpenInEditor: React.FC<{
 	readonly editorId: EditorPickerId;
 	readonly editorName: string;
 }> = ({stack, canHaveKeyboardShortcuts, editorId, editorName}) => {
-	const isMounted = useRef(true);
-	const [state, dispatch] = useReducer(reducer, initialState);
+	const {editorInfo} = useSettings();
+	const configureDefaultApps = useConfigureDefaultApps();
 	const {registerKeybinding} = useKeybinding();
-	const dispatchIfMounted: typeof dispatch = useCallback((payload) => {
-		if (isMounted.current === false) return;
-		dispatch(payload);
-	}, []);
 
-	const openInBrowser = useCallback(() => {
-		dispatch({type: 'start'});
-		openInEditor(stack, editorId)
-			.then((data) => {
-				if (data.success) {
-					dispatchIfMounted({type: 'succeed'});
-				} else {
-					dispatchIfMounted({type: 'fail'});
+	const openWithEditor = useCallback(
+		async (selectedEditorId: EditorPickerId, selectedEditorName: string) => {
+			try {
+				const response = await openInEditor(stack, selectedEditorId);
+				if (!response.success) {
+					showNotification(`Could not open ${selectedEditorName}`, 2000);
 				}
-			})
-			.catch((err) => {
-				dispatchIfMounted({type: 'fail'});
-				console.log('Could not open browser', err);
-			})
-			.finally(() => {
-				setTimeout(() => {
-					dispatchIfMounted({type: 'reset'});
-				}, 2000);
-			});
-	}, [dispatchIfMounted, editorId, stack]);
+			} catch (err) {
+				showNotification((err as Error).message, 2000);
+			}
+		},
+		[stack],
+	);
 
-	useEffect(() => {
-		return () => {
-			isMounted.current = false;
-		};
-	}, []);
+	const openPreferredEditor = useCallback(() => {
+		openWithEditor(editorId, editorName).catch(() => undefined);
+	}, [editorId, editorName, openWithEditor]);
 
 	useEffect(() => {
 		if (!canHaveKeyboardShortcuts) {
 			return;
 		}
 
-		const onEditor = () => {
-			openInBrowser();
-		};
-
 		const {unregister} = registerKeybinding({
 			event: 'keydown',
 			key: 'o',
-			callback: onEditor,
+			callback: openPreferredEditor,
 			commandCtrlKey: true,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		return () => unregister();
-	}, [canHaveKeyboardShortcuts, openInBrowser, registerKeybinding]);
-	const label = useMemo(() => {
-		switch (state.type) {
-			case 'error':
-				return 'Failed to open';
-			case 'idle':
-				return `Open in ${editorName}`;
-			case 'success':
-				return `Opened in ${editorName}`;
-			case 'load':
-				return `Opening...`;
-			default:
-				throw new Error('invalid state');
-		}
-	}, [editorName, state.type]);
+	}, [canHaveKeyboardShortcuts, openPreferredEditor, registerKeybinding]);
+
+	const menuItems = useMemo((): ComboboxValue[] => {
+		const alternativeEditors = (editorInfo?.installedEditors ?? []).filter(
+			(editor) => editor.id !== editorId,
+		);
+		const editorItems: ComboboxValue[] = alternativeEditors.map((editor) => ({
+			id: `open-in-${editor.id}`,
+			keyHint: null,
+			label: <span style={menuLabel}>{editor.nameWithType}</span>,
+			leftItem: <EditorIcon editorId={editor.id} size={18} />,
+			onClick: () => {
+				openWithEditor(editor.id, editor.nameWithType).catch(() => undefined);
+			},
+			quickSwitcherLabel: null,
+			subMenu: null,
+			type: 'item',
+			value: editor.id,
+		}));
+
+		return editorItems;
+	}, [editorId, editorInfo?.installedEditors, openWithEditor]);
 
 	return (
-		<Button onClick={openInBrowser} disabled={state.type !== 'idle'}>
-			{label}
+		<AppLaunchButton
+			actionButtonId="error-overlay-open-in-editor"
+			ariaLabel={`Open in ${editorName}`}
+			disabled={false}
+			menuAriaLabel="Open in another app"
+			menuButtonId="error-overlay-open-in-another-app"
+			menuItems={menuItems}
+			onConfigureApps={configureDefaultApps}
+			onClick={openPreferredEditor}
+			size="default"
+			style={null}
+			title={`Open in ${editorName}`}
+		>
+			<EditorIcon editorId={editorId} size={14} />
+			Open in {editorName}
 			{canHaveKeyboardShortcuts ? (
 				<ShortcutHint keyToPress="o" cmdOrCtrl />
 			) : null}
-		</Button>
+		</AppLaunchButton>
 	);
 };

--- a/packages/studio/src/error-overlay/remotion-overlay/SearchGitHubIssues.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/SearchGitHubIssues.tsx
@@ -40,7 +40,7 @@ export const SearchGithubIssues: React.FC<{
 
 	return (
 		<Button onClick={openInBrowser}>
-			Search GitHub Issues{' '}
+			Search Issues{' '}
 			{canHaveKeyboardShortcuts ? (
 				<ShortcutHint keyToPress="g" cmdOrCtrl />
 			) : null}

--- a/packages/studio/src/error-overlay/remotion-overlay/ShortcutHint.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/ShortcutHint.tsx
@@ -6,7 +6,7 @@ export const cmdOrCtrlCharacter = isMac ? '⌘' : 'Ctrl';
 
 const container: React.CSSProperties = {
 	display: 'inline-block',
-	marginLeft: 6,
+	marginLeft: 3,
 	opacity: 0.6,
 	verticalAlign: 'middle',
 	fontSize: 'inherit',
@@ -35,7 +35,7 @@ export const ShortcutHint: React.FC<{
 
 	return (
 		<span style={container}>
-			{cmdOrCtrl ? `${cmdOrCtrlCharacter}` : ''}
+			{cmdOrCtrl ? `${cmdOrCtrlCharacter}${isMac ? '' : '+'}` : ''}
 			<span style={style}>{keyToPress.toUpperCase()}</span>
 		</span>
 	);

--- a/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/StackFrame.tsx
@@ -4,20 +4,17 @@ import type {
 } from '@remotion/studio-shared';
 import React, {useCallback, useState} from 'react';
 import {Button} from '../../components/Button';
-import {
-	BLACK,
-	BORDER_STACK_FRAME_BLUE,
-	WHITE_ALPHA_60,
-} from '../../helpers/colors';
+import {BORDER_WHITE_ALPHA_12, LIGHT_TEXT, WHITE} from '../../helpers/colors';
 import {openInEditor} from '../../helpers/open-in-editor';
-import {CaretDown, CaretRight} from './carets';
+import {CaretDown} from '../../icons/caret';
 import {CodeFrame} from './CodeFrame';
 import {formatLocation} from './format-location';
 
 const location: React.CSSProperties = {
-	color: WHITE_ALPHA_60,
+	color: LIGHT_TEXT,
 	fontFamily: 'monospace',
 	fontSize: 14,
+	overflowWrap: 'anywhere',
 };
 
 const header: React.CSSProperties = {
@@ -28,13 +25,12 @@ const header: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'row',
 	alignItems: 'center',
-	borderBottom: BORDER_STACK_FRAME_BLUE,
-	backgroundColor: BLACK,
 };
 
 const left: React.CSSProperties = {
 	paddingRight: 14,
 	flex: 1,
+	minWidth: 0,
 };
 
 const fnName: React.CSSProperties = {
@@ -77,7 +73,12 @@ export const StackElement: React.FC<{
 	}, []);
 	return (
 		<div className="css-reset">
-			<div style={header}>
+			<div
+				style={{
+					...header,
+					borderBottom: showCodeFrame ? 'none' : BORDER_WHITE_ALPHA_12,
+				}}
+			>
 				<div style={left}>
 					<div style={fnName}>
 						{s.originalFunctionName ?? defaultFunctionName}
@@ -95,9 +96,8 @@ export const StackElement: React.FC<{
 									}}
 									style={{
 										...location,
+										color: locationHovered ? WHITE : LIGHT_TEXT,
 										cursor: 'pointer',
-										textDecoration: locationHovered ? 'underline' : 'none',
-										textUnderlineOffset: locationHovered ? 4 : undefined,
 									}}
 								>
 									{formatLocation(s.originalFileName as string)}:
@@ -114,7 +114,14 @@ export const StackElement: React.FC<{
 				</div>
 				{s.originalScriptCode && s.originalScriptCode.length > 0 ? (
 					<Button onClick={toggleCodeFrame}>
-						{showCodeFrame ? <CaretDown invert={false} /> : <CaretRight />}
+						<div
+							style={{
+								display: 'flex',
+								transform: showCodeFrame ? undefined : 'rotate(-90deg)',
+							}}
+						>
+							<CaretDown />
+						</div>
 					</Button>
 				) : null}
 			</div>

--- a/packages/studio/src/error-overlay/remotion-overlay/Symbolicating.tsx
+++ b/packages/studio/src/error-overlay/remotion-overlay/Symbolicating.tsx
@@ -7,8 +7,8 @@ export const Symbolicating: React.FC = (props) => {
 			id="loading"
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 32 32"
-			width="16"
-			height="16"
+			width="14"
+			height="14"
 			fill={WHITE}
 			{...props}
 		>

--- a/packages/studio/src/helpers/colors.ts
+++ b/packages/studio/src/helpers/colors.ts
@@ -64,7 +64,6 @@ export const ERROR_CODE_FRAME_LINE_BACKGROUND = '#121212';
 export const ERROR_LINK_COLOR = '#58a6ff';
 export const INFO_BLUE = '#60a5fa';
 export const SERVER_DISCONNECTED_BACKGROUND = '#e74c3c';
-export const STACK_FRAME_BORDER_BLUE = 'rgb(66, 144, 245)';
 export const TIMELINE_BACKGROUND_COLOR = '#15181B';
 // WHITE_ALPHA_10 composited over TIMELINE_BACKGROUND_COLOR.
 export const TIMELINE_NEGATIVE_START_BACKGROUND_COLOR = '#2C2F32';
@@ -92,7 +91,6 @@ export const BORDER_BLACK_ALPHA_60 = `1px solid ${BLACK_ALPHA_60}`;
 export const BORDER_WHITE_ALPHA_12 = `1px solid ${WHITE_ALPHA_12}`;
 export const BORDER_WHITE_ALPHA_20 = `1px solid ${WHITE_ALPHA_20}`;
 export const BORDER_INFO_BLUE = '1px solid rgba(59, 130, 246, 0.4)';
-export const BORDER_STACK_FRAME_BLUE = `1px solid ${STACK_FRAME_BORDER_BLUE}`;
 export const BORDER_TIMELINE_DROP_BLUE = `1px solid ${TIMELINE_DROP_BLUE_ALPHA_75}`;
 export const BORDER_TIMELINE_MARQUEE_BLUE = `1px solid ${TIMELINE_MARQUEE_BLUE_ALPHA_75}`;
 export const SHADOW_BLACK = `0 0 4px ${BLACK}`;


### PR DESCRIPTION
## Summary

- redesign the Studio error overlay actions with shared editor and coding-agent launchers
- refine symbolicated and unsymbolicated stack presentation, spacing, contrast, and overflow behavior
- hide React runtime frames by default while keeping application frames and copied stacks concise

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run test:e2e error-overlay.test.mts`
- `bunx turbo run lint test --filter='@remotion/studio'`

Closes #10693
