### PR TITLE
`@remotion/studio-codemods`: Stop wrapping self-closing roots in `<Sequence>`

### DIFF
--- a/packages/browser-studio/src/test/browser-studio-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-operations.test.ts
@@ -179,7 +179,7 @@ export const MyComponent = () => <AbsoluteFill>Existing</AbsoluteFill>;
 	);
 });
 
-test('wraps a self-closing root, aliases bindings, and remaps the root', () => {
+test('inserts beside a self-closing root, aliases bindings, and remaps the root', () => {
 	const project: VirtualProject = {
 		rootDir: '/project',
 		entryPoint: '/project/src/index.tsx',
@@ -212,11 +212,12 @@ registerRoot(Root);
 	const output = updated.files['/project/src/index.tsx'];
 
 	expect(output).toContain(
-		"import {AbsoluteFill, Composition, registerRoot, Solid as RemotionSolid, Sequence as RemotionSequence} from 'remotion';",
+		"import {AbsoluteFill, Composition, registerRoot, Solid as RemotionSolid} from 'remotion';",
 	);
-	expect(output).toContain('<RemotionSequence>');
+	expect(output).not.toContain('<RemotionSequence>');
+	expect(output).toContain('<AbsoluteFill />');
 	expect(output).toContain('<RemotionSolid width={1280}');
-	expect(nodePathRemappings).toHaveLength(3);
+	expect(nodePathRemappings).toHaveLength(2);
 	expect(nodePathRemappings).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({oldNodePath: expect.any(Array)}),

--- a/packages/studio-codemods/src/index.ts
+++ b/packages/studio-codemods/src/index.ts
@@ -790,39 +790,24 @@ const replaceNullRoot = ({
 const replaceJsxElementRoot = ({
 	element,
 	root,
-	sequenceLocalName,
 	source,
 	unit,
-	wrapRootInSequence,
 }: {
 	element: string;
 	root: AstNode;
-	sequenceLocalName: string | null;
 	source: string;
 	unit: string;
-	wrapRootInSequence: boolean;
 }): TextEdit => {
 	const start = getPosition(root, 'start');
 	const indent = lineIndentAt(source, start);
 	const original = source.slice(start, getPosition(root, 'end'));
-	if (wrapRootInSequence && sequenceLocalName === null) {
-		throw new Error('Expected a Sequence import for a self-closing root');
-	}
-
-	const existingRoot = wrapRootInSequence
-		? [
-				`${indent}${unit}<${sequenceLocalName}>`,
-				`${indent}${unit}${unit}${original}`,
-				`${indent}${unit}</${sequenceLocalName}>`,
-			]
-		: [`${indent}${unit}${original}`];
 
 	return {
 		start,
 		end: getPosition(root, 'end'),
 		text: [
 			'<>',
-			...existingRoot,
+			`${indent}${unit}${original}`,
 			`${indent}${unit}${element}`,
 			`${indent}</>`,
 		].join('\n'),
@@ -882,11 +867,8 @@ export const insertSolidIntoSource = ({
 		candidates: ['Solid', 'RemotionSolid'],
 		importedName: 'Solid',
 	});
-	const openingElement =
-		root.type === 'JSXElement' ? getNode(root, 'openingElement') : null;
-	const isSelfClosing = openingElement?.selfClosing === true;
 	const sequenceImport =
-		isSelfClosing || from !== null
+		from !== null
 			? chooseLocalName({
 					ast,
 					candidates: ['Sequence', 'RemotionSequence'],
@@ -922,10 +904,8 @@ export const insertSolidIntoSource = ({
 				? replaceJsxElementRoot({
 						element,
 						root,
-						sequenceLocalName: sequenceImport?.localName ?? null,
 						source,
 						unit,
-						wrapRootInSequence: isSelfClosing,
 					})
 				: appendToJsxRoot({
 						element,

--- a/packages/studio-codemods/src/insert-jsx-element.ts
+++ b/packages/studio-codemods/src/insert-jsx-element.ts
@@ -898,25 +898,6 @@ const createSequenceElement = (): namedTypes.JSXElement => {
 	);
 };
 
-const createSequenceWithChild = ({
-	child,
-	sequenceLocalName,
-}: {
-	child: namedTypes.JSXElement;
-	sequenceLocalName: string;
-}): namedTypes.JSXElement => {
-	return recast.types.builders.jsxElement(
-		recast.types.builders.jsxOpeningElement(
-			recast.types.builders.jsxIdentifier(sequenceLocalName),
-			[],
-		),
-		recast.types.builders.jsxClosingElement(
-			recast.types.builders.jsxIdentifier(sequenceLocalName),
-		),
-		[child],
-	);
-};
-
 const createNumberAttribute = (
 	name: string,
 	value: number,
@@ -2007,12 +1988,7 @@ const addElementToComponentRoot = ({
 	}
 
 	if (rootNode.type === 'JSXElement') {
-		const existingRoot = rootNode.openingElement.selfClosing
-			? createSequenceWithChild({
-					child: stripParenthesizedExtra(rootNode),
-					sequenceLocalName: ensureSequenceImport(ast),
-				})
-			: stripParenthesizedExtra(rootNode);
+		const existingRoot = stripParenthesizedExtra(rootNode);
 		const fragment = recast.types.builders.jsxFragment(
 			recast.types.builders.jsxOpeningFragment(),
 			recast.types.builders.jsxClosingFragment(),
@@ -2734,14 +2710,12 @@ const getInsertionRootSourceEdit = ({
 	nullRoot,
 	prettierConfigOverride,
 	root,
-	sequenceLocalName,
 }: {
 	input: string;
 	insertion: string;
 	nullRoot: NullLiteral | null;
 	prettierConfigOverride: Record<string, unknown> | null;
 	root: namedTypes.JSXElement | namedTypes.JSXFragment | null;
-	sequenceLocalName: string | null;
 }): SourceEdit => {
 	const endOfLine = input.includes('\r\n') ? '\r\n' : '\n';
 	const unit = getIndentationUnit(input, prettierConfigOverride);
@@ -2813,33 +2787,17 @@ const getInsertionRootSourceEdit = ({
 	const end = recastLocToOffset(input, root.loc.end);
 	const indent = getLineIndent(input, start);
 	const original = input.slice(start, end);
-	const existingRoot = root.openingElement.selfClosing
-		? [
-				`${indent}${unit}<${sequenceLocalName}>`,
-				indentExistingJsx({
-					indent: `${indent}${unit}${unit}`,
-					original,
-					originalIndent: indent,
-				}),
-				`${indent}${unit}</${sequenceLocalName}>`,
-			]
-		: [
-				indentExistingJsx({
-					indent: `${indent}${unit}`,
-					original,
-					originalIndent: indent,
-				}),
-			];
-
-	if (root.openingElement.selfClosing && sequenceLocalName === null) {
-		throw new Error('Expected a Sequence import for a self-closing root');
-	}
+	const existingRoot = indentExistingJsx({
+		indent: `${indent}${unit}`,
+		original,
+		originalIndent: indent,
+	});
 
 	return {
 		end,
 		replacement: [
 			'<>',
-			...existingRoot,
+			existingRoot,
 			indentInsertedJsx({indent: `${indent}${unit}`, insertion}),
 			`${indent}</>`,
 		].join(endOfLine),
@@ -3447,20 +3405,6 @@ export const insertJsxElementIntoComposition = async ({
 		exportName: location.exportName,
 		element: finalElementToInsert,
 	});
-	const finalRoot = componentDeclaration
-		? getComponentRootNode(componentDeclaration)
-		: null;
-	const firstFinalRootChild =
-		finalRoot?.type === 'JSXFragment'
-			? (finalRoot.children?.[0] ?? null)
-			: null;
-	const sequenceLocalName =
-		rootBeforeInsertion?.type === 'JSXElement' &&
-		rootBeforeInsertion.openingElement.selfClosing &&
-		firstFinalRootChild?.type === 'JSXElement' &&
-		firstFinalRootChild.openingElement.name.type === 'JSXIdentifier'
-			? firstFinalRootChild.openingElement.name.name
-			: null;
 	const output = applySourceEdits({
 		edits: [
 			...getInsertImportSourceEdits({
@@ -3482,7 +3426,6 @@ export const insertJsxElementIntoComposition = async ({
 				nullRoot: nullRootBeforeInsertion,
 				prettierConfigOverride,
 				root: rootBeforeInsertion,
-				sequenceLocalName,
 			}),
 		],
 		input,

--- a/packages/studio-server/src/test/resolve-composition-component.test.ts
+++ b/packages/studio-server/src/test/resolve-composition-component.test.ts
@@ -422,7 +422,7 @@ test('canAddSequence=true for self-closing root JSX return', async () => {
 	}
 });
 
-test('wraps a self-closing root in a Sequence before inserting', async () => {
+test('inserts a Solid next to a self-closing root without wrapping it', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -452,12 +452,9 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 			compositionFile: 'Root.tsx',
 			compositionId: 'test',
 			element: {
-				type: 'asset',
-				assetType: 'audio',
-				src: 'music.mp3',
-				srcType: 'static',
-				dimensions: null,
-				durationInFrames: null,
+				type: 'solid',
+				width: 1920,
+				height: 1080,
 				position: null,
 			},
 			from: null,
@@ -465,14 +462,14 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 		});
 
 		expect(result.output).toContain(
-			"import {staticFile, Sequence} from 'remotion';",
+			"import {staticFile, Solid} from 'remotion';",
 		);
-		expect(result.output).toContain('<Sequence>');
+		expect(result.output).not.toContain('<Sequence');
 		expect(result.output).toContain(
 			'<Video src={staticFile("background.mov")} />',
 		);
-		expect(result.output).toContain('</Sequence>');
-		expect(result.output).toContain("<Audio src={staticFile('music.mp3')} />");
+		expect(result.output).toContain('<Solid');
+		expect(result.output).toMatch(/style=\{\{\s*position: 'absolute'\s*\}\}/);
 		expect(result.nodePathRemappings).toEqual([
 			{
 				oldNodePath: lineContainingToNodePath(componentInput, '<Video'),
@@ -480,11 +477,7 @@ test('wraps a self-closing root in a Sequence before inserting', async () => {
 			},
 			{
 				oldNodePath: null,
-				newNodePath: lineContainingToNodePath(result.output, '<Sequence>'),
-			},
-			{
-				oldNodePath: null,
-				newNodePath: lineContainingToNodePath(result.output, '<Audio'),
+				newNodePath: lineContainingToNodePath(result.output, '<Solid'),
 			},
 		]);
 	} finally {
@@ -550,7 +543,7 @@ test('inserts an asset as a sibling of a connected composition', async () => {
 	}
 });
 
-test('removes parentheses when wrapping a self-closing root in a Sequence', async () => {
+test('inserts beside a parenthesized self-closing root without wrapping it', async () => {
 	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remotion-resolve-'));
 	try {
 		await fs.writeFile(
@@ -596,8 +589,12 @@ test('removes parentheses when wrapping a self-closing root in a Sequence', asyn
 			prettierConfigOverride: {singleQuote: true, useTabs: true},
 		});
 
-		expect(result.output).toContain('<Sequence>\n\t\t\t\t<Video');
-		expect(result.output).not.toContain('<Sequence>\n\t\t\t(');
+		const videoStart = result.output.indexOf('<Video');
+		const imageStart = result.output.indexOf('<CanvasImage');
+		expect(result.output).toContain('<>');
+		expect(result.output).not.toContain('<Sequence');
+		expect(videoStart).toBeGreaterThan(-1);
+		expect(imageStart).toBeGreaterThan(videoStart);
 	} finally {
 		await fs.rm(tempDir, {recursive: true, force: true});
 	}


### PR DESCRIPTION
## Summary

- keep existing self-closing composition roots as direct fragment children when inserting JSX
- preserve the existing timeline wrappers while avoiding an unnecessary `Sequence` import
- update desktop and Browser Studio node-path remapping regressions

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/resolve-composition-component.test.ts` in `packages/studio-server`
- `bun test src/test/browser-studio-operations.test.ts` in `packages/browser-studio`
- `bun test src/test` in `packages/studio-codemods`

Closes #10982
