### PR TITLE
`@remotion/codex-plugin`: Publish marketplace-compatible Agent Plugin releases

### DIFF
--- a/packages/codex-plugin/README.cursor.md
+++ b/packages/codex-plugin/README.cursor.md
@@ -1,13 +1,15 @@
-# Remotion for Cursor
+# Remotion Agent Plugin
 
-The official [Remotion](https://www.remotion.dev/) Agent Plugin for Cursor. It
-teaches the agent how to create videos with React, including animations, audio,
-captions, 3D, transitions, charts, text effects, and rendering.
+The official portable [Remotion](https://www.remotion.dev/) Agent Plugin. It
+teaches compatible coding agents how to create videos with React, including
+animations, audio, captions, 3D, transitions, charts, text effects, and
+rendering.
 
 ## Install
 
-Install Remotion from the Cursor Marketplace, or clone this repository for local
-development:
+Install Remotion from a compatible Agent Plugins marketplace. This portable
+package is intended for clients such as GitHub Copilot and Cursor. For local
+Cursor development, clone this repository:
 
 ```bash
 git clone https://github.com/remotion-dev/cursor-plugin.git ~/.cursor/plugins/local/remotion

--- a/packages/codex-plugin/test/plugin.test.ts
+++ b/packages/codex-plugin/test/plugin.test.ts
@@ -115,6 +115,30 @@ test('links to embedded skills use the renamed file', () => {
 	}
 });
 
+test('file links stay within each skill directory', () => {
+	for (const skillName of getDirectories(generatedSkillsRoot)) {
+		const skillRoot = path.join(generatedSkillsRoot, skillName);
+		for (const file of getMarkdownFiles(skillRoot)) {
+			const contents = readFileSync(file, 'utf-8');
+			for (const match of contents.matchAll(/!?\[[^\]]+]\(([^)]+)\)/g)) {
+				const target = match[1];
+				if (!target.startsWith('./') && !target.startsWith('../')) {
+					continue;
+				}
+
+				const targetWithoutFragment = target.split('#')[0];
+				const relativeTarget = path.relative(
+					skillRoot,
+					path.resolve(path.dirname(file), targetWithoutFragment),
+				);
+				expect(relativeTarget).not.toBe('..');
+				expect(relativeTarget.startsWith(`..${path.sep}`)).toBe(false);
+				expect(path.isAbsolute(relativeTarget)).toBe(false);
+			}
+		}
+	}
+});
+
 test('maps is available from either standalone parent skill', () => {
 	for (const parentSkill of ['remotion-best-practices', 'remotion-markup']) {
 		const parentRoot = path.join(generatedSkillsRoot, parentSkill);

--- a/packages/it-tests/src/templates/publish.ts
+++ b/packages/it-tests/src/templates/publish.ts
@@ -167,7 +167,11 @@ const publishBuiltAgentPlugin = async ({
 	}
 
 	await $`git commit -m ${commitMessage}`.cwd(workingDir);
-	await $`git push origin ${defaultBranch.trim()}`.cwd(workingDir);
+	const versionTag = `v${packageJson.version}`;
+	await $`git tag ${versionTag}`.cwd(workingDir);
+	await $`git push --atomic origin ${defaultBranch.trim()} ${versionTag}`.cwd(
+		workingDir,
+	);
 };
 
 const publishAgentPlugins = async () => {

--- a/packages/skills/scripts/prepare-embedded-skills.ts
+++ b/packages/skills/scripts/prepare-embedded-skills.ts
@@ -10,6 +10,63 @@ import path from 'node:path';
 
 const embeddedSkillFilename = 'REFERENCE.md';
 
+// Agent Skills file references must stay inside the skill directory. Keep the
+// handoff text while removing links to sibling skills from distributable builds.
+const removeCrossSkillLinks = (skillsRoot: string) => {
+	const skillDirectories = readdirSync(skillsRoot, {withFileTypes: true})
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(skillsRoot, entry.name));
+
+	const rewriteMarkdownFiles = (skillRoot: string, directory: string) => {
+		for (const entry of readdirSync(directory, {withFileTypes: true})) {
+			const file = path.join(directory, entry.name);
+			if (entry.isDirectory()) {
+				rewriteMarkdownFiles(skillRoot, file);
+				continue;
+			}
+
+			if (!entry.isFile() || !file.endsWith('.md')) {
+				continue;
+			}
+
+			const contents = readFileSync(file, 'utf-8');
+			const rewritten = contents.replace(
+				/(!?)\[([^\]]+)]\(([^)]+)\)/g,
+				(match, imagePrefix: string, label: string, target: string) => {
+					if (
+						imagePrefix === '!' ||
+						(!target.startsWith('./') && !target.startsWith('../'))
+					) {
+						return match;
+					}
+
+					const targetWithoutFragment = target.split('#')[0];
+					const relativeTarget = path.relative(
+						skillRoot,
+						path.resolve(path.dirname(file), targetWithoutFragment),
+					);
+					if (
+						relativeTarget === '..' ||
+						relativeTarget.startsWith(`..${path.sep}`) ||
+						path.isAbsolute(relativeTarget)
+					) {
+						return label;
+					}
+
+					return match;
+				},
+			);
+			if (contents !== rewritten) {
+				writeFileSync(file, rewritten);
+			}
+		}
+	};
+
+	for (const skillDirectory of skillDirectories) {
+		rewriteMarkdownFiles(skillDirectory, skillDirectory);
+	}
+};
+
 const prepareEmbeddedSkillRoot = ({
 	embeddedRoot,
 	parentEntryFilename,
@@ -107,6 +164,8 @@ export const prepareEmbeddedSkills = (skillsRoot: string) => {
 	for (const embeddedRoot of embeddedRoots) {
 		prepareEmbeddedSkillRoot(embeddedRoot);
 	}
+
+	removeCrossSkillLinks(skillsRoot);
 };
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary

- keep file references inside each packaged skill so portable Agent Plugin validators accept all Remotion skills
- publish generated Codex and Cursor repositories with immutable version tags
- describe the portable build as compatible with GitHub Copilot and Cursor

## Testing

- `bun run build`
- `bun run stylecheck`
- Awesome Copilot Vally validation: 12/12 packaged skills passed
