### PR TITLE
Derive native audio suspension from playback intent

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -19,6 +19,7 @@ import type {RemotionAudioContextState} from './use-audio-context.js';
 import {useSingletonAudioContext} from './use-audio-context.js';
 import {
 	type AudioContextResumeResult,
+	RESUME_WAIT_TIMEOUT,
 	waitUntilActuallyResumed,
 } from './wait-until-actually-resumed.js';
 
@@ -181,6 +182,7 @@ type AudioContextResumeAttempt = {
 	abortController: AbortController;
 	id: number;
 	promise: Promise<AudioContextResumeResult>;
+	settle: (result: AudioContextResumeResult) => void;
 };
 
 const shouldSaveForLater = (
@@ -398,7 +400,24 @@ export const SharedAudioContextProvider: React.FC<{
 		}
 
 		if (audioContextIsPlayingEventually.current) {
-			return Promise.resolve();
+			if (!_experimentalKeepAudioContextAlive) {
+				return Promise.resolve();
+			}
+
+			if (ctxAndGain.getState() === 'running') {
+				return Promise.resolve();
+			}
+
+			// The playback loop calls resume() every frame. Without a recent
+			// user gesture a retry cannot succeed anyway, so skip it rather
+			// than piling one pending native resume per frame while blocked.
+			if (navigator.userActivation?.isActive === false) {
+				return Promise.resolve();
+			}
+
+			return ctxAndGain.resume().catch(() => {
+				// Still blocked; a later attempt retries. Callers do not await.
+			});
 		}
 
 		audioContextIsPlayingEventually.current = true;
@@ -422,7 +441,7 @@ export const SharedAudioContextProvider: React.FC<{
 
 		if (
 			_experimentalKeepAudioContextAlive &&
-			ctxAndGain.audioContext.state === 'running'
+			ctxAndGain.getState() === 'running'
 		) {
 			// The context was never suspended, so there is nothing to wait for:
 			// the resume-wait machinery, its timeout and the mute-on-failure
@@ -434,7 +453,42 @@ export const SharedAudioContextProvider: React.FC<{
 		const abortController = new AbortController();
 		const resumeAttemptId = nextResumeAttemptId.current++;
 
+		let settle: (result: AudioContextResumeResult) => void = () => undefined;
 		const waitPromise = new Promise<AudioContextResumeResult>((resolve) => {
+			settle = resolve;
+
+			if (_experimentalKeepAudioContextAlive) {
+				// Settled with 'resumed' by the statechange listener below.
+				// Bounded like the default path so a blocked autoplay does not
+				// park the frame clock: 'cancelled' lets playback advance
+				// without muting, and the next gesture retries the resume.
+				const timeout = setTimeout(() => {
+					Log.warn(
+						{logLevel, tag: 'audio'},
+						'AudioContext did not resume in time, continuing silently until the next user gesture',
+					);
+					settle('cancelled');
+				}, RESUME_WAIT_TIMEOUT);
+				settle = (result) => {
+					clearTimeout(timeout);
+					resolve(result);
+				};
+
+				abortController.signal.addEventListener(
+					'abort',
+					() => settle('cancelled'),
+					{once: true},
+				);
+				resumePromise.catch((err) => {
+					Log.warn(
+						{logLevel, tag: 'audio'},
+						'AudioContext resume rejected; retrying on the next attempt',
+						err,
+					);
+				});
+				return;
+			}
+
 			waitUntilActuallyResumed(
 				ctxAndGain.audioContext,
 				logLevel,
@@ -458,6 +512,7 @@ export const SharedAudioContextProvider: React.FC<{
 			abortController,
 			id: resumeAttemptId,
 			promise: waitPromise,
+			settle,
 		};
 
 		return resumePromise.catch(() => {
@@ -469,6 +524,22 @@ export const SharedAudioContextProvider: React.FC<{
 	const getIsResumingAudioContext = useCallback(() => {
 		return isResuming.current?.promise ?? null;
 	}, []);
+
+	const syncContextState = useCallback(() => {
+		if (!ctxAndGain) {
+			return Promise.resolve();
+		}
+
+		const wantRunning =
+			_experimentalKeepAudioContextAlive ||
+			audioContextIsPlayingEventually.current;
+
+		if (!wantRunning && ctxAndGain.getState() === 'running') {
+			return ctxAndGain.suspend();
+		}
+
+		return Promise.resolve();
+	}, [ctxAndGain, _experimentalKeepAudioContextAlive]);
 
 	const suspend = useCallback(() => {
 		isResuming.current?.abortController.abort();
@@ -498,8 +569,39 @@ export const SharedAudioContextProvider: React.FC<{
 			return Promise.resolve();
 		}
 
-		return ctxAndGain.suspend();
-	}, [ctxAndGain, _experimentalKeepAudioContextAlive]);
+		return syncContextState();
+	}, [ctxAndGain, _experimentalKeepAudioContextAlive, syncContextState]);
+
+	// The only place a non-keep-alive native suspend() is issued. Reacting to
+	// statechange covers what callers cannot: a resume() settling after pause
+	// already ran, an iOS interruption ending while paused, and a browser
+	// auto-starting a blocked context on a later gesture. Resuming stays in
+	// resume(), which runs on the user-gesture call chain.
+	useEffect(() => {
+		if (!ctxAndGain) {
+			return;
+		}
+
+		const {audioContext} = ctxAndGain;
+		const onStateChange = (): void => {
+			if (
+				_experimentalKeepAudioContextAlive &&
+				audioContext.state === 'running'
+			) {
+				isResuming.current?.settle('resumed');
+			}
+
+			syncContextState().catch(() => {
+				// A suspend() against a closed context rejects; there is
+				// nothing left to converge.
+			});
+		};
+
+		audioContext.addEventListener('statechange', onStateChange);
+		return () => {
+			audioContext.removeEventListener('statechange', onStateChange);
+		};
+	}, [ctxAndGain, _experimentalKeepAudioContextAlive, syncContextState]);
 
 	// With _experimentalKeepAudioContextAlive, start the context as early as
 	// possible so the first play never waits on the suspended→running transition. Where

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -99,11 +99,14 @@ export const useSingletonAudioContext = ({
 			transitionTarget = 'running';
 			const promise = audioContext.resume();
 
-			promise.finally(() => {
+			const clear = () => {
 				if (transitionTarget === 'running') {
 					transitionTarget = null;
 				}
-			});
+			};
+
+			// Not .finally(): its derived promise would re-reject unhandled.
+			promise.then(clear, clear);
 
 			return promise;
 		};
@@ -112,11 +115,13 @@ export const useSingletonAudioContext = ({
 			transitionTarget = 'suspended';
 			const promise = audioContext.suspend();
 
-			promise.finally(() => {
+			const clear = () => {
 				if (transitionTarget === 'suspended') {
 					transitionTarget = null;
 				}
-			});
+			};
+
+			promise.then(clear, clear);
 
 			return promise;
 		};

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -1,6 +1,6 @@
 import {Log, type LogLevel} from '../log.js';
 
-const RESUME_WAIT_TIMEOUT = 1000;
+export const RESUME_WAIT_TIMEOUT = 1000;
 
 export type AudioContextResumeResult = 'resumed' | 'cancelled' | 'failed';
 

--- a/packages/core/src/test/audio-suspend-intent.test.tsx
+++ b/packages/core/src/test/audio-suspend-intent.test.tsx
@@ -1,0 +1,290 @@
+// Default-mode suspension: suspend() declares paused intent and the provider
+// converges the native context toward it, including states callers cannot
+// reach — a resume() settling after pause, an interruption ending, a browser
+// auto-starting a blocked context.
+import {afterEach, expect, test} from 'bun:test';
+import {act, cleanup} from '@testing-library/react';
+import {
+	makeNode,
+	mock,
+	nativeOps,
+	renderProvider,
+	scheduleAt,
+	withMockedAudioContext,
+} from './mock-audio-context.js';
+
+afterEach(() => {
+	cleanup();
+});
+
+const flush = () =>
+	act(async () => {
+		await Promise.resolve();
+	});
+
+test('the provider creates the context parked', async () => {
+	await withMockedAudioContext(async () => {
+		renderProvider(false);
+		await flush();
+
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('play then pause resumes and suspends the native context', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+
+		await act(async () => {
+			await value.resume();
+		});
+		await act(async () => {
+			await value.suspend();
+		});
+
+		expect(nativeOps()).toEqual(['resume', 'suspend']);
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('pausing while a resume is still pending ends with the context suspended', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		const pendingNativeResume = mock.finishNativeResume;
+		expect(pendingNativeResume).not.toBeNull();
+
+		const suspendPromise = value.suspend();
+		await flush();
+
+		await act(async () => {
+			pendingNativeResume?.();
+			await suspendPromise;
+		});
+		await flush();
+
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('a pause reaching suspend() twice still ends with the context suspended', async () => {
+	// A real pause declares intent twice: once in the pause() method, once in
+	// the use-playback effect when `playing` flips.
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		const pendingNativeResume = mock.finishNativeResume;
+
+		const first = value.suspend();
+		const second = value.suspend();
+		await flush();
+
+		await act(async () => {
+			pendingNativeResume?.();
+			await Promise.all([first, second]);
+		});
+		await flush();
+
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('playing again while the paused resume is still pending is not suspended', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		const pendingNativeResume = mock.finishNativeResume;
+
+		const suspendPromise = value.suspend();
+		await flush();
+
+		mock.stallNativeResume = false;
+		await act(async () => {
+			await value.resume();
+		});
+		mock.ops = [];
+
+		await act(async () => {
+			pendingNativeResume?.();
+			await suspendPromise;
+		});
+		await flush();
+
+		expect(nativeOps()).toEqual([]);
+		expect(mock.lastContext?.state).toBe('running');
+	});
+});
+
+test('a second resume() while one is pending issues no extra native resume', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(false);
+
+		await act(async () => {
+			value.resume();
+			value.resume();
+			await Promise.resolve();
+		});
+
+		expect(nativeOps()).toEqual(['resume']);
+
+		await act(async () => {
+			mock.finishNativeResume?.();
+			await Promise.resolve();
+		});
+	});
+});
+
+test('an interruption ending while paused does not leave the context running', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+
+		await act(async () => {
+			await value.resume();
+		});
+		await act(async () => {
+			await value.suspend();
+		});
+		mock.ops = [];
+
+		act(() => {
+			mock.lastContext?.setNativeState('interrupted');
+		});
+		// The interruption itself must not be answered with a suspend.
+		expect(nativeOps()).toEqual([]);
+
+		act(() => {
+			mock.lastContext?.setNativeState('running');
+		});
+		await flush();
+
+		expect(nativeOps()).toEqual(['suspend']);
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('every unwanted transition to running is answered exactly once', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+
+		await act(async () => {
+			await value.resume();
+		});
+		await act(async () => {
+			await value.suspend();
+		});
+		mock.ops = [];
+
+		act(() => {
+			mock.lastContext?.setNativeState('running');
+		});
+		await flush();
+		act(() => {
+			mock.lastContext?.setNativeState('running');
+		});
+		await flush();
+
+		// One suspend per flip — the suspend's own statechange must not
+		// trigger another round.
+		expect(nativeOps()).toEqual(['suspend', 'suspend']);
+		expect(mock.lastContext?.state).toBe('suspended');
+	});
+});
+
+test('a context auto-started while paused is suspended and queued audio plays on resume', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+		const started: number[] = [];
+
+		scheduleAt(value, makeNode(started), 2);
+		expect(started).toEqual([]);
+
+		// Chrome starts a blocked context on a later gesture even if the
+		// Player is paused by then.
+		act(() => {
+			mock.lastContext?.setNativeState('running');
+		});
+		expect(mock.lastContext?.state).toBe('suspended');
+
+		await act(async () => {
+			await value.resume();
+		});
+		expect(started).toEqual([2]);
+		expect(mock.lastContext?.state).toBe('running');
+	});
+});
+
+test('resuming after a buffering pause resumes the native context again', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+
+		await act(async () => {
+			await value.resume();
+		});
+		mock.ops = [];
+
+		await act(async () => {
+			await value.suspend();
+		});
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+
+		expect(nativeOps()).toEqual(['suspend', 'resume']);
+		expect(mock.lastContext?.state).toBe('running');
+	});
+});
+
+test('a node scheduled while parked starts once on the next resume', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(false);
+		const started: number[] = [];
+
+		scheduleAt(value, makeNode(started), 5);
+		expect(started).toEqual([]);
+
+		await act(async () => {
+			await value.resume();
+		});
+		expect(started).toEqual([5]);
+
+		await act(async () => {
+			await value.resume();
+		});
+		expect(started).toEqual([5]);
+	});
+});
+
+test('a rejected resume settles the wait as failed so playback mutes', async () => {
+	await withMockedAudioContext(async () => {
+		mock.rejectNativeResume = true;
+		const value = renderProvider(false);
+
+		const captured: {wait: Promise<unknown> | null} = {wait: null};
+		await act(async () => {
+			value.resume();
+			captured.wait = value.getIsResumingAudioContext();
+			await Promise.resolve();
+		});
+
+		expect(captured.wait).not.toBeNull();
+		expect(await captured.wait).toBe('failed');
+		expect(value.getIsResumingAudioContext()).toBeNull();
+	});
+});

--- a/packages/core/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/core/src/test/keep-audio-context-alive.test.tsx
@@ -1,192 +1,113 @@
 import {afterEach, expect, test} from 'bun:test';
-import {act, cleanup, render} from '@testing-library/react';
-import type React from 'react';
-import {useContext} from 'react';
+import {act, cleanup} from '@testing-library/react';
+import {RESUME_WAIT_TIMEOUT} from '../audio/wait-until-actually-resumed.js';
 import {
-	SharedAudioContext,
-	SharedAudioContextProvider,
-} from '../audio/shared-audio-tags.js';
-import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
-import {WrapSequenceContext} from './wrap-sequence-context.js';
+	makeNode,
+	mock,
+	nativeOps,
+	renderProvider,
+	scheduleAt,
+	withMockedAudioContext,
+} from './mock-audio-context.js';
 
 afterEach(() => {
 	cleanup();
 });
 
