### PR TITLE
`@remotion/studio`: Fix selection after context-menu deletion

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1827,11 +1827,57 @@ test.describe('visual mode', () => {
 		await expect(visibleOutlines.first()).toBeVisible();
 	});
 
-	test('should preserve following interactive elements after deleting a sibling', async ({
+	test('should clear selection after context-menu deletion and preserve following interactive elements', async ({
 		context,
 		page,
 	}) => {
+		await context.addInitScript(() => {
+			type RegisteredTool = {
+				readonly name: string;
+				readonly execute: (input: Record<string, unknown>) => Promise<unknown>;
+			};
+			const tools = new Map<string, RegisteredTool>();
+			Object.defineProperty(window, '__remotion_webmcp_tools', {
+				value: tools,
+			});
+			Object.defineProperty(document, 'modelContext', {
+				value: {
+					registerTool: async (
+						tool: RegisteredTool,
+						options: {readonly signal: AbortSignal},
+					) => {
+						tools.set(tool.name, tool);
+						options.signal.addEventListener('abort', () => {
+							if (tools.get(tool.name) === tool) {
+								tools.delete(tool.name);
+							}
+						});
+					},
+				},
+			});
+		});
 		await navigateToLostNodePathE2e(page);
+		const getWebMcpSelection = () =>
+			page.evaluate(async () => {
+				const tools = (
+					window as typeof window & {
+						readonly __remotion_webmcp_tools?: Map<
+							string,
+							{readonly execute: () => Promise<unknown>}
+						>;
+					}
+				).__remotion_webmcp_tools;
+				if (!tools) {
+					return null;
+				}
+
+				const tool = tools.get('get_selection');
+				if (!tool) {
+					return null;
+				}
+
+				return tool.execute();
+			});
 		const otherPage = await context.newPage();
 		await navigateToLostNodePathE2e(otherPage);
 		const canvas = page.locator('.remotion-studio-composition-container');
@@ -1921,8 +1967,14 @@ test.describe('visual mode', () => {
 		const eyebrow = page.locator(
 			'[data-timeline-marquee-item][title="Eyebrow"]',
 		);
-		await eyebrow.click();
-		await page.keyboard.press('Delete');
+		await eyebrow.click({button: 'right'});
+		await expect.poll(getWebMcpSelection).toEqual(
+			expect.objectContaining({
+				selectionType: 'sequence',
+				selectedSequence: expect.objectContaining({name: 'Eyebrow'}),
+			}),
+		);
+		await page.getByRole('button', {name: 'Delete', exact: true}).click();
 
 		await expect
 			.poll(() => fs.readFileSync(lostNodePathE2eFile, 'utf-8'))
@@ -1948,6 +2000,13 @@ test.describe('visual mode', () => {
 		).toBeVisible();
 		await expect(gridlineVisibilityToggle).toBeVisible();
 		await expect(otherGridlineVisibilityToggle).toBeVisible();
+		await expect.poll(getWebMcpSelection).toEqual(
+			expect.objectContaining({
+				currentSelection: null,
+				selectionType: null,
+				selectedSequence: null,
+			}),
+		);
 
 		await page.getByRole('button', {name: /^Undo/}).click();
 		await expect

--- a/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/SequenceSelectionInspector.tsx
@@ -16,7 +16,6 @@ import {
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {splitVideoFromAudio} from '../split-video-from-audio-api';
-import {deleteSequencesFromSource} from '../Timeline/delete-selected-timeline-item';
 import {duplicateSequencesFromSource} from '../Timeline/duplicate-selected-timeline-item';
 import {
 	getTimelineSequenceSplitEligibility,
@@ -27,6 +26,7 @@ import {
 	type TimelineSelection,
 	useTimelineSelection,
 } from '../Timeline/TimelineSelection';
+import {useDeleteTimelineItems} from '../Timeline/use-delete-timeline-items';
 import {getSequenceFreezeFrameMenuItem} from '../Timeline/use-sequence-freeze-frame-menu-item';
 import {AlignmentControls} from './AlignmentControls';
 import {
@@ -130,6 +130,7 @@ const SequenceSourceQuickActions: React.FC<{
 	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const confirm = useConfirmationDialog();
+	const deleteTimelineItems = useDeleteTimelineItems();
 	const propStatusesForOverride = useMemo(
 		() =>
 			Internals.getPropStatusesCtx(
@@ -167,10 +168,8 @@ const SequenceSourceQuickActions: React.FC<{
 			return;
 		}
 
-		deleteSequencesFromSource([selection.nodePathInfo], confirm).catch(
-			() => undefined,
-		);
-	}, [confirm, selection.nodePathInfo, sourceActionsDisabled]);
+		deleteTimelineItems([selection]);
+	}, [deleteTimelineItems, selection, sourceActionsDisabled]);
 	const splitVideoFromAudioDisabledReason = sourceActionsDisabled
 		? 'Studio is read-only'
 		: selection.nodePathInfo.numberOfSequencesWithThisNodePath > 1

--- a/packages/studio/src/components/SelectedOutlineElement.tsx
+++ b/packages/studio/src/components/SelectedOutlineElement.tsx
@@ -12,7 +12,6 @@ import {
 import {SetSelectedModalContext} from '../state/modals';
 import {Transform3DModeStateContext} from '../state/transform-3d-mode';
 import {useConfirmationDialog} from './ConfirmationDialog';
-import {deleteJsxNode} from './delete-jsx-node-api';
 import {useSelectComposition} from './InitialCompositionLoader';
 import {showNotification} from './Notifications/NotificationCenter';
 import type {SelectedOutline} from './selected-outline-geometry';
@@ -37,6 +36,7 @@ import {
 	type TimelineSelectionInteraction,
 } from './Timeline/TimelineSelection';
 import {getOriginalLocationFromStack} from './Timeline/TimelineStack/get-stack';
+import {useDeleteTimelineItems} from './Timeline/use-delete-timeline-items';
 import {
 	useDefaultCodingAgentInfo,
 	useEditorOpening,
@@ -99,6 +99,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		Internals.SequenceStackTracesUpdateContext,
 	);
 	const confirm = useConfirmationDialog();
+	const deleteTimelineItems = useDeleteTimelineItems();
 	const selectAsset = useSelectAsset();
 	const selectComposition = useSelectComposition();
 	const {compositions} = useContext(Internals.CompositionManager);
@@ -244,42 +245,17 @@ const SelectedOutlineElementUnmemoized: React.FC<
 						});
 					}
 				: null,
-			onDeleteSequenceFromSource: async () => {
+			onDeleteSequenceFromSource: () => {
 				if (sourceEditDisabled || previewServerState.type !== 'connected') {
 					return;
 				}
 
-				if (
-					contextMenuTarget.nodePathInfo.numberOfSequencesWithThisNodePath > 1
-				) {
-					const shouldDelete = await confirm({
-						title: 'Delete sequence?',
-						message:
-							'This sequence is programmatically duplicated ' +
-							contextMenuTarget.nodePathInfo.numberOfSequencesWithThisNodePath +
-							' times in the code. Deleting removes all instances. Continue?',
-						confirmLabel: 'Delete',
-					});
-					if (!shouldDelete) {
-						return;
-					}
-				}
-
-				try {
-					const result = await deleteJsxNode({
-						nodes: [
-							{
-								fileName: nodePath.absolutePath,
-								nodePath: nodePath.nodePath,
-							},
-						],
-					});
-					if (!result.success) {
-						showNotification(result.reason, 4000);
-					}
-				} catch (err) {
-					showNotification((err as Error).message, 4000);
-				}
+				deleteTimelineItems([
+					{
+						type: 'sequence',
+						nodePathInfo: contextMenuTarget.nodePathInfo,
+					},
+				]);
 			},
 			onDisableSequenceInteractivity: () => {
 				if (
@@ -437,6 +413,7 @@ const SelectedOutlineElementUnmemoized: React.FC<
 		canConfigureApps,
 		codingAgentInfo,
 		confirm,
+		deleteTimelineItems,
 		editorInfo,
 		getTarget,
 		onSelect,

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -1,21 +1,11 @@
-import {LINEAR_KEYFRAME_EASING} from '@remotion/studio-shared';
 import type React from 'react';
 import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {useKeybinding} from '../../helpers/use-keybinding';
-import {
-	EditorShowGuidesContext,
-	persistGuidesList,
-} from '../../state/editor-guides';
 import {useConfirmationDialog} from '../ConfirmationDialog';
-import {
-	deleteSelectedTimelineItems,
-	getTimelineSelectionAfterDeletingItems,
-} from './delete-selected-timeline-item';
 import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
 import {getCurrentFrame} from './imperative-state';
-import {resetSelectedTimelineProps} from './reset-selected-timeline-props';
 import {
 	shouldHandleTimelineDuplicateShortcut,
 	shouldHandleTimelineSplitShortcut,
@@ -25,10 +15,7 @@ import {
 	useCurrentTimelineSelectionStateAsRef,
 	useTimelineSelection,
 } from './TimelineSelection';
-import {
-	getEasingSelections,
-	updateSelectedTimelineEasings,
-} from './update-selected-easing';
+import {useDeleteTimelineItems} from './use-delete-timeline-items';
 
 export const TimelineDeleteKeybindings: React.FC = () => {
 	const keybindings = useKeybinding();
@@ -40,109 +27,19 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 	const propStatusesRef = useContext(
 		Internals.VisualModePropStatusesRefContext,
 	);
-	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
-	const {setGuidesList} = useContext(EditorShowGuidesContext);
 	const {canSelect} = useTimelineSelection();
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const confirm = useConfirmationDialog();
+	const deleteTimelineItems = useDeleteTimelineItems();
 	useEffect(() => {
 		if (!canSelect || previewServerState.type !== 'connected') {
 			return;
 		}
 
-		const {clientId} = previewServerState;
-		const handleDelete = () => {
-			const timelinePosition = getCurrentFrame();
-			const {selectedItems, clearSelection, selectItems} =
-				currentSelection.current;
-			const sequences = sequencesRef.current;
-			const propStatuses = propStatusesRef.current;
-			if (selectedItems.length === 0) {
-				return;
-			}
-
-			const selectedGuide = selectedItems.find((item) => item.type === 'guide');
-			if (selectedGuide) {
-				setGuidesList((prevGuides) => {
-					const newGuides = prevGuides.filter(
-						(guide) => guide.id !== selectedGuide.guideId,
-					);
-					persistGuidesList(newGuides);
-					return newGuides;
-				});
-				clearSelection();
-				return;
-			}
-
-			const deletePromise = deleteSelectedTimelineItems({
-				selections: selectedItems,
-				sequences,
-				overrideIdsToNodePaths: overrideIdToNodePathMappings,
-				setPropStatuses,
-				clientId,
-				confirm,
-				propStatuses,
-				timelinePosition,
-			});
-
-			if (deletePromise !== null) {
-				deletePromise
-					.then((deleted) => {
-						if (deleted) {
-							const nextSelection = getTimelineSelectionAfterDeletingItems({
-								selections: selectedItems,
-								sequences,
-								overrideIdsToNodePaths: overrideIdToNodePathMappings,
-								propStatuses,
-								timelinePosition,
-							});
-							if (nextSelection.length === 0) {
-								clearSelection();
-							} else {
-								selectItems(nextSelection);
-							}
-						}
-					})
-					.catch(() => undefined);
-				return;
-			}
-
-			const easingSelections = getEasingSelections(selectedItems);
-			if (easingSelections.length === selectedItems.length) {
-				const resetEasingPromise = updateSelectedTimelineEasings({
-					selections: easingSelections,
-					sequences,
-					overrideIdsToNodePaths: overrideIdToNodePathMappings,
-					propStatuses,
-					setPropStatuses,
-					clientId,
-					easing: LINEAR_KEYFRAME_EASING,
-				});
-
-				if (resetEasingPromise !== null) {
-					resetEasingPromise.catch(() => undefined);
-					return;
-				}
-			}
-
-			const resetPromise = resetSelectedTimelineProps({
-				selections: selectedItems,
-				sequences,
-				overrideIdsToNodePaths: overrideIdToNodePathMappings,
-				propStatuses,
-				setPropStatuses,
-				clientId,
-			});
-
-			if (resetPromise !== null) {
-				resetPromise.catch(() => undefined);
-			}
-		};
-
 		const backspace = keybindings.registerKeybinding({
 			event: 'keydown',
 			key: 'Backspace',
-			callback: handleDelete,
+			callback: () => deleteTimelineItems(null),
 			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -151,7 +48,7 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		const deleteKey = keybindings.registerKeybinding({
 			event: 'keydown',
 			key: 'Delete',
-			callback: handleDelete,
+			callback: () => deleteTimelineItems(null),
 			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -229,13 +126,12 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		canSelect,
 		confirm,
 		currentSelection,
+		deleteTimelineItems,
 		keybindings,
 		overrideIdToNodePathMappings,
 		propStatusesRef,
 		previewServerState,
 		sequencesRef,
-		setGuidesList,
-		setPropStatuses,
 	]);
 
 	return null;

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -36,11 +36,8 @@ import {SetSelectedModalContext} from '../../state/modals';
 import {AudioWaveform} from '../AudioWaveform';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
-import {deleteJsxNode} from '../delete-jsx-node-api';
 import {useSelectComposition} from '../InitialCompositionLoader';
-import {showNotification} from '../Notifications/NotificationCenter';
 import {useSelectAsset} from '../use-select-asset';
-import {deleteSequencesFromSource} from './delete-selected-timeline-item';
 import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {
@@ -74,6 +71,7 @@ import {
 import {TimelineVideoInfo} from './TimelineVideoInfo';
 import {TimelineViewportContext} from './TimelineViewport';
 import {TimelineWidthContext} from './TimelineWidthProvider';
+import {useDeleteTimelineItems} from './use-delete-timeline-items';
 import {useOpenSequenceInApps} from './use-open-sequence-in-apps';
 import {getSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
 
@@ -485,6 +483,7 @@ const TimelineSequenceInner: React.FC<{
 	const selectAsset = useSelectAsset();
 	const selectComposition = useSelectComposition();
 	const confirm = useConfirmationDialog();
+	const deleteTimelineItems = useDeleteTimelineItems();
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
 	const {selectedItems} = useTimelineSelection();
@@ -581,43 +580,20 @@ const TimelineSequenceInner: React.FC<{
 			() => undefined,
 		);
 	}, [confirm, previewInteractive, selectedSequenceNodePathInfos]);
-	const onDeleteSequenceFromSource = useCallback(async () => {
-		if (!validatedLocation?.source || !nodePath || deleteDisabled) {
+	const onDeleteSequenceFromSource = useCallback(() => {
+		if (
+			!validatedLocation?.source ||
+			!nodePath ||
+			!nodePathInfo ||
+			deleteDisabled
+		) {
 			return;
 		}
 
-		if (nodePathInfo && nodePathInfo.numberOfSequencesWithThisNodePath > 1) {
-			const shouldDelete = await confirm({
-				title: 'Delete sequence?',
-				message:
-					'This sequence is programmatically duplicated ' +
-					nodePathInfo.numberOfSequencesWithThisNodePath +
-					' times in the code. Deleting removes all instances. Continue?',
-				confirmLabel: 'Delete',
-			});
-			if (!shouldDelete) {
-				return;
-			}
-		}
-
-		try {
-			const result = await deleteJsxNode({
-				nodes: [
-					{
-						fileName: validatedLocation.source,
-						nodePath: nodePath.nodePath,
-					},
-				],
-			});
-			if (!result.success) {
-				showNotification(result.reason, 4000);
-			}
-		} catch (err) {
-			showNotification((err as Error).message, 4000);
-		}
+		deleteTimelineItems([{type: 'sequence', nodePathInfo}]);
 	}, [
-		confirm,
 		deleteDisabled,
+		deleteTimelineItems,
 		nodePath,
 		nodePathInfo,
 		validatedLocation?.source,
@@ -627,10 +603,13 @@ const TimelineSequenceInner: React.FC<{
 			return;
 		}
 
-		deleteSequencesFromSource(selectedSequenceNodePathInfos, confirm).catch(
-			() => undefined,
+		deleteTimelineItems(
+			selectedSequenceNodePathInfos.map((selectedNodePathInfo) => ({
+				type: 'sequence',
+				nodePathInfo: selectedNodePathInfo,
+			})),
 		);
-	}, [confirm, previewInteractive, selectedSequenceNodePathInfos]);
+	}, [deleteTimelineItems, previewInteractive, selectedSequenceNodePathInfos]);
 	const onDisableSequenceInteractivity = useCallback(() => {
 		if (
 			disableInteractivityDisabled ||

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -41,7 +41,6 @@ import {Transform3DModeStateContext} from '../../state/transform-3d-mode';
 import {CompositionOrStillIcon} from '../CompositionOrStillIcon';
 import {useConfirmationDialog} from '../ConfirmationDialog';
 import {ContextMenu} from '../ContextMenu';
-import {deleteJsxNode} from '../delete-jsx-node-api';
 import {
 	addEffectFromDragData,
 	getEffectDragData,
@@ -62,7 +61,6 @@ import {
 	rotateFieldKey,
 } from '../selected-outline-types';
 import {useSelectAsset} from '../use-select-asset';
-import {deleteSequencesFromSource} from './delete-selected-timeline-item';
 import {disableSequenceInteractivity} from './disable-sequence-interactivity';
 import {duplicateSequencesFromSource} from './duplicate-selected-timeline-item';
 import {
@@ -90,6 +88,7 @@ import {
 	useTimelineSelection,
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
+import {useDeleteTimelineItems} from './use-delete-timeline-items';
 import {useOpenSequenceInApps} from './use-open-sequence-in-apps';
 import {useRenameSequence} from './use-rename-sequence';
 import {getSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
@@ -304,6 +303,7 @@ const TimelineSequenceItemInner: React.FC<{
 	const {isHighestContext} = useKeybinding();
 	const selectAsset = useSelectAsset();
 	const selectComposition = useSelectComposition();
+	const deleteTimelineItems = useDeleteTimelineItems();
 	const {onSelect, selectable, selected} =
 		useTimelineRowSelection(nodePathInfo);
 	const {selectItem, selectedItems} = useTimelineSelection();
@@ -422,43 +422,20 @@ const TimelineSequenceItemInner: React.FC<{
 		);
 	}, [confirm, previewInteractive, selectedSequenceNodePathInfos]);
 
-	const onDeleteSequenceFromSource = useCallback(async () => {
-		if (deleteDisabled || !validatedLocation?.source || !nodePath) {
+	const onDeleteSequenceFromSource = useCallback(() => {
+		if (
+			deleteDisabled ||
+			!validatedLocation?.source ||
+			!nodePath ||
+			!nodePathInfo
+		) {
 			return;
 		}
 
-		if (nodePathInfo && nodePathInfo.numberOfSequencesWithThisNodePath > 1) {
-			const shouldDelete = await confirm({
-				title: 'Delete sequence?',
-				message:
-					'This sequence is programmatically duplicated ' +
-					nodePathInfo.numberOfSequencesWithThisNodePath +
-					' times in the code. Deleting removes all instances. Continue?',
-				confirmLabel: 'Delete',
-			});
-			if (!shouldDelete) {
-				return;
-			}
-		}
-
-		try {
-			const result = await deleteJsxNode({
-				nodes: [
-					{
-						fileName: validatedLocation.source,
-						nodePath: nodePath.nodePath,
-					},
-				],
-			});
-			if (!result.success) {
-				showNotification(result.reason, 4000);
-			}
-		} catch (err) {
-			showNotification((err as Error).message, 4000);
-		}
+		deleteTimelineItems([{type: 'sequence', nodePathInfo}]);
 	}, [
-		confirm,
 		deleteDisabled,
+		deleteTimelineItems,
 		nodePath,
 		validatedLocation?.source,
 		nodePathInfo,
@@ -468,10 +445,13 @@ const TimelineSequenceItemInner: React.FC<{
 			return;
 		}
 
-		deleteSequencesFromSource(selectedSequenceNodePathInfos, confirm).catch(
-			() => undefined,
+		deleteTimelineItems(
+			selectedSequenceNodePathInfos.map((selectedNodePathInfo) => ({
+				type: 'sequence',
+				nodePathInfo: selectedNodePathInfo,
+			})),
 		);
-	}, [confirm, previewInteractive, selectedSequenceNodePathInfos]);
+	}, [deleteTimelineItems, previewInteractive, selectedSequenceNodePathInfos]);
 
 	const onDisableSequenceInteractivity = useCallback(() => {
 		if (

--- a/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
+++ b/packages/studio/src/components/Timeline/delete-selected-timeline-item.ts
@@ -73,11 +73,11 @@ export const deleteSequencesFromSource = async (
 				showNotification(result.reason, 4000);
 			}
 
-			return true;
+			return result.success;
 		})
 		.catch((err) => {
 			showNotification((err as Error).message, 4000);
-			return true;
+			return false;
 		});
 };
 

--- a/packages/studio/src/components/Timeline/use-delete-timeline-items.ts
+++ b/packages/studio/src/components/Timeline/use-delete-timeline-items.ts
@@ -1,0 +1,149 @@
+import {LINEAR_KEYFRAME_EASING} from '@remotion/studio-shared';
+import {useCallback, useContext} from 'react';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {
+	EditorShowGuidesContext,
+	persistGuidesList,
+} from '../../state/editor-guides';
+import {useConfirmationDialog} from '../ConfirmationDialog';
+import {
+	deleteSelectedTimelineItems,
+	getTimelineSelectionAfterDeletingItems,
+} from './delete-selected-timeline-item';
+import {getCurrentFrame} from './imperative-state';
+import {resetSelectedTimelineProps} from './reset-selected-timeline-props';
+import {
+	type TimelineSelection,
+	useCurrentTimelineSelectionStateAsRef,
+} from './TimelineSelection';
+import {
+	getEasingSelections,
+	updateSelectedTimelineEasings,
+} from './update-selected-easing';
+
+export const useDeleteTimelineItems = () => {
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const sequencesRef = useContext(Internals.SequenceManagerRefContext);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const propStatusesRef = useContext(
+		Internals.VisualModePropStatusesRefContext,
+	);
+	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
+	const {setGuidesList} = useContext(EditorShowGuidesContext);
+	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const confirm = useConfirmationDialog();
+
+	return useCallback(
+		(selectedItemsOverride: readonly TimelineSelection[] | null) => {
+			if (previewServerState.type !== 'connected') {
+				return;
+			}
+
+			const {clientId} = previewServerState;
+			const {
+				selectedItems: currentSelectedItems,
+				clearSelection,
+				selectItems,
+			} = currentSelection.current;
+			const selectedItems = selectedItemsOverride ?? currentSelectedItems;
+			const sequences = sequencesRef.current;
+			const propStatuses = propStatusesRef.current;
+			const timelinePosition = getCurrentFrame();
+			if (selectedItems.length === 0) {
+				return;
+			}
+
+			const selectedGuide = selectedItems.find((item) => item.type === 'guide');
+			if (selectedGuide) {
+				setGuidesList((prevGuides) => {
+					const newGuides = prevGuides.filter(
+						(guide) => guide.id !== selectedGuide.guideId,
+					);
+					persistGuidesList(newGuides);
+					return newGuides;
+				});
+				clearSelection();
+				return;
+			}
+
+			const deletePromise = deleteSelectedTimelineItems({
+				selections: selectedItems,
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				setPropStatuses,
+				clientId,
+				confirm,
+				propStatuses,
+				timelinePosition,
+			});
+
+			if (deletePromise !== null) {
+				deletePromise
+					.then((deleted) => {
+						if (!deleted) {
+							return;
+						}
+
+						const nextSelection = getTimelineSelectionAfterDeletingItems({
+							selections: selectedItems,
+							sequences,
+							overrideIdsToNodePaths: overrideIdToNodePathMappings,
+							propStatuses,
+							timelinePosition,
+						});
+						if (nextSelection.length === 0) {
+							clearSelection();
+						} else {
+							selectItems(nextSelection);
+						}
+					})
+					.catch(() => undefined);
+				return;
+			}
+
+			const easingSelections = getEasingSelections(selectedItems);
+			if (easingSelections.length === selectedItems.length) {
+				const resetEasingPromise = updateSelectedTimelineEasings({
+					selections: easingSelections,
+					sequences,
+					overrideIdsToNodePaths: overrideIdToNodePathMappings,
+					propStatuses,
+					setPropStatuses,
+					clientId,
+					easing: LINEAR_KEYFRAME_EASING,
+				});
+
+				if (resetEasingPromise !== null) {
+					resetEasingPromise.catch(() => undefined);
+					return;
+				}
+			}
+
+			const resetPromise = resetSelectedTimelineProps({
+				selections: selectedItems,
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				propStatuses,
+				setPropStatuses,
+				clientId,
+			});
+
+			if (resetPromise !== null) {
+				resetPromise.catch(() => undefined);
+			}
+		},
+		[
+			confirm,
+			currentSelection,
+			overrideIdToNodePathMappings,
+			previewServerState,
+			propStatusesRef,
+			sequencesRef,
+			setGuidesList,
+			setPropStatuses,
+		],
+	);
+};


### PR DESCRIPTION
## Summary

- route keyboard, timeline context-menu, canvas-outline, and Inspector deletions through one selection-aware flow
- update selection only after a source deletion succeeds
- cover context-menu deletion, HMR, selection cleanup, and undo/redo in the existing Studio E2E workflow

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test src` in `packages/studio` (627 tests)
- focused Playwright Studio regression (1 test)

Closes #10928
