### PR TITLE
`@remotion/studio`: Fix Browser Studio document title + Make Element Install a modal

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1101,6 +1101,10 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 	await expect(
 		studio.getByText('Install Element', {exact: true}),
 	).toBeVisible();
+	await expect(page).toHaveTitle(
+		'📦 Install Linked Element - Remotion Studio',
+		{timeout: 5000},
+	);
 	await expect(
 		studio.getByText('Unverified Browser Studio link'),
 	).toBeVisible();
@@ -1158,6 +1162,9 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 				).__browserStudioInstallPreservedIframe,
 		),
 	).toBe(true);
+	await expect(page).toHaveTitle('MyComp / template-blank - Remotion Studio', {
+		timeout: 5000,
+	});
 });
 
 test('reports inline SVG imports as unsupported without changing the project', async ({

--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -195,6 +195,10 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 				studio.locator('.remotion-studio-composition-container'),
 			).toBeVisible();
 			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp');
+			await expect(page).toHaveTitle(
+				'MyComp / template-blank - Remotion Studio',
+				{timeout: 5000},
+			);
 			await studio.locator('button:has(svg[viewBox="0 0 415 426"])').click();
 			const popupPromise = page.waitForEvent('popup');
 			await studio.getByText('About Remotion', {exact: true}).click();
@@ -329,8 +333,16 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 				studio.getByTitle('/project').getByText('MyComp1'),
 			).toBeVisible();
 			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp1');
+			await expect(page).toHaveTitle(
+				'MyComp1 / template-blank - Remotion Studio',
+				{timeout: 5000},
+			);
 			await page.goBack();
 			await expect.poll(() => new URL(page.url()).search).toBe('?/MyComp');
+			await expect(page).toHaveTitle(
+				'MyComp / template-blank - Remotion Studio',
+				{timeout: 5000},
+			);
 			await studio.getByRole('button', {name: 'Render on web'}).click();
 			await expect(
 				studio.getByText('Render MyComp', {exact: true}),

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -1,9 +1,6 @@
 import type {Size} from '@remotion/player';
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
-import type {
-	ElementInstallExpectedFileState,
-	ElementInstallRequest,
-} from '@remotion/studio-shared';
+import type {ElementInstallRequest} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -71,7 +68,6 @@ import {
 	enqueueElementInstallRequest,
 	subscribeToElementInstallRequests,
 } from './element-install-request';
-import {ElementInstallConfirmation} from './ElementInstallConfirmation';
 import {handleDrop} from './handle-drop';
 import {
 	getFromForDrop,
@@ -90,21 +86,6 @@ import {getCurrentFrame} from './Timeline/imperative-state';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
 
 const elementInstallDependencyIgnoreList = ['react', 'react-dom', 'remotion'];
-
-type ElementInstallPlan = {
-	readonly compositionFile: string;
-	readonly filePath: string;
-	readonly expectedFileState: ElementInstallExpectedFileState;
-};
-
-type ElementInstallReview = {
-	readonly currentPlan: ElementInstallPlan | null;
-	readonly dependenciesToReview: string[];
-	readonly missingPackages: string[];
-	readonly newPlan: ElementInstallPlan;
-	readonly sourceIsUnverified: boolean;
-	readonly sourceLabel: string;
-};
 
 const getContainerStyle = (
 	editorZoomGestures: boolean,
@@ -256,15 +237,10 @@ export const Canvas: React.FC<{
 	const [isAddingAsset, setIsAddingAsset] = useState(false);
 	const [compositionDropPreview, setCompositionDropPreview] =
 		useState<CompositionDropPreview | null>(null);
-	const [installingElementName, setInstallingElementName] = useState<
-		string | null
-	>(null);
 	const [pendingElementInstallRequests, setPendingElementInstallRequests] =
 		useState<ElementInstallRequest[]>([]);
 	const [activeElementInstallRequest, setActiveElementInstallRequest] =
 		useState<ElementInstallRequest | null>(null);
-	const [elementInstallReview, setElementInstallReview] =
-		useState<ElementInstallReview | null>(null);
 	const lastFocusedAtRef = useRef<number | null>(
 		typeof document === 'undefined' || document.hasFocus() ? Date.now() : null,
 	);
@@ -833,19 +809,6 @@ export const Canvas: React.FC<{
 	}, [subscribeToEvent, updateElementInstallTarget]);
 
 	useEffect(() => {
-		if (installingElementName === null) {
-			return;
-		}
-
-		const previousTitle = document.title;
-		document.title = `📦 Install ${installingElementName} - Remotion Studio`;
-
-		return () => {
-			document.title = previousTitle;
-		};
-	}, [installingElementName]);
-
-	useEffect(() => {
 		if (previewServerClientId === null) {
 			return;
 		}
@@ -930,6 +893,11 @@ export const Canvas: React.FC<{
 		setPendingElementInstallRequests(remainingRequests);
 	}, [activeElementInstallRequest, pendingElementInstallRequests]);
 
+	const closeElementInstallDialog = useCallback(() => {
+		setSelectedModal(null);
+		setActiveElementInstallRequest(null);
+	}, [setSelectedModal]);
+
 	useEffect(() => {
 		if (activeElementInstallRequest === null) {
 			return;
@@ -937,7 +905,6 @@ export const Canvas: React.FC<{
 
 		let canceled = false;
 		const handleInstallRequest = async () => {
-			setInstallingElementName(activeElementInstallRequest.element.displayName);
 			try {
 				const [newPreflight, currentPreflight] = await Promise.all([
 					prepareElementInstall({
@@ -965,7 +932,6 @@ export const Canvas: React.FC<{
 						`Could not review Element installation: ${newPreflight.reason}`,
 						4000,
 					);
-					setInstallingElementName(null);
 					setActiveElementInstallRequest(null);
 					return;
 				}
@@ -1005,12 +971,14 @@ export const Canvas: React.FC<{
 				const currentPlan = currentPreflight.success
 					? currentPreflight.plan
 					: null;
-				setSelectedModal(null);
-				setElementInstallReview({
+				setSelectedModal({
+					type: 'element-install',
 					currentPlan,
 					dependenciesToReview,
 					missingPackages,
 					newPlan: newPreflight.plan,
+					onClose: closeElementInstallDialog,
+					request: activeElementInstallRequest,
 					sourceIsUnverified,
 					sourceLabel,
 				});
@@ -1025,7 +993,6 @@ export const Canvas: React.FC<{
 					}`,
 					4000,
 				);
-				setInstallingElementName(null);
 				setActiveElementInstallRequest(null);
 			}
 		};
@@ -1034,13 +1001,11 @@ export const Canvas: React.FC<{
 		return () => {
 			canceled = true;
 		};
-	}, [activeElementInstallRequest, setSelectedModal]);
-
-	const closeElementInstallDialog = useCallback(() => {
-		setElementInstallReview(null);
-		setInstallingElementName(null);
-		setActiveElementInstallRequest(null);
-	}, []);
+	}, [
+		activeElementInstallRequest,
+		closeElementInstallDialog,
+		setSelectedModal,
+	]);
 
 	const onDragOver = useCallback(
 		(event: DragEvent) => {
@@ -1513,33 +1478,6 @@ export const Canvas: React.FC<{
 					canvasSize={size}
 					assetMetadata={assetResolution}
 					containerRef={canvasRef}
-				/>
-			)}
-			{activeElementInstallRequest === null ||
-			elementInstallReview === null ? null : (
-				<ElementInstallConfirmation
-					currentCompositionMetadata={
-						config === null ||
-						currentCompositionId !== activeElementInstallRequest.compositionId
-							? null
-							: {
-									durationInFrames: config.durationInFrames,
-									fps: config.fps,
-									height: config.height,
-									width: config.width,
-								}
-					}
-					currentPlan={elementInstallReview.currentPlan}
-					dependenciesToReview={elementInstallReview.dependenciesToReview}
-					missingPackages={elementInstallReview.missingPackages}
-					newPlan={elementInstallReview.newPlan}
-					onClose={closeElementInstallDialog}
-					request={activeElementInstallRequest}
-					sourceIsUnverified={elementInstallReview.sourceIsUnverified}
-					sourceLabel={elementInstallReview.sourceLabel}
-					usesBrowserDependencyResolution={
-						getBrowserStudioOperations() !== null
-					}
 				/>
 			)}
 		</>

--- a/packages/studio/src/components/CurrentCompositionSideEffects.tsx
+++ b/packages/studio/src/components/CurrentCompositionSideEffects.tsx
@@ -3,13 +3,16 @@ import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
 import {
 	setCurrentCanvasContentId,
+	setCurrentModal,
 	setRenderJobs,
 } from '../helpers/document-title';
+import {SelectedModalContext} from '../state/modals';
 import {RenderQueueContext} from './RenderQueue/context';
 
 export const TitleUpdater: React.FC = () => {
 	const renderQueue = useContext(RenderQueueContext);
 	const {canvasContent} = useContext(Internals.CompositionManager);
+	const selectedModal = useContext(SelectedModalContext);
 	const {jobs} = renderQueue;
 
 	useEffect(() => {
@@ -39,6 +42,10 @@ export const TitleUpdater: React.FC = () => {
 	useEffect(() => {
 		setRenderJobs(jobs);
 	}, [jobs]);
+
+	useEffect(() => {
+		setCurrentModal(selectedModal);
+	}, [selectedModal]);
 
 	return null;
 };

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -1,8 +1,4 @@
 import {StudioProtocolInternals} from '@remotion/studio-protocol';
-import type {
-	ElementInstallExpectedFileState,
-	ElementInstallRequest,
-} from '@remotion/studio-shared';
 import React, {
 	useCallback,
 	useContext,
@@ -14,6 +10,7 @@ import React, {
 import {createPortal} from 'react-dom';
 import {Internals} from 'remotion';
 import {ShortcutHint} from '../error-overlay/remotion-overlay/ShortcutHint';
+import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {
 	INPUT_BACKGROUND,
 	LIGHT_TEXT,
@@ -30,6 +27,10 @@ import {
 import {resolvedStackToSymbolicated} from '../helpers/resolved-stack-to-symbolicated';
 import {useCreateComposition} from '../helpers/use-create-composition';
 import {validateCompositionName} from '../helpers/validate-new-comp-data';
+import type {
+	ElementInstallModalState,
+	ElementInstallPlan,
+} from '../state/modals';
 import {useZIndex} from '../state/z-index';
 import {Button} from './Button';
 import {prepareElementInstall} from './element-install-api';
@@ -351,12 +352,6 @@ export const ElementLibraryAddConfirmation: React.FC<{
 	);
 };
 
-type ElementInstallPlan = {
-	readonly compositionFile: string;
-	readonly filePath: string;
-	readonly expectedFileState: ElementInstallExpectedFileState;
-};
-
 type NewCompositionPlanState =
 	| {
 			readonly type: 'loading';
@@ -373,37 +368,35 @@ type NewCompositionPlanState =
 			readonly reason: string;
 	  };
 
-type CurrentCompositionMetadata = {
-	readonly durationInFrames: number;
-	readonly fps: number;
-	readonly height: number;
-	readonly width: number;
-};
-
 export const ElementInstallConfirmation: React.FC<{
-	readonly currentCompositionMetadata: CurrentCompositionMetadata | null;
-	readonly currentPlan: ElementInstallPlan | null;
-	readonly dependenciesToReview: string[];
-	readonly missingPackages: string[];
-	readonly newPlan: ElementInstallPlan;
-	readonly onClose: () => void;
-	readonly request: ElementInstallRequest;
-	readonly sourceIsUnverified: boolean;
-	readonly sourceLabel: string;
-	readonly usesBrowserDependencyResolution: boolean;
-}> = ({
-	currentCompositionMetadata,
-	currentPlan,
-	dependenciesToReview,
-	missingPackages,
-	newPlan,
-	onClose,
-	request,
-	sourceIsUnverified,
-	sourceLabel,
-	usesBrowserDependencyResolution,
-}) => {
-	const {compositions} = useContext(Internals.CompositionManager);
+	readonly state: ElementInstallModalState;
+}> = ({state}) => {
+	const {
+		currentPlan,
+		dependenciesToReview,
+		missingPackages,
+		newPlan,
+		onClose,
+		request,
+		sourceIsUnverified,
+		sourceLabel,
+	} = state;
+	const config = Internals.useUnsafeVideoConfig();
+	const {canvasContent, compositions} = useContext(
+		Internals.CompositionManager,
+	);
+	const currentCompositionMetadata =
+		config === null ||
+		canvasContent?.type !== 'composition' ||
+		canvasContent.compositionId !== request.compositionId
+			? null
+			: {
+					durationInFrames: config.durationInFrames,
+					fps: config.fps,
+					height: config.height,
+					width: config.width,
+				};
+	const usesBrowserDependencyResolution = getBrowserStudioOperations() !== null;
 	const {currentZIndex} = useZIndex();
 	const [mode, setMode] = useState<'current-composition' | 'new-composition'>(
 		currentPlan === null ? 'new-composition' : 'current-composition',

--- a/packages/studio/src/components/Modals.tsx
+++ b/packages/studio/src/components/Modals.tsx
@@ -7,7 +7,10 @@ import {AskAiModal} from './AskAiModal';
 import {callApi} from './call-api';
 import {ConfirmationDialog, useConfirmationDialog} from './ConfirmationDialog';
 import {EffectPickerModal} from './EffectPickerModal';
-import {ElementLibraryAddConfirmation} from './ElementInstallConfirmation';
+import {
+	ElementInstallConfirmation,
+	ElementLibraryAddConfirmation,
+} from './ElementInstallConfirmation';
 import {ElementLibraryModal} from './ElementLibraryModal';
 import {FixComputedValueModal} from './FixComputedValueModal';
 import {DeleteComposition} from './NewComposition/DeleteComposition';
@@ -274,6 +277,9 @@ export const Modals: React.FC<{
 					name={modalContextType.name}
 					url={modalContextType.url}
 				/>
+			)}
+			{modalContextType && modalContextType.type === 'element-install' && (
+				<ElementInstallConfirmation state={modalContextType} />
 			)}
 			{modalContextType && modalContextType.type === 'add-effect' && (
 				<EffectPickerModal state={modalContextType} />

--- a/packages/studio/src/helpers/document-title.ts
+++ b/packages/studio/src/helpers/document-title.ts
@@ -1,6 +1,7 @@
 import {NoReactInternals} from 'remotion/no-react';
 import type {AnyRenderJob} from '../components/RenderQueue/context';
 import {isClientRenderJob} from '../components/RenderQueue/context';
+import {getNavigationWindow} from './url-state';
 
 let currentItemName: string | null = null;
 let renderJobs: AnyRenderJob[] = [];
@@ -27,13 +28,13 @@ const suffix = `- ${productName}`;
 
 const updateTitle = () => {
 	if (!currentItemName) {
-		document.title = productName;
+		getNavigationWindow().document.title = productName;
 		return;
 	}
 
 	const currentCompTitle = `${currentItemName} / ${window.remotion_projectName}`;
 
-	document.title = [
+	getNavigationWindow().document.title = [
 		getProgressInBrackets(currentItemName, renderJobs),
 		`${currentCompTitle} ${suffix}`,
 	]

--- a/packages/studio/src/helpers/document-title.ts
+++ b/packages/studio/src/helpers/document-title.ts
@@ -1,9 +1,11 @@
 import {NoReactInternals} from 'remotion/no-react';
 import type {AnyRenderJob} from '../components/RenderQueue/context';
 import {isClientRenderJob} from '../components/RenderQueue/context';
+import type {ModalState} from '../state/modals';
 import {getNavigationWindow} from './url-state';
 
 let currentItemName: string | null = null;
+let currentModal: ModalState | null = null;
 let renderJobs: AnyRenderJob[] = [];
 
 export const setCurrentCanvasContentId = (id: string | null) => {
@@ -23,10 +25,20 @@ export const setRenderJobs = (jobs: AnyRenderJob[]) => {
 	updateTitle();
 };
 
+export const setCurrentModal = (modal: ModalState | null) => {
+	currentModal = modal;
+	updateTitle();
+};
+
 const productName = 'Remotion Studio';
 const suffix = `- ${productName}`;
 
 const updateTitle = () => {
+	if (currentModal?.type === 'element-install') {
+		getNavigationWindow().document.title = `📦 Install ${currentModal.request.element.displayName} - ${productName}`;
+		return;
+	}
+
 	if (!currentItemName) {
 		getNavigationWindow().document.title = productName;
 		return;

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -11,7 +11,12 @@ import type {
 	X264Preset,
 } from '@remotion/renderer';
 import type {HardwareAccelerationOption} from '@remotion/renderer/client';
-import type {CanvasCaptureData, RenderDefaults} from '@remotion/studio-shared';
+import type {
+	CanvasCaptureData,
+	ElementInstallExpectedFileState,
+	ElementInstallRequest,
+	RenderDefaults,
+} from '@remotion/studio-shared';
 import type {
 	RenderStillOnWebImageFormat,
 	WebRendererAudioCodec,
@@ -143,6 +148,24 @@ export type CanvasCaptureImport = {
 	readonly width: number;
 };
 
+export type ElementInstallPlan = {
+	readonly compositionFile: string;
+	readonly filePath: string;
+	readonly expectedFileState: ElementInstallExpectedFileState;
+};
+
+export type ElementInstallModalState = {
+	readonly type: 'element-install';
+	readonly currentPlan: ElementInstallPlan | null;
+	readonly dependenciesToReview: string[];
+	readonly missingPackages: string[];
+	readonly newPlan: ElementInstallPlan;
+	readonly onClose: () => void;
+	readonly request: ElementInstallRequest;
+	readonly sourceIsUnverified: boolean;
+	readonly sourceLabel: string;
+};
+
 export type ModalState =
 	| {
 			type: 'new-comp';
@@ -232,6 +255,7 @@ export type ModalState =
 			name: string;
 			url: string;
 	  }
+	| ElementInstallModalState
 	| AddEffectModalState
 	| ConfirmationDialogState
 	| SvgImportDialogState;


### PR DESCRIPTION
## Summary

- Mirror Studio's dynamic document title to the Browser Studio host window.
- Represent Element installation in selected modal state and derive its temporary title centrally.
- Cover composition, browser navigation, and Element install title transitions in Browser Studio.

## Testing

- `bunx turbo run make --filter='@remotion/studio' --filter='@remotion/browser-studio'`
- `bunx turbo run lint --filter='@remotion/studio' --filter='@remotion/browser-studio'`
- `bunx oxfmt packages/studio/src/helpers/document-title.ts packages/studio/src/components/CurrentCompositionSideEffects.tsx packages/studio/src/components/Canvas.tsx packages/studio/src/components/ElementInstallConfirmation.tsx packages/studio/src/components/Modals.tsx packages/studio/src/state/modals.ts packages/browser-studio/e2e/browser-studio.test.ts --check`
- `bunx playwright test e2e/browser-studio.test.ts --project=chromium --grep "loads Browser Studio, opens external links, and can add, delete, and duplicate|confirms and imports an Element payload from the URL fragment"`

Closes #10932
