### PR TITLE
Docs: Redeploy brand changes on Vercel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -527,6 +527,7 @@
         "@remotion/animated-emoji": "workspace:*",
         "@remotion/animation-utils": "workspace:*",
         "@remotion/babel-loader": "workspace:*",
+        "@remotion/brand": "workspace:*",
         "@remotion/browser-studio": "workspace:*",
         "@remotion/bundler": "workspace:*",
         "@remotion/captions": "workspace:*",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -44,6 +44,7 @@
 		"@remotion/animated-emoji": "workspace:*",
 		"@remotion/animation-utils": "workspace:*",
 		"@remotion/babel-loader": "workspace:*",
+		"@remotion/brand": "workspace:*",
 		"@remotion/browser-studio": "workspace:*",
 		"@remotion/bundler": "workspace:*",
 		"@remotion/captions": "workspace:*",


### PR DESCRIPTION
## Summary

- declare `@remotion/brand` as a workspace dependency of the Docs app
- include Brand changes in Vercel's affected-project detection so `/brand` is redeployed

## Why

The Docs build bundles `@remotion/brand` and copies its output into `packages/docs/build/brand`, but the dependency was missing from `packages/docs/package.json`. Vercel therefore skipped brand-only commits as “Not affected” before Turbo ran.

## Validation

- `bunx oxfmt packages/docs/package.json --write`
- `bun run build`
- `bun run stylecheck`
- `bun install --frozen-lockfile`
- `bunx turbo query affected --packages docs --base '3902edd83030^' --head 3902edd83030`

Closes #10942
