### PR TITLE
Elements: Align audio oscilloscope color

### DIFF
--- a/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
+++ b/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
@@ -35,7 +35,7 @@ const audioOscilloscopeSchema = {
 	},
 	lineColor: {
 		type: 'color',
-		default: '#55e6ff',
+		default: '#0b84f3',
 		description: 'Waveform color',
 	},
 	lineWidth: {
@@ -170,7 +170,7 @@ const AudioOscilloscopeInner = forwardRef<
 			amplitude = 2,
 			audioSrc = 'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 			controls,
-			lineColor = '#55e6ff',
+			lineColor = '#0b84f3',
 			lineWidth = 6,
 			name,
 			style,


### PR DESCRIPTION
## Summary

Changes the Audio Oscilloscope Element's default waveform color to `#0b84f3` so it fits better alongside neighboring Elements in the library.

## Verification

- `bunx oxfmt packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx --write`
- `bun run build`
- `bun run stylecheck` *(fails on pre-existing lint errors in `packages/brand/src/*.element.tsx`)*

## Preview

- [Audio Oscilloscope](https://remotion-git-codex-oscilloscope-align-color-remotion.vercel.app/elements/audio/oscilloscope)
