### PR TITLE
`@remotion/studio`: Add timeline-matching duration preset

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -125,6 +125,7 @@ export type TSequence = {
 	from: number;
 	trimBefore: number | null;
 	duration: number;
+	unclippedDuration?: number;
 	id: string;
 	displayName: string;
 	documentationLink: string | null;

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -88,6 +88,10 @@ export type SequencePropsWithoutDuration = {
 	/**
 	 * @deprecated For internal use only.
 	 */
+	readonly _remotionInternalUnclippedDuration?: number;
+	/**
+	 * @deprecated For internal use only.
+	 */
 	readonly _remotionInternalPremountDisplay?: number | null;
 	/**
 	 * @deprecated For internal use only.
@@ -154,6 +158,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		controls,
 		_remotionInternalEffects,
 		_remotionInternalLoopDisplay: loopDisplay,
+		_remotionInternalUnclippedDuration: unclippedDuration,
 		_remotionInternalStack: stack,
 		_remotionInternalDocumentationLink: documentationLink,
 		_remotionInternalSingleChildComponent: singleChildComponent,
@@ -475,6 +480,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					displayName: timelineClipName,
 					documentationLink: resolvedDocumentationLink,
 					duration: actualDurationInFrames,
+					unclippedDuration: unclippedDuration ?? durationInFrames,
 					from,
 					trimBefore: registeredTrimBefore,
 					id,
@@ -501,6 +507,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 					documentationLink: resolvedDocumentationLink,
 					doesVolumeChange: isMedia.data.doesVolumeChange,
 					duration: actualDurationInFrames,
+					unclippedDuration: unclippedDuration ?? durationInFrames,
 					from,
 					trimBefore: registeredTrimBefore,
 					id,
@@ -534,6 +541,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 			from,
 			trimBefore: registeredTrimBefore,
 			duration: actualDurationInFrames,
+			unclippedDuration: unclippedDuration ?? durationInFrames,
 			id,
 			displayName: timelineClipName,
 			documentationLink: resolvedDocumentationLink,
@@ -558,6 +566,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 		};
 	}, [
 		durationInFrames,
+		unclippedDuration,
 		id,
 		name,
 		registerSequence,

--- a/packages/core/src/loop/index.tsx
+++ b/packages/core/src/loop/index.tsx
@@ -94,6 +94,7 @@ export const Loop: React.FC<LoopProps> & {
 		<LoopContext.Provider value={loopContext}>
 			<Sequence
 				durationInFrames={durationInFrames}
+				_remotionInternalUnclippedDuration={durationInFrames * times}
 				from={from}
 				name={name ?? '<Loop>'}
 				_remotionInternalDocumentationLink="https://www.remotion.dev/docs/loop"

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -19,6 +19,7 @@ import {Img, imgSchema} from '../Img.js';
 import {Interactive} from '../Interactive.js';
 import {Internals} from '../internals.js';
 import {Loading} from '../loading-indicator.js';
+import {Loop} from '../loop/index.js';
 import type {OverrideIdToNodePaths} from '../sequence-node-path.js';
 import {OverrideIdsToNodePathsGettersContext} from '../sequence-node-path.js';
 import {Sequence} from '../Sequence.js';
@@ -240,6 +241,37 @@ test('Sequence calls registerSequence exactly once on mount', () => {
 	);
 
 	expect(registerCalls).toBe(1);
+});
+
+test('Sequence registration preserves durations beyond the composition end', () => {
+	const registeredSequences: TSequence[] = [];
+
+	render(
+		<SequenceTestWrapper
+			compositionDurationInFrames={30}
+			currentFrame={25}
+			onRegisterSequence={(sequence) => {
+				registeredSequences.push(sequence);
+			}}
+		>
+			<Sequence name="Clipped" from={10} durationInFrames={100} />
+			<Loop name="Loop" durationInFrames={10} times={5}>
+				Loop
+			</Loop>
+		</SequenceTestWrapper>,
+	);
+
+	const clipped = registeredSequences.find(
+		(sequence) => sequence.displayName === 'Clipped',
+	);
+	const loop = registeredSequences.find(
+		(sequence) => sequence.displayName === 'Loop',
+	);
+	expect(clipped?.duration).toBe(20);
+	expect(clipped?.unclippedDuration).toBe(100);
+	expect(loop?.from).toBe(20);
+	expect(loop?.loopDisplay?.startOffset).toBe(-20);
+	expect(loop?.unclippedDuration).toBe(50);
 });
 
 test('Interactive runtime values update mounted consumers without re-registering the sequence', () => {

--- a/packages/core/src/use-media-in-timeline.ts
+++ b/packages/core/src/use-media-in-timeline.ts
@@ -219,6 +219,7 @@ export const useMediaInTimeline = ({
 			src,
 			id,
 			duration,
+			unclippedDuration: duration,
 			from: 0,
 			trimBefore: null,
 			parent: parentSequence?.id ?? null,

--- a/packages/example/e2e/composition-duration-preset.test.mts
+++ b/packages/example/e2e/composition-duration-preset.test.mts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import {expect, test} from '@playwright/test';
+import {EXPANDED_SIDEBAR_STATE, rootFile, STUDIO_URL} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test.describe('Composition duration preset', () => {
+	test.beforeEach(async () => {
+		await startStudio();
+	});
+
+	test.afterEach(async () => {
+		await stopStudio();
+	});
+
+	test('matches the composition duration to the unclipped timeline end', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/duration-preset-e2e`);
+		await expect(page).toHaveURL(/duration-preset-e2e/, {timeout: 15_000});
+
+		if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
+			await page.locator('[data-sidebar-toggle="right"]').click();
+		}
+
+		const durationLabel = page.getByText('Duration', {exact: true});
+		await expect(durationLabel).toBeVisible({timeout: 15_000});
+		await durationLabel.hover();
+		await page.getByRole('button', {name: 'Choose duration preset'}).click();
+		await page.getByText('Match timeline (120 frames)', {exact: true}).click();
+
+		const durationInput = page.getByRole('button', {
+			name: 'Duration',
+			exact: true,
+		});
+		await expect(durationInput).toContainText('120 frames', {timeout: 15_000});
+		await expect
+			.poll(() => {
+				const source = fs.readFileSync(rootFile, 'utf-8');
+				const compositionStart = source.indexOf('id="duration-preset-e2e"');
+				const compositionEnd = source.indexOf('/>', compositionStart);
+				return source.slice(compositionStart, compositionEnd);
+			})
+			.toContain('durationInFrames={120}');
+	});
+});

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {AbsoluteFill, Composition, Folder, useCurrentScale} from 'remotion';
+import {
+	AbsoluteFill,
+	Composition,
+	Folder,
+	Sequence,
+	useCurrentScale,
+} from 'remotion';
 import {BarChart} from './BarChart';
 import {
 	CAPTIONS_DURATION_IN_FRAMES,
@@ -55,9 +61,25 @@ const UseCurrentScaleOnLoad: React.FC = () => {
 	);
 };
 
+const DurationPresetE2e: React.FC = () => {
+	return (
+		<Sequence name="Duration preset layer" from={20} durationInFrames={100}>
+			<AbsoluteFill style={{backgroundColor: 'black'}} />
+		</Sequence>
+	);
+};
+
 export const E2eTestRoot: React.FC = () => {
 	return (
 		<>
+			<Composition
+				id="duration-preset-e2e"
+				component={DurationPresetE2e}
+				width={1920}
+				height={1080}
+				fps={30}
+				durationInFrames={60}
+			/>
 			<Composition
 				id="use-current-scale-on-load"
 				component={UseCurrentScaleOnLoad}

--- a/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
+++ b/packages/studio/src/components/InspectorPanel/CompositionMetadata.tsx
@@ -1,6 +1,14 @@
 import type {RecastCodemod} from '@remotion/studio-shared';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {Internals} from 'remotion';
+import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {WHITE_ALPHA_40} from '../../helpers/colors';
 import {isCompositionStill} from '../../helpers/is-composition-still';
 import {resolvedStackToSymbolicated} from '../../helpers/resolved-stack-to-symbolicated';
@@ -13,6 +21,7 @@ import {
 } from '../NewComposition/InputDragger';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {applyCodemod} from '../RenderQueue/actions';
+import {getTimelineMatchingDuration} from '../Timeline/get-timeline-matching-duration';
 import {useResolvedStack} from '../Timeline/use-resolved-stack';
 import {InspectorDetailRow} from './common';
 import {
@@ -253,6 +262,11 @@ export const CompositionMetadata: React.FC<{
 	readonly stack: string | null;
 }> = ({compositionId, disabled, stack}) => {
 	const video = Internals.useVideo();
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {compositions} = useContext(Internals.CompositionManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
 	const resolvedVideoConfig = Internals.useResolvedVideoConfig(compositionId);
 	const resolvedConfig =
 		resolvedVideoConfig?.type === 'success' ||
@@ -418,6 +432,15 @@ export const CompositionMetadata: React.FC<{
 			symbolicatedStack,
 		],
 	);
+	const timeline = useMemo(
+		() =>
+			calculateTimeline({
+				sequences,
+				overrideIdsToNodePaths: overrideIdToNodePathMappings,
+				compositions,
+			}),
+		[compositions, overrideIdToNodePathMappings, sequences],
+	);
 
 	if (video === null || resolvedConfig === null) {
 		return null;
@@ -434,6 +457,10 @@ export const CompositionMetadata: React.FC<{
 	const durationIsComputed =
 		metadataSource?.durationInFrames === 'calculate-metadata';
 	const isStill = isCompositionStill(video);
+	const timelineMatchingDuration = getTimelineMatchingDuration({
+		currentDuration: video.durationInFrames,
+		timeline,
+	});
 	const dimensionPresetValues = dimensionPresets.flatMap(
 		(preset, index): ComboboxValue[] => [
 			...(index === 2 || index === 4
@@ -469,6 +496,28 @@ export const CompositionMetadata: React.FC<{
 			quickSwitcherLabel: null,
 		}),
 	);
+	const durationPresetValues: ComboboxValue[] =
+		timelineMatchingDuration === null
+			? []
+			: [
+					{
+						type: 'item',
+						id: 'match-timeline',
+						label: `Match timeline (${timelineMatchingDuration} frames)`,
+						value: timelineMatchingDuration,
+						onClick: () => {
+							saveMetadata({durationInFrames: timelineMatchingDuration});
+						},
+						keyHint: null,
+						leftItem: null,
+						subMenu: null,
+						quickSwitcherLabel: null,
+					},
+				];
+	const durationPresetIsApplicable =
+		timelineMatchingDuration !== null &&
+		timelineMatchingDuration !==
+			(pendingValues.durationInFrames?.value ?? video.durationInFrames);
 
 	return (
 		<div style={compositionMetadataContainer}>
@@ -537,7 +586,23 @@ export const CompositionMetadata: React.FC<{
 							/>
 						</div>
 					</InspectorDetailRow>
-					<InspectorDetailRow label="Duration">
+					<InspectorDetailRow
+						label={(hovered) => (
+							<div style={metadataLabelControls}>
+								<span style={metadataLabelText}>Duration</span>
+								{disabled ||
+								durationIsComputed ||
+								!durationPresetIsApplicable ? null : (
+									<PresetDropdown
+										disabled={pendingValues.durationInFrames !== undefined}
+										title="Choose duration preset"
+										values={durationPresetValues}
+										visible={hovered}
+									/>
+								)}
+							</div>
+						)}
+					>
 						<CompositionMetadataValue
 							computed={durationIsComputed}
 							disabled={disabled}

--- a/packages/studio/src/components/Timeline/get-timeline-matching-duration.ts
+++ b/packages/studio/src/components/Timeline/get-timeline-matching-duration.ts
@@ -1,0 +1,72 @@
+import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
+import {shouldShowTrackInTimeline} from './should-show-track-in-timeline';
+
+export const getTimelineMatchingDuration = ({
+	currentDuration,
+	timeline,
+}: {
+	readonly currentDuration: number;
+	readonly timeline: TimelineTrackData[];
+}): number | null => {
+	const tracksById = new Map(
+		timeline.map((track) => [track.sequence.id, track]),
+	);
+	const endById = new Map<string, number>();
+	const indefinitelyRepeatedById = new Map<string, boolean>();
+
+	const isIndefinitelyRepeated = (track: TimelineTrackData): boolean => {
+		const cached = indefinitelyRepeatedById.get(track.sequence.id);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		const parent = track.sequence.parent
+			? tracksById.get(track.sequence.parent)
+			: null;
+		const isIndefinitelyRepeatedTrack =
+			(track.sequence.loopDisplay !== undefined &&
+				track.sequence.unclippedDuration === Infinity) ||
+			(parent ? isIndefinitelyRepeated(parent) : false);
+		indefinitelyRepeatedById.set(
+			track.sequence.id,
+			isIndefinitelyRepeatedTrack,
+		);
+		return isIndefinitelyRepeatedTrack;
+	};
+
+	const getUnclippedEnd = (track: TimelineTrackData): number => {
+		const cached = endById.get(track.sequence.id);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		const parent = track.sequence.parent
+			? tracksById.get(track.sequence.parent)
+			: null;
+		const parentEnd = parent ? getUnclippedEnd(parent) : null;
+		const ownEnd = isIndefinitelyRepeated(track)
+			? Infinity
+			: track.cascadedStart +
+				(track.sequence.loopDisplay?.startOffset ?? 0) +
+				(track.sequence.unclippedDuration ?? track.sequence.duration);
+		const end = parentEnd === null ? ownEnd : Math.min(ownEnd, parentEnd);
+		endById.set(track.sequence.id, end);
+		return end;
+	};
+
+	let longestEnd: number | null = null;
+	for (const track of timeline) {
+		if (!shouldShowTrackInTimeline(track, currentDuration)) {
+			continue;
+		}
+
+		const end = getUnclippedEnd(track);
+		if (!Number.isFinite(end) || end <= 0) {
+			continue;
+		}
+
+		longestEnd = Math.max(longestEnd ?? 0, end);
+	}
+
+	return longestEnd === null ? null : Math.max(1, Math.ceil(longestEnd));
+};

--- a/packages/studio/src/test/timeline-matching-duration.test.ts
+++ b/packages/studio/src/test/timeline-matching-duration.test.ts
@@ -1,0 +1,186 @@
+import {expect, test} from 'bun:test';
+import type {LoopDisplay, TSequence} from 'remotion';
+import {getTimelineMatchingDuration} from '../components/Timeline/get-timeline-matching-duration';
+import {calculateTimeline} from '../helpers/calculate-timeline';
+
+const makeSequence = ({
+	duration,
+	from,
+	id,
+	loopDisplay = undefined,
+	parent = null,
+	showInTimeline = true,
+	unclippedDuration,
+}: {
+	readonly duration: number;
+	readonly from: number;
+	readonly id: string;
+	readonly loopDisplay?: LoopDisplay;
+	readonly parent?: string | null;
+	readonly showInTimeline?: boolean;
+	readonly unclippedDuration?: number;
+}): TSequence => ({
+	controls: null,
+	displayName: id,
+	documentationLink: null,
+	duration,
+	effects: [],
+	effectRuntimeValues: null,
+	from,
+	frozenFrame: null,
+	getStack: () => null,
+	id,
+	isInsideSeries: false,
+	loopDisplay,
+	nonce: [[0, 0]],
+	parent,
+	postmountDisplay: null,
+	premountDisplay: null,
+	refForOutline: null,
+	showInTimeline,
+	trimBefore: null,
+	type: 'sequence',
+	unclippedDuration,
+});
+
+const getMatchingDuration = (sequences: TSequence[]) =>
+	getTimelineMatchingDuration({
+		currentDuration: 300,
+		timeline: calculateTimeline({
+			sequences,
+			overrideIdsToNodePaths: {},
+		}),
+	});
+
+test('matches the last finite timeline layer using unclipped nested timing', () => {
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 50,
+				from: 250,
+				id: 'clipped-by-composition',
+				unclippedDuration: 100,
+			}),
+		]),
+	).toBe(350);
+
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 80,
+				from: 20,
+				id: 'parent',
+				unclippedDuration: 80,
+			}),
+			makeSequence({
+				duration: 20,
+				from: 60,
+				id: 'child',
+				parent: 'parent',
+				unclippedDuration: 100,
+			}),
+		]),
+	).toBe(100);
+
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 80,
+				from: -20,
+				id: 'negative-start',
+				unclippedDuration: 100.5,
+			}),
+		]),
+	).toBe(81);
+});
+
+test('ignores hidden, unbounded, and currently invisible layers', () => {
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 100,
+				from: 0,
+				id: 'finite',
+				unclippedDuration: 150,
+			}),
+			makeSequence({
+				duration: 300,
+				from: 0,
+				id: 'unbounded',
+				unclippedDuration: Infinity,
+			}),
+			makeSequence({
+				duration: 300,
+				from: 0,
+				id: 'hidden',
+				showInTimeline: false,
+				unclippedDuration: 500,
+			}),
+			makeSequence({
+				duration: 0,
+				from: 350,
+				id: 'after-composition',
+				unclippedDuration: 100,
+			}),
+		]),
+	).toBe(150);
+
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 300,
+				from: 0,
+				id: 'unbounded',
+				unclippedDuration: Infinity,
+			}),
+		]),
+	).toBeNull();
+});
+
+test('uses the stable start of finite loops and ignores infinite repetitions', () => {
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 10,
+				from: 20,
+				id: 'finite-loop',
+				loopDisplay: {
+					durationInFrames: 10,
+					numberOfTimes: 3,
+					startOffset: -20,
+				},
+				unclippedDuration: 50,
+			}),
+		]),
+	).toBe(50);
+
+	expect(
+		getMatchingDuration([
+			makeSequence({
+				duration: 10,
+				from: 20,
+				id: 'infinite-loop',
+				loopDisplay: {
+					durationInFrames: 10,
+					numberOfTimes: 30,
+					startOffset: -20,
+				},
+				unclippedDuration: Infinity,
+			}),
+			makeSequence({
+				duration: 10,
+				from: 0,
+				id: 'repeated-child',
+				parent: 'infinite-loop',
+				unclippedDuration: 10,
+			}),
+			makeSequence({
+				duration: 5,
+				from: 0,
+				id: 'repeated-grandchild',
+				parent: 'repeated-child',
+				unclippedDuration: 5,
+			}),
+		]),
+	).toBeNull();
+});


### PR DESCRIPTION
## Summary

- add a duration preset that matches the composition to the longest finite sequence shown in the timeline
- preserve unclipped sequence durations during Studio registration without changing rendering behavior
- account for nested clipping, negative starts, hidden tracks, and finite or infinite loops

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/sequence-register-once.test.tsx` in `packages/core`
- `bun test src/test/timeline-matching-duration.test.ts` in `packages/studio`
- `bunx playwright test e2e/composition-duration-preset.test.mts` in `packages/example`

Closes #9742
