### PR TITLE
remotion.dev/brand: Add portrait Canvas Capture short

### DIFF
--- a/packages/brand/src/CanvasCaptureShort/CanvasCaptureShort.tsx
+++ b/packages/brand/src/CanvasCaptureShort/CanvasCaptureShort.tsx
@@ -1,0 +1,108 @@
+import {Video} from '@remotion/media';
+import {TransitionSeries} from '@remotion/transitions';
+import {AbsoluteFill} from 'remotion';
+
+export const CanvasCaptureShort: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: 'black'}}>
+			<TransitionSeries name="Canvas Capture short timeline">
+				<TransitionSeries.Sequence name="Short 1" durationInFrames={125}>
+					<Video
+						name="Short 1"
+						src="https://remotion.media/canvas-capture-short/short-01.mov"
+						trimBefore={37}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Sequence name="Short 2" durationInFrames={194}>
+					<Video
+						name="Short 2"
+						src="https://remotion.media/canvas-capture-short/short-02.mov"
+						trimBefore={69}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Sequence name="Short 3" durationInFrames={255}>
+					<Video
+						name="Short 3"
+						src="https://remotion.media/canvas-capture-short/short-03.mov"
+						trimBefore={71}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Sequence name="Short 4" durationInFrames={158}>
+					<Video
+						name="Short 4"
+						src="https://remotion.media/canvas-capture-short/short-04.mov"
+						trimBefore={65}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Sequence name="Short 5" durationInFrames={271}>
+					<Video
+						name="Short 5"
+						src="https://remotion.media/canvas-capture-short/short-05.mov"
+						trimBefore={62}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+				<TransitionSeries.Sequence name="Short 6" durationInFrames={247}>
+					<Video
+						name="Short 6"
+						src="https://remotion.media/canvas-capture-short/short-06.mov"
+						trimBefore={80}
+						style={{
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							width: '100%',
+							height: '50%',
+						}}
+						objectFit="cover"
+						objectPosition="center center"
+					/>
+				</TransitionSeries.Sequence>
+			</TransitionSeries>
+		</AbsoluteFill>
+	);
+};

--- a/packages/brand/src/Root.tsx
+++ b/packages/brand/src/Root.tsx
@@ -17,6 +17,7 @@ import {Comp} from './Brand/Composition';
 import {TriangleDemo} from './Brand/TriangleToSquare';
 import {CanvasCaptureAnnouncement} from './CanvasCaptureAnnouncement/CanvasCaptureAnnouncement';
 import {CanvasCaptureComposition} from './CanvasCapturePreview';
+import {CanvasCaptureShort} from './CanvasCaptureShort/CanvasCaptureShort';
 import {Checker} from './Checker';
 import {CloseUp1} from './CloseUp1';
 import {CloseUp2} from './CloseUp2';
@@ -182,6 +183,14 @@ export const RemotionRoot: React.FC = () => {
 						fps={30}
 						width={1920}
 						height={1080}
+					/>
+					<Composition
+						id="CanvasCaptureShort"
+						component={CanvasCaptureShort}
+						durationInFrames={1250}
+						fps={30}
+						width={1080}
+						height={1920}
 					/>
 				</Folder>
 				<Composition


### PR DESCRIPTION
## Summary

- add a 9:16 Canvas Capture short composition to `packages/brand`
- crop six camera takes into the top half of the portrait frame
- trim the takes tightly into a 41.67-second ripple-editable timeline
- serve the source footage from verified `remotion.media` objects

## Verification

- `bunx turbo run lint --filter='@remotion/brand'`
- `bun run build`
- `bun run stylecheck`
- `bunx remotion compositions src/index.ts` in `packages/brand`
- verified the public SHA-256 hash of all six R2 objects against the source files
