### PR TITLE
`remotion`: Canonicalize playing and buffering subscriptions

### DIFF
--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -25,29 +25,41 @@ export type PlaybackRateContextValue = {
 	setPlaybackRate: (u: React.SetStateAction<number>) => void;
 };
 
+export type PlayingState = Readonly<{
+	playing: boolean;
+}>;
+
+export type BufferingState = Readonly<{
+	buffering: boolean;
+}>;
+
 export type SetTimelineContextValue = {
 	setFrame: (u: React.SetStateAction<Record<string, number>>) => void;
 	setPlaying: (u: React.SetStateAction<boolean>) => void;
-	subscribePlaying: (
-		listener: (state: Readonly<{playing: boolean}>) => void,
-	) => () => void;
-	frameRef: RefObject<Record<string, number>>;
+	setBuffering: (buffering: boolean) => void;
+	subscribePlaying: (listener: (state: PlayingState) => void) => () => void;
+	subscribeBuffering: (listener: (state: BufferingState) => void) => () => void;
 	isPlaying: () => boolean;
+	isBuffering: () => boolean;
+	frameRef: RefObject<Record<string, number>>;
 	audioAndVideoTags: RefObject<PlayableMediaTag[]>;
 };
 
+const missingSetTimelineContext = (): never => {
+	throw new Error(
+		'SetTimelineContext is missing. This is likely caused by a Remotion version mismatch.',
+	);
+};
+
 export const SetTimelineContext = createContext<SetTimelineContextValue>({
-	setFrame: () => {
-		throw new Error('default');
-	},
-	setPlaying: () => {
-		throw new Error('default');
-	},
+	setFrame: missingSetTimelineContext,
+	setPlaying: missingSetTimelineContext,
+	setBuffering: missingSetTimelineContext,
 	subscribePlaying: () => () => undefined,
+	subscribeBuffering: () => () => undefined,
+	isPlaying: () => false,
+	isBuffering: missingSetTimelineContext,
 	frameRef: {current: {}},
-	isPlaying: () => {
-		throw new Error('default');
-	},
 	audioAndVideoTags: {current: []},
 });
 
@@ -68,6 +80,10 @@ export const TimelineContextProvider: React.FC<{
 		() => createRuntimeValueStore({playing: false}),
 		[],
 	);
+	const bufferingStore = useMemo(
+		() => createRuntimeValueStore({buffering: false}),
+		[],
+	);
 
 	const [playbackRate, setPlaybackRate] = useState(1);
 	const audioAndVideoTags = useRef<PlayableMediaTag[]>([]);
