### PR TITLE
`@remotion/studio`: Add composition context menu to Quick Switcher

### DIFF
--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherContent.tsx
@@ -314,6 +314,7 @@ export const QuickSwitcherContent: React.FC<{
 					id: 'composition-' + composition.id,
 					title: composition.id,
 					type: 'composition',
+					composition,
 					level: result.level,
 					onSelected: () => {
 						if (compositionSelection !== null) {

--- a/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
+++ b/packages/studio/src/components/QuickSwitcher/QuickSwitcherResult.tsx
@@ -1,4 +1,13 @@
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import type {_InternalTypes} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
 	LIGHT_TEXT,
 	TRANSPARENT,
@@ -6,13 +15,20 @@ import {
 	WHITE_ALPHA_06,
 } from '../../helpers/colors';
 import type {AssetFileType} from '../../helpers/get-preview-file-type';
+import {noop} from '../../helpers/noop';
 import {useKeybinding} from '../../helpers/use-keybinding';
 import {ExpandedFolderIcon} from '../../icons/folder';
 import {StillIcon} from '../../icons/still';
 import {UploadIcon} from '../../icons/upload';
 import {FilmIcon} from '../../icons/video';
+import {SetSelectedModalContext} from '../../state/modals';
 import {AssetFileIcon} from '../AssetFileIcon';
+import {getCompositionContextMenuItems} from '../composition-menu-items';
+import {ContextMenu} from '../ContextMenu';
 import {Spacing} from '../layout';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {useResolvedStack} from '../Timeline/use-resolved-stack';
+import {useEditorOpening} from '../use-default-editor-info';
 import {
 	QUICK_SWITCHER_RESULT_LABEL_FONT_SIZE,
 	useScrollIntoViewOnSelected,
@@ -25,6 +41,7 @@ type QuickSwitcherResultDetail =
 	  }
 	| {
 			type: 'composition';
+			composition: _InternalTypes['AnyComposition'];
 			compositionType: 'composition' | 'still';
 			level: number;
 	  }
@@ -110,6 +127,38 @@ export const QuickSwitcherResult: React.FC<{
 	const ref = useRef<HTMLDivElement>(null);
 	const keybindings = useKeybinding();
 	const onSelected = result.type === 'folder' ? null : result.onSelected;
+	const composition = result.type === 'composition' ? result.composition : null;
+	const {setSelectedModal} = useContext(SetSelectedModalContext);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
+	const {defaultEditorId, defaultEditorName} = useEditorOpening(
+		connectionStatus === 'connected',
+	);
+	const resolvedLocation = useResolvedStack(composition?.stack ?? null);
+	const getContextMenuItems = useCallback((): ComboboxValue[] => {
+		if (composition === null) {
+			return [];
+		}
+
+		return getCompositionContextMenuItems({
+			closeMenu: noop,
+			composition,
+			connectionStatus,
+			editorId: defaultEditorId,
+			editorName: defaultEditorName,
+			includeCompositionManagementItems: true,
+			resolvedLocation,
+			setSelectedModal,
+			readOnlyStudio: window.remotion_isReadOnlyStudio,
+		});
+	}, [
+		composition,
+		connectionStatus,
+		defaultEditorId,
+		defaultEditorName,
+		resolvedLocation,
+		setSelectedModal,
+	]);
 
 	useEffect(() => {
 		if (result.type === 'folder') {
@@ -183,7 +232,7 @@ export const QuickSwitcherResult: React.FC<{
 		};
 	}, [hovered, result.type, selected]);
 
-	return (
+	const row = (
 		<div
 			ref={ref}
 			key={result.id}
@@ -241,4 +290,10 @@ export const QuickSwitcherResult: React.FC<{
 			</div>
 		</div>
 	);
+
+	if (composition === null) {
+		return row;
+	}
+
+	return <ContextMenu getItems={getContextMenuItems}>{row}</ContextMenu>;
 };


### PR DESCRIPTION
## Summary

- add a context menu to composition results in the Quick Switcher
- reuse the composition selector's existing menu items and availability logic
- leave folder and asset results unchanged

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test formatting --filter='@remotion/studio'`

Closes #10921
