### PR TITLE
`@remotion/studio`: Hide FPS counter on narrow viewports

### DIFF
--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -227,7 +227,7 @@ export const PreviewToolbar: React.FC<{
 			<Flex />
 			<div style={sideContainer}>
 				<Flex />
-				<FpsCounter playbackSpeed={playbackRate} />
+				{isMobileLayout ? null : <FpsCounter playbackSpeed={playbackRate} />}
 				<Spacing x={2} />
 				<PreviewToolbarControl>
 					<RenderButton


### PR DESCRIPTION
## Summary

Hide the Studio FPS counter when the preview toolbar uses the narrow viewport layout.

## Testing

- `bunx turbo run lint test make --filter=@remotion/studio`
- `bun run build`
- `bun run stylecheck`

Closes #10947
