### PR TITLE
`@remotion/studio`: Prevent timeline asset drops through modals

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -348,6 +348,67 @@ test.describe('visual mode', () => {
 			await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
 			const timeline = page.locator('[data-timeline-scrollable]');
 			await expect(timeline).toBeVisible();
+			const timelineBox = await timeline.boundingBox();
+			if (timelineBox === null) {
+				throw new Error('Expected timeline to have a bounding box');
+			}
+
+			const dragData = StudioProtocolInternals.makeDragData({
+				type: 'asset',
+				assetPath: 'quick.mov',
+				durationInSeconds: 5.866667,
+				height: null,
+				width: null,
+			});
+			const dragAssetOver = (target: Locator) => {
+				return target.evaluate(
+					(element, {coordinates, data}) => {
+						const dataTransfer = new DataTransfer();
+						dataTransfer.setData(data.mimeType, data.payload);
+						element.dispatchEvent(
+							new DragEvent('dragover', {
+								bubbles: true,
+								cancelable: true,
+								clientX: coordinates.clientX,
+								clientY: coordinates.clientY,
+								dataTransfer,
+							}),
+						);
+					},
+					{
+						coordinates: {
+							clientX: timelineBox.x + timelineBox.width / 2,
+							clientY: timelineBox.y + timelineBox.height / 2,
+						},
+						data: dragData,
+					},
+				);
+			};
+			const dropIndicator = page.locator(
+				'[data-timeline-asset-drop-indicator]',
+			);
+			await dragAssetOver(timeline);
+			await expect(dropIndicator).toBeVisible();
+			await page.evaluate(() => {
+				document.dispatchEvent(new DragEvent('dragend', {bubbles: true}));
+			});
+			await expect(dropIndicator).toBeHidden();
+
+			await page.getByRole('button', {name: /Search\.\.\./}).click();
+			const quickSwitcher = page.getByRole('dialog');
+			await quickSwitcher.getByRole('textbox').fill('> Settings');
+			await quickSwitcher.getByText('Settings...', {exact: true}).click();
+			const settings = page.getByRole('dialog');
+			await expect(
+				settings.getByText('Default codec', {exact: true}),
+			).toBeVisible();
+			await dragAssetOver(settings);
+			await expect(dropIndicator).toBeHidden();
+			await expect(
+				settings.getByText('Default codec', {exact: true}),
+			).toBeVisible();
+			await page.keyboard.press('Escape');
+
 			expect(await dropFile({...file, target: timeline})).toBe(true);
 			await expect(modalTitle).toBeVisible();
 		} finally {

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -15,18 +15,8 @@ import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
 import {useResolvedStack} from './use-resolved-stack';
 
-const isEventInsideElement = (event: DragEvent, element: HTMLElement) => {
-	if (event.target instanceof Node && element.contains(event.target)) {
-		return true;
-	}
-
-	const rect = element.getBoundingClientRect();
-	return (
-		event.clientX >= rect.left &&
-		event.clientX <= rect.right &&
-		event.clientY >= rect.top &&
-		event.clientY <= rect.bottom
-	);
+const isEventTargetInsideElement = (event: DragEvent, element: HTMLElement) => {
+	return event.target instanceof Node && element.contains(event.target);
 };
 
 export const useTimelineAssetDrop = () => {
@@ -76,7 +66,8 @@ export const useTimelineAssetDrop = () => {
 			}
 
 			const scrollable = scrollableRef.current;
-			return scrollable !== null && isEventInsideElement(event, scrollable)
+			return scrollable !== null &&
+				isEventTargetInsideElement(event, scrollable)
 				? getFrameFromTimelineDrop({
 						clientX: event.clientX,
 						durationInFrames: videoConfig.durationInFrames,
@@ -97,7 +88,7 @@ export const useTimelineAssetDrop = () => {
 				timeline === null ||
 				dataTransfer === null ||
 				!isSupportedDropEvent(event) ||
-				!isEventInsideElement(event, timeline)
+				!isEventTargetInsideElement(event, timeline)
 			) {
 				setAssetDropFrame(null);
 				return;
@@ -110,7 +101,7 @@ export const useTimelineAssetDrop = () => {
 			const shouldShowDropFrame =
 				canInsertAsset &&
 				scrollable !== null &&
-				isEventInsideElement(event, scrollable);
+				isEventTargetInsideElement(event, scrollable);
 			setAssetDropFrame(shouldShowDropFrame ? getDropFrame(event) : null);
 		},
 		[canInsertAsset, getDropFrame],
@@ -125,7 +116,7 @@ export const useTimelineAssetDrop = () => {
 				timeline === null ||
 				dataTransfer === null ||
 				!isSupportedDropEvent(event) ||
-				!isEventInsideElement(event, timeline)
+				!isEventTargetInsideElement(event, timeline)
 			) {
 				return;
 			}


### PR DESCRIPTION
## Summary

- require timeline drag-and-drop events to target the referenced timeline container
- prevent modal backdrop drags from activating the timeline drop target
- cover direct timeline drags and modal-targeted drags in the existing Studio E2E workflow

## Test plan

- `bunx playwright test e2e/studio.test.mts --grep "should route Canvas Capture drops by Studio target"`
- `bun run build`
- `bun run lint` in `packages/studio`
- `bunx eslint e2e/studio.test.mts` in `packages/example`
- `bun run stylecheck` *(blocked by pre-existing lint errors in unchanged `packages/brand/*.element.tsx` files)*

Red/green verified: with the coordinate fallback, a drag targeting the Settings modal displayed the timeline drop indicator; with target containment, the indicator stays hidden while direct timeline drags continue to work.
