### PR TITLE
`@remotion/transitions`: Cancel rendering when HTML-in-canvas drawing fails

### DIFF
--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -113,53 +113,54 @@ export const HtmlInCanvasPresentation = <
 			}
 
 			const handle = delayRender('onPaint');
-			const clearOutput = () => {
-				const context = outputCanvas.getContext('2d');
-				if (!context) {
-					throw new Error('Failed to create output canvas context');
+			try {
+				const clearOutput = () => {
+					const context = outputCanvas.getContext('2d');
+					if (!context) {
+						throw new Error('Failed to create output canvas context');
+					}
+
+					context.clearRect(0, 0, outputCanvas.width, outputCanvas.height);
+				};
+
+				if (!prevImage && !nextImage) {
+					instance.clear();
+					clearOutput();
+					return;
 				}
 
-				context.clearRect(0, 0, outputCanvas.width, outputCanvas.height);
-			};
+				const width = prevImage?.width ?? nextImage?.width ?? 0;
+				const height = prevImage?.height ?? nextImage?.height ?? 0;
 
-			if (!prevImage && !nextImage) {
-				instance.clear();
-				clearOutput();
+				if (width === 0 || height === 0) {
+					instance.clear();
+					clearOutput();
+					return;
+				}
+
+				shaderCanvas.width = width;
+				shaderCanvas.height = height;
+
+				instance.draw({
+					prevImage,
+					nextImage,
+					width,
+					height,
+					time: progress,
+					passedProps: passedPropsRef.current,
+				});
+
+				await Internals.runEffectChain({
+					state: chainState.get(width, height)!,
+					source: shaderCanvas,
+					effects: effectsRef.current ?? [],
+					width,
+					height,
+					output: outputCanvas,
+				});
+			} finally {
 				continueRender(handle);
-				return;
 			}
-
-			const width = prevImage?.width ?? nextImage?.width ?? 0;
-			const height = prevImage?.height ?? nextImage?.height ?? 0;
-
-			if (width === 0 || height === 0) {
-				instance.clear();
-				clearOutput();
-				continueRender(handle);
-				return;
-			}
-
-			shaderCanvas.width = width;
-			shaderCanvas.height = height;
-
-			instance.draw({
-				prevImage,
-				nextImage,
-				width,
-				height,
-				time: progress,
-				passedProps: passedPropsRef.current,
-			});
-
-			await Internals.runEffectChain({
-				state: chainState.get(width, height)!,
-				source: shaderCanvas,
-				effects: effectsRef.current ?? [],
-				width,
-				height,
-				output: outputCanvas,
-			});
-			continueRender(handle);
 		},
 		[chainState, continueRender, delayRender, instance, shaderCanvas],
 	);

--- a/packages/transitions/src/html-in-canvas-presentation.tsx
+++ b/packages/transitions/src/html-in-canvas-presentation.tsx
@@ -103,7 +103,7 @@ export const HtmlInCanvasPresentation = <
 	}, [instance]);
 
 	const chainState = Internals.useEffectChainState();
-	const {delayRender, continueRender} = useDelayRender();
+	const {delayRender, continueRender, cancelRender} = useDelayRender();
 
 	const draw: DrawFunction = useCallback(
 		async (prevImage, nextImage, progress) => {
@@ -126,6 +126,7 @@ export const HtmlInCanvasPresentation = <
 				if (!prevImage && !nextImage) {
 					instance.clear();
 					clearOutput();
+					continueRender(handle);
 					return;
 				}
 
@@ -135,6 +136,7 @@ export const HtmlInCanvasPresentation = <
 				if (width === 0 || height === 0) {
 					instance.clear();
 					clearOutput();
+					continueRender(handle);
 					return;
 				}
 
@@ -158,11 +160,19 @@ export const HtmlInCanvasPresentation = <
 					height,
 					output: outputCanvas,
 				});
-			} finally {
 				continueRender(handle);
+			} catch (error) {
+				cancelRender(error);
 			}
 		},
-		[chainState, continueRender, delayRender, instance, shaderCanvas],
+		[
+			cancelRender,
+			chainState,
+			continueRender,
+			delayRender,
+			instance,
+			shaderCanvas,
+		],
 	);
 
 	const passThrough =


### PR DESCRIPTION
Fixes a stall when a transition shader fails

Problem
When a html-in-canvas transition draws, we tell Remotion "wait, I'm
painting" (delayRender). If the shader throws — bad effect, zero-size
canvas on resize, GL error — we never told it "done" (continueRender),
so the player just froze on that frame. In our editor this showed as
2× playback dropping to 17/60 fps and needing a seek to recover.

This isn't meant to be an error guard — delayRender is just for
loading. Broken HTML is already handled by the early returns (empty
images, zero size) and the isSupported() check at the top. Those stay.

Fix
Wrap the whole paint in try / finally so continueRender always runs,
even if draw() or the effect chain throws. One bad frame now logs an
error and recovers next frame instead of locking the timeline.

Small change, no new API, ~30 lines.

How I tested
- Ran the transitions tests
- Tried the Player testbed with a shader transition and forced a throw
  — before: frozen, after: recovers

Checklist
- [x] Read CONTRIBUTING.md
- [x] Tests pass
- [x] No docs needed (bugfix)