@@ -82,6 +98,10 @@ export const TimelineContextProvider: React.FC<{
 	const readIsPlaying = useCallback(
 		() => playingStore.store.getSnapshot().playing,
 		[playingStore],
+	);
+	const readIsBuffering = useCallback(
+		() => bufferingStore.store.getSnapshot().buffering,
+		[bufferingStore],
 	);
 
 	const {delayRender, continueRender} = useDelayRender();
@@ -142,17 +162,23 @@ export const TimelineContextProvider: React.FC<{
 			setPlaying: (updater) => {
 				const current = playingStore.store.getSnapshot().playing;
 				const next = typeof updater === 'function' ? updater(current) : updater;
-
 				if (current !== next) {
 					playingStore.setSnapshot({playing: next});
 				}
 			},
+			setBuffering: (buffering) => {
+				if (readIsBuffering() !== buffering) {
+					bufferingStore.setSnapshot({buffering});
+				}
+			},
 			subscribePlaying: playingStore.store.subscribe,
-			frameRef,
+			subscribeBuffering: bufferingStore.store.subscribe,
 			isPlaying: readIsPlaying,
+			isBuffering: readIsBuffering,
+			frameRef,
 			audioAndVideoTags,
 		};
-	}, [playingStore, readIsPlaying]);
+	}, [bufferingStore, playingStore, readIsBuffering, readIsPlaying]);
 
 	return (
 		<AbsoluteTimeContext.Provider value={timelineContextValue}>

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -4,123 +4,50 @@ import React, {
 	useEffect,
 	useLayoutEffect,
 	useMemo,
-	useRef,
 	useState,
 } from 'react';
 import type {LogLevel} from './log';
 import {LogLevelContext} from './log-level-context';
 import {playbackLogging} from './playback-logging';
+import {SetTimelineContext} from './TimelineContext.js';
 import {useRemotionEnvironment} from './use-remotion-environment';
 
-type Block = {
-	id: string;
-};
-
-type OnBufferingCallback = () => void;
-type OnResumeCallback = () => void;
-
-type ListenForBuffering = (callback: OnBufferingCallback) => {
-	remove: () => void;
-};
-
-type ListenForResume = (callback: OnResumeCallback) => {
-	remove: () => void;
-};
-
-type AddBlock = (block: Block) => {
-	unblock: () => void;
-};
-
 type BufferManager = {
-	addBlock: AddBlock;
-	listenForBuffering: ListenForBuffering;
-	listenForResume: ListenForResume;
-	buffering: React.RefObject<boolean>;
+	addBlock: () => {unblock: () => void};
 };
 
 const useBufferManager = (
 	logLevel: LogLevel,
 	mountTime: number | null,
+	setBuffering: (buffering: boolean) => void,
+	isBuffering: () => boolean,
 ): BufferManager => {
-	const [blocks, setBlocks] = useState<Block[]>([]);
-	// Listener registries are refs, not state: `usePlayback` parks its loop
-	// during buffering and registers its resume listener from a rAF callback.
-	// With state, that registration only lands after the next React commit -
-	// if the last block unblocks before then, the resume dispatch reads the
-	// previous array, the listener is never called, and the playback loop
-	// stays parked forever (frame clock frozen while isPlaying() is true).
-	const onBufferingCallbacks = useRef<OnBufferingCallback[]>([]);
-	const onResumeCallbacks = useRef<OnResumeCallback[]>([]);
+	const [blockCount, setBlockCount] = useState(0);
 
 	const env = useRemotionEnvironment();
 	const rendering = env.isRendering;
 
-	const buffering = useRef(false);
-
-	const addBlock: AddBlock = useCallback(
-		(block: Block) => {
-			if (rendering) {
-				return {
-					unblock: () => undefined,
-				};
-			}
-
-			let unblocked = false;
-
-			setBlocks((b) => [...b, block]);
+	const addBlock = useCallback(() => {
+		if (rendering) {
 			return {
-				unblock: () => {
-					if (unblocked) {
-						return;
-					}
-
-					unblocked = true;
-					setBlocks((b) => {
-						const newArr = b.filter((bx) => bx !== block);
-						if (newArr.length === b.length) {
-							return b;
-						}
-
-						return newArr;
-					});
-				},
+				unblock: () => undefined,
 			};
-		},
-		[rendering],
-	);
+		}
 
-	const listenForBuffering: ListenForBuffering = useCallback(
-		(callback: OnBufferingCallback) => {
-			onBufferingCallbacks.current = [
-				...onBufferingCallbacks.current,
-				callback,
-			];
+		let unblocked = false;
 
-			return {
-				remove: () => {
-					onBufferingCallbacks.current = onBufferingCallbacks.current.filter(
-						(cb) => cb !== callback,
-					);
-				},
-			};
-		},
-		[],
-	);
+		setBlockCount((count) => count + 1);
+		return {
+			unblock: () => {
+				if (unblocked) {
+					return;
+				}
 
-	const listenForResume: ListenForResume = useCallback(
-		(callback: OnResumeCallback) => {
-			onResumeCallbacks.current = [...onResumeCallbacks.current, callback];
-
-			return {
-				remove: () => {
-					onResumeCallbacks.current = onResumeCallbacks.current.filter(
-						(cb) => cb !== callback,
-					);
-				},
-			};
-		},
-		[],
-	);
+				unblocked = true;
+				setBlockCount((count) => count - 1);
+			},
+		};
+	}, [rendering]);
 
 	useEffect(() => {
 		if (rendering) {
@@ -130,9 +57,8 @@ const useBufferManager = (
 		// Only fire on the `false -> true` transition: adding a block while
 		// already buffering (e.g. a second media element starts loading) must
 		// not re-dispatch `waiting` to listeners.
-		if (blocks.length > 0 && !buffering.current) {
-			buffering.current = true;
-			[...onBufferingCallbacks.current].forEach((c) => c());
+		if (blockCount > 0 && !isBuffering()) {
+			setBuffering(true);
 			playbackLogging({
 				logLevel,
 				message: 'Player is entering buffer state',
@@ -141,12 +67,8 @@ const useBufferManager = (
 			});
 		}
 
-		// Intentionally only firing when blocks change, not the callbacks
-		// otherwise a buffering callback might remove itself after being called
-		// and trigger again
-
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [blocks]);
+	}, [blockCount]);
 
 	if (typeof window !== 'undefined') {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -158,9 +80,8 @@ const useBufferManager = (
 			// Only fire on the `true -> false` transition: the initial mount and
 			// a block that was added and removed within the same commit must not
 			// dispatch `resume` to listeners.
-			if (blocks.length === 0 && buffering.current) {
-				buffering.current = false;
-				[...onResumeCallbacks.current].forEach((c) => c());
+			if (blockCount === 0 && isBuffering()) {
+				setBuffering(false);
 				playbackLogging({
 					logLevel,
 					message: 'Player is exiting buffer state',
@@ -168,16 +89,11 @@ const useBufferManager = (
 					tag: 'player',
 				});
 			}
-			// Intentionally only firing when blocks change, not the callbacks
-			// otherwise a resume callback might remove itself after being called
-			// and trigger again
 			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [blocks]);
+		}, [blockCount]);
 	}
 
-	return useMemo(() => {
-		return {addBlock, listenForBuffering, listenForResume, buffering};
-	}, [addBlock, buffering, listenForBuffering, listenForResume]);
+	return useMemo(() => ({addBlock}), [addBlock]);
 };
 
 export const BufferingContextReact = React.createContext<BufferManager | null>(
@@ -188,37 +104,17 @@ export const BufferingProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
 	const {logLevel, mountTime} = useContext(LogLevelContext);
-	const bufferManager = useBufferManager(logLevel ?? 'info', mountTime);
+	const {isBuffering, setBuffering} = useContext(SetTimelineContext);
+	const bufferManager = useBufferManager(
+		logLevel ?? 'info',
+		mountTime,
+		setBuffering,
+		isBuffering,
+	);
 
 	return (
 		<BufferingContextReact.Provider value={bufferManager}>
 			{children}
 		</BufferingContextReact.Provider>
 	);
-};
-
-export const useIsPlayerBuffering = (bufferManager: BufferManager) => {
-	const [isBuffering, setIsBuffering] = useState(
-		bufferManager.buffering.current,
-	);
-
-	useEffect(() => {
-		const onBuffer = () => {
-			setIsBuffering(true);
-		};
-
-		const onResume = () => {
-			setIsBuffering(false);
-		};
-
-		const buffer = bufferManager.listenForBuffering(onBuffer);
-		const resume = bufferManager.listenForResume(onResume);
-
-		return () => {
-			buffer.remove();
-			resume.remove();
-		};
-	}, [bufferManager]);
-
-	return isBuffering;
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -16,11 +16,7 @@ import {
 	useFrameForVolumeProp,
 	useMediaStartsAt,
 } from './audio/use-audio-frame.js';
-import {
-	BufferingContextReact,
-	BufferingProvider,
-	useIsPlayerBuffering,
-} from './buffering.js';
+import {BufferingContextReact, BufferingProvider} from './buffering.js';
 import {calculateMediaDuration} from './calculate-media-duration.js';
 import {
 	CanUseRemotionHooks,
@@ -212,6 +208,7 @@ import {
 	type TimelineContextValue,
 } from './TimelineContext.js';
 import {truthy} from './truthy.js';
+import {useBuffering} from './use-buffering.js';
 import {useCropStyle} from './use-crop-style.js';
 import {
 	calculateScale,
@@ -437,7 +434,7 @@ export const Internals = {
 	setInputPropsOverride,
 	useVideoEnabled,
 	useAudioEnabled,
-	useIsPlayerBuffering,
+	useBuffering,
 	TimelinePosition,
 	DelayRenderContextType,
 	TimelineContext,

--- a/packages/core/src/test/Img.test.tsx
+++ b/packages/core/src/test/Img.test.tsx
@@ -1,7 +1,6 @@
 import {afterEach, beforeEach, expect, test} from 'bun:test';
 import {act, cleanup, fireEvent, render, waitFor} from '@testing-library/react';
 import React from 'react';
-import {BufferingContextReact} from '../buffering.js';
 import type {
 	EffectApplyParams,
 	EffectDefinition,
@@ -12,6 +11,7 @@ import type {RemotionEnvironment} from '../remotion-environment-context.js';
 import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
 import type {SequenceContextType} from '../SequenceContext.js';
 import {SequenceContext} from '../SequenceContext.js';
+import {SetTimelineContext} from '../TimelineContext.js';
 import {WrapSequenceContext} from './wrap-sequence-context.js';
 
 const drawImageCalls: unknown[][] = [];
@@ -154,25 +154,13 @@ const makeSequenceContext = (premounting: boolean): SequenceContextType => ({
 const BufferingEvents: React.FC<{
 	readonly events: string[];
 }> = ({events}) => {
-	const manager = React.useContext(BufferingContextReact);
+	const {subscribeBuffering} = React.useContext(SetTimelineContext);
 
 	React.useLayoutEffect(() => {
-		if (!manager) {
-			throw new Error('Expected BufferingContextReact');
-		}
-
-		const buffering = manager.listenForBuffering(() => {
-			events.push('waiting');
+		return subscribeBuffering((state) => {
+			events.push(state.buffering ? 'waiting' : 'resume');
 		});
-		const resume = manager.listenForResume(() => {
-			events.push('resume');
-		});
-
-		return () => {
-			buffering.remove();
-			resume.remove();
-		};
-	}, [events, manager]);
+	}, [events, subscribeBuffering]);
 
 	return null;
 };

--- a/packages/core/src/test/buffering.test.tsx
+++ b/packages/core/src/test/buffering.test.tsx
@@ -4,6 +4,10 @@ import React, {useContext, useLayoutEffect} from 'react';
 import {BufferingContextReact, BufferingProvider} from '../buffering.js';
 import type {RemotionEnvironment} from '../remotion-environment-context.js';
 import {RemotionEnvironmentContext} from '../remotion-environment-context.js';
+import {
+	SetTimelineContext,
+	TimelineContextProvider,
+} from '../TimelineContext.js';
 
 const previewEnvironment: RemotionEnvironment = {
 	isStudio: false,
@@ -15,155 +19,134 @@ const previewEnvironment: RemotionEnvironment = {
 
 let manager: React.ContextType<typeof BufferingContextReact> = null;
 let events: string[] = [];
+let readIsBuffering = () => false;
 
 const Harness: React.FC = () => {
-	const context = useContext(BufferingContextReact);
-	manager = context;
+	manager = useContext(BufferingContextReact);
+	const {isBuffering, subscribeBuffering} = useContext(SetTimelineContext);
+	readIsBuffering = isBuffering;
 
-	// Subscribe in a layout effect like `useBufferStateEmitter` does, so that
-	// listeners are registered before the provider's effects run on mount.
 	useLayoutEffect(() => {
-		const buffer = context!.listenForBuffering(() => {
-			events.push('waiting');
+		return subscribeBuffering((state) => {
+			events.push(state.buffering ? 'waiting' : 'resume');
 		});
-		const resume = context!.listenForResume(() => {
-			events.push('resume');
-		});
-
-		return () => {
-			buffer.remove();
-			resume.remove();
-		};
-	}, [context]);
+	}, [subscribeBuffering]);
 
 	return null;
 };
 
-const renderProvider = () => {
-	return render(
-		<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+const Provider: React.FC<{readonly children?: React.ReactNode}> = ({
+	children,
+}) => (
+	<RemotionEnvironmentContext.Provider value={previewEnvironment}>
+		<TimelineContextProvider frameState={null}>
 			<BufferingProvider>
 				<Harness />
+				{children}
 			</BufferingProvider>
-		</RemotionEnvironmentContext.Provider>,
-	);
-};
+		</TimelineContextProvider>
+	</RemotionEnvironmentContext.Provider>
+);
 
 beforeEach(() => {
 	manager = null;
 	events = [];
+	readIsBuffering = () => false;
 });
 
 test('does not emit "resume" on mount', () => {
-	renderProvider();
-
+	render(<Provider />);
 	expect(events).toEqual([]);
 });
 
 test('emits "waiting" and "resume" only on empty <-> non-empty transitions', () => {
-	renderProvider();
+	render(<Provider />);
 
 	let firstBlock: {unblock: () => void} | null = null;
 	let secondBlock: {unblock: () => void} | null = null;
 
 	act(() => {
-		firstBlock = manager!.addBlock({id: 'first'});
+		firstBlock = manager!.addBlock();
 	});
 	expect(events).toEqual(['waiting']);
-	expect(manager!.buffering.current).toBe(true);
+	expect(readIsBuffering()).toBe(true);
 
-	// A second block while already buffering must not re-dispatch "waiting"
 	act(() => {
-		secondBlock = manager!.addBlock({id: 'second'});
+		secondBlock = manager!.addBlock();
 	});
 	expect(events).toEqual(['waiting']);
 
-	// Going from 2 -> 1 blocks is not a transition
 	act(() => {
 		firstBlock!.unblock();
 	});
 	expect(events).toEqual(['waiting']);
-	expect(manager!.buffering.current).toBe(true);
+	expect(readIsBuffering()).toBe(true);
 
 	act(() => {
 		secondBlock!.unblock();
 	});
 	expect(events).toEqual(['waiting', 'resume']);
-	expect(manager!.buffering.current).toBe(false);
+	expect(readIsBuffering()).toBe(false);
 });
 
 test('a block added and removed within the same commit emits no events', () => {
-	renderProvider();
+	render(<Provider />);
 
 	act(() => {
-		const block = manager!.addBlock({id: 'transient'});
+		const block = manager!.addBlock();
 		block.unblock();
 	});
 
 	expect(events).toEqual([]);
-	expect(manager!.buffering.current).toBe(false);
+	expect(readIsBuffering()).toBe(false);
 });
 
-test('a listener registered while buffering ends still receives "resume"', () => {
-	// usePlayback() parks its loop during buffering and registers its resume
-	// listener from outside the React render cycle (a rAF callback). The
-	// registration must be visible to the resume dispatch of the very next
-	// commit - if it only lands one commit later, the resume is missed and the
-	// playback loop stays parked forever.
-	let registerOnNextCommit = false;
+test('a subscriber registered while buffering receives the resume transition', () => {
+	let shouldSubscribe = false;
 	let resumed = false;
 
-	const LateRegistrar: React.FC<{readonly generation: number}> = ({
+	const LateSubscriber: React.FC<{readonly generation: number}> = ({
 		generation,
 	}) => {
-		const context = useContext(BufferingContextReact);
+		const {subscribeBuffering} = useContext(SetTimelineContext);
 
 		useLayoutEffect(() => {
-			if (registerOnNextCommit) {
-				registerOnNextCommit = false;
-				context!.listenForResume(() => {
-					resumed = true;
-				});
+			if (!shouldSubscribe) {
+				return;
 			}
-		}, [context, generation]);
+
+			return subscribeBuffering((state) => {
+				if (!state.buffering) {
+					resumed = true;
+				}
+			});
+		}, [generation, subscribeBuffering]);
 
 		return null;
 	};
 
-	const renderWithGeneration = (generation: number) =>
-		render(
-			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
-				<BufferingProvider>
-					<Harness />
-					<LateRegistrar generation={generation} />
-				</BufferingProvider>
-			</RemotionEnvironmentContext.Provider>,
-		);
-
-	const {rerender} = renderWithGeneration(1);
+	const {rerender} = render(
+		<Provider>
+			<LateSubscriber generation={1} />
+		</Provider>,
+	);
 
 	let block: {unblock: () => void} | null = null;
 	act(() => {
-		block = manager!.addBlock({id: 'scrub'});
+		block = manager!.addBlock();
 	});
-	expect(manager!.buffering.current).toBe(true);
+	expect(readIsBuffering()).toBe(true);
 
-	// Register inside the same commit that empties the block list - the child's
-	// layout effect runs before the provider's dispatch effect, like the
-	// playback loop registering mid-transition.
-	registerOnNextCommit = true;
+	shouldSubscribe = true;
 	act(() => {
 		rerender(
-			<RemotionEnvironmentContext.Provider value={previewEnvironment}>
-				<BufferingProvider>
-					<Harness />
-					<LateRegistrar generation={2} />
-				</BufferingProvider>
-			</RemotionEnvironmentContext.Provider>,
+			<Provider>
+				<LateSubscriber generation={2} />
+			</Provider>,
 		);
 		block!.unblock();
 	});
 
-	expect(manager!.buffering.current).toBe(false);
+	expect(readIsBuffering()).toBe(false);
 	expect(resumed).toBe(true);
 });

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -1,7 +1,6 @@
 import {afterEach, beforeEach, expect, test} from 'bun:test';
 import {act, cleanup, render, waitFor} from '@testing-library/react';
 import React from 'react';
-import {BufferingContextReact} from '../buffering.js';
 import {canvasImageSchema} from '../canvas-image/CanvasImage.js';
 import {CanvasImage} from '../canvas-image/index.js';
 import type {TSequence} from '../CompositionManager.js';
@@ -129,25 +128,13 @@ const makeSequenceContext = (premounting: boolean): SequenceContextType => ({
 const BufferingEvents: React.FC<{
 	readonly events: string[];
 }> = ({events}) => {
-	const manager = React.useContext(BufferingContextReact);
+	const {subscribeBuffering} = React.useContext(Internals.SetTimelineContext);
 
 	React.useLayoutEffect(() => {
-		if (!manager) {
-			throw new Error('Expected BufferingContextReact');
-		}
-
-		const buffering = manager.listenForBuffering(() => {
-			events.push('waiting');
+		return subscribeBuffering((state) => {
+			events.push(state.buffering ? 'waiting' : 'resume');
 		});
-		const resume = manager.listenForResume(() => {
-			events.push('resume');
-		});
-
-		return () => {
-			buffering.remove();
-			resume.remove();
-		};
-	}, [events, manager]);
+	}, [events, subscribeBuffering]);
 
 	return null;
 };

--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -5,6 +5,7 @@ import type {CompositionManagerContext} from '../CompositionManagerContext.js';
 import {CompositionManager} from '../CompositionManagerContext.js';
 import type {LoggingContextValue} from '../log-level-context.js';
 import {LogLevelContext} from '../log-level-context.js';
+import {createRuntimeValueStore} from '../runtime-value-store.js';
 import {SequenceManagerProvider} from '../SequenceManager.js';
 import type {
 	PlaybackRateContextValue,
@@ -70,15 +71,6 @@ const mockPlaybackRateContext: PlaybackRateContextValue = {
 	},
 };
 
-const mockSetTimelineContext: SetTimelineContextValue = {
-	setFrame: () => undefined,
-	setPlaying: () => undefined,
-	subscribePlaying: () => () => undefined,
-	frameRef: {current: {}},
-	isPlaying: () => false,
-	audioAndVideoTags: {current: []},
-};
-
 const MaybeTimelineProvider: React.FC<{
 	readonly children: React.ReactNode;
 	readonly timelineContext: TimelineContextValue;
@@ -131,13 +123,35 @@ export const WrapSequenceContext: React.FC<{
 		}),
 		[currentFrame],
 	);
+	const bufferingStore = useMemo(
+		() => createRuntimeValueStore({buffering: false}),
+		[],
+	);
+	const setTimelineContext = useMemo<SetTimelineContextValue>(
+		() => ({
+			setFrame: () => undefined,
+			setPlaying: () => undefined,
+			setBuffering: (buffering) => {
+				if (bufferingStore.store.getSnapshot().buffering !== buffering) {
+					bufferingStore.setSnapshot({buffering});
+				}
+			},
+			subscribePlaying: () => () => undefined,
+			subscribeBuffering: bufferingStore.store.subscribe,
+			isPlaying: () => false,
+			isBuffering: () => bufferingStore.store.getSnapshot().buffering,
+			frameRef: {current: {}},
+			audioAndVideoTags: {current: []},
+		}),
+		[bufferingStore],
+	);
 
 	return (
 		<LogLevelContext.Provider value={logContext}>
-			<BufferingProvider>
-				<CanUseRemotionHooksProvider>
-					<MaybeTimelineProvider timelineContext={timelineContext}>
-						<SetTimelineContext.Provider value={mockSetTimelineContext}>
+			<SetTimelineContext.Provider value={setTimelineContext}>
+				<BufferingProvider>
+					<CanUseRemotionHooksProvider>
+						<MaybeTimelineProvider timelineContext={timelineContext}>
 							<MaybePlaybackRateProvider>
 								<SequenceManagerProvider>
 									<CompositionManager.Provider value={compositionContext}>
@@ -145,10 +159,10 @@ export const WrapSequenceContext: React.FC<{
 									</CompositionManager.Provider>
 								</SequenceManagerProvider>
 							</MaybePlaybackRateProvider>
-						</SetTimelineContext.Provider>
-					</MaybeTimelineProvider>
-				</CanUseRemotionHooksProvider>
-			</BufferingProvider>
+						</MaybeTimelineProvider>
+					</CanUseRemotionHooksProvider>
+				</BufferingProvider>
+			</SetTimelineContext.Provider>
 		</LogLevelContext.Provider>
 	);
 };

--- a/packages/core/src/timeline-position-state.ts
+++ b/packages/core/src/timeline-position-state.ts
@@ -118,3 +118,4 @@ export const useTimelineSetFrame = (): ((
 };
 
 export {usePlaying} from './use-playing.js';
+export {useBuffering} from './use-buffering.js';

--- a/packages/core/src/use-buffer-state.ts
+++ b/packages/core/src/use-buffer-state.ts
@@ -34,9 +34,7 @@ export const useBufferState = (): UseBufferState => {
 					new Error().stack,
 				);
 
-				const {unblock} = addBlock({
-					id: String(Math.random()),
-				});
+				const {unblock} = addBlock();
 
 				let unblocked = false;
 

--- a/packages/core/src/use-buffering.ts
+++ b/packages/core/src/use-buffering.ts
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+import {SetTimelineContext} from './TimelineContext.js';
+import {useSyncExternalStore} from './use-sync-external-store.js';
+
+export const useBuffering = () => {
+	const {isBuffering, subscribeBuffering} = useContext(SetTimelineContext);
+	return useSyncExternalStore(subscribeBuffering, isBuffering, isBuffering);
+};

--- a/packages/core/src/use-media-playback.ts
+++ b/packages/core/src/use-media-playback.ts
@@ -1,14 +1,7 @@
 import type {RefObject} from 'react';
-import {
-	useCallback,
-	useContext,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef} from 'react';
 import {useMediaStartsAt} from './audio/use-audio-frame.js';
 import {useBufferUntilFirstFrame} from './buffer-until-first-frame.js';
-import {BufferingContextReact, useIsPlayerBuffering} from './buffering.js';
 import {getMediaSyncAction} from './get-media-sync-action.js';
 import {useLogLevel, useMountTime} from './log-level-context.js';
 import {Log} from './log.js';
@@ -21,6 +14,7 @@ import {
 	usePlaybackRate,
 	useTimelinePosition,
 } from './timeline-position-state.js';
+import {useBuffering} from './use-buffering.js';
 import {useCurrentFrame} from './use-current-frame.js';
 import {useMediaBuffering} from './use-media-buffering.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
@@ -28,6 +22,33 @@ import {useRequestVideoCallbackTime} from './use-request-video-callback-time.js'
 import {useVideoConfig} from './use-video-config.js';
 import {getMediaTime} from './video/get-current-time.js';
 import {warnAboutNonSeekableMedia} from './warn-about-non-seekable-media.js';
+
+// In Safari, amplified media can lag behind by around 0.4 seconds.
+const DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_AMPLIFICATION = 0.65;
+
+const getPauseReason = ({
+	reason,
+	isPremounting,
+	isPostmounting,
+}: {
+	reason: 'not-playing' | 'buffering';
+	isPremounting: boolean;
+	isPostmounting: boolean;
+}) => {
+	if (reason === 'buffering') {
+		return 'player is buffering but media tag is not';
+	}
+
+	if (isPremounting) {
+		return 'media is premounting';
+	}
+
+	if (isPostmounting) {
+		return 'media is postmounting';
+	}
+
+	return 'Player is not playing';
+};
 
 export const useMediaPlayback = ({
 	mediaRef,
@@ -58,19 +79,13 @@ export const useMediaPlayback = ({
 	const frame = useCurrentFrame();
 	const absoluteFrame = useTimelinePosition();
 	const playing = usePlaying();
-	const buffering = useContext(BufferingContextReact);
+	const playerBuffering = useBuffering();
 	const {fps} = useVideoConfig();
 	const mediaStartsAt = useMediaStartsAt();
 	const lastSeekDueToShift = useRef<number | null>(null);
 	const lastSeek = useRef<number | null>(null);
 	const logLevel = useLogLevel();
 	const mountTime = useMountTime();
-
-	if (!buffering) {
-		throw new Error(
-			'useMediaPlayback must be used inside a <BufferingContext>',
-		);
-	}
 
 	const isVariableFpsVideoMap = useRef<Record<string, boolean>>({});
 
@@ -130,69 +145,18 @@ export const useMediaPlayback = ({
 	const playbackRate = localPlaybackRate * globalPlaybackRate;
 
 	const acceptableTimeShiftButLessThanDuration = (() => {
-		// In Safari, it seems to lag behind mostly around ~0.4 seconds
-		const DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_NORMAL_PLAYBACK = 0.45;
-
-		// If there is amplification, the acceptable timeshift is higher
-		const DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_AMPLIFICATION =
-			DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_NORMAL_PLAYBACK + 0.2;
-
-		const defaultAcceptableTimeshift =
-			DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_AMPLIFICATION;
 		// For short audio, a lower acceptable time shift is used
 		if (mediaRef.current?.duration) {
 			return Math.min(
 				mediaRef.current.duration,
-				acceptableTimeshift ?? defaultAcceptableTimeshift,
+				acceptableTimeshift ?? DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_AMPLIFICATION,
 			);
 		}
 
-		return acceptableTimeshift ?? defaultAcceptableTimeshift;
+		return (
+			acceptableTimeshift ?? DEFAULT_ACCEPTABLE_TIMESHIFT_WITH_AMPLIFICATION
+		);
 	})();
-
-	const isPlayerBuffering = useIsPlayerBuffering(buffering);
-
-	useEffect(() => {
-		if (mediaRef.current?.paused) {
-			return;
-		}
-
-		if (!playing) {
-			playbackLogging({
-				logLevel,
-				tag: 'pause',
-				message: `Pausing ${mediaRef.current?.src} because ${isPremounting ? 'media is premounting' : isPostmounting ? 'media is postmounting' : 'Player is not playing'}`,
-				mountTime,
-			});
-			mediaRef.current?.pause();
-			return;
-		}
-
-		const isMediaTagBufferingOrStalled = isMediaTagBuffering || isBuffering();
-
-		const playerBufferingNotStateButLive = buffering.buffering.current;
-		if (playerBufferingNotStateButLive && !isMediaTagBufferingOrStalled) {
-			playbackLogging({
-				logLevel,
-				tag: 'pause',
-				message: `Pausing ${mediaRef.current?.src} because player is buffering but media tag is not`,
-				mountTime,
-			});
-			mediaRef.current?.pause();
-		}
-	}, [
-		isBuffering,
-		isMediaTagBuffering,
-		buffering,
-		isPlayerBuffering,
-		isPremounting,
-		logLevel,
-		mediaRef,
-		mediaType,
-		mountTime,
-		playing,
-		isPostmounting,
-	]);
 
 	const env = useRemotionEnvironment();
 
@@ -225,6 +189,27 @@ export const useMediaPlayback = ({
 		}
 
 		const {current} = mediaRef;
+		const isMediaTagBufferingOrStalled = isMediaTagBuffering || isBuffering();
+		let pauseReason: 'not-playing' | 'buffering' | null = null;
+		if (!playing) {
+			pauseReason = 'not-playing';
+		} else if (playerBuffering && !isMediaTagBufferingOrStalled) {
+			pauseReason = 'buffering';
+		}
+
+		if (!current.paused && pauseReason !== null) {
+			playbackLogging({
+				logLevel,
+				tag: 'pause',
+				message: `Pausing ${current.src} because ${getPauseReason({
+					reason: pauseReason,
+					isPremounting,
+					isPostmounting,
+				})}`,
+				mountTime,
+			});
+			current.pause();
+		}
 
 		const action = getMediaSyncAction({
 			duration: current.duration,
@@ -241,8 +226,8 @@ export const useMediaPlayback = ({
 			lastSeekDueToShift: lastSeekDueToShift.current,
 			playing,
 			playbackRate,
-			mediaTagBufferingOrStalled: isMediaTagBuffering || isBuffering(),
-			playerBuffering: buffering.buffering.current,
+			mediaTagBufferingOrStalled: isMediaTagBufferingOrStalled,
+			playerBuffering,
 			absoluteFrame,
 			onlyWarnForMediaSeekingError,
 			isPremounting,
@@ -328,7 +313,6 @@ export const useMediaPlayback = ({
 		absoluteFrame,
 		acceptableTimeShiftButLessThanDuration,
 		bufferUntilFirstFrame,
-		buffering.buffering,
 		rvcCurrentTime,
 		logLevel,
 		desiredUnclampedTime,
@@ -338,6 +322,7 @@ export const useMediaPlayback = ({
 		mediaType,
 		onlyWarnForMediaSeekingError,
 		playbackRate,
+		playerBuffering,
 		playing,
 		src,
 		onAutoPlayError,

--- a/packages/core/src/use-media-tag.ts
+++ b/packages/core/src/use-media-tag.ts
@@ -1,9 +1,11 @@
 import type {RefObject} from 'react';
-import {useEffect, useRef} from 'react';
+import {useContext, useEffect, useRef} from 'react';
 import {useLogLevel, useMountTime} from './log-level-context.js';
 import {playAndHandleNotAllowedError} from './play-and-handle-not-allowed-error.js';
+import {playbackLogging} from './playback-logging.js';
 import type {PlayableMediaTag} from './timeline-position-state.js';
 import {useTimelineContext} from './timeline-position-state.js';
+import {SetTimelineContext} from './TimelineContext.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
 
 export const useMediaTag = ({
@@ -22,6 +24,7 @@ export const useMediaTag = ({
 	isPostmounting: boolean;
 }) => {
 	const {audioAndVideoTags, isPlaying} = useTimelineContext();
+	const {subscribePlaying} = useContext(SetTimelineContext);
 	const isPlayingRef = useRef(isPlaying);
 	isPlayingRef.current = isPlaying;
 	const logLevel = useLogLevel();
@@ -53,8 +56,27 @@ export const useMediaTag = ({
 			},
 		};
 		audioAndVideoTags.current.push(tag);
+		const unsubscribe = subscribePlaying((state) => {
+			if (state.playing) {
+				return;
+			}
+
+			const media = mediaRef.current;
+			if (!media || media.paused) {
+				return;
+			}
+
+			playbackLogging({
+				logLevel,
+				tag: 'pause',
+				message: `Pausing ${media.src} because Player is not playing`,
+				mountTime,
+			});
+			media.pause();
+		});
 
 		return () => {
+			unsubscribe();
 			audioAndVideoTags.current = audioAndVideoTags.current.filter(
 				(a) => a.id !== id,
 			);
@@ -70,5 +92,6 @@ export const useMediaTag = ({
 		logLevel,
 		mountTime,
 		env.isPlayer,
+		subscribePlaying,
 	]);
 };

--- a/packages/media/src/audio/audio-for-preview.tsx
+++ b/packages/media/src/audio/audio-for-preview.tsx
@@ -25,6 +25,7 @@ const {
 	usePreload,
 	SequenceContext,
 	usePlaying,
+	useBuffering,
 } = Internals;
 
 type NewAudioForPreviewProps = {
@@ -125,17 +126,9 @@ const AudioForPreviewAssertedShowing: React.FC<NewAudioForPreviewProps> = ({
 	const isPostmounting = Boolean(parentSequence?.postmounting);
 	const sequenceOffset = (parentSequence?.absoluteFrom ?? 0) / videoConfig.fps;
 
-	const bufferingContext = useContext(Internals.BufferingContextReact);
-
-	if (!bufferingContext) {
-		throw new Error(
-			'useMediaPlayback must be used inside a <BufferingContext>',
-		);
-	}
-
 	const effectiveMuted = muted || playerMuted || userPreferredVolume <= 0;
 
-	const isPlayerBuffering = Internals.useIsPlayerBuffering(bufferingContext);
+	const isPlayerBuffering = useBuffering();
 	const initialPlaying = useRef(playing && !isPlayerBuffering);
 	const initialIsPremounting = useRef(isPremounting);
 	const initialIsPostmounting = useRef(isPostmounting);

--- a/packages/media/src/video/video-for-preview.tsx
+++ b/packages/media/src/video/video-for-preview.tsx
@@ -47,6 +47,7 @@ const {
 	SequenceContext,
 	useEffectChainState,
 	usePlaying,
+	useBuffering,
 } = Internals;
 
 type VideoForPreviewProps = NativeVideoProps & {
@@ -187,18 +188,10 @@ const VideoForPreviewAssertedShowing: React.FC<
 	currentTimeRef.current = currentTime;
 
 	const preloadedSrc = usePreload(src);
-	const buffering = useContext(Internals.BufferingContextReact);
-
-	if (!buffering) {
-		throw new Error(
-			'useMediaPlayback must be used inside a <BufferingContext>',
-		);
-	}
-
 	// TODO: Consider Sequence hidden
 	const effectiveMuted = muted || playerMuted || userPreferredVolume <= 0;
 
-	const isPlayerBuffering = Internals.useIsPlayerBuffering(buffering);
+	const isPlayerBuffering = useBuffering();
 	const initialPlaying = useRef(playing && !isPlayerBuffering);
 	const initialIsPremounting = useRef(isPremounting);
 	const initialIsPostmounting = useRef(isPostmounting);

--- a/packages/player/src/EmitterProvider.tsx
+++ b/packages/player/src/EmitterProvider.tsx
@@ -1,5 +1,4 @@
-import React, {useContext, useEffect, useState} from 'react';
-import {Internals} from 'remotion';
+import React, {useEffect, useState} from 'react';
 import {PlayerEventEmitterContext} from './emitter-context.js';
 import {PlayerEmitter} from './event-emitter.js';
 import {useBufferStateEmitter} from './use-buffer-state-emitter.js';
@@ -9,10 +8,6 @@ export const PlayerEmitterProvider: React.FC<{
 	readonly currentPlaybackRate: number | null;
 }> = ({children, currentPlaybackRate}) => {
 	const [emitter] = useState(() => new PlayerEmitter());
-	const bufferManager = useContext(Internals.BufferingContextReact);
-	if (!bufferManager) {
-		throw new Error('BufferingContextReact not found');
-	}
 
 	useEffect(() => {
 		if (currentPlaybackRate) {

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -251,9 +251,17 @@ const PlayerFn = <
 		() => Internals.createRuntimeValueStore({playing: false}),
 		[],
 	);
+	const bufferingStore = useMemo(
+		() => Internals.createRuntimeValueStore({buffering: false}),
+		[],
+	);
 	const readIsPlaying = useCallback(
 		() => playingStore.store.getSnapshot().playing,
 		[playingStore],
+	);
+	const readIsBuffering = useCallback(
+		() => bufferingStore.store.getSnapshot().buffering,
+		[bufferingStore],
 	);
 	const [currentPlaybackRate, setCurrentPlaybackRate] = useState(playbackRate);
 
@@ -437,17 +445,30 @@ const PlayerFn = <
 			setPlaying: (updater) => {
 				const current = playingStore.store.getSnapshot().playing;
 				const next = typeof updater === 'function' ? updater(current) : updater;
-
 				if (current !== next) {
 					playingStore.setSnapshot({playing: next});
 				}
 			},
+			setBuffering: (buffering) => {
+				if (readIsBuffering() !== buffering) {
+					bufferingStore.setSnapshot({buffering});
+				}
+			},
 			subscribePlaying: playingStore.store.subscribe,
-			frameRef,
+			subscribeBuffering: bufferingStore.store.subscribe,
 			isPlaying: readIsPlaying,
+			isBuffering: readIsBuffering,
+			frameRef,
 			audioAndVideoTags,
 		};
-	}, [playingStore, setFrame, frameRef, readIsPlaying]);
+	}, [
+		bufferingStore,
+		setFrame,
+		frameRef,
+		playingStore,
+		readIsBuffering,
+		readIsPlaying,
+	]);
 
 	if (typeof window !== 'undefined') {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -475,26 +496,28 @@ const PlayerFn = <
 
 	const player = (
 		<Internals.IsPlayerContextProvider>
-			<SharedPlayerContexts
-				timelineContext={timelineContextValue}
-				playbackRateContext={playbackRateContextValue}
-				component={component}
-				compositionHeight={compositionHeight}
-				compositionWidth={compositionWidth}
-				durationInFrames={durationInFrames}
-				fps={fps}
-				numberOfSharedAudioTags={numberOfSharedAudioTags}
-				initiallyMuted={initiallyMuted}
-				logLevel={logLevel}
-				audioLatencyHint={audioLatencyHint}
-				sampleRate={sampleRate}
-				_experimentalKeepAudioContextAlive={_experimentalKeepAudioContextAlive}
-				volumePersistenceKey={volumePersistenceKey}
-				initialVolume={initialVolume}
-				inputProps={actualInputProps}
-				audioEnabled
-			>
-				<Internals.SetTimelineContext.Provider value={setTimelineContextValue}>
+			<Internals.SetTimelineContext.Provider value={setTimelineContextValue}>
+				<SharedPlayerContexts
+					timelineContext={timelineContextValue}
+					playbackRateContext={playbackRateContextValue}
+					component={component}
+					compositionHeight={compositionHeight}
+					compositionWidth={compositionWidth}
+					durationInFrames={durationInFrames}
+					fps={fps}
+					numberOfSharedAudioTags={numberOfSharedAudioTags}
+					initiallyMuted={initiallyMuted}
+					logLevel={logLevel}
+					audioLatencyHint={audioLatencyHint}
+					sampleRate={sampleRate}
+					_experimentalKeepAudioContextAlive={
+						_experimentalKeepAudioContextAlive
+					}
+					volumePersistenceKey={volumePersistenceKey}
+					initialVolume={initialVolume}
+					inputProps={actualInputProps}
+					audioEnabled
+				>
 					<PlayerEmitterProvider currentPlaybackRate={currentPlaybackRate}>
 						<PlayerUI
 							ref={rootRef}
@@ -548,8 +571,8 @@ const PlayerFn = <
 							noSuspense={Boolean(noSuspense)}
 						/>
 					</PlayerEmitterProvider>
-				</Internals.SetTimelineContext.Provider>
-			</SharedPlayerContexts>
+				</SharedPlayerContexts>
+			</Internals.SetTimelineContext.Provider>
 		</Internals.IsPlayerContextProvider>
 	);
 

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -638,15 +638,11 @@ const PlayerUI: React.ForwardRefRenderFunction<
 	const shouldShowPoster =
 		poster &&
 		[
-			showPosterWhenPaused && !player.isPlaying() && !seeking,
-			showPosterWhenEnded &&
-				frame === durationInFrames - 1 &&
-				!player.isPlaying(),
-			showPosterWhenUnplayed && !hasPlayed && !player.isPlaying(),
-			showPosterWhenBuffering && showBufferIndicator && player.isPlaying(),
-			showPosterWhenBufferingAndPaused &&
-				showBufferIndicator &&
-				!player.isPlaying(),
+			showPosterWhenPaused && !playing && !seeking,
+			showPosterWhenEnded && frame === durationInFrames - 1 && !playing,
+			showPosterWhenUnplayed && !hasPlayed && !playing,
+			showPosterWhenBuffering && showBufferIndicator && playing,
+			showPosterWhenBufferingAndPaused && showBufferIndicator && !playing,
 		].some(Boolean);
 
 	const {left, top, width, height, ...outerWithoutScale} = outer;

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -18,6 +18,7 @@ import type {
 	LogLevel,
 	PlayableMediaTag,
 	PlaybackRateContextValue,
+	SetTimelineContextValue,
 	TimelineContextValue,
 } from 'remotion';
 import {Internals} from 'remotion';
@@ -84,6 +85,10 @@ const ThumbnailFn = <
 
 	const rootRef = useRef<ThumbnailMethods>(null);
 	const audioAndVideoTags = useRef<PlayableMediaTag[]>([]);
+	const bufferingStore = useMemo(
+		() => Internals.createRuntimeValueStore({buffering: false}),
+		[],
+	);
 
 	const timelineState: TimelineContextValue = useMemo(() => {
 		const value: TimelineContextValue = {
@@ -105,6 +110,25 @@ const ThumbnailFn = <
 			},
 		};
 	}, []);
+	const frameRef = useRef(timelineState.frame);
+	frameRef.current = timelineState.frame;
+	const setTimelineContext: SetTimelineContextValue = useMemo(() => {
+		return {
+			setFrame: () => undefined,
+			setPlaying: () => undefined,
+			setBuffering: (buffering) => {
+				if (bufferingStore.store.getSnapshot().buffering !== buffering) {
+					bufferingStore.setSnapshot({buffering});
+				}
+			},
+			subscribePlaying: () => () => undefined,
+			subscribeBuffering: bufferingStore.store.subscribe,
+			isPlaying: () => false,
+			isBuffering: () => bufferingStore.store.getSnapshot().buffering,
+			frameRef,
+			audioAndVideoTags,
+		};
+	}, [bufferingStore]);
 
 	useImperativeHandle(ref, () => rootRef.current as ThumbnailMethods, []);
 
@@ -122,37 +146,39 @@ const ThumbnailFn = <
 
 	return (
 		<Internals.IsPlayerContextProvider>
-			<SharedPlayerContexts
-				timelineContext={timelineState}
-				playbackRateContext={playbackRateContext}
-				component={Component}
-				compositionHeight={compositionHeight}
-				compositionWidth={compositionWidth}
-				durationInFrames={durationInFrames}
-				fps={fps}
-				numberOfSharedAudioTags={0}
-				initiallyMuted
-				logLevel={logLevel}
-				audioLatencyHint="playback"
-				sampleRate={48000}
-				inputProps={passedInputProps}
-				audioEnabled={false}
-				_experimentalKeepAudioContextAlive={false}
-			>
-				<ThumbnailEmitterContext.Provider value={emitter}>
-					<ThumbnailUI
-						ref={rootRef}
-						className={className}
-						errorFallback={errorFallback}
-						inputProps={passedInputProps}
-						renderLoading={renderLoading}
-						style={style}
-						overflowVisible={overflowVisible}
-						overrideInternalClassName={overrideInternalClassName}
-						noSuspense={Boolean(noSuspense)}
-					/>
-				</ThumbnailEmitterContext.Provider>
-			</SharedPlayerContexts>
+			<Internals.SetTimelineContext.Provider value={setTimelineContext}>
+				<SharedPlayerContexts
+					timelineContext={timelineState}
+					playbackRateContext={playbackRateContext}
+					component={Component}
+					compositionHeight={compositionHeight}
+					compositionWidth={compositionWidth}
+					durationInFrames={durationInFrames}
+					fps={fps}
+					numberOfSharedAudioTags={0}
+					initiallyMuted
+					logLevel={logLevel}
+					audioLatencyHint="playback"
+					sampleRate={48000}
+					inputProps={passedInputProps}
+					audioEnabled={false}
+					_experimentalKeepAudioContextAlive={false}
+				>
+					<ThumbnailEmitterContext.Provider value={emitter}>
+						<ThumbnailUI
+							ref={rootRef}
+							className={className}
+							errorFallback={errorFallback}
+							inputProps={passedInputProps}
+							renderLoading={renderLoading}
+							style={style}
+							overflowVisible={overflowVisible}
+							overrideInternalClassName={overrideInternalClassName}
+							noSuspense={Boolean(noSuspense)}
+						/>
+					</ThumbnailEmitterContext.Provider>
+				</SharedPlayerContexts>
+			</Internals.SetTimelineContext.Provider>
 		</Internals.IsPlayerContextProvider>
 	);
 };

--- a/packages/player/src/browser-mediasession.ts
+++ b/packages/player/src/browser-mediasession.ts
@@ -31,9 +31,7 @@ export const useBrowserMediaSession = ({
 		if (playing) {
 			hasEverPlayed.current = true;
 		}
-	}, [playing]);
 
-	useEffect(() => {
 		if (!navigator.mediaSession) {
 			return;
 		}

--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -219,6 +219,67 @@ const AudioComposition = () => {
 	);
 };
 
+test('Player.pause() pauses mounted HTML5 media synchronously', () => {
+	const originalPlay = HTMLMediaElement.prototype.play;
+	const originalPause = HTMLMediaElement.prototype.pause;
+	const originalPaused = Object.getOwnPropertyDescriptor(
+		HTMLMediaElement.prototype,
+		'paused',
+	);
+	const playerRef = createRef<PlayerRef>();
+	let pauseCalls = 0;
+	let paused = true;
+
+	Object.defineProperty(HTMLMediaElement.prototype, 'paused', {
+		configurable: true,
+		get: () => paused,
+	});
+	HTMLMediaElement.prototype.play = () => {
+		paused = false;
+		return Promise.resolve();
+	};
+
+	HTMLMediaElement.prototype.pause = () => {
+		paused = true;
+		pauseCalls++;
+	};
+
+	try {
+		render(
+			React.createElement(Player, {
+				ref: playerRef,
+				component: AudioComposition,
+				durationInFrames: 300,
+				compositionWidth: 1920,
+				compositionHeight: 1080,
+				fps: 30,
+			}),
+		);
+
+		act(() => playerRef.current?.play());
+		pauseCalls = 0;
+
+		act(() => {
+			playerRef.current?.pause();
+			expect(pauseCalls).toBe(1);
+		});
+
+		expect(pauseCalls).toBe(1);
+	} finally {
+		HTMLMediaElement.prototype.play = originalPlay;
+		HTMLMediaElement.prototype.pause = originalPause;
+		if (originalPaused) {
+			Object.defineProperty(
+				HTMLMediaElement.prototype,
+				'paused',
+				originalPaused,
+			);
+		} else {
+			delete (HTMLMediaElement.prototype as {paused?: boolean}).paused;
+		}
+	}
+});
+
 const PlayerWithMuteButton = ({
 	onError,
 	initiallyMuted = false,

--- a/packages/player/src/use-buffer-state-emitter.ts
+++ b/packages/player/src/use-buffer-state-emitter.ts
@@ -5,25 +5,15 @@ import type {PlayerEmitter, ThumbnailEmitter} from './event-emitter.js';
 export const useBufferStateEmitter = (
 	emitter: PlayerEmitter | ThumbnailEmitter,
 ) => {
-	const bufferManager = useContext(Internals.BufferingContextReact);
-
-	if (!bufferManager) {
-		throw new Error('BufferingContextReact not found');
-	}
+	const {subscribeBuffering} = useContext(Internals.SetTimelineContext);
 
 	useLayoutEffect(() => {
-		const clear1 = bufferManager.listenForBuffering(() => {
-			bufferManager.buffering.current = true;
-			emitter.dispatchWaiting({});
+		return subscribeBuffering((state) => {
+			if (state.buffering) {
+				emitter.dispatchWaiting({});
+			} else {
+				emitter.dispatchResume({});
+			}
 		});
-		const clear2 = bufferManager.listenForResume(() => {
-			bufferManager.buffering.current = false;
-			emitter.dispatchResume({});
-		});
-
-		return () => {
-			clear1.remove();
-			clear2.remove();
-		};
-	}, [bufferManager, emitter]);
+	}, [emitter, subscribeBuffering]);
 };

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -55,6 +55,9 @@ export const usePlayback = ({
 	const setFrame = Internals.Timeline.useTimelineSetFrame();
 	const sharedAudioContext = useContext(Internals.SharedAudioContext);
 	const {setPlayerMuted} = useContext(Internals.SetMediaVolumeContext);
+	const {isBuffering, subscribeBuffering} = useContext(
+		Internals.SetTimelineContext,
+	);
 	const logLevel = Internals.useLogLevel();
 
 	// requestAnimationFrame() does not work if the tab is not active.
@@ -63,13 +66,6 @@ export const usePlayback = ({
 	const isBackgroundedRef = useIsBackgrounded();
 
 	const lastTimeUpdateTimestamp = useRef<number>(0);
-
-	const context = useContext(Internals.BufferingContextReact);
-	if (!context) {
-		throw new Error(
-			'Missing the buffering context. Most likely you have a Remotion version mismatch.',
-		);
-	}
 
 	useBrowserMediaSession({
 		browserMediaControlsBehavior,
@@ -228,7 +224,7 @@ export const usePlayback = ({
 				return;
 			}
 
-			if (!muted && !audioContextFailed && !context.buffering.current) {
+			if (!muted && !audioContextFailed && !isBuffering()) {
 				sharedAudioContext?.resume?.();
 			}
 
@@ -253,7 +249,7 @@ export const usePlayback = ({
 			if (
 				nextFrame !== getCurrentFrame() &&
 				(!hasEnded || moveToBeginningWhenEnded) &&
-				!context.buffering.current
+				!isBuffering()
 			) {
 				setFrame((c) => ({...c, [config.id]: nextFrame}));
 			}
@@ -296,13 +292,17 @@ export const usePlayback = ({
 				return;
 			}
 
-			if (context.buffering.current) {
+			if (isBuffering()) {
 				if (!muted && !audioContextFailed) {
 					sharedAudioContext?.suspend?.();
 				}
 
-				const stopListening = context.listenForResume(() => {
-					stopListening.remove();
+				const unsubscribe = subscribeBuffering((state) => {
+					if (state.buffering) {
+						return;
+					}
+
+					unsubscribe();
 					if (
 						!muted &&
 						!audioContextFailed &&
@@ -362,10 +362,11 @@ export const usePlayback = ({
 		moveToBeginningWhenEnded,
 		isBackgroundedRef,
 		getCurrentFrame,
-		context,
+		isBuffering,
 		isPlaying,
 		sharedAudioContext,
 		setPlayerMuted,
+		subscribeBuffering,
 		logLevel,
 		muted,
 	]);

--- a/packages/player/src/use-player-methods.ts
+++ b/packages/player/src/use-player-methods.ts
@@ -24,8 +24,9 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 	const {
 		setPlaying,
 		frameRef,
-		isPlaying: readIsPlaying,
 		audioAndVideoTags,
+		isPlaying: readIsPlaying,
+		isBuffering,
 	} = useContext(Internals.SetTimelineContext);
 	const audioContext = useContext(Internals.SharedAudioContext);
 	const audioTagsContext = useContext(Internals.SharedAudioTagsContext);
@@ -38,13 +39,6 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 
 	if (!emitter) {
 		throw new TypeError('Expected Player event emitter context');
-	}
-
-	const bufferingContext = useContext(Internals.BufferingContextReact);
-	if (!bufferingContext) {
-		throw new Error(
-			'Missing the buffering context. Most likely you have a Remotion version mismatch.',
-		);
 	}
 
 	const getCurrentFrame = useCallback(() => {
@@ -253,14 +247,6 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 		[pause, play, readIsPlaying],
 	);
 
-	const isPlaying = useCallback(() => {
-		return readIsPlaying();
-	}, [readIsPlaying]);
-
-	const isBuffering = useCallback(() => {
-		return bufferingContext.buffering.current;
-	}, [bufferingContext.buffering]);
-
 	return useMemo(() => {
 		return {
 			frameBack,
@@ -270,7 +256,7 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 			pause,
 			seek,
 			getCurrentFrame,
-			isPlaying,
+			isPlaying: readIsPlaying,
 			isBuffering,
 			pauseAndReturnToPlayStart,
 			toggle,
@@ -280,11 +266,11 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 		frameBack,
 		frameForward,
 		getCurrentFrame,
-		isBuffering,
-		isPlaying,
+		readIsPlaying,
 		pause,
 		pauseAndReturnToPlayStart,
 		play,
+		isBuffering,
 		seek,
 		toggle,
 	]);

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -78,23 +78,8 @@ const PlayPauseInner: React.FC<{
 		frameForward,
 		emitter,
 		getCurrentFrame,
-		isPlaying,
 	} = PlayerInternals.usePlayerMethods();
-	const [playing, setPlaying] = useState(isPlaying);
-
-	useEffect(() => {
-		const onPlay = () => setPlaying(true);
-		const onPause = () => setPlaying(false);
-
-		setPlaying(isPlaying());
-		emitter.addEventListener('play', onPlay);
-		emitter.addEventListener('pause', onPause);
-
-		return () => {
-			emitter.removeEventListener('play', onPlay);
-			emitter.removeEventListener('pause', onPause);
-		};
-	}, [emitter, isPlaying]);
+	const playing = Internals.usePlaying();
 
 	const isStill = useIsStill();
 


### PR DESCRIPTION
## Summary

Following the pattern in #10956 - goal is reducing callbacks and race conditions by consolidating readers and writers to `buffering` and `playing` state. This PR aims to make ZERO behavior differences, while cleaning up the dependency chain.

## Details

Playback state still has two different ownership models after moving `playing` into a runtime store: `playing` is store-backed, while buffering is held in a separate mutable ref/context, and registered HTML5 media reacts through a mixture of effects and Player-owned imperative tag access.

This PR makes both signals canonical while keeping their independent notification channels:

- store `playing` and `buffering` in dedicated runtime stores
- expose canonical reactive and imperative reads for both signals
- let registered media subscribe directly to playing transitions
- route buffering events and playback resumption through buffering transitions
- remove the legacy buffering ref/listener registry and Player-owned media pause path
- preserve play, buffering, Freeze, Thumbnail, and imperative frame-read behavior
- make `Player.pause()` pause mounted HTML5 media synchronously

The invariant is that each playback signal has one source of truth and transition consumers subscribe only at the owning boundary.

Two pause paths intentionally remain. The media-tag subscription owns the synchronous `playing → false` transition, while the media synchronization effect still handles mount-while-paused, Freeze, premounting/postmounting, and buffering. Keeping those responsibilities separate preserves the existing lifecycle behavior while making `Player.pause()` immediate.

## Test plan

- [x] Rebased onto `main` after #10956 and its React compatibility shim
- [x] `bunx turbo run make --filter=remotion --filter=@remotion/player --filter=@remotion/media --filter=@remotion/studio --filter=@remotion/canvas`
- [x] `cd packages/core && bun test src/test` (672 pass)
- [x] `cd packages/player && bun test src` (41 pass)
- [x] Affected package lint and formatting
- [x] Adversarial review of providers, transitions, media, buffering, Thumbnail, and React compatibility
- [ ] Browser-check play, pause, seek, buffering, Freeze, and mounted HTML5 media
