### PR TITLE
docs: add RenderComp Free (50 MIT templates) to the templates list

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -24,6 +24,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - [Free Remotion Components](https://www.clippkit.com/)
 - [Remotion Bits - Ready-made blocks to use for you and your agents](https://remotion-bits.dev/)
 - [SwiftClip - 30 production-ready Remotion templates](https://swift-clip.vercel.app/) ([Source code](https://github.com/zz41354899/SwiftClip))
+- [RenderComp Free - 50 MIT-licensed Remotion templates](https://rendercomp.com/free) ([Source code](https://github.com/RenderComp/free-remotion-templates))
 - Docker Build & Render ([Source code](https://github.com/scotthavird/remotion-docker-template))
 - [Template for deploying Remotion on Railway](https://railway.com/deploy/remotion-on-rails) ([Blog](https://medium.com/@viveknathani/remotion-on-rails-0852acc9595e))
 - [Multiple shared Remotion components in a Monorepo template](https://github.com/Takamasa045/remotion-studio-monorepo)


### PR DESCRIPTION
Adds RenderComp Free, a free pack of 50 MIT-licensed Remotion templates with full source and no account/email gate.

Disclosure: I maintain RenderComp, which is an independent project and is not affiliated with Remotion. The preview page links to the paid RenderComp catalog, so I'm happy to adjust the wording, link directly to GitHub instead, or drop the entry if it does not fit the resources page.
