### PR TITLE
Elements: Align caption highlight colors

### DIFF
--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -44,7 +44,7 @@ const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
 const textColor = '#ffffff';
-const highlightColor = '#18ff0e';
+const highlightColor = '#4da3ff';
 const activeWordScale = 1.03;
 const defaultCombineTokensWithinMilliseconds = 800;
 

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -42,7 +42,7 @@ const desiredFontSize = 80;
 const maximumTextWidth = 800;
 const fontWeight = '700';
 const textColor = '#ffffff';
-const highlightColor = '#18ff0e';
+const highlightColor = '#4da3ff';
 const defaultCombineTokensWithinMilliseconds = 800;
 
 const wordHighlightCaptionsSchema = {


### PR DESCRIPTION
## Summary

- replace the green Popping Word caption highlight with a brighter blue
- use the same brighter blue for Word Highlight captions
- keep the caption styles in the same color family as Moving Pill captions while preserving text readability

Related to #10967

## Verification

- `bun run build`
- `bunx oxfmt packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx --check`
- `bun run stylecheck` *(fails on pre-existing lint errors in `packages/brand/src/*.element.tsx`)*


## Preview

- [Popping Word Captions](https://remotion-git-codex-align-caption-colors-remotion.vercel.app/elements/captions/popping-word-captions)
- [Word Highlight Captions](https://remotion-git-codex-align-caption-colors-remotion.vercel.app/elements/captions/word-highlight-captions)

