### PR TITLE
`@remotion/timeline-utils`: Release waveform progress snapshots after decoding

### DIFF
--- a/packages/timeline-utils/src/audio-waveform/subscribe-to-waveform-peaks.ts
+++ b/packages/timeline-utils/src/audio-waveform/subscribe-to-waveform-peaks.ts
@@ -34,6 +34,7 @@ let nextRequestId = 0;
 const emitPeaks = (load: InFlightLoad, peaks: Float32Array, final: boolean) => {
 	if (final) {
 		peaksCache.set(load.cacheKey, peaks);
+		load.latestPeaks = null;
 		inFlightByCacheKey.delete(load.cacheKey);
 		if (load.requestId !== null) {
 			inFlightByRequestId.delete(load.requestId);


### PR DESCRIPTION
## Summary

- release the latest progressive waveform snapshot once the final peaks enter the cache
- prevent the subscriber cleanup closure from retaining an obsolete full-size `Float32Array`

## Verification

- `bun run --cwd packages/timeline-utils test`
- `bun run build`
- `bun run stylecheck`

