### PR TITLE
Internal: Consolidate package publish checks

### DIFF
--- a/packages/it-tests/src/monorepo/no-dev-files.test.ts
+++ b/packages/it-tests/src/monorepo/no-dev-files.test.ts
@@ -89,11 +89,28 @@ const assertNoDevFilesPublished = async (pkgPath: string) => {
 	}
 };
 
-for (const pkg of packages) {
-	test.concurrent(
-		'should not publish any dev files for @remotion/' + pkg.pkg,
-		async () => {
-			await assertNoDevFilesPublished(pkg.path);
-		},
-	);
-}
+test(
+	'should not publish any dev files',
+	async () => {
+		const results = await Promise.allSettled(
+			packages.map((pkg) => assertNoDevFilesPublished(pkg.path)),
+		);
+		const errors = results.flatMap((result, index) => {
+			if (result.status === 'fulfilled') {
+				return [];
+			}
+
+			return [
+				`@remotion/${packages[index].pkg}: ${
+					result.reason instanceof Error
+						? result.reason.message
+						: String(result.reason)
+				}`,
+			];
+		});
+		if (errors.length > 0) {
+			throw new Error(errors.join('\n'));
+		}
+	},
+	{timeout: 40000},
+);


### PR DESCRIPTION
## Summary

- consolidate 105 package publishability checks into one bounded workflow
- keep the existing eight-process pack concurrency limit
- wait for every package check and aggregate package-specific failures

## CI timing evidence

Sampled the test timing output from every job in successful main run [33188834214](https://github.com/remotion-dev/remotion/actions/runs/33188834214). The package publish checks appeared as a repeated cluster of up to 1.34 seconds per test, even though every case exercises the same publishability contract and shares one explicit pack queue.

Matched three-run local samples reduced median wall time from 5.99 seconds to 5.09 seconds. The old per-package test wrappers could also time out while waiting for a pack slot under host load; the consolidated workflow applies one 40-second timeout to the complete scan instead.

## Verification

- `bun test src/monorepo/no-dev-files.test.ts --run --timeout 40000`
- injected a temporary forbidden TypeScript file and verified the error names `@remotion/animated-emoji`
- full monorepo suite: 27 passed; only the environment's existing Ruby `bundle install` setup failed
- `bun run build`
- `bun run stylecheck`
