### PR TITLE
Increase timeline waveform fidelity with composition FPS

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -9,6 +9,7 @@ import React, {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {LoopDisplay} from 'remotion';
 import {Internals} from 'remotion';
 import {WHITE_ALPHA_70, WHITE_ALPHA_60} from '../helpers/colors';
+import {TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM} from '../helpers/get-timeline-max-zoom';
 import {TIMELINE_BORDER} from '../helpers/timeline-layout';
 
 const EMPTY_PEAKS = new Float32Array(0);
@@ -78,6 +79,10 @@ const AudioWaveformInner: React.FC<{
 		throw new Error('Expected video config');
 	}
 
+	const waveformSampleRate = Math.ceil(
+		vidConf.fps * TIMELINE_FRAME_WIDTH_AT_MAX_ZOOM,
+	);
+
 	const waveformCanvas = useRef<HTMLCanvasElement>(null);
 	const volumeCanvas = useRef<HTMLCanvasElement>(null);
 	const shouldRenderVolumeOverlay =
@@ -110,10 +115,11 @@ const AudioWaveformInner: React.FC<{
 
 		return subscribeToWaveformPeaks({
 			src,
+			waveformSampleRate,
 			onPeaks: (p) => setPeaks(p),
 			onError: (err) => setError(err),
 		});
-	}, [src]);
+	}, [src, waveformSampleRate]);
 
 	const portionPeaks = useMemo(() => {
 		if (!peaks) {
@@ -129,6 +135,7 @@ const AudioWaveformInner: React.FC<{
 			peaks,
 			playbackRate,
 			startFrom,
+			waveformSampleRate,
 		});
 	}, [
 		displayDurationInFrames,
@@ -139,6 +146,7 @@ const AudioWaveformInner: React.FC<{
 		playbackRate,
 		startFrom,
 		vidConf.fps,
+		waveformSampleRate,
 	]);
 
 	// Drawing must happen in a layout effect: when the timeline zooms, the

--- a/packages/timeline-utils/src/audio-waveform-worker.ts
+++ b/packages/timeline-utils/src/audio-waveform-worker.ts
@@ -39,6 +39,7 @@ self.addEventListener(
 		const controller = new AbortController();
 
 		loadWaveformPeaks(message.src, controller.signal, {
+			waveformSampleRate: message.waveformSampleRate,
 			onProgress: ({peaks, final}) => {
 				if (!final) {
 					postPeaks(message.requestId, peaks, false);

--- a/packages/timeline-utils/src/audio-waveform/audio-waveform-worker-types.ts
+++ b/packages/timeline-utils/src/audio-waveform/audio-waveform-worker-types.ts
@@ -2,6 +2,7 @@ export type AudioWaveformWorkerLoadMessage = {
 	readonly type: 'load';
 	readonly requestId: number;
 	readonly src: string;
+	readonly waveformSampleRate: number;
 };
 
 export type AudioWaveformWorkerIncomingMessage = AudioWaveformWorkerLoadMessage;

--- a/packages/timeline-utils/src/audio-waveform/load-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/load-waveform-peaks.ts
@@ -21,6 +21,7 @@ type Progress = {
 type LoadWaveformPeaksOptions = {
 	readonly onProgress?: (progress: Progress) => void;
 	readonly progressIntervalInMs?: number;
+	readonly waveformSampleRate?: number;
 };
 
 export async function loadWaveformPeaks(
@@ -28,7 +29,13 @@ export async function loadWaveformPeaks(
 	signal: AbortSignal,
 	options?: LoadWaveformPeaksOptions,
 ): Promise<Float32Array> {
-	const cached = peaksCache.get(url);
+	const waveformSampleRate = options?.waveformSampleRate ?? TARGET_SAMPLE_RATE;
+	if (!Number.isFinite(waveformSampleRate) || waveformSampleRate <= 0) {
+		throw new Error('The waveform sample rate must be a positive number.');
+	}
+
+	const cacheKey = `${waveformSampleRate}:${url}`;
+	const cached = peaksCache.get(cacheKey);
 	if (cached) {
 		emitWaveformProgress({
 			peaks: cached,
@@ -65,14 +72,14 @@ export async function loadWaveformPeaks(
 			);
 		}
 
-		const sampleRate = await audioTrack.getSampleRate();
+		const audioSampleRate = await audioTrack.getSampleRate();
 		const durationInSeconds =
 			(await audioTrack.getDurationFromMetadata({skipLiveWait: true})) ??
 			(await audioTrack.computeDuration({skipLiveWait: true}));
-		const totalPeaks = Math.ceil(durationInSeconds * TARGET_SAMPLE_RATE);
+		const totalPeaks = Math.ceil(durationInSeconds * waveformSampleRate);
 		const samplesPerPeak = Math.max(
 			1,
-			Math.floor(sampleRate / TARGET_SAMPLE_RATE),
+			Math.floor(audioSampleRate / waveformSampleRate),
 		);
 
 		const sink = new AudioSampleSink(audioTrack);
@@ -81,7 +88,9 @@ export async function loadWaveformPeaks(
 			samplesPerPeak,
 			onProgress: options?.onProgress,
 			progressIntervalInMs:
-				options?.progressIntervalInMs ?? DEFAULT_PROGRESS_INTERVAL_IN_MS,
+				options?.progressIntervalInMs ??
+				DEFAULT_PROGRESS_INTERVAL_IN_MS *
+					Math.max(1, waveformSampleRate / TARGET_SAMPLE_RATE),
 			now: () => Date.now(),
 		});
 
@@ -124,7 +133,7 @@ export async function loadWaveformPeaks(
 
 		processor.finalize();
 		const {peaks} = processor;
-		peaksCache.set(url, peaks);
+		peaksCache.set(cacheKey, peaks);
 		return peaks;
 	} finally {
 		input.dispose();

--- a/packages/timeline-utils/src/audio-waveform/slice-visible-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/slice-visible-waveform-peaks.ts
@@ -11,6 +11,7 @@ export const sliceVisibleWaveformPeaks = ({
 	peaks,
 	playbackRate,
 	startFrom,
+	waveformSampleRate,
 }: {
 	readonly displayDurationInFrames: number;
 	readonly displayOffsetInFrames: number;
@@ -20,6 +21,7 @@ export const sliceVisibleWaveformPeaks = ({
 	readonly peaks: Float32Array;
 	readonly playbackRate: number;
 	readonly startFrom: number;
+	readonly waveformSampleRate?: number;
 }) => {
 	if (
 		!shouldTileLoopDisplay(loopDisplay) ||
@@ -34,6 +36,7 @@ export const sliceVisibleWaveformPeaks = ({
 			peaks,
 			playbackRate,
 			startFrom: startFrom + displayOffsetInFrames * playbackRate,
+			waveformSampleRate,
 		});
 	}
 
@@ -52,6 +55,7 @@ export const sliceVisibleWaveformPeaks = ({
 			peaks,
 			playbackRate,
 			startFrom: startFrom + segment.loopOffsetInFrames * playbackRate,
+			waveformSampleRate,
 		});
 		parts.push(part);
 		totalLength += part.length;

--- a/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/slice-waveform-peaks.ts
@@ -6,12 +6,14 @@ export const sliceWaveformPeaks = ({
 	peaks,
 	playbackRate,
 	startFrom,
+	waveformSampleRate = TARGET_SAMPLE_RATE,
 }: {
 	readonly peaks: Float32Array;
 	readonly startFrom: number;
 	readonly durationInFrames: number;
 	readonly fps: number;
 	readonly playbackRate: number;
+	readonly waveformSampleRate?: number;
 }) => {
 	if (peaks.length === 0) {
 		return peaks;
@@ -20,9 +22,9 @@ export const sliceWaveformPeaks = ({
 	const startTimeInSeconds = startFrom / fps;
 	const durationInSeconds = (durationInFrames / fps) * playbackRate;
 
-	const startPeakIndex = Math.floor(startTimeInSeconds * TARGET_SAMPLE_RATE);
+	const startPeakIndex = Math.floor(startTimeInSeconds * waveformSampleRate);
 	const endPeakIndex = Math.ceil(
-		(startTimeInSeconds + durationInSeconds) * TARGET_SAMPLE_RATE,
+		(startTimeInSeconds + durationInSeconds) * waveformSampleRate,
 	);
 
 	if (!Number.isFinite(startPeakIndex) || !Number.isFinite(endPeakIndex)) {

--- a/packages/timeline-utils/src/audio-waveform/subscribe-to-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/subscribe-to-waveform-peaks.ts
@@ -2,6 +2,7 @@ import type {
 	AudioWaveformWorkerLoadMessage,
 	AudioWaveformWorkerOutgoingMessage,
 } from './audio-waveform-worker-types';
+import {TARGET_SAMPLE_RATE} from './constants';
 import {loadWaveformPeaks} from './load-waveform-peaks';
 import {makeAudioWaveformWorker} from './make-audio-waveform-worker';
 
@@ -12,6 +13,8 @@ type WaveformPeaksListener = {
 
 type InFlightLoad = {
 	readonly src: string;
+	readonly cacheKey: string;
+	readonly waveformSampleRate: number;
 	readonly listeners: Set<WaveformPeaksListener>;
 	latestPeaks: Float32Array | null;
 	requestId: number | null;
@@ -21,7 +24,7 @@ type InFlightLoad = {
 // so remounts (timeline virtualization, zoom window cropping) and multiple
 // clips with the same src never re-fetch or re-decode the audio.
 const peaksCache = new Map<string, Float32Array>();
-const inFlightBySrc = new Map<string, InFlightLoad>();
+const inFlightByCacheKey = new Map<string, InFlightLoad>();
 const inFlightByRequestId = new Map<number, InFlightLoad>();
 
 let worker: Worker | null = null;
@@ -30,8 +33,8 @@ let nextRequestId = 0;
 
 const emitPeaks = (load: InFlightLoad, peaks: Float32Array, final: boolean) => {
 	if (final) {
-		peaksCache.set(load.src, peaks);
-		inFlightBySrc.delete(load.src);
+		peaksCache.set(load.cacheKey, peaks);
+		inFlightByCacheKey.delete(load.cacheKey);
 		if (load.requestId !== null) {
 			inFlightByRequestId.delete(load.requestId);
 		}
@@ -45,7 +48,7 @@ const emitPeaks = (load: InFlightLoad, peaks: Float32Array, final: boolean) => {
 };
 
 const emitError = (load: InFlightLoad, error: Error) => {
-	inFlightBySrc.delete(load.src);
+	inFlightByCacheKey.delete(load.cacheKey);
 	if (load.requestId !== null) {
 		inFlightByRequestId.delete(load.requestId);
 	}
@@ -63,6 +66,7 @@ const startMainThreadLoad = (load: InFlightLoad) => {
 	const controller = new AbortController();
 
 	loadWaveformPeaks(load.src, controller.signal, {
+		waveformSampleRate: load.waveformSampleRate,
 		onProgress: ({peaks, final}) => {
 			if (final) {
 				return;
@@ -141,14 +145,17 @@ const getOrCreateWorker = (): Worker | null => {
 
 export const subscribeToWaveformPeaks = ({
 	src,
+	waveformSampleRate = TARGET_SAMPLE_RATE,
 	onPeaks,
 	onError,
 }: {
 	readonly src: string;
+	readonly waveformSampleRate?: number;
 	readonly onPeaks: (peaks: Float32Array, final: boolean) => void;
 	readonly onError: (error: Error) => void;
 }): (() => void) => {
-	const cached = peaksCache.get(src);
+	const cacheKey = `${waveformSampleRate}:${src}`;
+	const cached = peaksCache.get(cacheKey);
 	if (cached) {
 		onPeaks(cached, true);
 		return () => undefined;
@@ -156,7 +163,7 @@ export const subscribeToWaveformPeaks = ({
 
 	const listener: WaveformPeaksListener = {onPeaks, onError};
 
-	const existing = inFlightBySrc.get(src);
+	const existing = inFlightByCacheKey.get(cacheKey);
 	if (existing) {
 		existing.listeners.add(listener);
 		if (existing.latestPeaks) {
@@ -170,11 +177,13 @@ export const subscribeToWaveformPeaks = ({
 
 	const load: InFlightLoad = {
 		src,
+		cacheKey,
+		waveformSampleRate,
 		listeners: new Set([listener]),
 		latestPeaks: null,
 		requestId: null,
 	};
-	inFlightBySrc.set(src, load);
+	inFlightByCacheKey.set(cacheKey, load);
 
 	const workerInstance = getOrCreateWorker();
 	if (workerInstance) {
@@ -185,6 +194,7 @@ export const subscribeToWaveformPeaks = ({
 			type: 'load',
 			requestId,
 			src,
+			waveformSampleRate,
 		};
 		workerInstance.postMessage(message);
 	} else {

--- a/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
+++ b/packages/timeline-utils/src/test/load-waveform-peaks-server.test.ts
@@ -50,6 +50,21 @@ test('loadWaveformPeaks progress matches completed peak count for MP4 audio', as
 	expect(lastCompleted).toBe(peaks.length);
 });
 
+test('loadWaveformPeaks caches each requested fidelity separately', async () => {
+	const defaultPeaks = await loadWaveformPeaks(
+		SAMPLE_MEDIA_URL,
+		new AbortController().signal,
+	);
+	const detailedPeaks = await loadWaveformPeaks(
+		SAMPLE_MEDIA_URL,
+		new AbortController().signal,
+		{waveformSampleRate: 200},
+	);
+
+	expect(detailedPeaks.length).toBeGreaterThan(defaultPeaks.length * 1.9);
+	expect(detailedPeaks.length).toBeLessThan(defaultPeaks.length * 2.1);
+});
+
 test('loadWaveformPeaks draws a non-zero first peak for edts.mp4', async () => {
 	const peaks = await loadWaveformPeaks(
 		EDTS_MEDIA_URL,

--- a/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
+++ b/packages/timeline-utils/src/test/slice-waveform-peaks.test.ts
@@ -17,6 +17,23 @@ test('Should slice waveform peaks based on timeline window', () => {
 	);
 });
 
+test('Should slice waveform peaks at the requested fidelity', () => {
+	const peaks = Float32Array.from({length: 2700}, (_, i) => i);
+
+	const sliced = sliceWaveformPeaks({
+		peaks,
+		startFrom: 30,
+		durationInFrames: 30,
+		fps: 30,
+		playbackRate: 1,
+		waveformSampleRate: 900,
+	});
+
+	expect(Array.from(sliced)).toEqual(
+		Array.from({length: 900}, (_, i) => i + 900),
+	);
+});
+
 test('Should return an empty waveform unchanged', () => {
 	const peaks = new Float32Array(0);
 


### PR DESCRIPTION
## Summary

- derive waveform fidelity from composition FPS at 30 peaks per frame (900 Hz at 30 fps)
- carry the selected fidelity through decoding, slicing, worker messages, and fidelity-aware caches
- throttle progressive waveform snapshots proportionally to keep worker copy bandwidth bounded

## Verification

- `bun run --cwd packages/timeline-utils test`
- `bun run --cwd packages/studio test`
- `bun run --cwd packages/timeline-utils lint`
- `bun run --cwd packages/studio lint`
- `bunx turbo run make --filter='@remotion/timeline-utils' --filter='@remotion/studio'`
- real-media cache-fidelity integration test (red/green verified)