-const previewEnvironment = {
-	isClientSideRendering: false,
-	isPlayer: true,
-	isReadOnlyStudio: false,
-	isRendering: false,
-	isStudio: false,
-};
-
-let nativeSuspendCalls = 0;
-let gainValues: number[] = [];
-
-class TrackedAudioContext {
-	public state = 'suspended' as AudioContextState;
-	public baseLatency = 0;
-	public outputLatency = 0;
-	public currentTime = 0;
-	public destination = {};
-
-	addEventListener() {
-		return undefined;
-	}
-
-	removeEventListener() {
-		return undefined;
-	}
-
-	createGain() {
-		return {
-			connect: () => undefined,
-			gain: {
-				cancelScheduledValues: () => undefined,
-				linearRampToValueAtTime: () => undefined,
-				setValueAtTime: (value: number) => {
-					gainValues.push(value);
-				},
-			},
-		};
-	}
-
-	suspend() {
-		nativeSuspendCalls++;
-		this.state = 'suspended';
-		return Promise.resolve();
-	}
-
-	resume() {
-		this.state = 'running';
-		return Promise.resolve();
-	}
-
-	getOutputTimestamp() {
-		return {contextTime: this.currentTime, performanceTime: 0};
-	}
-
-	createMediaElementSource() {
-		return {
-			connect: () => undefined,
-			disconnect: () => undefined,
-		};
-	}
-}
-
-const makeNode = (started: number[]) => {
-	return {
-		playbackRate: {value: 1},
-		start: (scheduledTime: number) => {
-			started.push(scheduledTime);
-		},
-	} as unknown as AudioBufferSourceNode;
-};
-
-const scheduleAt = (
-	value: NonNullable<React.ContextType<typeof SharedAudioContext>>,
-	node: AudioBufferSourceNode,
-	scheduledTime: number,
-) => {
-	return value.scheduleAudioNode({
-		node,
-		mediaTimestamp: 0,
-		sourceOffset: 0,
-		scheduledTime,
-		duration: 1,
-		offset: 0,
-		originalUnloopedMediaTimestamp: 0,
+const flush = () =>
+	act(async () => {
+		await Promise.resolve();
 	});
-};
-
-const renderProvider = (_experimentalKeepAudioContextAlive: boolean) => {
-	const ref: {
-		current: NonNullable<React.ContextType<typeof SharedAudioContext>> | null;
-	} = {current: null};
-
-	const Probe: React.FC = () => {
-		ref.current = useContext(SharedAudioContext);
-		return null;
-	};
-
-	render(
-		<RemotionEnvironmentContext.Provider value={previewEnvironment}>
-			<WrapSequenceContext>
-				<SharedAudioContextProvider
-					audioEnabled
-					audioLatencyHint="interactive"
-					previewSampleRate={null}
-					_experimentalKeepAudioContextAlive={
-						_experimentalKeepAudioContextAlive
-					}
-				>
-					<Probe />
-				</SharedAudioContextProvider>
-			</WrapSequenceContext>
-		</RemotionEnvironmentContext.Provider>,
-	);
-
-	if (!ref.current) {
-		throw new Error('Expected the shared audio context to be available');
-	}
-
-	return ref.current;
-};
-
-const withMockedAudioContext = async (fn: () => Promise<void>) => {
-	const originalAudioContext = globalThis.AudioContext;
-	globalThis.AudioContext =
-		TrackedAudioContext as unknown as typeof AudioContext;
-	nativeSuspendCalls = 0;
-	gainValues = [];
-	try {
-		await fn();
-	} finally {
-		globalThis.AudioContext = originalAudioContext;
-	}
-};
-
-test('suspend() suspends the AudioContext by default', async () => {
-	await withMockedAudioContext(async () => {
-		const value = renderProvider(false);
-
-		await act(async () => {
-			value.resume();
-			await Promise.resolve();
-		});
-		nativeSuspendCalls = 0;
-
-		await act(async () => {
-			value.suspend();
-			await Promise.resolve();
-		});
-		expect(nativeSuspendCalls).toBe(1);
-	});
-});
 
 test('_experimentalKeepAudioContextAlive silences the gain instead of suspending', async () => {
 	await withMockedAudioContext(async () => {
 		const value = renderProvider(true);
 
 		await act(async () => {
-			value.resume();
-			await Promise.resolve();
+			await value.resume();
 		});
-		nativeSuspendCalls = 0;
-		gainValues = [];
+		mock.ops = [];
 
 		await act(async () => {
-			value.suspend();
-			await Promise.resolve();
+			await value.suspend();
 		});
-		expect(nativeSuspendCalls).toBe(0);
-		expect(gainValues).toContain(0);
+
+		expect(mock.ops).toContain('gain:0');
+		expect(mock.ops).not.toContain('suspend');
+		expect(mock.lastContext?.state).toBe('running');
 	});
 });
 
-test('_experimentalKeepAudioContextAlive queues nodes scheduled while silenced', async () => {
+test('repeated pause/play cycles stay on the gain, never the native context', async () => {
 	await withMockedAudioContext(async () => {
+		const value = renderProvider(true);
+
+		await act(async () => {
+			await value.resume();
+		});
+		mock.ops = [];
+
+		const cycles: string[][] = [];
+		for (let i = 0; i < 3; i++) {
+			await act(async () => {
+				await value.suspend();
+			});
+			await act(async () => {
+				await value.resume();
+			});
+			cycles.push([...mock.ops]);
+			mock.ops = [];
+		}
+
+		for (const cycle of cycles) {
+			expect(cycle.filter((op) => op === 'resume' || op === 'suspend')).toEqual(
+				[],
+			);
+			expect(cycle).toEqual(cycles[0]);
+			expect(cycle[0]).toBe('gain:0');
+			expect(cycle[cycle.length - 1]).toBe('gain:1');
+		}
+
+		expect(value.getIsResumingAudioContext()).toBeNull();
+	});
+});
+
+test('nodes scheduled while silenced start exactly once, in order, on resume', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(true);
+		const started: number[] = [];
+
+		await act(async () => {
+			await value.resume();
+		});
+		await act(async () => {
+			await value.suspend();
+		});
+
+		scheduleAt(value, makeNode(started), 1);
+		scheduleAt(value, makeNode(started), 2);
+		scheduleAt(value, makeNode(started), 3);
+		// Queueing follows playback intent, not native state (still running).
+		expect(started).toEqual([]);
+		expect(mock.lastContext?.state).toBe('running');
+
+		await act(async () => {
+			await value.resume();
+		});
+		await flush();
+		expect(started).toEqual([1, 2, 3]);
+
+		await act(async () => {
+			await value.resume();
+		});
+		await flush();
+		expect(started).toEqual([1, 2, 3]);
+	});
+});
+
+test('a later resume() retries a stalled native resume on the same wait promise', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
 		const value = renderProvider(true);
 
 		await act(async () => {
@@ -194,25 +115,128 @@ test('_experimentalKeepAudioContextAlive queues nodes scheduled while silenced',
 			await Promise.resolve();
 		});
 
-		const startedWhileRunning: number[] = [];
-		scheduleAt(value, makeNode(startedWhileRunning), 1);
-		expect(startedWhileRunning).toEqual([1]);
-
-		await act(async () => {
-			value.suspend();
-			await Promise.resolve();
-		});
-
-		// The native state is still 'running' here, so the node must be queued
-		// based on the silenced state rather than on the context state.
-		const startedWhileSilenced: number[] = [];
-		scheduleAt(value, makeNode(startedWhileSilenced), 2);
-		expect(startedWhileSilenced).toEqual([]);
+		const firstWait = value.getIsResumingAudioContext();
+		expect(firstWait).not.toBeNull();
+		const resumesBefore = nativeOps().filter((op) => op === 'resume').length;
 
 		await act(async () => {
 			value.resume();
 			await Promise.resolve();
 		});
-		expect(startedWhileSilenced).toEqual([2]);
+		expect(value.getIsResumingAudioContext()).toBe(firstWait);
+
+		mock.stallNativeResume = false;
+		await act(async () => {
+			await value.resume();
+		});
+
+		const resumesAfter = nativeOps().filter((op) => op === 'resume').length;
+		expect(resumesAfter).toBeGreaterThan(resumesBefore);
+		expect(await firstWait).toBe('resumed');
+		expect(value.getIsResumingAudioContext()).toBeNull();
+		expect(mock.lastContext?.state).toBe('running');
+	});
+});
+
+test('a rejected native resume keeps playing intent and a later attempt recovers', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(true);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		const wait = value.getIsResumingAudioContext();
+		expect(wait).not.toBeNull();
+
+		mock.stallNativeResume = false;
+		mock.rejectNativeResume = true;
+		await act(async () => {
+			await value.resume();
+		});
+		expect(mock.lastContext?.state).toBe('suspended');
+
+		mock.rejectNativeResume = false;
+		await act(async () => {
+			await value.resume();
+		});
+
+		expect(await wait).toBe('resumed');
+		expect(mock.lastContext?.state).toBe('running');
+	});
+});
+
+test('a stalled resume stops parking playback after the wait timeout', async () => {
+	await withMockedAudioContext(async () => {
+		mock.stallNativeResume = true;
+		const value = renderProvider(true);
+
+		await act(async () => {
+			value.resume();
+			await Promise.resolve();
+		});
+		const wait = value.getIsResumingAudioContext();
+		expect(wait).not.toBeNull();
+
+		// 'cancelled' lets the frame clock advance without muting; audio joins
+		// on the next gesture.
+		const result = await Promise.race([
+			wait,
+			new Promise((resolve) => {
+				setTimeout(() => resolve('pending'), RESUME_WAIT_TIMEOUT + 250);
+			}),
+		]);
+		expect(result).toBe('cancelled');
+		expect(value.getIsResumingAudioContext()).toBeNull();
+	});
+});
+
+test('an interruption ending while silenced does not suspend the context', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(true);
+
+		await act(async () => {
+			await value.resume();
+		});
+		await act(async () => {
+			await value.suspend();
+		});
+		mock.ops = [];
+
+		act(() => {
+			mock.lastContext?.setNativeState('interrupted');
+		});
+		act(() => {
+			mock.lastContext?.setNativeState('running');
+		});
+		await flush();
+
+		expect(nativeOps()).toEqual([]);
+		expect(mock.lastContext?.state).toBe('running');
+
+		await act(async () => {
+			await value.resume();
+		});
+		expect(mock.ops).toContain('gain:1');
+	});
+});
+
+test('unmounting suspends the running context', async () => {
+	await withMockedAudioContext(async () => {
+		const value = renderProvider(true);
+
+		await act(async () => {
+			await value.resume();
+		});
+		mock.ops = [];
+
+		act(() => {
+			cleanup();
+		});
+		await flush();
+
+		expect(nativeOps()).toEqual(['suspend']);
+		expect(mock.lastContext?.state).toBe('suspended');
 	});
 });

