### PR TITLE
`remotion`: Update sequence registrations in place

### DIFF
--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -3,7 +3,6 @@ import React, {
 	forwardRef,
 	useCallback,
 	useContext,
-	useEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -13,6 +12,7 @@ import type {
 	LoopDisplay,
 	SequenceControls,
 	SequenceRegistrationControls,
+	TSequence,
 } from './CompositionManager.js';
 import type {EffectDefinition} from './effects/effect-types.js';
 import {getStackForControls} from './enable-sequence-stack-traces.js';
@@ -30,15 +30,13 @@ import {
 } from './sequence-crop.js';
 import type {SequenceContextType} from './SequenceContext.js';
 import {SequenceContext} from './SequenceContext.js';
-import {
-	SequenceManager,
-	SequenceRegistrationContext,
-} from './SequenceManager.js';
+import {SequenceRegistrationContext} from './SequenceManager.js';
 import {IsInsideSeriesContext} from './series/is-inside-series.js';
 import {useTimelinePosition} from './timeline-position-state.js';
 import type {BasicMediaInTimelineReturnType} from './use-media-in-timeline.js';
 import {usePremounting} from './use-premounting.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
+import {useSequenceRegistration} from './use-sequence-registration.js';
 import {useVideoConfig} from './use-video-config.js';
 import {ENABLE_V5_BREAKING_CHANGES} from './v5-flag.js';
 import {withInteractivitySchema} from './with-interactivity-schema.js';
@@ -295,7 +293,6 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		0,
 		Math.min(videoConfig.durationInFrames - from, parentSequenceDuration),
 	);
-	const {registerSequence, unregisterSequence} = useContext(SequenceManager);
 	const sequenceRegistrationEnabled = useContext(SequenceRegistrationContext);
 	const wrapperRefForOutline = useRef<HTMLDivElement | null>(null);
 	const refForOutline =
@@ -460,14 +457,10 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			controlsSupportsEffects,
 		]);
 
