### PR TITLE
Fix maximum timeline zoom at 30 pixels per frame

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3108,6 +3108,37 @@ test.describe('visual mode', () => {
 			await expect(
 				page.locator('input[type="range"][alt^="Timeline zoom"]'),
 			).toHaveValue(String(Math.round(normalizedTimelineZoom * 1000)));
+			const webMcpMaximumTimelineZoomResult = await page.evaluate(async () => {
+				const tools = (
+					window as typeof window & {
+						readonly __remotion_webmcp_tools: Map<
+							string,
+							{
+								readonly execute: (
+									input: Record<string, unknown>,
+								) => Promise<unknown>;
+							}
+						>;
+					}
+				).__remotion_webmcp_tools;
+				const tool = tools.get('set_timeline_zoom');
+				if (!tool) {
+					throw new Error('set_timeline_zoom was not registered');
+				}
+
+				return tool.execute({zoom: 1});
+			});
+			expect(webMcpMaximumTimelineZoomResult).toEqual({
+				currentComposition: 'AnimatedBarChart',
+				timelineZoom: 1,
+			});
+			await expect(
+				page.locator('input[type="range"][alt^="Timeline zoom"]'),
+			).toHaveValue('1000');
+			const maximumTimelineWidth = await page
+				.locator('[data-timeline-scrubber]')
+				.evaluate((element) => element.getBoundingClientRect().width);
+			expect((maximumTimelineWidth - 32) / 180).toBe(30);
 			const webMcpMuteResult = await page.evaluate(async () => {
 				const tools = (
 					window as typeof window & {
@@ -3267,7 +3298,7 @@ test.describe('visual mode', () => {
 				volume: 1,
 				playbackRate: 1.5,
 				looping: true,
-				timelineZoom: normalizedTimelineZoom,
+				timelineZoom: 1,
 			});
 
 			fs.writeFileSync(

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3099,11 +3099,15 @@ test.describe('visual mode', () => {
 			});
 			expect(webMcpTimelineZoomResult).toEqual({
 				currentComposition: 'AnimatedBarChart',
-				timelineZoom: 0.489,
+				timelineZoom: expect.any(Number),
 			});
+			const normalizedTimelineZoom = (
+				webMcpTimelineZoomResult as {readonly timelineZoom: number}
+			).timelineZoom;
+			expect(normalizedTimelineZoom).toBeCloseTo(0.5, 2);
 			await expect(
 				page.locator('input[type="range"][alt^="Timeline zoom"]'),
-			).toHaveValue('489');
+			).toHaveValue(String(Math.round(normalizedTimelineZoom * 1000)));
 			const webMcpMuteResult = await page.evaluate(async () => {
 				const tools = (
 					window as typeof window & {
@@ -3263,7 +3267,7 @@ test.describe('visual mode', () => {
 				volume: 1,
 				playbackRate: 1.5,
 				looping: true,
-				timelineZoom: 0.489,
+				timelineZoom: normalizedTimelineZoom,
 			});
 
 			fs.writeFileSync(

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -8,6 +8,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
+import {getTimelineMaxZoom} from '../../helpers/get-timeline-max-zoom';
 import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
 import {startCapturedPointerSession} from '../../helpers/pointer-session';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
@@ -63,6 +64,10 @@ const getClientXWithScroll = (x: number) => {
 
 export const TimelineDragHandler: React.FC = () => {
 	const video = Internals.useUnsafeVideoConfig();
+	const timelineSize = PlayerInternals.useElementSize(scrollableRef, {
+		triggerOnWindowResize: true,
+		shouldApplyCssTransforms: true,
+	});
 
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const {canvasContent, currentAssetMetadata} = useContext(
@@ -78,12 +83,17 @@ export const TimelineDragHandler: React.FC = () => {
 			canvasContent.type === 'composition'
 				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
 				: TIMELINE_MIN_ZOOM;
+		const maxZoom = getTimelineMaxZoom({
+			durationInFrames: video?.durationInFrames ?? 1,
+			timelineViewportWidth:
+				timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0,
+		});
 		return {
 			...container,
-			width: 100 * zoom + '%',
+			width: 100 * Math.min(zoom, maxZoom) + '%',
 			height: TIMELINE_TIME_INDICATOR_HEIGHT,
 		};
-	}, [canvasContent, zoomMap]);
+	}, [canvasContent, timelineSize?.width, video?.durationInFrames, zoomMap]);
 
 	const hasPlayableContent =
 		canvasContent?.type === 'composition' ||

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -8,10 +8,13 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, useVideoConfig} from 'remotion';
-import {getTimelineMaxZoom} from '../../helpers/get-timeline-max-zoom';
+import {
+	getTimelineWidth,
+	getTimelineZoom,
+} from '../../helpers/get-timeline-max-zoom';
 import {isStudioSelectionEnabled} from '../../helpers/interactivity-enabled';
 import {startCapturedPointerSession} from '../../helpers/pointer-session';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
 import {setCurrentFrame} from './imperative-state';
@@ -30,6 +33,7 @@ import {
 	getFrameWhileScrollingRight,
 	getScrollPositionForCursorOnLeftEdge,
 	getScrollPositionForCursorOnRightEdge,
+	getTimelineContentWidth,
 	scrollToTimelineXOffset,
 	startTimelineEdgeAutoScroll,
 } from './timeline-scroll-logic';
@@ -79,18 +83,19 @@ export const TimelineDragHandler: React.FC = () => {
 			return {};
 		}
 
-		const zoom =
-			canvasContent.type === 'composition'
-				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
-				: TIMELINE_MIN_ZOOM;
-		const maxZoom = getTimelineMaxZoom({
-			durationInFrames: video?.durationInFrames ?? 1,
+		const durationInFrames = video?.durationInFrames ?? 1;
+		const zoom = getTimelineZoom({
+			durationInFrames,
 			timelineViewportWidth:
 				timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0,
+			zoom:
+				canvasContent.type === 'composition'
+					? (zoomMap[canvasContent.compositionId] ?? null)
+					: null,
 		});
 		return {
 			...container,
-			width: 100 * Math.min(zoom, maxZoom) + '%',
+			width: getTimelineWidth({durationInFrames, zoom}),
 			height: TIMELINE_TIME_INDICATOR_HEIGHT,
 		};
 	}, [canvasContent, timelineSize?.width, video?.durationInFrames, zoomMap]);
@@ -125,7 +130,7 @@ const TimelineDragHandlerInner: React.FC = () => {
 	const {isHighestContext} = useZIndex();
 	const setFrame = Internals.useTimelineSetFrame();
 
-	const width = scrollableRef.current?.scrollWidth ?? 0;
+	const width = getTimelineContentWidth();
 	const left = size?.left ?? 0;
 
 	const [dragging, setDragging] = useState<

--- a/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineInOutDragHandler.tsx
@@ -16,7 +16,7 @@ import {
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {defaultInOutValue} from '../TimelineInOutToggle';
 import {scrollableRef} from './timeline-refs';
-import {getFrameFromX} from './timeline-scroll-logic';
+import {getFrameFromX, getTimelineContentWidth} from './timeline-scroll-logic';
 import {inMarkerAreaRef, outMarkerAreaRef} from './TimelineInOutPointer';
 import {
 	TimelineInOutPointerHandle,
@@ -81,7 +81,7 @@ const TimelineInOutDragHandlerInner: React.FC = () => {
 		[timelineWidth, videoConfig.durationInFrames],
 	);
 
-	const width = scrollableRef.current?.scrollWidth ?? 0;
+	const width = getTimelineContentWidth();
 	const left = size?.left ?? 0;
 
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();

--- a/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
@@ -1,8 +1,9 @@
 import {useCallback, useContext, useEffect, useRef, type FC} from 'react';
 import {Internals} from 'remotion';
+import {getTimelineZoom} from '../../helpers/get-timeline-max-zoom';
 import {useIsVideoComposition} from '../../helpers/is-current-selected-still';
 import {EditorZoomGesturesContext} from '../../state/editor-zoom-gestures';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
 import {viewportClientXToScrollContentX} from './timeline-scroll-logic';
 
@@ -28,6 +29,16 @@ export const TimelinePinchZoom: FC = () => {
 
 	const zoomRef = useRef(zoom);
 	zoomRef.current = zoom;
+	const getCurrentTimelineZoom = useCallback(
+		(compositionId: string) => {
+			return getTimelineZoom({
+				durationInFrames: videoConfig?.durationInFrames ?? 1,
+				timelineViewportWidth: scrollableRef.current?.clientWidth ?? 0,
+				zoom: zoomRef.current[compositionId] ?? null,
+			});
+		},
+		[videoConfig?.durationInFrames],
+	);
 
 	const pinchBaseZoomRef = useRef<number | null>(null);
 	const suppressWheelFromWebKitPinchRef = useRef(false);
@@ -143,8 +154,9 @@ export const TimelinePinchZoom: FC = () => {
 			e.preventDefault();
 			suppressWheelFromWebKitPinchRef.current = true;
 
-			pinchBaseZoomRef.current =
-				zoomRef.current[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
+			pinchBaseZoomRef.current = getCurrentTimelineZoom(
+				canvasContent.compositionId,
+			);
 		};
 
 		const onGestureChange = (event: Event) => {
@@ -202,6 +214,7 @@ export const TimelinePinchZoom: FC = () => {
 		isVideoComposition,
 		videoConfig,
 		canvasContent,
+		getCurrentTimelineZoom,
 		setZoom,
 	]);
 
@@ -240,8 +253,7 @@ export const TimelinePinchZoom: FC = () => {
 
 			touchPinchRef.current = {
 				initialDistance,
-				initialZoom:
-					zoomRef.current[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM,
+				initialZoom: getCurrentTimelineZoom(canvasContent.compositionId),
 			};
 		};
 
@@ -305,6 +317,7 @@ export const TimelinePinchZoom: FC = () => {
 		isVideoComposition,
 		videoConfig,
 		canvasContent,
+		getCurrentTimelineZoom,
 		setZoom,
 	]);
 

--- a/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
@@ -1,7 +1,8 @@
 import type React from 'react';
 import {useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {getTimelineZoom} from '../../helpers/get-timeline-max-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {
 	getCurrentDuration,
 	getCurrentFrame,
@@ -42,9 +43,11 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 			: null;
 	// Asset previews have a synthetic video config, but no composition ID
 	// with which to look up a persisted timeline zoom.
-	const zoom = compositionId
-		? (zoomMap[compositionId] ?? TIMELINE_MIN_ZOOM)
-		: TIMELINE_MIN_ZOOM;
+	const zoom = getTimelineZoom({
+		durationInFrames: video?.durationInFrames ?? 1,
+		timelineViewportWidth: scrollableRef.current?.clientWidth ?? 0,
+		zoom: compositionId ? (zoomMap[compositionId] ?? null) : null,
+	});
 
 	if (video) {
 		setCurrentFrame(timelinePosition);

--- a/packages/studio/src/components/Timeline/TimelineSlider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSlider.tsx
@@ -8,7 +8,7 @@ import React, {
 import {Internals, useVideoConfig} from 'remotion';
 import {TIMELINE_PLAYHEAD_COLOR} from '../../helpers/colors';
 import {getXPositionOfItemInTimelineImperatively} from '../../helpers/get-left-of-timeline-slider';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {getCurrentDuration, getCurrentFrame} from './imperative-state';
 import {scrollableRef, sliderAreaRef} from './timeline-refs';
 import {TimelineSliderHandle} from './TimelineSliderHandle';
@@ -90,8 +90,8 @@ const TimelineSliderInner: React.FC = () => {
 
 	const zoomLevel =
 		canvasContent?.type === 'composition'
-			? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
-			: TIMELINE_MIN_ZOOM;
+			? (zoomMap[canvasContent.compositionId] ?? null)
+			: null;
 
 	useLayoutEffect(() => {
 		const el = ref.current;

--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -1,8 +1,11 @@
 import {PlayerInternals} from '@remotion/player';
 import {createContext, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
-import {getTimelineMaxZoom} from '../../helpers/get-timeline-max-zoom';
-import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
+import {
+	getTimelineWidth,
+	getTimelineZoom,
+} from '../../helpers/get-timeline-max-zoom';
+import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {scrollableRef, sliderAreaRef} from './timeline-refs';
 
 type TimelineWidthContextType = number | null;
@@ -22,22 +25,22 @@ export const TimelineWidthProvider: React.FC<{
 	const videoConfig = Internals.useUnsafeVideoConfig();
 
 	const width = useMemo(() => {
-		const zoom =
-			canvasContent?.type === 'composition'
-				? (zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM)
-				: TIMELINE_MIN_ZOOM;
-
 		const scrollableWidth = size?.width ?? scrollableRef.current?.clientWidth;
 		if (scrollableWidth === undefined) {
 			return sliderAreaRef.current?.clientWidth ?? null;
 		}
 
-		const maxZoom = getTimelineMaxZoom({
-			durationInFrames: videoConfig?.durationInFrames ?? 1,
+		const durationInFrames = videoConfig?.durationInFrames ?? 1;
+		const zoom = getTimelineZoom({
+			durationInFrames,
 			timelineViewportWidth: scrollableWidth,
+			zoom:
+				canvasContent?.type === 'composition'
+					? (zoomMap[canvasContent.compositionId] ?? null)
+					: null,
 		});
 
-		return scrollableWidth * Math.min(zoom, maxZoom);
+		return getTimelineWidth({durationInFrames, zoom});
 	}, [canvasContent, size?.width, videoConfig?.durationInFrames, zoomMap]);
 
 	return (

--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -1,6 +1,7 @@
 import {PlayerInternals} from '@remotion/player';
 import {createContext, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
+import {getTimelineMaxZoom} from '../../helpers/get-timeline-max-zoom';
 import {TIMELINE_MIN_ZOOM, TimelineZoomCtx} from '../../state/timeline-zoom';
 import {scrollableRef, sliderAreaRef} from './timeline-refs';
 
@@ -18,6 +19,7 @@ export const TimelineWidthProvider: React.FC<{
 	});
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const {canvasContent} = useContext(Internals.CompositionManager);
+	const videoConfig = Internals.useUnsafeVideoConfig();
 
 	const width = useMemo(() => {
 		const zoom =
@@ -30,8 +32,13 @@ export const TimelineWidthProvider: React.FC<{
 			return sliderAreaRef.current?.clientWidth ?? null;
 		}
 
-		return scrollableWidth * zoom;
-	}, [canvasContent, size?.width, zoomMap]);
+		const maxZoom = getTimelineMaxZoom({
+			durationInFrames: videoConfig?.durationInFrames ?? 1,
+			timelineViewportWidth: scrollableWidth,
+		});
+
+		return scrollableWidth * Math.min(zoom, maxZoom);
+	}, [canvasContent, size?.width, videoConfig?.durationInFrames, zoomMap]);
 
 	return (
 		<TimelineWidthContext.Provider value={width}>

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -3,9 +3,9 @@ import React, {useCallback, useContext} from 'react';
 import {Internals} from 'remotion';
 import {BLACK} from '../../helpers/colors';
 import {
-	getTimelineMaxZoom,
+	getTimelineMinZoom,
+	getTimelineZoom,
 	sliderValueToTimelineZoom,
-	TIMELINE_MIN_ZOOM,
 	TIMELINE_ZOOM_SLIDER_PROPS,
 	timelineZoomToSliderValue,
 } from '../../helpers/get-timeline-max-zoom';
@@ -32,10 +32,12 @@ const buttonStyle: React.CSSProperties = {
 
 const TimelineZoomSlider: React.FC<{
 	readonly maxWidth?: number;
-	readonly maxZoom: number;
-}> = ({maxWidth, maxZoom}) => {
+	readonly minZoom: number;
+	readonly timelineViewportWidth: number;
+}> = ({maxWidth, minZoom, timelineViewportWidth}) => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom, zoom: zoomMap} = useContext(TimelineZoomCtx);
+	const videoConfig = Internals.useUnsafeVideoConfig();
 	const {tabIndex} = useZIndex();
 	const isStill = useIsStill();
 
@@ -50,7 +52,7 @@ const TimelineZoomSlider: React.FC<{
 				() =>
 					sliderValueToTimelineZoom({
 						sliderValue: Number(e.target.value),
-						maxZoom,
+						minZoom,
 					}),
 				{
 					anchorFrame: null,
@@ -58,7 +60,7 @@ const TimelineZoomSlider: React.FC<{
 				},
 			);
 		},
-		[canvasContent, maxZoom, setZoom],
+		[canvasContent, minZoom, setZoom],
 	);
 
 	if (
@@ -69,18 +71,23 @@ const TimelineZoomSlider: React.FC<{
 		return null;
 	}
 
-	const zoom = zoomMap[canvasContent.compositionId] ?? TIMELINE_MIN_ZOOM;
+	const zoom = getTimelineZoom({
+		durationInFrames: videoConfig?.durationInFrames ?? 1,
+		timelineViewportWidth,
+		zoom: zoomMap[canvasContent.compositionId] ?? null,
+	});
+	const roundedZoom = Math.round(zoom * 100) / 100;
 
 	return (
 		<input
 			style={maxWidth === undefined ? undefined : {maxWidth}}
-			title={`Timeline zoom (${zoom}x)`}
-			alt={`Timeline zoom (${zoom}x)`}
+			title={`Timeline zoom (${roundedZoom}px/frame)`}
+			alt={`Timeline zoom (${roundedZoom}px/frame)`}
 			type="range"
 			min={TIMELINE_ZOOM_SLIDER_PROPS.min}
 			max={TIMELINE_ZOOM_SLIDER_PROPS.max}
 			step={TIMELINE_ZOOM_SLIDER_PROPS.step}
-			value={timelineZoomToSliderValue({zoom, maxZoom})}
+			value={timelineZoomToSliderValue({zoom, minZoom})}
 			onChange={onChange}
 			className="__remotion-timeline-slider"
 			tabIndex={tabIndex}
@@ -98,10 +105,11 @@ const TimelineZoomControlsInner: React.FC<{
 		triggerOnWindowResize: true,
 		shouldApplyCssTransforms: true,
 	});
-	const maxZoom = getTimelineMaxZoom({
+	const timelineViewportWidth =
+		timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0;
+	const minZoom = getTimelineMinZoom({
 		durationInFrames: videoConfig?.durationInFrames ?? 1,
-		timelineViewportWidth:
-			timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0,
+		timelineViewportWidth,
 	});
 
 	const onMinusClicked = useCallback(() => {
@@ -150,7 +158,11 @@ const TimelineZoomControlsInner: React.FC<{
 				{(color) => <CanvasZoomOutIcon color={color} />}
 			</ControlButton>
 			<Spacing x={0.5} />
-			<TimelineZoomSlider maxWidth={sliderMaxWidth} maxZoom={maxZoom} />
+			<TimelineZoomSlider
+				maxWidth={sliderMaxWidth}
+				minZoom={minZoom}
+				timelineViewportWidth={timelineViewportWidth}
+			/>
 			<Spacing x={0.5} />
 			<ControlButton
 				onClick={onPlusClicked}

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -1,3 +1,4 @@
+import {PlayerInternals} from '@remotion/player';
 import React, {useCallback, useContext} from 'react';
 import {Internals} from 'remotion';
 import {BLACK} from '../../helpers/colors';
@@ -14,6 +15,7 @@ import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
 import {ControlButton} from '../ControlButton';
 import {Spacing} from '../layout';
+import {scrollableRef} from './timeline-refs';
 
 const TIMELINE_ZOOM_BUTTON_FACTOR = 1.2;
 
@@ -92,7 +94,15 @@ const TimelineZoomControlsInner: React.FC<{
 	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom} = useContext(TimelineZoomCtx);
 	const videoConfig = Internals.useUnsafeVideoConfig();
-	const maxZoom = getTimelineMaxZoom(videoConfig?.durationInFrames ?? 1);
+	const timelineSize = PlayerInternals.useElementSize(scrollableRef, {
+		triggerOnWindowResize: true,
+		shouldApplyCssTransforms: true,
+	});
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames: videoConfig?.durationInFrames ?? 1,
+		timelineViewportWidth:
+			timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0,
+	});
 
 	const onMinusClicked = useCallback(() => {
 		if (canvasContent === null || canvasContent.type !== 'composition') {

--- a/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
+++ b/packages/studio/src/components/Timeline/timeline-scroll-logic.ts
@@ -1,7 +1,11 @@
 import {interpolate} from 'remotion';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {setCurrentFrame} from './imperative-state';
-import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
+import {
+	scrollableRef,
+	sliderAreaRef,
+	timelineVerticalScroll,
+} from './timeline-refs';
 import {redrawTimelineSliderFast} from './TimelineSlider';
 
 export const canScrollTimelineIntoDirection = () => {
@@ -14,6 +18,14 @@ export const canScrollTimelineIntoDirection = () => {
 };
 
 export const SCROLL_INCREMENT = 200;
+
+export const getTimelineContentWidth = () => {
+	return (
+		sliderAreaRef.current?.clientWidth ??
+		scrollableRef.current?.scrollWidth ??
+		0
+	);
+};
 
 export const EDGE_SCROLL_VERTICAL_INCREMENT = 60;
 
@@ -250,7 +262,7 @@ export const isCursorInViewport = ({
 	frame: number;
 	durationInFrames: number;
 }) => {
-	const width = scrollableRef.current?.scrollWidth ?? 0;
+	const width = getTimelineContentWidth();
 	const scrollLeft = scrollableRef.current?.scrollLeft ?? 0;
 
 	const scrollPosOnRightEdge = getScrollPositionForCursorOnRightEdge({
@@ -290,7 +302,7 @@ export const ensureFrameIsInViewport = ({
 	// listener in TimelineSlider, which reads the frame imperatively.
 	setCurrentFrame(frame);
 	redrawTimelineSliderFast.current?.draw(frame);
-	const width = scrollableRef.current?.scrollWidth ?? 0;
+	const width = getTimelineContentWidth();
 	const scrollLeft = scrollableRef.current?.scrollLeft ?? 0;
 	if (direction === 'fit-left') {
 		const currentFrameLeft = getFrameFromX({
@@ -396,7 +408,7 @@ export const getScrollPositionForCursorOnRightEdge = ({
 	const fromRight = framesRemaining * frameIncrement + TIMELINE_PADDING;
 
 	const scrollPos =
-		(scrollableRef.current?.scrollWidth as number) -
+		getTimelineContentWidth() -
 		fromRight -
 		(scrollableRef.current?.clientWidth as number) +
 		TIMELINE_PADDING +
@@ -406,7 +418,7 @@ export const getScrollPositionForCursorOnRightEdge = ({
 };
 
 const getFrameIncrement = (durationInFrames: number) => {
-	const width = scrollableRef.current?.scrollWidth ?? 0;
+	const width = getTimelineContentWidth();
 	return getFrameIncrementFromWidth(durationInFrames, width);
 };
 
@@ -555,7 +567,7 @@ export const prepareToPreserveTimelineCursor = ({
 		return () => undefined;
 	}
 
-	const oldTimelineWidth = current.scrollWidth;
+	const oldTimelineWidth = getTimelineContentWidth();
 	const oldScrollLeft = current.scrollLeft;
 	const frameIncrement = getFrameIncrementFromWidth(
 		currentDurationInFrames,
@@ -576,7 +588,7 @@ export const prepareToPreserveTimelineCursor = ({
 			anchorContentX: prevCursorPosition,
 			oldScrollLeft,
 			oldTimelineWidth,
-			newTimelineWidth: current.scrollWidth,
+			newTimelineWidth: getTimelineContentWidth(),
 		});
 	};
 };

--- a/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
+++ b/packages/studio/src/components/Timeline/use-timeline-asset-drop.ts
@@ -12,7 +12,10 @@ import {showNotification} from '../Notifications/NotificationCenter';
 import {useSvgImportDialog} from '../SvgImportDialog';
 import {getCurrentFrame} from './imperative-state';
 import {scrollableRef, timelineVerticalScroll} from './timeline-refs';
-import {getFrameFromTimelineDrop} from './timeline-scroll-logic';
+import {
+	getFrameFromTimelineDrop,
+	getTimelineContentWidth,
+} from './timeline-scroll-logic';
 import {useResolvedStack} from './use-resolved-stack';
 
 const isEventTargetInsideElement = (event: DragEvent, element: HTMLElement) => {
@@ -73,7 +76,7 @@ export const useTimelineAssetDrop = () => {
 						durationInFrames: videoConfig.durationInFrames,
 						scrollLeft: scrollable.scrollLeft,
 						timelineLeft: scrollable.getBoundingClientRect().left,
-						timelineWidth: scrollable.scrollWidth,
+						timelineWidth: getTimelineContentWidth(),
 					})
 				: getCurrentFrame();
 		},

--- a/packages/studio/src/components/WebMcp.tsx
+++ b/packages/studio/src/components/WebMcp.tsx
@@ -36,6 +36,7 @@ import {findTrackForNodePathInfo} from './Timeline/find-track-for-node-path-info
 import {getCurrentDuration, getCurrentFrame} from './Timeline/imperative-state';
 import {parseKeyframeFieldFromNodePath} from './Timeline/parse-keyframe-field-from-node-path';
 import {shouldShowTrackInTimeline} from './Timeline/should-show-track-in-timeline';
+import {scrollableRef} from './Timeline/timeline-refs';
 import {
 	getTimelineSelectionFromNodePathInfo,
 	useTimelineSelection,
@@ -733,7 +734,11 @@ export const WebMcp: FC = () => {
 							timelineZoom: timelineZoomToNormalized({
 								zoom:
 									timelineZoomRef.current[compositionId] ?? TIMELINE_MIN_ZOOM,
-								maxZoom: getTimelineMaxZoom(getCurrentDuration()),
+								maxZoom: getTimelineMaxZoom({
+									durationInFrames: getCurrentDuration(),
+									timelineViewportWidth:
+										scrollableRef.current?.clientWidth ?? 0,
+								}),
 							}),
 						});
 					},
@@ -1137,13 +1142,19 @@ export const WebMcp: FC = () => {
 							);
 						}
 
-						const maxZoom = getTimelineMaxZoom(durationInFrames);
+						const timelineViewportWidth =
+							scrollableRef.current?.clientWidth ?? 0;
+						const maxZoom = getTimelineMaxZoom({
+							durationInFrames,
+							timelineViewportWidth,
+						});
 						const timelineZoom = clampTimelineZoom({
 							zoom: normalizedToTimelineZoom({
 								normalized: zoom,
 								maxZoom,
 							}),
 							durationInFrames,
+							timelineViewportWidth,
 						});
 						setTimelineZoom(compositionId, () => timelineZoom, {
 							anchorFrame: null,

--- a/packages/studio/src/components/WebMcp.tsx
+++ b/packages/studio/src/components/WebMcp.tsx
@@ -12,9 +12,9 @@ import {
 } from '../helpers/format-file-location';
 import {
 	clampTimelineZoom,
-	getTimelineMaxZoom,
+	getTimelineMinZoom,
+	getTimelineZoom,
 	normalizedToTimelineZoom,
-	TIMELINE_MIN_ZOOM,
 	timelineZoomToNormalized,
 } from '../helpers/get-timeline-max-zoom';
 import type {TimelineTrackData} from '../helpers/get-timeline-sequence-sort-key';
@@ -723,6 +723,19 @@ export const WebMcp: FC = () => {
 							});
 						}
 
+						const durationInFrames = getCurrentDuration();
+						const timelineViewportWidth =
+							scrollableRef.current?.clientWidth ?? 0;
+						const minZoom = getTimelineMinZoom({
+							durationInFrames,
+							timelineViewportWidth,
+						});
+						const timelineZoom = getTimelineZoom({
+							durationInFrames,
+							timelineViewportWidth,
+							zoom: timelineZoomRef.current[compositionId] ?? null,
+						});
+
 						return Promise.resolve({
 							currentComposition: compositionId,
 							currentFrame: getCurrentFrame(),
@@ -732,13 +745,8 @@ export const WebMcp: FC = () => {
 							playbackRate: playbackRateRef.current,
 							looping: loadLoopOption(),
 							timelineZoom: timelineZoomToNormalized({
-								zoom:
-									timelineZoomRef.current[compositionId] ?? TIMELINE_MIN_ZOOM,
-								maxZoom: getTimelineMaxZoom({
-									durationInFrames: getCurrentDuration(),
-									timelineViewportWidth:
-										scrollableRef.current?.clientWidth ?? 0,
-								}),
+								zoom: timelineZoom,
+								minZoom,
 							}),
 						});
 					},
@@ -1144,14 +1152,14 @@ export const WebMcp: FC = () => {
 
 						const timelineViewportWidth =
 							scrollableRef.current?.clientWidth ?? 0;
-						const maxZoom = getTimelineMaxZoom({
+						const minZoom = getTimelineMinZoom({
 							durationInFrames,
 							timelineViewportWidth,
 						});
 						const timelineZoom = clampTimelineZoom({
 							zoom: normalizedToTimelineZoom({
 								normalized: zoom,
-								maxZoom,
+								minZoom,
 							}),
 							durationInFrames,
 							timelineViewportWidth,
@@ -1165,7 +1173,7 @@ export const WebMcp: FC = () => {
 							currentComposition: compositionId,
 							timelineZoom: timelineZoomToNormalized({
 								zoom: timelineZoom,
-								maxZoom,
+								minZoom,
 							}),
 						});
 					},

--- a/packages/studio/src/components/ZoomPersistor.tsx
+++ b/packages/studio/src/components/ZoomPersistor.tsx
@@ -5,7 +5,7 @@ import {TimelineZoomCtx} from '../state/timeline-zoom';
 import {deriveCanvasContentFromUrl} from './load-canvas-content-from-url';
 
 const makeKey = () => {
-	return `remotion.zoom-map`;
+	return `remotion.zoom-map-pixels-per-frame`;
 };
 
 const persistCurrentZoom = (zoom: Record<string, number>) => {

--- a/packages/studio/src/helpers/get-timeline-max-zoom.ts
+++ b/packages/studio/src/helpers/get-timeline-max-zoom.ts
@@ -1,27 +1,25 @@
 import {TIMELINE_PADDING} from './timeline-layout';
 
-export const TIMELINE_MIN_ZOOM = 1;
+const TIMELINE_ZOOM_FALLBACK = 1;
 export const TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM = 30;
 
 const TIMELINE_ZOOM_SLIDER_MAX = 1000;
 
-export const getTimelineMaxZoom = ({
+export const getTimelineMinZoom = ({
 	durationInFrames,
 	timelineViewportWidth,
 }: {
 	readonly durationInFrames: number;
 	readonly timelineViewportWidth: number;
 }): number => {
-	if (timelineViewportWidth <= 0) {
-		return TIMELINE_MIN_ZOOM;
+	if (durationInFrames <= 0 || timelineViewportWidth <= 0) {
+		return TIMELINE_ZOOM_FALLBACK;
 	}
 
-	const timelineWidthAtMaxZoom =
-		durationInFrames * TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM + TIMELINE_PADDING * 2;
-
-	return Math.max(
-		TIMELINE_MIN_ZOOM,
-		timelineWidthAtMaxZoom / timelineViewportWidth,
+	return Math.min(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+		Math.max(1, timelineViewportWidth - TIMELINE_PADDING * 2) /
+			durationInFrames,
 	);
 };
 
@@ -34,34 +32,69 @@ export const clampTimelineZoom = ({
 	readonly durationInFrames: number;
 	readonly timelineViewportWidth: number;
 }): number => {
-	const maxZoom = getTimelineMaxZoom({
+	const minZoom = getTimelineMinZoom({
 		durationInFrames,
 		timelineViewportWidth,
 	});
-	const clamped = Math.min(maxZoom, Math.max(TIMELINE_MIN_ZOOM, zoom));
+	const clamped = Math.min(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+		Math.max(minZoom, zoom),
+	);
 
-	if (clamped === maxZoom) {
-		return maxZoom;
+	if (clamped === minZoom || clamped === TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM) {
+		return clamped;
 	}
 
-	return Math.min(maxZoom, Math.round(clamped * 10) / 10);
+	return Math.min(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+		Math.max(minZoom, Math.round(clamped * 1000) / 1000),
+	);
+};
+
+export const getTimelineZoom = ({
+	durationInFrames,
+	timelineViewportWidth,
+	zoom,
+}: {
+	readonly durationInFrames: number;
+	readonly timelineViewportWidth: number;
+	readonly zoom: number | null;
+}): number => {
+	return clampTimelineZoom({
+		durationInFrames,
+		timelineViewportWidth,
+		zoom: zoom ?? getTimelineMinZoom({durationInFrames, timelineViewportWidth}),
+	});
+};
+
+export const getTimelineWidth = ({
+	durationInFrames,
+	zoom,
+}: {
+	readonly durationInFrames: number;
+	readonly zoom: number;
+}): number => {
+	return durationInFrames * zoom + TIMELINE_PADDING * 2;
 };
 
 export const timelineZoomToNormalized = ({
 	zoom,
-	maxZoom,
+	minZoom,
 }: {
-	zoom: number;
-	maxZoom: number;
+	readonly zoom: number;
+	readonly minZoom: number;
 }): number => {
-	if (maxZoom <= TIMELINE_MIN_ZOOM) {
+	if (minZoom >= TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM) {
 		return 0;
 	}
 
-	const clampedZoom = Math.min(maxZoom, Math.max(TIMELINE_MIN_ZOOM, zoom));
+	const clampedZoom = Math.min(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+		Math.max(minZoom, zoom),
+	);
 	const normalized =
-		Math.log(clampedZoom / TIMELINE_MIN_ZOOM) /
-		Math.log(maxZoom / TIMELINE_MIN_ZOOM);
+		Math.log(clampedZoom / minZoom) /
+		Math.log(TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM / minZoom);
 	return (
 		Math.round(normalized * TIMELINE_ZOOM_SLIDER_MAX) / TIMELINE_ZOOM_SLIDER_MAX
 	);
@@ -69,41 +102,41 @@ export const timelineZoomToNormalized = ({
 
 export const timelineZoomToSliderValue = ({
 	zoom,
-	maxZoom,
+	minZoom,
 }: {
-	zoom: number;
-	maxZoom: number;
+	readonly zoom: number;
+	readonly minZoom: number;
 }): number => {
 	return Math.round(
-		timelineZoomToNormalized({zoom, maxZoom}) * TIMELINE_ZOOM_SLIDER_MAX,
+		timelineZoomToNormalized({zoom, minZoom}) * TIMELINE_ZOOM_SLIDER_MAX,
 	);
 };
 
 export const normalizedToTimelineZoom = ({
 	normalized,
-	maxZoom,
+	minZoom,
 }: {
-	normalized: number;
-	maxZoom: number;
+	readonly normalized: number;
+	readonly minZoom: number;
 }): number => {
-	if (maxZoom <= TIMELINE_MIN_ZOOM) {
-		return TIMELINE_MIN_ZOOM;
+	if (minZoom >= TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM) {
+		return TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM;
 	}
 
 	const t = Math.min(1, Math.max(0, normalized));
-	return TIMELINE_MIN_ZOOM * (maxZoom / TIMELINE_MIN_ZOOM) ** t;
+	return minZoom * (TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM / minZoom) ** t;
 };
 
 export const sliderValueToTimelineZoom = ({
 	sliderValue,
-	maxZoom,
+	minZoom,
 }: {
-	sliderValue: number;
-	maxZoom: number;
+	readonly sliderValue: number;
+	readonly minZoom: number;
 }): number => {
 	return normalizedToTimelineZoom({
 		normalized: sliderValue / TIMELINE_ZOOM_SLIDER_MAX,
-		maxZoom,
+		minZoom,
 	});
 };
 

--- a/packages/studio/src/helpers/get-timeline-max-zoom.ts
+++ b/packages/studio/src/helpers/get-timeline-max-zoom.ts
@@ -1,32 +1,50 @@
-export const TIMELINE_MIN_ZOOM = 1;
-export const TIMELINE_MAX_ZOOM_FLOOR = 5;
+import {TIMELINE_PADDING} from './timeline-layout';
 
-/**
- * How many frames fill the timeline viewport at max zoom.
- * 30 frames matches the previous 5x cap on a 150-frame composition
- * (5 seconds at 30fps) and keeps a single frame wide enough to trim.
- */
-export const TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM = 30;
+export const TIMELINE_MIN_ZOOM = 1;
+export const TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM = 30;
 
 const TIMELINE_ZOOM_SLIDER_MAX = 1000;
 
-export const getTimelineMaxZoom = (durationInFrames: number): number => {
-	const frameLevelZoom = durationInFrames / TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM;
-	return Math.max(TIMELINE_MAX_ZOOM_FLOOR, Math.ceil(frameLevelZoom * 10) / 10);
+export const getTimelineMaxZoom = ({
+	durationInFrames,
+	timelineViewportWidth,
+}: {
+	readonly durationInFrames: number;
+	readonly timelineViewportWidth: number;
+}): number => {
+	if (timelineViewportWidth <= 0) {
+		return TIMELINE_MIN_ZOOM;
+	}
+
+	const timelineWidthAtMaxZoom =
+		durationInFrames * TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM + TIMELINE_PADDING * 2;
+
+	return Math.max(
+		TIMELINE_MIN_ZOOM,
+		timelineWidthAtMaxZoom / timelineViewportWidth,
+	);
 };
 
 export const clampTimelineZoom = ({
 	zoom,
 	durationInFrames,
+	timelineViewportWidth,
 }: {
-	zoom: number;
-	durationInFrames: number;
+	readonly zoom: number;
+	readonly durationInFrames: number;
+	readonly timelineViewportWidth: number;
 }): number => {
-	const clamped = Math.min(
-		getTimelineMaxZoom(durationInFrames),
-		Math.max(TIMELINE_MIN_ZOOM, zoom),
-	);
-	return Math.round(clamped * 10) / 10;
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames,
+		timelineViewportWidth,
+	});
+	const clamped = Math.min(maxZoom, Math.max(TIMELINE_MIN_ZOOM, zoom));
+
+	if (clamped === maxZoom) {
+		return maxZoom;
+	}
+
+	return Math.min(maxZoom, Math.round(clamped * 10) / 10);
 };
 
 export const timelineZoomToNormalized = ({

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -9,12 +9,7 @@ import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-s
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
 import {
 	clampTimelineZoom,
-	TIMELINE_MIN_ZOOM,
-} from '../helpers/get-timeline-max-zoom';
-
-export {
-	getTimelineMaxZoom,
-	TIMELINE_MIN_ZOOM,
+	getTimelineZoom,
 } from '../helpers/get-timeline-max-zoom';
 
 export type TimelineSetZoomOptions = {
@@ -59,10 +54,17 @@ export const TimelineZoomContext: React.FC<{
 
 			flushSync(() => {
 				setZoomState((prevZoomMap) => {
+					const durationInFrames = getCurrentDuration();
+					const timelineViewportWidth = scrollableRef.current?.clientWidth ?? 0;
+					const previousZoom = getTimelineZoom({
+						durationInFrames,
+						timelineViewportWidth,
+						zoom: prevZoomMap[compositionId] ?? null,
+					});
 					const newZoom = clampTimelineZoom({
-						zoom: callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
-						durationInFrames: getCurrentDuration(),
-						timelineViewportWidth: scrollableRef.current?.clientWidth ?? 0,
+						zoom: callback(previousZoom),
+						durationInFrames,
+						timelineViewportWidth,
 					});
 
 					return {...prevZoomMap, [compositionId]: newZoom};

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -4,6 +4,7 @@ import {
 	getCurrentDuration,
 	getCurrentFrame,
 } from '../components/Timeline/imperative-state';
+import {scrollableRef} from '../components/Timeline/timeline-refs';
 import {prepareToPreserveTimelineCursor} from '../components/Timeline/timeline-scroll-logic';
 import {getZoomFromLocalStorage} from '../components/ZoomPersistor';
 import {
@@ -61,6 +62,7 @@ export const TimelineZoomContext: React.FC<{
 					const newZoom = clampTimelineZoom({
 						zoom: callback(prevZoomMap[compositionId] ?? TIMELINE_MIN_ZOOM),
 						durationInFrames: getCurrentDuration(),
+						timelineViewportWidth: scrollableRef.current?.clientWidth ?? 0,
 					});
 
 					return {...prevZoomMap, [compositionId]: newZoom};

--- a/packages/studio/src/test/get-timeline-max-zoom.test.ts
+++ b/packages/studio/src/test/get-timeline-max-zoom.test.ts
@@ -1,122 +1,123 @@
 import {expect, test} from 'bun:test';
 import {
 	clampTimelineZoom,
-	getTimelineMaxZoom,
+	getTimelineMinZoom,
+	getTimelineWidth,
+	getTimelineZoom,
 	normalizedToTimelineZoom,
 	sliderValueToTimelineZoom,
 	TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
-	TIMELINE_MIN_ZOOM,
 	TIMELINE_ZOOM_SLIDER_PROPS,
 	timelineZoomToNormalized,
 	timelineZoomToSliderValue,
 } from '../helpers/get-timeline-max-zoom';
 import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 
-test('max zoom gives every frame a fixed width', () => {
+test('maximum zoom is a fixed number of pixels per frame', () => {
 	const durationInFrames = 60 * 60 * 30;
-	const timelineViewportWidth = 1200;
-	const maxZoom = getTimelineMaxZoom({
+	const timelineWidth = getTimelineWidth({
 		durationInFrames,
-		timelineViewportWidth,
+		zoom: TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
 	});
-	const usableTimelineWidth =
-		maxZoom * timelineViewportWidth - TIMELINE_PADDING * 2;
+	const usableTimelineWidth = timelineWidth - TIMELINE_PADDING * 2;
 
 	expect(usableTimelineWidth / durationInFrames).toBe(
 		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
 	);
 });
 
-test('short compositions stay fitted to the viewport', () => {
-	expect(
-		getTimelineMaxZoom({durationInFrames: 10, timelineViewportWidth: 1200}),
-	).toBe(TIMELINE_MIN_ZOOM);
+test('minimum zoom fits a long composition into the viewport', () => {
+	const durationInFrames = 300;
+	const timelineViewportWidth = 1200;
+	const minZoom = getTimelineMinZoom({
+		durationInFrames,
+		timelineViewportWidth,
+	});
+
+	expect(getTimelineWidth({durationInFrames, zoom: minZoom})).toBe(
+		timelineViewportWidth,
+	);
 });
 
-test('clamps and rounds timeline zoom', () => {
+test('short compositions do not exceed the maximum frame width', () => {
+	expect(
+		getTimelineMinZoom({durationInFrames: 10, timelineViewportWidth: 1200}),
+	).toBe(TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM);
+});
+
+test('clamps and rounds timeline zoom in pixels per frame', () => {
+	const durationInFrames = 600;
 	const timelineViewportWidth = 1200;
+	const minZoom = getTimelineMinZoom({
+		durationInFrames,
+		timelineViewportWidth,
+	});
+
 	expect(
 		clampTimelineZoom({
 			zoom: 0.2,
-			durationInFrames: 150,
+			durationInFrames,
 			timelineViewportWidth,
 		}),
-	).toBe(TIMELINE_MIN_ZOOM);
+	).toBe(minZoom);
 	expect(
 		clampTimelineZoom({
-			zoom: 3.16,
-			durationInFrames: 300,
+			zoom: 3.1615,
+			durationInFrames,
 			timelineViewportWidth,
 		}),
-	).toBe(3.2);
-	const maxZoom = getTimelineMaxZoom({
-		durationInFrames: 150,
-		timelineViewportWidth,
-	});
+	).toBe(3.162);
 	expect(
 		clampTimelineZoom({
 			zoom: 9999,
-			durationInFrames: 150,
+			durationInFrames,
 			timelineViewportWidth,
 		}),
-	).toBe(maxZoom);
-	expect(
-		clampTimelineZoom({
-			zoom: 9999,
-			durationInFrames: 60 * 60 * 30,
-			timelineViewportWidth,
-		}),
-	).toBe(
-		getTimelineMaxZoom({
-			durationInFrames: 60 * 60 * 30,
-			timelineViewportWidth,
-		}),
-	);
+	).toBe(TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM);
 });
 
-test('timeline zoom slider maps min and max', () => {
-	const maxZoom = getTimelineMaxZoom({
-		durationInFrames: 60 * 60 * 30,
-		timelineViewportWidth: 1200,
-	});
+test('uses fit-to-viewport zoom when no persisted zoom exists', () => {
+	const durationInFrames = 300;
+	const timelineViewportWidth = 1200;
 
-	expect(timelineZoomToSliderValue({zoom: TIMELINE_MIN_ZOOM, maxZoom})).toBe(0);
-	expect(timelineZoomToSliderValue({zoom: maxZoom, maxZoom})).toBe(
-		TIMELINE_ZOOM_SLIDER_PROPS.max,
-	);
-	expect(sliderValueToTimelineZoom({sliderValue: 0, maxZoom})).toBe(
-		TIMELINE_MIN_ZOOM,
-	);
+	expect(
+		getTimelineZoom({
+			durationInFrames,
+			timelineViewportWidth,
+			zoom: null,
+		}),
+	).toBe(getTimelineMinZoom({durationInFrames, timelineViewportWidth}));
+});
+
+test('timeline zoom slider maps fit and maximum zoom', () => {
+	const minZoom = 2;
+
+	expect(timelineZoomToSliderValue({zoom: minZoom, minZoom})).toBe(0);
+	expect(
+		timelineZoomToSliderValue({
+			zoom: TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+			minZoom,
+		}),
+	).toBe(TIMELINE_ZOOM_SLIDER_PROPS.max);
+	expect(sliderValueToTimelineZoom({sliderValue: 0, minZoom})).toBe(minZoom);
 	expect(
 		sliderValueToTimelineZoom({
 			sliderValue: TIMELINE_ZOOM_SLIDER_PROPS.max,
-			maxZoom,
+			minZoom,
 		}),
-	).toBe(maxZoom);
+	).toBe(TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM);
 });
 
-test('normalized timeline zoom maps min, midpoint and max', () => {
-	const maxZoom = 6;
+test('normalized timeline zoom maps minimum, midpoint and maximum', () => {
+	const minZoom = 2;
+	const midpoint = Math.sqrt(minZoom * TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM);
 
-	expect(normalizedToTimelineZoom({normalized: 0, maxZoom})).toBe(
-		TIMELINE_MIN_ZOOM,
+	expect(normalizedToTimelineZoom({normalized: 0, minZoom})).toBe(minZoom);
+	expect(normalizedToTimelineZoom({normalized: 0.5, minZoom})).toBeCloseTo(
+		midpoint,
 	);
-	expect(normalizedToTimelineZoom({normalized: 0.5, maxZoom})).toBeCloseTo(
-		Math.sqrt(maxZoom),
+	expect(normalizedToTimelineZoom({normalized: 1, minZoom})).toBe(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
 	);
-	expect(normalizedToTimelineZoom({normalized: 1, maxZoom})).toBe(maxZoom);
-	expect(
-		timelineZoomToNormalized({zoom: Math.sqrt(maxZoom), maxZoom}),
-	).toBeCloseTo(0.5);
-});
-
-test('timeline zoom slider increases with zoom', () => {
-	const maxZoom = getTimelineMaxZoom({
-		durationInFrames: 60 * 60 * 30,
-		timelineViewportWidth: 1200,
-	});
-
-	expect(timelineZoomToSliderValue({zoom: 100, maxZoom})).toBeGreaterThan(
-		timelineZoomToSliderValue({zoom: 5, maxZoom}),
-	);
+	expect(timelineZoomToNormalized({zoom: midpoint, minZoom})).toBeCloseTo(0.5);
 });

--- a/packages/studio/src/test/get-timeline-max-zoom.test.ts
+++ b/packages/studio/src/test/get-timeline-max-zoom.test.ts
@@ -4,49 +4,81 @@ import {
 	getTimelineMaxZoom,
 	normalizedToTimelineZoom,
 	sliderValueToTimelineZoom,
-	TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM,
-	TIMELINE_MAX_ZOOM_FLOOR,
+	TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
 	TIMELINE_MIN_ZOOM,
 	TIMELINE_ZOOM_SLIDER_PROPS,
 	timelineZoomToNormalized,
 	timelineZoomToSliderValue,
 } from '../helpers/get-timeline-max-zoom';
+import {TIMELINE_PADDING} from '../helpers/timeline-layout';
 
-test('keeps the previous max zoom for short compositions', () => {
-	expect(getTimelineMaxZoom(1)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
-	expect(getTimelineMaxZoom(30)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
-	expect(getTimelineMaxZoom(150)).toBe(TIMELINE_MAX_ZOOM_FLOOR);
+test('max zoom gives every frame a fixed width', () => {
+	const durationInFrames = 60 * 60 * 30;
+	const timelineViewportWidth = 1200;
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames,
+		timelineViewportWidth,
+	});
+	const usableTimelineWidth =
+		maxZoom * timelineViewportWidth - TIMELINE_PADDING * 2;
+
+	expect(usableTimelineWidth / durationInFrames).toBe(
+		TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+	);
 });
 
-test('raises max zoom so longer compositions can still show individual frames', () => {
-	expect(getTimelineMaxZoom(151)).toBe(5.1);
-	expect(getTimelineMaxZoom(300)).toBe(10);
-	expect(getTimelineMaxZoom(60 * 60 * 30)).toBe(3600);
-	expect(getTimelineMaxZoom(2 * 60 * 60 * 30)).toBe(7200);
-});
-
-test('max zoom shows a fixed number of frames in the viewport', () => {
-	const oneHourInFrames = 60 * 60 * 30;
-	const maxZoom = getTimelineMaxZoom(oneHourInFrames);
-
-	expect(oneHourInFrames / maxZoom).toBe(TIMELINE_FRAMES_VISIBLE_AT_MAX_ZOOM);
+test('short compositions stay fitted to the viewport', () => {
+	expect(
+		getTimelineMaxZoom({durationInFrames: 10, timelineViewportWidth: 1200}),
+	).toBe(TIMELINE_MIN_ZOOM);
 });
 
 test('clamps and rounds timeline zoom', () => {
-	expect(clampTimelineZoom({zoom: 0.2, durationInFrames: 150})).toBe(
-		TIMELINE_MIN_ZOOM,
-	);
-	expect(clampTimelineZoom({zoom: 3.16, durationInFrames: 150})).toBe(3.2);
-	expect(clampTimelineZoom({zoom: 9999, durationInFrames: 150})).toBe(
-		TIMELINE_MAX_ZOOM_FLOOR,
-	);
-	expect(clampTimelineZoom({zoom: 9999, durationInFrames: 60 * 60 * 30})).toBe(
-		3600,
+	const timelineViewportWidth = 1200;
+	expect(
+		clampTimelineZoom({
+			zoom: 0.2,
+			durationInFrames: 150,
+			timelineViewportWidth,
+		}),
+	).toBe(TIMELINE_MIN_ZOOM);
+	expect(
+		clampTimelineZoom({
+			zoom: 3.16,
+			durationInFrames: 300,
+			timelineViewportWidth,
+		}),
+	).toBe(3.2);
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames: 150,
+		timelineViewportWidth,
+	});
+	expect(
+		clampTimelineZoom({
+			zoom: 9999,
+			durationInFrames: 150,
+			timelineViewportWidth,
+		}),
+	).toBe(maxZoom);
+	expect(
+		clampTimelineZoom({
+			zoom: 9999,
+			durationInFrames: 60 * 60 * 30,
+			timelineViewportWidth,
+		}),
+	).toBe(
+		getTimelineMaxZoom({
+			durationInFrames: 60 * 60 * 30,
+			timelineViewportWidth,
+		}),
 	);
 });
 
 test('timeline zoom slider maps min and max', () => {
-	const maxZoom = getTimelineMaxZoom(60 * 60 * 30);
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames: 60 * 60 * 30,
+		timelineViewportWidth: 1200,
+	});
 
 	expect(timelineZoomToSliderValue({zoom: TIMELINE_MIN_ZOOM, maxZoom})).toBe(0);
 	expect(timelineZoomToSliderValue({zoom: maxZoom, maxZoom})).toBe(
@@ -79,7 +111,10 @@ test('normalized timeline zoom maps min, midpoint and max', () => {
 });
 
 test('timeline zoom slider increases with zoom', () => {
-	const maxZoom = getTimelineMaxZoom(60 * 60 * 30);
+	const maxZoom = getTimelineMaxZoom({
+		durationInFrames: 60 * 60 * 30,
+		timelineViewportWidth: 1200,
+	});
 
 	expect(timelineZoomToSliderValue({zoom: 100, maxZoom})).toBeGreaterThan(
 		timelineZoomToSliderValue({zoom: 5, maxZoom}),

--- a/packages/studio/src/test/timeline-scroll-logic.test.ts
+++ b/packages/studio/src/test/timeline-scroll-logic.test.ts
@@ -1,10 +1,15 @@
 import {expect, test} from 'bun:test';
-import {timelineVerticalScroll} from '../components/Timeline/timeline-refs';
+import {
+	scrollableRef,
+	sliderAreaRef,
+	timelineVerticalScroll,
+} from '../components/Timeline/timeline-refs';
 import {
 	getFrameFromX,
 	getFrameFromTimelineDrop,
 	getFrameIncrementFromWidth,
 	getScrollLeftToKeepCursorInPlace,
+	getTimelineContentWidth,
 	startTimelineEdgeAutoScroll,
 } from '../components/Timeline/timeline-scroll-logic';
 import {TIMELINE_PADDING} from '../helpers/timeline-layout';
@@ -58,6 +63,16 @@ test('gets a timeline drop frame from viewport coordinates and scroll position',
 
 test('getFrameIncrementFromWidth never returns a negative increment', () => {
 	expect(getFrameIncrementFromWidth(100, 0)).toBe(0.01);
+});
+
+test('uses the timeline content width when it is narrower than the viewport', () => {
+	scrollableRef.current = {scrollWidth: 1200} as HTMLDivElement;
+	sliderAreaRef.current = {clientWidth: 332} as HTMLDivElement;
+
+	expect(getTimelineContentWidth()).toBe(332);
+
+	scrollableRef.current = null;
+	sliderAreaRef.current = null;
 });
 
 test('keeps the same timeline position under the cursor after zooming', () => {


### PR DESCRIPTION
## Summary

- store timeline zoom directly as CSS pixels per frame, with a viewport-independent maximum of 30
- use the viewport only to derive the fit-to-window minimum, including the capped behavior for short compositions
- use the actual timeline content width for coordinate math when the content is narrower than the viewport
- version persisted zoom values and keep slider, pinch, and WebMCP zoom behavior consistent

## Verification

- bun run --cwd packages/studio test (635 tests)
- bun run --cwd packages/studio lint (0 errors; 6 existing warnings)
- bunx turbo run make --filter=@remotion/studio
- targeted Playwright Studio workflow, including a 30px/frame DOM assertion (red/green verified)