--- a/packages/core/src/test/mock-audio-context.tsx
+++ b/packages/core/src/test/mock-audio-context.tsx
@@ -1,0 +1,211 @@
+import {render} from '@testing-library/react';
+import type React from 'react';
+import {useContext} from 'react';
+import {
+	SharedAudioContext,
+	SharedAudioContextProvider,
+} from '../audio/shared-audio-tags.js';
+import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
+import {WrapSequenceContext} from './wrap-sequence-context.js';
+
+const previewEnvironment = {
+	isClientSideRendering: false,
+	isPlayer: true,
+	isReadOnlyStudio: false,
+	isRendering: false,
+	isStudio: false,
+};
+
+export type MockAudioContextControls = {
+	// Ordered log of everything crossing the native boundary:
+	// 'resume', 'suspend', 'gain:<value>'.
+	ops: string[];
+	stallNativeResume: boolean;
+	rejectNativeResume: boolean;
+	finishNativeResume: (() => void) | null;
+	lastContext: MockAudioContext | null;
+};
+
+export const mock: MockAudioContextControls = {
+	ops: [],
+	stallNativeResume: false,
+	rejectNativeResume: false,
+	finishNativeResume: null,
+	lastContext: null,
+};
+
+export class MockAudioContext {
+	public state = 'suspended' as AudioContextState;
+	public baseLatency = 0;
+	public outputLatency = 0;
+	public currentTime = 0;
+	public destination = {};
+	private readonly stateChangeListeners = new Set<EventListener>();
+	private outputTime = 0;
+
+	constructor() {
+		mock.lastContext = this;
+	}
+
+	addEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.add(listener);
+		}
+	}
+
+	removeEventListener(name: string, listener: EventListener) {
+		if (name === 'statechange') {
+			this.stateChangeListeners.delete(listener);
+		}
+	}
+
+	// Sets the state and fires statechange without logging a native op —
+	// models the browser flipping state on its own (an interruption ending,
+	// auto-starting a blocked context on a gesture). Real browsers dispatch
+	// statechange in a later task; tests must not depend on same-tick
+	// ordering between a native call and its statechange.
+	setNativeState(next: AudioContextState) {
+		this.state = next;
+		for (const listener of this.stateChangeListeners) {
+			listener(new Event('statechange'));
+		}
+	}
+
+	createGain() {
+		return {
+			connect: () => undefined,
+			gain: {
+				cancelScheduledValues: () => undefined,
+				linearRampToValueAtTime: (value: number) => {
+					mock.ops.push(`gain:${value}`);
+				},
+				setValueAtTime: (value: number) => {
+					mock.ops.push(`gain:${value}`);
+				},
+			},
+		};
+	}
+
+	suspend() {
+		mock.ops.push('suspend');
+		this.setNativeState('suspended');
+		return Promise.resolve();
+	}
+
+	resume() {
+		mock.ops.push('resume');
+		if (mock.rejectNativeResume) {
+			return Promise.reject(new Error('NotAllowedError'));
+		}
+
+		if (mock.stallNativeResume) {
+			return new Promise<void>((resolve) => {
+				mock.finishNativeResume = () => {
+					this.setNativeState('running');
+					resolve();
+				};
+			});
+		}
+
+		this.setNativeState('running');
+		return Promise.resolve();
+	}
+
+	getOutputTimestamp() {
+		// A running context's clocks advance; a suspended one's are frozen.
+		// Reads happen from waitUntilActuallyResumed's polling, so advancing
+		// per read models exactly what the poller observes in a browser.
+		if (this.state === 'running') {
+			this.currentTime += 0.01;
+			this.outputTime += 10;
+		}
+
+		return {contextTime: this.currentTime, performanceTime: this.outputTime};
+	}
+
+	createMediaElementSource() {
+		return {
+			connect: () => undefined,
+			disconnect: () => undefined,
+		};
+	}
+}
+
+export const nativeOps = () =>
+	mock.ops.filter((op) => op === 'resume' || op === 'suspend');
+
+export const makeNode = (started: number[]) => {
+	return {
+		playbackRate: {value: 1},
+		start: (scheduledTime: number) => {
+			started.push(scheduledTime);
+		},
+	} as unknown as AudioBufferSourceNode;
+};
+
+export const scheduleAt = (
+	value: NonNullable<React.ContextType<typeof SharedAudioContext>>,
+	node: AudioBufferSourceNode,
+	scheduledTime: number,
+) => {
+	return value.scheduleAudioNode({
+		node,
+		mediaTimestamp: 0,
+		sourceOffset: 0,
+		scheduledTime,
+		duration: 1,
+		offset: 0,
+		originalUnloopedMediaTimestamp: 0,
+	});
+};
+
+export const renderProvider = (_experimentalKeepAudioContextAlive: boolean) => {
+	const ref: {
+		current: NonNullable<React.ContextType<typeof SharedAudioContext>> | null;
+	} = {current: null};
+
+	const Probe: React.FC = () => {
+		ref.current = useContext(SharedAudioContext);
+		return null;
+	};
+
+	render(
+		<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+			<WrapSequenceContext>
+				<SharedAudioContextProvider
+					audioEnabled
+					audioLatencyHint="interactive"
+					previewSampleRate={null}
+					_experimentalKeepAudioContextAlive={
+						_experimentalKeepAudioContextAlive
+					}
+				>
+					<Probe />
+				</SharedAudioContextProvider>
+			</WrapSequenceContext>
+		</RemotionEnvironmentContext.Provider>,
+	);
+
+	if (!ref.current) {
+		throw new Error('Expected the shared audio context to be available');
+	}
+
+	// Mount behavior has its own test; scenarios start from a clean log.
+	mock.ops = [];
+	return ref.current;
+};
+
+export const withMockedAudioContext = async (fn: () => Promise<void>) => {
+	const originalAudioContext = globalThis.AudioContext;
+	globalThis.AudioContext = MockAudioContext as unknown as typeof AudioContext;
+	mock.ops = [];
+	mock.stallNativeResume = false;
+	mock.rejectNativeResume = false;
+	mock.finishNativeResume = null;
+	mock.lastContext = null;
+	try {
+		await fn();
+	} finally {
+		globalThis.AudioContext = originalAudioContext;
+	}
+};

