### PR TITLE
`@remotion/media`: Fix video rendering stalls on Windows

### DIFF
--- a/packages/media/src/test/keyframe-bank.test.ts
+++ b/packages/media/src/test/keyframe-bank.test.ts
@@ -54,6 +54,56 @@ test('a long frame duration can satisfy requests beyond the jump threshold', asy
 	samples[1].close();
 });
 
+test('releases old frames before requesting more decoder output', async () => {
+	let openFrames = 0;
+	const sink: VideoSampleSink = {
+		getSample() {
+			return Promise.reject(new Error('Not implemented'));
+		},
+		async *samples() {
+			for (let i = 0; i < 20; i++) {
+				if (openFrames >= 8) {
+					throw new Error('Decoder ran out of output surfaces');
+				}
+
+				openFrames++;
+				const sample = makeSample({timestamp: i / 30, duration: 1 / 30});
+				const originalClose = sample.close.bind(sample);
+				let closed = false;
+				sample.close = () => {
+					if (!closed) {
+						closed = true;
+						openFrames--;
+					}
+
+					originalClose();
+				};
+
+				yield sample;
+			}
+		},
+		async *samplesAtTimestamps() {
+			yield* [];
+		},
+	};
+
+	const bank = await makeKeyframeBank({
+		logLevel: 'error',
+		src: 'limited-decoder-surfaces.mp4',
+		videoSampleSink: sink,
+		initialTimestampRequest: 0,
+	});
+
+	for (let i = 0; i < 12; i++) {
+		expect((await bank.getFrameFromTimestamp(i / 30, 30))?.timestamp).toBe(
+			i / 30,
+		);
+	}
+
+	bank.prepareForDeletion('error', 'test');
+	expect(openFrames).toBe(0);
+});
+
 test('uses next sample timestamp instead of reported duration while rendering', async () => {
 	const samples = [
 		makeSample({timestamp: 0, duration: 10}),

--- a/packages/media/src/video-extraction/keyframe-bank.ts
+++ b/packages/media/src/video-extraction/keyframe-bank.ts
@@ -200,6 +200,15 @@ export const makeKeyframeBank = async ({
 		fps: number,
 	) => {
 		while (!hasDecodedEnoughForTimestamp(timestampInSeconds)) {
+			// Windows hardware decoders can stop producing frames when too many
+			// decoded VideoFrames are still open. Free frames outside the safe
+			// window before asking the decoder for another one.
+			deleteFramesBeforeTimestamp({
+				logLevel: parentLogLevel,
+				timestampInSeconds:
+					timestampInSeconds - getSafeWindowOfMonotonicity(fps),
+			});
+
 			const sample = await sampleIterator.next();
 
 			if (sample.value) {


### PR DESCRIPTION
## Summary

- release cached video samples before requesting additional decoder output
- prevent client-side renders from stalling when Windows decoders exhaust their output surface pool
- add a regression test that simulates a decoder limited to eight open frames

Fixes #11020.

## Verification

- `bunx vitest src/test/keyframe-bank.test.ts --browser --run` from `packages/media`
- `bun run build`
- `bun run stylecheck`
- manually rendered the 300-frame `NewVideo` composition in Chrome 152 on Windows
- red/green verified: the regression test fails without the production change and passes with it
