### PR TITLE
`@remotion/studio`: Fix source inspector alignment

### DIFF
--- a/packages/example/e2e/inspector-control-layout.test.mts
+++ b/packages/example/e2e/inspector-control-layout.test.mts
@@ -61,7 +61,7 @@ test.describe('Inspector control layout', () => {
 		await stopStudio();
 	});
 
-	test('does not indent controls after array fields', async ({page}) => {
+	test('keeps inspector controls aligned', async ({page}) => {
 		await page.goto(`${STUDIO_URL}/inspector-control-layout-e2e`);
 		await expect(page).toHaveURL(/inspector-control-layout-e2e/, {
 			timeout: 15_000,
@@ -92,6 +92,18 @@ test.describe('Inspector control layout', () => {
 			.getByRole('button', {name: 'Add keyframe'})
 			.first();
 		const colorButton = page.getByRole('button', {name: '#ff5c4d'});
+		const sourceAction = page.getByRole('button', {name: 'tablet.mp4'});
+		const duplicateAction = page.getByRole('button', {
+			name: 'Duplicate',
+			exact: true,
+		});
+		const [sourceActionBox, duplicateActionBox] = await Promise.all([
+			getBox(sourceAction),
+			getBox(duplicateAction),
+		]);
+		expect(
+			Math.abs(sourceActionBox.x - duplicateActionBox.x),
+		).toBeLessThanOrEqual(1);
 
 		await expectInspectorControlsToUseAvailableWidth(
 			origin,

--- a/packages/example/src/InspectorControlLayoutE2e.tsx
+++ b/packages/example/src/InspectorControlLayoutE2e.tsx
@@ -3,11 +3,17 @@ import {
 	AbsoluteFill,
 	Interactive,
 	Sequence,
+	staticFile,
 	type InteractivitySchema,
 	type SequenceControls,
 } from 'remotion';
 
 const inspectorControlLayoutSchema = {
+	src: {
+		type: 'asset',
+		default: undefined,
+		description: 'Source',
+	},
 	first: {
 		type: 'array',
 		item: {type: 'number', step: 0.0001},
@@ -49,6 +55,7 @@ const inspectorControlLayoutSchema = {
 
 type InspectorControlLayoutProps = {
 	readonly name: string;
+	readonly src: string;
 	readonly first: readonly number[];
 	readonly second: readonly number[];
 	readonly label: string;
@@ -80,6 +87,7 @@ export const InspectorControlLayoutE2e: React.FC = () => {
 	return (
 		<InteractiveInspectorControlLayout
 			name="Inspector control layout"
+			src={staticFile('tablet.mp4')}
 			first={[-0.1276, 51.5072]}
 			second={[139.6917, 35.6895]}
 			label="London"

--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -29,6 +29,7 @@ const sourceActions: React.CSSProperties = {
 	display: 'flex',
 	flex: 1,
 	gap: 4,
+	margin: '0 4px',
 	minWidth: 0,
 };
 


### PR DESCRIPTION
## Summary

- restore the horizontal inset for the source inspector action row
- extend the inspector layout E2E fixture with an asset source
- assert that source and standard inspector quick actions stay aligned

## Testing

- `bun run build`
- affected-package lint and formatting checks
- inspector layout Playwright E2E test
- repository skill checks

`bun run stylecheck` is currently blocked by pre-existing lint errors in unchanged `packages/brand/*.element.tsx` files.

Closes #10846