--- a/packages/player/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/player/src/test/keep-audio-context-alive.test.tsx
@@ -228,3 +228,38 @@ test('_experimentalKeepAudioContextAlive resumes immediately after buffering', a
 
 	expect(gainValuesDuringBufferResume).toContain(1);
 });
+
+test('a synchronous play() + pause() still suspends the AudioContext', async () => {
+	// Both state updates batch into one commit, so the use-playback effect
+	// never observes playing=true; the pause() method's own intent
+	// declaration must cover this.
+	const originalAudioContext = globalThis.AudioContext;
+	globalThis.AudioContext =
+		TrackedAudioContext as unknown as typeof AudioContext;
+	try {
+		nativeSuspendCalls = 0;
+		const playerRef = createRef<PlayerRef>();
+		render(
+			<Player
+				ref={playerRef}
+				component={AudioComposition}
+				durationInFrames={300}
+				compositionWidth={1920}
+				compositionHeight={1080}
+				fps={30}
+			/>,
+		);
+		nativeSuspendCalls = 0;
+
+		await act(async () => {
+			playerRef.current?.play();
+			playerRef.current?.pause();
+			await Promise.resolve();
+		});
+
+		expect(playerRef.current?.isPlaying()).toBe(false);
+		expect(nativeSuspendCalls).toBeGreaterThan(0);
+	} finally {
+		globalThis.AudioContext = originalAudioContext;
+	}
+});

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -153,12 +153,12 @@ export const usePlayback = ({
 	]);
 
 	useEffect(() => {
-		if (!config) {
+		if (!playing) {
+			sharedAudioContext?.suspend?.();
 			return;
 		}
 
-		if (!playing) {
-			sharedAudioContext?.suspend?.();
+		if (!config) {
 			return;
 		}
 

--- a/packages/player/src/use-player-methods.ts
+++ b/packages/player/src/use-player-methods.ts
@@ -162,6 +162,8 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 
 			setPlaying(false);
 			emitter.dispatchPause();
+			// Also declared by the use-playback effect, but a synchronous
+			// play()+pause() batches to a no-op commit and never re-runs it.
 			audioContext?.suspend();
 		}
 	}, [audioContext, emitter, setPlaying, timelineImperativeContext]);


### PR DESCRIPTION
## Summary

Follow-up to #10905 and #10904 (both closed), replacing the promise choreography from those attempts with a structural fix.

`suspend()` now declares paused intent; the provider converges the native context toward intent — on intent edges and on `statechange`. Native suspension has a single owner, and the states no caller can reach are covered by the same mechanism instead of special cases:

- a `resume()` that settles after pause already ran (including a synchronous `play()` + `pause()`, where both state updates batch into one commit)
- an iOS audio interruption (phone call, Siri) ending while the Player is paused
- a browser auto-starting a previously blocked context on a later user gesture

All of these previously left the context running while the Player showed paused — and since `scheduleAudioNode` skips the save-for-later queue on a running context, seeking while paused could start audio audibly. The resume direction stays in `resume()`, which runs on the user-gesture call chain. Keep-alive mode wants the context running regardless of paused intent, so the convergence never touches it — no mode flag in the mechanism.

## Keep-alive: retry stalled resumes, bounded

With `_experimentalKeepAudioContextAlive` (editor-style playback), a stalled native `resume()` settled `'failed'` after 1s: the Player muted itself with the autoplay warning and stayed muted, because later `resume()` calls early-returned on the intent flag and never re-issued the native resume. Later attempts now retry onto the same wait, gated on `navigator.userActivation.isActive` so the per-frame playback loop does not pile up pending native resumes while blocked. The wait stays bounded: after the 1s timeout it settles `'cancelled'`, so the frame clock advances silently and audio joins on the next gesture instead of latching muted.

## Also fixed in passing

The context wrapper's transition bookkeeping used `promise.finally()`, whose derived promise nobody observes — every rejected native `resume()`/`suspend()` produced an unhandled rejection even though callers catch the returned promise. It now observes both settlement paths, which is also what makes the rejection paths testable.

## Tests

The core audio test file's private mock ignored event listeners entirely; it is replaced by a shared harness (`mock-audio-context.tsx`) that dispatches `statechange`, used by both core scenario files. The player package keeps its own simpler mocks. Coverage: 12 default-mode scenarios (`audio-suspend-intent.test.tsx`) including the double-`suspend()` pause sequence from the #10905 review, 8 keep-alive scenarios, and a Player-level test for the synchronous `play()` + `pause()` batch.

- `bun run test` in `packages/core` (703 tests)
- `bun run test` in `packages/player` (41 tests)
- `bun run lint` clean on all touched files
