### PR TITLE
`@remotion/player`: Prevent resume timeout from muting user-initiated playback

### DIFF
--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -88,6 +88,7 @@ type SharedAudioContextValue = {
 		options: ScheduleAudioNodeOptions,
 	) => ScheduleAudioNodeResult;
 	resume: () => Promise<void>;
+	resumeAsAutoPlay: () => Promise<void>;
 	suspend: () => Promise<void>;
 	getIsResumingAudioContext: () => Promise<AudioContextResumeResult> | null;
 	unscheduleAudioNode: (node: AudioBufferSourceNode) => void;
@@ -247,6 +248,7 @@ export const SharedAudioContextProvider: React.FC<{
 
 	const isResuming = useRef<AudioContextResumeAttempt | null>(null);
 	const nextResumeAttemptId = useRef(0);
+	const nextResumeIsAutoPlayAttempt = useRef(false);
 
 	const audioSyncAnchor = useMemo(() => ({value: 0}), []);
 
@@ -393,6 +395,8 @@ export const SharedAudioContextProvider: React.FC<{
 	}, [ctxAndGain, _experimentalKeepAudioContextAlive, logLevel]);
 
 	const resume = useCallback(() => {
+		const isAutoPlayAttempt = nextResumeIsAutoPlayAttempt.current;
+		nextResumeIsAutoPlayAttempt.current = false;
 		if (!ctxAndGain) {
 			return Promise.resolve();
 		}
@@ -439,6 +443,7 @@ export const SharedAudioContextProvider: React.FC<{
 				ctxAndGain.audioContext,
 				logLevel,
 				abortController.signal,
+				isAutoPlayAttempt,
 			).then(resolve);
 			resumePromise.catch((err) => {
 				Log.warn(
@@ -465,6 +470,11 @@ export const SharedAudioContextProvider: React.FC<{
 			// since callers (e.g. use-playback.ts) do not await this.
 		});
 	}, [ctxAndGain, _experimentalKeepAudioContextAlive, logLevel]);
+
+	const resumeAsAutoPlay = useCallback(() => {
+		nextResumeIsAutoPlayAttempt.current = true;
+		return resume();
+	}, [resume]);
 
 	const getIsResumingAudioContext = useCallback(() => {
 		return isResuming.current?.promise ?? null;
@@ -556,6 +566,7 @@ export const SharedAudioContextProvider: React.FC<{
 			audioSyncAnchorEmitter,
 			scheduleAudioNode,
 			resume,
+			resumeAsAutoPlay,
 			suspend,
 			getIsResumingAudioContext,
 			unscheduleAudioNode,
@@ -567,6 +578,7 @@ export const SharedAudioContextProvider: React.FC<{
 		audioSyncAnchorEmitter,
 		scheduleAudioNode,
 		resume,
+		resumeAsAutoPlay,
 		suspend,
 		getIsResumingAudioContext,
 		unscheduleAudioNode,

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -8,6 +8,7 @@ export const waitUntilActuallyResumed = (
 	audioContext: AudioContext,
 	logLevel: LogLevel,
 	signal: AbortSignal,
+	isAutoPlayAttempt: boolean,
 ): Promise<AudioContextResumeResult> => {
 	return new Promise((resolve) => {
 		const startCurrentTime = audioContext.currentTime;
@@ -86,23 +87,26 @@ export const waitUntilActuallyResumed = (
 		}
 
 		signal.addEventListener('abort', onAbort, {once: true});
-		timeout = setTimeout(() => {
-			// The success check is scheduled with requestAnimationFrame, which can
-			// be starved while the main thread is busy. Re-check once before
-			// declaring failure so a resume that actually completed is not
-			// reported as failed - the Player would otherwise mute itself even
-			// though playback was started by a user gesture and audio is running.
-			if (hasAudiblyStarted(startOutputPerformanceTime)) {
-				finish('resumed');
-				return;
-			}
+		if (isAutoPlayAttempt) {
+			timeout = setTimeout(() => {
+				// The success check is scheduled with requestAnimationFrame, which can
+				// be starved while the main thread is busy. Re-check once before
+				// declaring failure so a resume that actually completed is not
+				// reported as failed - the Player would otherwise mute itself even
+				// though playback was started by a user gesture and audio is running.
+				if (hasAudiblyStarted(startOutputPerformanceTime)) {
+					finish('resumed');
+					return;
+				}
 
-			Log.warn(
-				{logLevel, tag: 'audio'},
-				'WARNING: You enabled autoPlay on an unmuted <Player /> and the browser did not allow the video to be started. Remotion muted the <Player /> so it can play. To properly handle this, either set the `muted` prop or remove the `autoPlay` prop',
-			);
-			finish('failed');
-		}, RESUME_WAIT_TIMEOUT);
+				Log.warn(
+					{logLevel, tag: 'audio'},
+					'WARNING: You enabled autoPlay on an unmuted <Player /> and the browser did not allow the video to be started. Remotion muted the <Player /> so it can play. To properly handle this, either set the `muted` prop or remove the `autoPlay` prop',
+				);
+				finish('failed');
+			}, RESUME_WAIT_TIMEOUT);
+		}
+
 		animationFrame = requestAnimationFrame(check);
 	});
 };

--- a/packages/player/src/PlayerUI.tsx
+++ b/packages/player/src/PlayerUI.tsx
@@ -589,10 +589,11 @@ const PlayerUI: React.ForwardRefRenderFunction<
 
 	useEffect(() => {
 		if (shouldAutoplay) {
-			play();
+			setHasPlayed(true);
+			player.playAsAutoPlay();
 			setShouldAutoPlay(false);
 		}
-	}, [play, shouldAutoplay]);
+	}, [player, shouldAutoplay]);
 
 	const loadingMarkup = useMemo(() => {
 		return renderLoading

--- a/packages/player/src/test/audio-context-resume.test.tsx
+++ b/packages/player/src/test/audio-context-resume.test.tsx
@@ -1,16 +1,25 @@
-import {afterEach, expect, test} from 'bun:test';
+import {afterEach, beforeEach, expect, test} from 'bun:test';
 import {createRef} from 'react';
 import {Html5Audio, Internals} from 'remotion';
 import type {PlayerRef} from '../player-methods.js';
 import {Player} from '../Player.js';
 import {act, cleanup, render} from './test-utils.js';
 
+const originalAudioContext = globalThis.AudioContext;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
 afterEach(() => {
 	cleanup();
+	globalThis.AudioContext = originalAudioContext;
+	globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+	globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
 });
 
 let createdAudioContexts = 0;
 let resumeCalls = 0;
+let animationFrameId = 0;
+let animationFrames = new Map<number, FrameRequestCallback>();
 
 class FrozenAudioContext {
 	public state = 'suspended' as AudioContextState;
@@ -79,14 +88,11 @@ const AudioComposition = () => {
 	);
 };
 
-test('Player mutes and continues after an AudioContext resume stays pending', async () => {
-	const originalAudioContext = globalThis.AudioContext;
-	const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-	const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
-
-	let animationFrameId = 0;
-	const animationFrames = new Map<number, FrameRequestCallback>();
-
+beforeEach(() => {
+	createdAudioContexts = 0;
+	resumeCalls = 0;
+	animationFrameId = 0;
+	animationFrames = new Map<number, FrameRequestCallback>();
 	globalThis.AudioContext =
 		FrozenAudioContext as unknown as typeof AudioContext;
 	globalThis.requestAnimationFrame = (callback) => {
@@ -98,16 +104,17 @@ test('Player mutes and continues after an AudioContext resume stays pending', as
 	globalThis.cancelAnimationFrame = (id) => {
 		animationFrames.delete(id);
 	};
+});
 
-	const flushAnimationFrames = () => {
-		const callbacks = [...animationFrames.values()];
-		animationFrames.clear();
-		callbacks.forEach((callback) => callback(performance.now()));
-	};
+const flushAnimationFrames = () => {
+	const callbacks = [...animationFrames.values()];
+	animationFrames.clear();
+	callbacks.forEach((callback) => callback(performance.now()));
+};
 
-	try {
-		createdAudioContexts = 0;
-		resumeCalls = 0;
+test.serial(
+	'Player keeps waiting when a user-initiated AudioContext resume stays pending',
+	async () => {
 		const playerRef = createRef<PlayerRef>();
 		render(
 			<Player
@@ -129,15 +136,52 @@ test('Player mutes and continues after an AudioContext resume stays pending', as
 		expect(animationFrames.size).toBe(1);
 		const stalledFrame = playerRef.current?.getCurrentFrame();
 
-		await new Promise<void>((resolve) => setTimeout(resolve, 50));
+		await act(async () => {
+			await new Promise<void>((resolve) => setTimeout(resolve, 1050));
+		});
 		act(flushAnimationFrames);
+
+		expect(playerRef.current?.isPlaying()).toBe(true);
+		expect(playerRef.current?.isMuted()).toBe(false);
 		expect(playerRef.current?.getCurrentFrame()).toBe(stalledFrame);
+		expect(resumeCalls).toBe(1);
+		expect(animationFrames.size).toBe(1);
+
+		await act(async () => {
+			playerRef.current?.pause();
+			await Promise.resolve();
+		});
+		expect(playerRef.current?.isPlaying()).toBe(false);
+		expect(animationFrames.size).toBe(0);
+	},
+);
+
+test.serial(
+	'Player mutes and continues when an autoplay AudioContext resume stays pending',
+	async () => {
+		const playerRef = createRef<PlayerRef>();
+		render(
+			<Player
+				ref={playerRef}
+				component={AudioComposition}
+				durationInFrames={300}
+				compositionWidth={1920}
+				compositionHeight={1080}
+				fps={30}
+				autoPlay
+			/>,
+		);
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(createdAudioContexts).toBe(1);
+		expect(resumeCalls).toBe(1);
+		expect(animationFrames.size).toBe(1);
+		const stalledFrame = playerRef.current?.getCurrentFrame();
 
 		await act(async () => {
 			await new Promise<void>((resolve) => setTimeout(resolve, 1050));
 		});
-		expect(animationFrames.size).toBe(1);
-
 		await new Promise<void>((resolve) => setTimeout(resolve, 50));
 		act(flushAnimationFrames);
 
@@ -148,30 +192,5 @@ test('Player mutes and continues after an AudioContext resume stays pending', as
 		);
 		expect(resumeCalls).toBe(1);
 		expect(animationFrames.size).toBe(1);
-
-		await act(async () => {
-			playerRef.current?.pause();
-			await Promise.resolve();
-		});
-		expect(animationFrames.size).toBe(0);
-
-		await act(async () => {
-			playerRef.current?.unmute();
-			playerRef.current?.play();
-			await Promise.resolve();
-		});
-		expect(resumeCalls).toBe(2);
-		expect(animationFrames.size).toBe(1);
-
-		await act(async () => {
-			playerRef.current?.pause();
-			await Promise.resolve();
-		});
-		expect(playerRef.current?.isPlaying()).toBe(false);
-		expect(animationFrames.size).toBe(0);
-	} finally {
-		globalThis.AudioContext = originalAudioContext;
-		globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-		globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-	}
-});
+	},
+);

--- a/packages/player/src/use-player-methods.ts
+++ b/packages/player/src/use-player-methods.ts
@@ -9,6 +9,7 @@ export type UsePlayerMethods = {
 	frameForward: (frames: number) => void;
 	emitter: PlayerEmitter;
 	play: (e?: SyntheticEvent | PointerEvent) => void;
+	playAsAutoPlay: () => void;
 	pause: () => void;
 	pauseAndReturnToPlayStart: () => void;
 	seek: (newFrame: number) => void;
@@ -36,6 +37,7 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 	const emitter = useContext(PlayerEventEmitterContext);
 	const playStart = useRef(0);
 	const fallbackFrame = useRef<number | null>(null);
+	const nextPlayIsAutoPlayAttempt = useRef(false);
 
 	if (!emitter) {
 		throw new TypeError('Expected Player event emitter context');
@@ -96,6 +98,8 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 
 	const play = useCallback(
 		(e?: SyntheticEvent | PointerEvent) => {
+			const isAutoPlayAttempt = nextPlayIsAutoPlayAttempt.current;
+			nextPlayIsAutoPlayAttempt.current = false;
 			if (readIsPlaying()) {
 				return;
 			}
@@ -105,7 +109,11 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 				seek(0);
 			}
 
-			audioContext?.resume();
+			if (isAutoPlayAttempt) {
+				audioContext?.resumeAsAutoPlay();
+			} else {
+				audioContext?.resume();
+			}
 
 			/**
 			 * Play silent audio tags to warm them up for autoplay
@@ -138,6 +146,10 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 			setPlaying,
 		],
 	);
+	const playAsAutoPlay = useCallback(() => {
+		nextPlayIsAutoPlayAttempt.current = true;
+		play();
+	}, [play]);
 
 	const pause = useCallback(() => {
 		if (readIsPlaying()) {
@@ -253,6 +265,7 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 			frameForward,
 			emitter,
 			play,
+			playAsAutoPlay,
 			pause,
 			seek,
 			getCurrentFrame,
@@ -270,6 +283,7 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 		pause,
 		pauseAndReturnToPlayStart,
 		play,
+		playAsAutoPlay,
 		isBuffering,
 		seek,
 		toggle,


### PR DESCRIPTION
## Summary

- Restrict the one-second AudioContext resume fallback to the initial autoplay attempt
- Keep user-initiated playback waiting for the audio output clock instead of permanently muting the Player
- Preserve the existing muted-playback fallback when unmuted autoplay is blocked

## Testing

- Added Player integration coverage for pending user-initiated and autoplay AudioContext resumes
- Red/green verified the user-initiated regression against the previous unconditional timeout
- `bun run build`
- `bun run stylecheck`

Closes #10960
