### PR TITLE
`@remotion/studio`: Add folder hierarchy to Quick Switcher composition search

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1180,6 +1180,33 @@ test.describe('visual mode', () => {
 		await page.getByRole('button', {name: 'Compositions', exact: true}).click();
 
 		await page.keyboard.press('ControlOrMeta+k');
+		const folderSearch = page.getByRole('dialog');
+		await folderSearch
+			.getByPlaceholder('Search compositions...')
+			.fill('visual-controls');
+		await expect(
+			folderSearch.getByText('visual-controls', {exact: true}),
+		).toHaveCount(2);
+		await expect(
+			folderSearch.getByText('effect-keyframe-e2e', {exact: true}),
+		).toBeVisible();
+		await page.keyboard.press('Enter');
+		await expect(page).toHaveURL(/visual-controls/);
+
+		await page.keyboard.press('ControlOrMeta+k');
+		const compositionSearch = page.getByRole('dialog');
+		await compositionSearch
+			.getByPlaceholder('Search compositions...')
+			.fill('effect-keyframe-e2e');
+		await expect(
+			compositionSearch.getByText('visual-controls', {exact: true}),
+		).toHaveCount(1);
+		await expect(
+			compositionSearch.getByText('effect-keyframe-e2e', {exact: true}),
+		).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		await page.keyboard.press('ControlOrMeta+k');
 		await page
 			.getByPlaceholder('Search compositions...')
 			.fill('timeline virtualization');

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -10,6 +10,7 @@ import {Internals} from 'remotion';
 import type {_InternalTypes} from 'remotion';
 import type {StaticFile} from '../../api/get-static-files';
 import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
+import {createFolderTree} from '../../helpers/create-folder-tree';
 import {getPreviewFileType} from '../../helpers/get-preview-file-type';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {pushUrl} from '../../helpers/url-state';
@@ -27,11 +28,15 @@ import {useSelectAsset} from '../use-select-asset';
 import {useStaticFiles} from '../use-static-files';
 import {algoliaSearch} from './algolia-search';
 import {filterAssetsByType} from './asset-search';
+import {searchCompositionTree} from './composition-search';
 import {fuzzySearch} from './fuzzy-search';
 import type {QuickSwitcherMode} from './NoResults';
 import {QuickSwitcherNoResults} from './NoResults';
 import type {TQuickSwitcherResult} from './QuickSwitcherResult';
-import {QuickSwitcherResult} from './QuickSwitcherResult';
+import {
+	isQuickSwitcherResultSelectable,
+	QuickSwitcherResult,
+} from './QuickSwitcherResult';
 import {loopIndex} from './shared';
 
 const input: React.CSSProperties = {
@@ -174,7 +179,7 @@ export const QuickSwitcherContent: React.FC<{
 	assetSelection,
 	compositionSelection,
 }) => {
-	const {compositions} = useContext(Internals.CompositionManager);
+	const {compositions, folders} = useContext(Internals.CompositionManager);
 	const staticFiles = useStaticFiles();
 	const [state, setState] = useState(() => {
 		return {
@@ -289,42 +294,59 @@ export const QuickSwitcherContent: React.FC<{
 			];
 		}
 
-		return fuzzySearch(
-			actualQuery,
-			compositions
-				.filter((c) => c.id !== compositionSelection?.excludeCompositionId)
-				.map((c) => {
-					return {
-						id: 'composition-' + c.id,
-						title: c.id,
-						type: 'composition',
-						onSelected: () => {
-							if (compositionSelection !== null) {
-								compositionSelection.onSelected(c);
-								setSelectedModal(null);
-								return;
-							}
+		const tree = createFolderTree(
+			compositions.filter(
+				(composition) =>
+					composition.id !== compositionSelection?.excludeCompositionId,
+			),
+			folders,
+			{},
+		);
 
-							selectComposition(c, true);
+		return searchCompositionTree({items: tree, query: actualQuery}).map(
+			(result): TQuickSwitcherResult => {
+				if (result.type === 'folder') {
+					return result;
+				}
+
+				const {composition} = result;
+				return {
+					id: 'composition-' + composition.id,
+					title: composition.id,
+					type: 'composition',
+					level: result.level,
+					onSelected: () => {
+						if (compositionSelection !== null) {
+							compositionSelection.onSelected(composition);
 							setSelectedModal(null);
+							return;
+						}
 
-							const selector = `.__remotion-composition[data-compname="${c.id}"]`;
+						selectComposition(composition, true);
+						setSelectedModal(null);
 
-							Internals.compositionSelectorRef.current?.expandComposition(c.id);
-							waitForElm(selector).then(() => {
-								document
-									.querySelector(selector)
-									?.scrollIntoView({block: 'center'});
-							});
-						},
-						compositionType: isCompositionStill(c) ? 'still' : 'composition',
-					};
-				}),
+						const selector = `.__remotion-composition[data-compname="${composition.id}"]`;
+
+						Internals.compositionSelectorRef.current?.expandComposition(
+							composition.id,
+						);
+						waitForElm(selector).then(() => {
+							document
+								.querySelector(selector)
+								?.scrollIntoView({block: 'center'});
+						});
+					},
+					compositionType: isCompositionStill(composition)
+						? 'still'
+						: 'composition',
+				};
+			},
 		);
 	}, [
 		mode,
 		actualQuery,
 		compositions,
+		folders,
 		menuActions,
 		docResults,
 		assetSearch,
@@ -429,10 +451,14 @@ export const QuickSwitcherContent: React.FC<{
 		[],
 	);
 
+	const selectableResults = resultsArray.filter(
+		isQuickSwitcherResultSelectable,
+	);
 	const selectedIndexRounded = loopIndex(
 		state.selectedIndex,
-		resultsArray.length,
+		selectableResults.length,
 	);
+	const selectedResultId = selectableResults[selectedIndexRounded]?.id ?? null;
 	const focusInput = useCallback(() => {
 		if (!isTouchscreen) {
 			inputRef.current?.focus();
@@ -545,11 +571,11 @@ export const QuickSwitcherContent: React.FC<{
 				showSearchLoadingState ? null : resultsArray.length === 0 ? (
 					<QuickSwitcherNoResults mode={mode} query={actualQuery} />
 				) : (
-					resultsArray.map((result, i) => {
+					resultsArray.map((result) => {
 						return (
 							<QuickSwitcherResult
 								key={result.id}
-								selected={selectedIndexRounded === i}
+								selected={selectedResultId === result.id}
 								result={result}
 							/>
 						);

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../helpers/colors';
 import type {AssetFileType} from '../../helpers/get-preview-file-type';
 import {useKeybinding} from '../../helpers/use-keybinding';
+import {ExpandedFolderIcon} from '../../icons/folder';
 import {StillIcon} from '../../icons/still';
 import {UploadIcon} from '../../icons/upload';
 import {FilmIcon} from '../../icons/video';
@@ -25,6 +26,7 @@ type QuickSwitcherResultDetail =
 	| {
 			type: 'composition';
 			compositionType: 'composition' | 'still';
+			level: number;
 	  }
 	| {
 			type: 'menu-item';
@@ -38,11 +40,24 @@ type QuickSwitcherResultDetail =
 			subtitleLine: string;
 	  };
 
-export type TQuickSwitcherResult = {
-	title: string;
-	id: string;
-	onSelected: () => void;
-} & QuickSwitcherResultDetail;
+export type TQuickSwitcherResult =
+	| ({
+			title: string;
+			id: string;
+			onSelected: () => void;
+	  } & QuickSwitcherResultDetail)
+	| {
+			title: string;
+			id: string;
+			type: 'folder';
+			level: number;
+	  };
+
+export const isQuickSwitcherResultSelectable = (
+	result: TQuickSwitcherResult,
+): result is Exclude<TQuickSwitcherResult, {type: 'folder'}> => {
+	return result.type !== 'folder';
+};
 
 const container: React.CSSProperties = {
 	paddingLeft: 16,
@@ -94,8 +109,13 @@ export const QuickSwitcherResult: React.FC<{
 	const [hovered, setIsHovered] = useState(false);
 	const ref = useRef<HTMLDivElement>(null);
 	const keybindings = useKeybinding();
+	const onSelected = result.type === 'folder' ? null : result.onSelected;
 
 	useEffect(() => {
+		if (result.type === 'folder') {
+			return;
+		}
+
 		const {current} = ref;
 		if (!current) {
 			return;
@@ -111,16 +131,16 @@ export const QuickSwitcherResult: React.FC<{
 			current.removeEventListener('mouseenter', onMouseEnter);
 			current.removeEventListener('mouseleave', onMouseLeave);
 		};
-	}, []);
+	}, [result.type]);
 
 	useEffect(() => {
-		if (!selected) {
+		if (!selected || onSelected === null) {
 			return;
 		}
 
 		const binding = keybindings.registerKeybinding({
 			key: 'Enter',
-			callback: result.onSelected,
+			callback: onSelected,
 			commandCtrlKey: false,
 			event: 'keydown',
 			preventDefault: true,
@@ -132,22 +152,29 @@ export const QuickSwitcherResult: React.FC<{
 		return () => {
 			binding.unregister();
 		};
-	}, [keybindings, result.onSelected, selected]);
+	}, [keybindings, onSelected, selected]);
 
 	useScrollIntoViewOnSelected(ref, selected);
 
 	const style = useMemo(() => {
 		return {
 			...container,
-			backgroundColor: hovered || selected ? WHITE_ALPHA_06 : TRANSPARENT,
+			paddingLeft:
+				result.type === 'folder' || result.type === 'composition'
+					? 16 + result.level * 8
+					: container.paddingLeft,
+			backgroundColor:
+				result.type !== 'folder' && (hovered || selected)
+					? WHITE_ALPHA_06
+					: TRANSPARENT,
 		};
-	}, [hovered, selected]);
+	}, [hovered, result, selected]);
 
 	const labelStyle = useMemo(() => {
 		return {
 			...(result.type === 'search-result' ? searchLabel : label),
 			color:
-				result.type === 'search-result'
+				result.type === 'search-result' || result.type === 'folder'
 					? LIGHT_TEXT
 					: selected || hovered
 						? WHITE
@@ -157,7 +184,12 @@ export const QuickSwitcherResult: React.FC<{
 	}, [hovered, result.type, selected]);
 
 	return (
-		<div ref={ref} key={result.id} style={style} onClick={result.onSelected}>
+		<div
+			ref={ref}
+			key={result.id}
+			style={style}
+			onClick={onSelected ?? undefined}
+		>
 			{result.type === 'composition' ? (
 				result.compositionType === 'still' ? (
 					<StillIcon
@@ -170,6 +202,8 @@ export const QuickSwitcherResult: React.FC<{
 						style={iconStyle}
 					/>
 				)
+			) : result.type === 'folder' ? (
+				<ExpandedFolderIcon color={LIGHT_TEXT} style={iconStyle} />
 			) : result.type === 'asset' ? (
 				<AssetFileIcon
 					fileType={result.fileType}

--- a/packages/studio/src/components/QuickSwitcher/composition-search.ts
+++ b/packages/studio/src/components/QuickSwitcher/composition-search.ts
@@ -1,0 +1,215 @@
+import type {_InternalTypes} from 'remotion';
+import type {CompositionSelectorItemType} from '../CompositionSelectorItem';
+
+export type CompositionSearchResult =
+	| {
+			readonly type: 'folder';
+			readonly id: string;
+			readonly title: string;
+			readonly level: number;
+	  }
+	| {
+			readonly type: 'composition';
+			readonly composition: _InternalTypes['AnyComposition'];
+			readonly level: number;
+	  };
+
+type RankedCompositionSearchResult =
+	| {
+			readonly type: 'folder';
+			readonly id: string;
+			readonly title: string;
+			readonly level: number;
+			readonly score: number;
+			readonly children: RankedCompositionSearchResult[];
+	  }
+	| {
+			readonly type: 'composition';
+			readonly composition: _InternalTypes['AnyComposition'];
+			readonly level: number;
+			readonly score: number;
+	  };
+
+const normalizeSearchText = (text: string) => {
+	return text
+		.trim()
+		.toLowerCase()
+		.replace(/[\s/-]/g, '');
+};
+
+const getMatchScore = (query: string, candidate: string): number | null => {
+	const normalizedCandidate = normalizeSearchText(candidate);
+	if (normalizedCandidate === query) {
+		return 400_000 - normalizedCandidate.length;
+	}
+
+	if (normalizedCandidate.startsWith(query)) {
+		return 300_000 - (normalizedCandidate.length - query.length);
+	}
+
+	const substringIndex = normalizedCandidate.indexOf(query);
+	if (substringIndex !== -1) {
+		return (
+			200_000 -
+			substringIndex * 100 -
+			(normalizedCandidate.length - query.length)
+		);
+	}
+
+	let previousIndex = -1;
+	let firstIndex = -1;
+	let gapCount = 0;
+	for (const character of query) {
+		const nextIndex = normalizedCandidate.indexOf(character, previousIndex + 1);
+		if (nextIndex === -1) {
+			return null;
+		}
+
+		if (firstIndex === -1) {
+			firstIndex = nextIndex;
+		} else {
+			gapCount += nextIndex - previousIndex - 1;
+		}
+
+		previousIndex = nextIndex;
+	}
+
+	return (
+		100_000 -
+		gapCount * 100 -
+		firstIndex * 10 -
+		(normalizedCandidate.length - query.length)
+	);
+};
+
+export const searchCompositionTree = ({
+	items,
+	query,
+}: {
+	readonly items: CompositionSelectorItemType[];
+	readonly query: string;
+}): CompositionSearchResult[] => {
+	const normalizedQuery = normalizeSearchText(query);
+
+	const filterAndRank = (
+		treeItems: CompositionSelectorItemType[],
+		level: number,
+		inheritedFolderScore: number | null,
+	): RankedCompositionSearchResult[] => {
+		const rankedItems = treeItems
+			.map((item, originalIndex) => {
+				if (item.type === 'composition') {
+					const compositionPath = [
+						item.composition.parentFolderName,
+						item.composition.folderName,
+						item.composition.id,
+					]
+						.filter(Boolean)
+						.join('/');
+					const idScore =
+						normalizedQuery === ''
+							? 0
+							: getMatchScore(normalizedQuery, item.composition.id);
+					const compositionPathScore =
+						normalizedQuery === ''
+							? 0
+							: getMatchScore(normalizedQuery, compositionPath);
+					const directScore = Math.max(
+						idScore ?? -1,
+						compositionPathScore ?? -1,
+					);
+					const score = Math.max(directScore, inheritedFolderScore ?? -1);
+					if (score === -1) {
+						return null;
+					}
+
+					return {
+						result: {
+							type: 'composition' as const,
+							composition: item.composition,
+							level,
+							score,
+						},
+						originalIndex,
+					};
+				}
+
+				const fullPath = [item.parentName, item.folderName]
+					.filter(Boolean)
+					.join('/');
+				const nameScore =
+					normalizedQuery === ''
+						? 0
+						: getMatchScore(normalizedQuery, item.folderName);
+				const pathScore =
+					normalizedQuery === '' ? 0 : getMatchScore(normalizedQuery, fullPath);
+				const directFolderScore = Math.max(nameScore ?? -1, pathScore ?? -1);
+				const folderScore = Math.max(
+					directFolderScore === -1 ? -1 : directFolderScore - 1,
+					inheritedFolderScore ?? -1,
+				);
+				const children = filterAndRank(
+					item.items,
+					level + 1,
+					folderScore === -1 ? null : folderScore,
+				);
+				if (children.length === 0) {
+					return null;
+				}
+
+				return {
+					result: {
+						type: 'folder' as const,
+						id: `folder-${fullPath}`,
+						title: item.folderName,
+						level,
+						score: Math.max(
+							folderScore,
+							...children.map((child) => child.score),
+						),
+						children,
+					},
+					originalIndex,
+				};
+			})
+			.filter((item) => item !== null);
+
+		if (normalizedQuery !== '') {
+			rankedItems.sort((a, b) => {
+				return (
+					b.result.score - a.result.score || a.originalIndex - b.originalIndex
+				);
+			});
+		}
+
+		return rankedItems.map((item) => item.result);
+	};
+
+	const flatten = (
+		rankedItems: RankedCompositionSearchResult[],
+	): CompositionSearchResult[] => {
+		return rankedItems.flatMap((item): CompositionSearchResult[] => {
+			if (item.type === 'composition') {
+				return [
+					{
+						type: 'composition',
+						composition: item.composition,
+						level: item.level,
+					},
+				];
+			}
+
+			return [
+				{
+					type: 'folder',
+					id: item.id,
+					title: item.title,
+					level: item.level,
+				},
+				...flatten(item.children),
+			];
+		});
+	};
+
+	return flatten(filterAndRank(items, 0, null));
+};

--- a/packages/studio/src/test/quick-switcher-composition-search.test.ts
+++ b/packages/studio/src/test/quick-switcher-composition-search.test.ts
@@ -1,0 +1,80 @@
+import {expect, test} from 'bun:test';
+import type {_InternalTypes} from 'remotion';
+import type {CompositionSelectorItemType} from '../components/CompositionSelectorItem';
+import {searchCompositionTree} from '../components/QuickSwitcher/composition-search';
+
+const composition = (
+	id: string,
+	folderName: string | null,
+	parentFolderName: string | null,
+): CompositionSelectorItemType => {
+	return {
+		type: 'composition',
+		key: id,
+		composition: {
+			id,
+			folderName,
+			parentFolderName,
+		} as _InternalTypes['AnyComposition'],
+	};
+};
+
+const tree: CompositionSelectorItemType[] = [
+	{
+		type: 'folder',
+		key: 'marketing',
+		folder: {} as _InternalTypes['TFolder'],
+		folderName: 'Marketing',
+		parentName: null,
+		expanded: false,
+		items: [
+			composition('LaunchTrailer', 'Marketing', null),
+			composition('Credits', 'Marketing', null),
+			{
+				type: 'folder',
+				key: 'social',
+				folder: {} as _InternalTypes['TFolder'],
+				folderName: 'Social',
+				parentName: 'Marketing',
+				expanded: false,
+				items: [composition('SquareCut', 'Social', 'Marketing')],
+			},
+		],
+	},
+	composition('LaunchOverview', null, null),
+];
+
+const summarize = (query: string) => {
+	return searchCompositionTree({items: tree, query}).map((result) => {
+		return result.type === 'folder'
+			? `folder:${result.level}:${result.title}`
+			: `composition:${result.level}:${result.composition.id}`;
+	});
+};
+
+test('searches compositions as a ranked, pruned folder tree', () => {
+	expect(summarize('LaunchTrailer')).toEqual([
+		'folder:0:Marketing',
+		'composition:1:LaunchTrailer',
+	]);
+
+	expect(summarize('Marketing')).toEqual([
+		'folder:0:Marketing',
+		'composition:1:LaunchTrailer',
+		'composition:1:Credits',
+		'folder:1:Social',
+		'composition:2:SquareCut',
+	]);
+
+	expect(summarize('Launch')).toEqual([
+		'folder:0:Marketing',
+		'composition:1:LaunchTrailer',
+		'composition:0:LaunchOverview',
+	]);
+
+	expect(summarize('Marketing Square')).toEqual([
+		'folder:0:Marketing',
+		'folder:1:Social',
+		'composition:2:SquareCut',
+	]);
+});


### PR DESCRIPTION
## Summary

- show Quick Switcher composition results as a scored, filtered folder tree
- include only ancestor folders for composition matches, while folder matches reveal their descendants
- keep folder rows structural so arrow keys and Enter continue to select compositions only

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/quick-switcher-composition-search.test.ts`
- `bunx playwright test e2e/studio.test.mts --grep "should show and search the composition list"`

Closes #10920