-	useEffect(() => {
-		if (!env.isStudio && !sequenceRegistrationEnabled) {
-			return;
-		}
-
+	const getSequenceForRegistration = useCallback((): TSequence => {
 		if (isMedia) {
 			if (isMedia.type === 'image') {
-				registerSequence({
+				return {
 					type: 'image',
 					controls: registrationControls,
 					effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
@@ -490,47 +483,43 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					isInsideSeries,
 					frozenFrame: registeredFrozenFrame,
 					singleChildComponent: singleChildComponent ?? null,
-				});
-			} else {
-				registerSequence({
-					type: isMedia.type,
-					controls: registrationControls,
-					effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
-					effectRuntimeValues,
-					displayName: timelineClipName,
-					documentationLink: resolvedDocumentationLink,
-					doesVolumeChange: isMedia.data.doesVolumeChange,
-					duration: actualDurationInFrames,
-					from,
-					trimBefore: registeredTrimBefore,
-					id,
-					loopDisplay,
-					nonce: nonce.get(),
-					parent: parentSequence?.id ?? null,
-					playbackRate: isMedia.data.playbackRate,
-					postmountDisplay: postmountDisplay ?? null,
-					premountDisplay: premountDisplay ?? null,
-					showInTimeline,
-					src: isMedia.data.src,
-					getStack: () => stackRef.current,
-					startMediaFrom: startMediaFrom ?? isMedia.data.startMediaFrom,
-					mediaFrameAtSequenceZero,
-					volume: isMedia.data.volumes,
-					muted: isMedia.data.muted,
-					refForOutline: refForOutline ?? null,
-					isInsideSeries,
-					frozenFrame: registeredFrozenFrame,
-					frozenMediaFrame,
-					singleChildComponent: singleChildComponent ?? null,
-				});
+				};
 			}
 
-			return () => {
-				unregisterSequence(id);
+			return {
+				type: isMedia.type,
+				controls: registrationControls,
+				effects: _remotionInternalEffects ?? EMPTY_EFFECTS,
+				effectRuntimeValues,
+				displayName: timelineClipName,
+				documentationLink: resolvedDocumentationLink,
+				doesVolumeChange: isMedia.data.doesVolumeChange,
+				duration: actualDurationInFrames,
+				from,
+				trimBefore: registeredTrimBefore,
+				id,
+				loopDisplay,
+				nonce: nonce.get(),
+				parent: parentSequence?.id ?? null,
+				playbackRate: isMedia.data.playbackRate,
+				postmountDisplay: postmountDisplay ?? null,
+				premountDisplay: premountDisplay ?? null,
+				showInTimeline,
+				src: isMedia.data.src,
+				getStack: () => stackRef.current,
+				startMediaFrom: startMediaFrom ?? isMedia.data.startMediaFrom,
+				mediaFrameAtSequenceZero,
+				volume: isMedia.data.volumes,
+				muted: isMedia.data.muted,
+				refForOutline: refForOutline ?? null,
+				isInsideSeries,
+				frozenFrame: registeredFrozenFrame,
+				frozenMediaFrame,
+				singleChildComponent: singleChildComponent ?? null,
 			};
 		}
 
-		registerSequence({
+		return {
 			from,
 			trimBefore: registeredTrimBefore,
 			duration: actualDurationInFrames,
@@ -552,29 +541,19 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			isInsideSeries,
 			frozenFrame: registeredFrozenFrame,
 			singleChildComponent: singleChildComponent ?? null,
-		});
-		return () => {
-			unregisterSequence(id);
 		};
 	}, [
-		durationInFrames,
 		id,
-		name,
-		registerSequence,
 		timelineClipName,
-		unregisterSequence,
 		parentSequence?.id,
 		actualDurationInFrames,
 		from,
-		trimBefore,
 		registeredTrimBefore,
 		showInTimeline,
 		nonce,
 		loopDisplay,
 		premountDisplay,
 		postmountDisplay,
-		env.isStudio,
-		sequenceRegistrationEnabled,
 		registrationControls,
 		_remotionInternalEffects,
 		effectRuntimeValues,
@@ -588,6 +567,13 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		frozenMediaFrame,
 		singleChildComponent,
 	]);
+	useSequenceRegistration({
+		getSequence:
+			env.isStudio || sequenceRegistrationEnabled
+				? getSequenceForRegistration
+				: null,
+		id,
+	});
 
 	// Ceil to support floats
 	// https://github.com/remotion-dev/remotion/issues/2958

--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -12,6 +12,7 @@ import type {
 
 export type SequenceManagerContext = {
 	registerSequence: (seq: TSequence) => void;
+	updateSequence: ((seq: TSequence) => void) | null;
 	unregisterSequence: (id: string) => void;
 	sequences: TSequence[];
 };
@@ -26,6 +27,7 @@ export const SequenceManager = React.createContext<SequenceManagerContext>({
 	registerSequence: () => {
 		throw new Error('SequenceManagerContext not initialized');
 	},
+	updateSequence: null,
 	unregisterSequence: () => {
 		throw new Error('SequenceManagerContext not initialized');
 	},
@@ -329,6 +331,18 @@ export const SequenceManagerProvider: React.FC<{
 			return [...seqs, seq];
 		});
 	}, []);
+	const updateSequence = useCallback((seq: TSequence) => {
+		setSequences((seqs) => {
+			const index = seqs.findIndex((item) => item.id === seq.id);
+			if (index === -1 || seqs[index] === seq) {
+				return seqs;
+			}
+
+			const next = [...seqs];
+			next[index] = seq;
+			return next;
+		});
+	}, []);
 
 	const unregisterSequence = useCallback((seq: string) => {
 		setSequences((seqs) => seqs.filter((s) => s.id !== seq));
@@ -338,9 +352,10 @@ export const SequenceManagerProvider: React.FC<{
 		return {
 			registerSequence,
 			sequences,
+			updateSequence,
 			unregisterSequence,
 		};
-	}, [registerSequence, sequences, unregisterSequence]);
+	}, [registerSequence, sequences, unregisterSequence, updateSequence]);
 
 	const getDragOverrides = useCallback(
 		(nodePath: SequencePropsSubscriptionKey) => {

--- a/packages/core/src/test/canvas-image.test.tsx
+++ b/packages/core/src/test/canvas-image.test.tsx
@@ -193,6 +193,7 @@ const SequenceRegistrationWrapper: React.FC<{
 		() => ({
 			registerSequence,
 			unregisterSequence,
+			updateSequence: registerSequence,
 			sequences: [],
 		}),
 		[registerSequence, unregisterSequence],

--- a/packages/core/src/test/html-in-canvas.test.tsx
+++ b/packages/core/src/test/html-in-canvas.test.tsx
@@ -195,6 +195,7 @@ const SequenceTestWrapper: React.FC<{
 		return {
 			registerSequence,
 			sequences: [],
+			updateSequence: registerSequence,
 			unregisterSequence,
 		};
 	}, [registerSequence, unregisterSequence]);

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -108,7 +108,12 @@ const SequenceTestWrapperWithVisualModeOverrides: React.FC<
 	const unregisterSequence = useCallback(() => undefined, []);
 
 	const ctx: SequenceManagerContext = useMemo(
-		() => ({registerSequence, unregisterSequence, sequences: []}),
+		() => ({
+			registerSequence,
+			unregisterSequence,
+			updateSequence: registerSequence,
+			sequences: [],
+		}),
 		[registerSequence, unregisterSequence],
 	);
 
@@ -240,6 +245,54 @@ test('Sequence calls registerSequence exactly once on mount', () => {
 	);
 
 	expect(registerCalls).toBe(1);
+});
+
+test('Sequence timing changes update its registration without changing order', async () => {
+	let getSequences = (): TSequence[] => {
+		throw new Error('Sequence manager has not mounted');
+	};
+
+	const CaptureSequences = () => {
+		const sequencesRef = React.useContext(SequenceManagerRefContext);
+		getSequences = () => sequencesRef.current;
+		return null;
+	};
+
+	const renderSequences = (firstDuration: number) => (
+		<WrapSequenceContext>
+			<Internals.RemotionEnvironmentContext
+				value={{
+					isRendering: false,
+					isClientSideRendering: false,
+					isPlayer: false,
+					isStudio: true,
+					isReadOnlyStudio: false,
+				}}
+			>
+				<SequenceManagerProvider>
+					<CaptureSequences />
+					<Sequence name="First" durationInFrames={firstDuration} />
+					<Sequence name="Second" durationInFrames={20} />
+				</SequenceManagerProvider>
+			</Internals.RemotionEnvironmentContext>
+		</WrapSequenceContext>
+	);
+
+	const rendered = render(renderSequences(10));
+	await waitFor(() => {
+		expect(getSequences()).toHaveLength(2);
+	});
+	const initialIds = getSequences().map((sequence) => sequence.id);
+
+	rendered.rerender(renderSequences(15));
+	await waitFor(() => {
+		expect(getSequences()[0]?.duration).toBe(15);
+	});
+	expect(getSequences().map((sequence) => sequence.displayName)).toEqual([
+		'First',
+		'Second',
+	]);
+	expect(getSequences().map((sequence) => sequence.id)).toEqual(initialIds);
 });
 
 test('Interactive runtime values update mounted consumers without re-registering the sequence', () => {

--- a/packages/core/src/test/use-media-in-timeline.test.tsx
+++ b/packages/core/src/test/use-media-in-timeline.test.tsx
@@ -44,6 +44,7 @@ afterAll(() => {
 
 test('useMediaInTimeline registers muted changes and unregisters the sequence', () => {
 	const registerSequence = mock();
+	const updateSequence = mock();
 	const unregisterSequence = mock();
 	const wrapper: React.FC<{
 		children: React.ReactNode;
@@ -53,6 +54,7 @@ test('useMediaInTimeline registers muted changes and unregisters the sequence', 
 			return {
 				registerSequence,
 				unregisterSequence,
+				updateSequence,
 				sequences: [],
 			};
 		}, []);
@@ -97,7 +99,8 @@ test('useMediaInTimeline registers muted changes and unregisters the sequence', 
 	});
 
 	rerender({muted: true});
-	expect(registerSequence.mock.calls.at(-1)?.[0]).toMatchObject({muted: true});
+	expect(registerSequence).toHaveBeenCalledTimes(1);
+	expect(updateSequence.mock.calls.at(-1)?.[0]).toMatchObject({muted: true});
 
 	unmount();
 	expect(unregisterSequence).toHaveBeenCalled();
@@ -114,6 +117,7 @@ test('useMediaInTimeline keeps documentation links for custom display names', ()
 			return {
 				registerSequence,
 				unregisterSequence,
+				updateSequence: null,
 				sequences: [],
 			};
 		}, []);

--- a/packages/core/src/use-media-in-timeline.ts
+++ b/packages/core/src/use-media-in-timeline.ts
@@ -1,15 +1,13 @@
-import {useContext, useEffect, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import {useMediaStartsAt} from './audio/use-audio-frame.js';
-import type {LoopDisplay} from './CompositionManager.js';
+import type {LoopDisplay, TSequence} from './CompositionManager.js';
 import {getAssetDisplayName} from './get-asset-file-name.js';
 import {getTimelineDuration} from './get-timeline-duration.js';
 import {useNonce} from './nonce.js';
 import {SequenceContext} from './SequenceContext.js';
-import {
-	SequenceManager,
-	SequenceRegistrationContext,
-} from './SequenceManager.js';
+import {SequenceRegistrationContext} from './SequenceManager.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
+import {useSequenceRegistration} from './use-sequence-registration.js';
 import {useVideoConfig} from './use-video-config.js';
 import type {VolumeProp} from './volume-prop.js';
 import {evaluateVolume} from './volume-prop.js';
@@ -173,7 +171,6 @@ export const useMediaInTimeline = ({
 }) => {
 	const parentSequence = useContext(SequenceContext);
 	const startsAt = useMediaStartsAt();
-	const {registerSequence, unregisterSequence} = useContext(SequenceManager);
 	const sequenceRegistrationEnabled = useContext(SequenceRegistrationContext);
 	const {durationInFrames} = useVideoConfig();
 	const mediaStartsAt = useMediaStartsAt();
@@ -196,24 +193,12 @@ export const useMediaInTimeline = ({
 
 	const {isStudio} = useRemotionEnvironment();
 
-	useEffect(() => {
+	const getSequenceForRegistration = useCallback((): TSequence => {
 		if (!src) {
 			throw new Error('No src passed');
 		}
 
-		if (
-			!isStudio &&
-			!sequenceRegistrationEnabled &&
-			window.process?.env?.NODE_ENV !== 'test'
-		) {
-			return;
-		}
-
-		if (!showInTimeline) {
-			return;
-		}
-
-		registerSequence({
+		return {
 			effectRuntimeValues: null,
 			type: mediaType,
 			src,
@@ -242,18 +227,12 @@ export const useMediaInTimeline = ({
 			isInsideSeries: false,
 			frozenFrame: null,
 			frozenMediaFrame: null,
-		});
-
-		return () => {
-			unregisterSequence(id);
 		};
 	}, [
 		duration,
 		id,
 		parentSequence,
 		src,
-		registerSequence,
-		unregisterSequence,
 		volumes,
 		doesVolumeChange,
 		nonce,
@@ -261,15 +240,21 @@ export const useMediaInTimeline = ({
 		startsAt,
 		playbackRate,
 		getStack,
-		showInTimeline,
 		premountDisplay,
 		postmountDisplay,
 		loopDisplay,
 		documentationLink,
 		finalDisplayName,
-		isStudio,
-		sequenceRegistrationEnabled,
 		refForOutline,
 		muted,
 	]);
+	const registrationEnabled =
+		isStudio ||
+		sequenceRegistrationEnabled ||
+		(typeof window !== 'undefined' && window.process?.env?.NODE_ENV === 'test');
+	useSequenceRegistration({
+		getSequence:
+			registrationEnabled && showInTimeline ? getSequenceForRegistration : null,
+		id,
+	});
 };

--- a/packages/core/src/use-sequence-registration.ts
+++ b/packages/core/src/use-sequence-registration.ts
@@ -1,0 +1,50 @@
+import {useContext, useEffect, useRef} from 'react';
+import type {TSequence} from './CompositionManager.js';
+import {SequenceManager} from './SequenceManager.js';
+
+export const useSequenceRegistration = ({
+	getSequence,
+	id,
+}: {
+	getSequence: (() => TSequence) | null;
+	id: string;
+}) => {
+	const {registerSequence, unregisterSequence, updateSequence} =
+		useContext(SequenceManager);
+	const getSequenceRef = useRef(getSequence);
+	getSequenceRef.current = getSequence;
+	const lastRegisteredGetterRef = useRef<(() => TSequence) | null>(null);
+	const registrationEnabled = getSequence !== null;
+
+	useEffect(() => {
+		if (!registrationEnabled) {
+			return;
+		}
+
+		const currentGetter = getSequenceRef.current;
+		if (currentGetter === null) {
+			throw new Error('Expected a sequence registration getter');
+		}
+
+		registerSequence(currentGetter());
+		lastRegisteredGetterRef.current = currentGetter;
+
+		return () => {
+			lastRegisteredGetterRef.current = null;
+			unregisterSequence(id);
+		};
+	}, [id, registerSequence, registrationEnabled, unregisterSequence]);
+
+	useEffect(() => {
+		if (
+			getSequence === null ||
+			updateSequence === null ||
+			lastRegisteredGetterRef.current === getSequence
+		) {
+			return;
+		}
+
+		updateSequence(getSequence());
+		lastRegisteredGetterRef.current = getSequence;
+	}, [getSequence, updateSequence]);
+};

--- a/packages/gif/src/test/Gif.test.tsx
+++ b/packages/gif/src/test/Gif.test.tsx
@@ -139,6 +139,7 @@ const SequenceRegistrationWrapper: React.FC<{
 			({
 				registerSequence,
 				unregisterSequence,
+				updateSequence: registerSequence,
 				sequences: [],
 			}) as React.ContextType<typeof Internals.SequenceManager>,
 		[registerSequence, unregisterSequence],

--- a/packages/player/src/test/audio-context-resume.test.tsx
+++ b/packages/player/src/test/audio-context-resume.test.tsx
@@ -67,6 +67,7 @@ class FrozenAudioContext {
 const sequenceManager = {
 	registerSequence: () => undefined,
 	unregisterSequence: () => undefined,
+	updateSequence: null,
 	sequences: [],
 };
 

--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -229,6 +229,7 @@ const AudioComposition = () => {
 			value: {
 				registerSequence: () => undefined,
 				unregisterSequence: () => undefined,
+				updateSequence: null,
 				sequences: [],
 			},
 		},

--- a/packages/player/src/test/keep-audio-context-alive.test.tsx
+++ b/packages/player/src/test/keep-audio-context-alive.test.tsx
@@ -70,6 +70,7 @@ class TrackedAudioContext {
 const sequenceManager = {
 	registerSequence: () => undefined,
 	unregisterSequence: () => undefined,
+	updateSequence: null,
 	sequences: [],
 };
 

--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -73,6 +73,7 @@ const SequenceTestWrapper: React.FC<{
 		() => ({
 			registerSequence,
 			unregisterSequence: () => undefined,
+			updateSequence: registerSequence,
 			sequences: [],
 		}),
 		[registerSequence],


### PR DESCRIPTION
## Summary

- update mounted sequence snapshots in place instead of unregistering and appending them again
- preserve timeline registration order and runtime identity when timing or media metadata changes
- share the lifecycle behavior between `<Sequence>` and standalone media registrations

## Testing

- `bun test src/test/sequence-register-once.test.tsx src/test/use-media-in-timeline.test.tsx` from `packages/core`
- regression test verified red with unregister/register behavior and green with in-place updates
- `bun run build`
- `bun run stylecheck`
- `bun .agents/skills/nullable-new-params/scripts/find-new-optional-params.ts`
