### PR TITLE
`@remotion/studio-codemods`: Split JSX without Prettier

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -319,7 +319,6 @@ const getElementInstallPlanForProject = async ({
 					compositionFile: destination.compositionFile,
 					compositionId: destination.compositionId,
 					environment: makeInMemoryInsertJsxElementCodemodEnvironment({
-						formatFile: formatCodemodFile,
 						project,
 						svgMarkupToJsx,
 					}),
@@ -1368,7 +1367,6 @@ export const createBrowserStudioOperations = ({
 				nodePath,
 				sequenceKeys,
 				splitFrame,
-				formatFile: formatCodemodFile,
 			});
 			const nodePathMutation = controller.applyMutation({
 				fileName: absolutePath,
@@ -1904,7 +1902,6 @@ export const createBrowserStudioOperations = ({
 				project: getProject(),
 			});
 			const result = await insertJsxElementIntoProjectWithNodePathRemappings({
-				formatFile: formatCodemodFile,
 				project,
 				request,
 				svgMarkupToJsx,
@@ -2048,7 +2045,6 @@ export const createBrowserStudioOperations = ({
 				const durationInFrames = request.element.durationInFrames ?? null;
 				const insertion =
 					await insertJsxElementIntoProjectWithNodePathRemappings({
-						formatFile: formatCodemodFile,
 						project,
 						request: {
 							compositionFile: request.compositionFile,

--- a/packages/studio-codemods/src/insert-jsx-element.ts
+++ b/packages/studio-codemods/src/insert-jsx-element.ts
@@ -31,6 +31,11 @@ import {
 	captureJsxNodePaths,
 	getNodePathRemappings,
 } from './get-node-path-remappings';
+import {
+	getIndentationUnit,
+	indentInsertedJsx,
+	printInsertedJsx,
+} from './print-jsx';
 import {recastLocToOffset} from './recast-loc-to-offset';
 import {
 	ensureNamedImport,
@@ -51,7 +56,9 @@ export type InsertJsxElementCodemodEnvironment = {
 	dirname: (fileName: string) => string;
 	extname: (fileName: string) => string;
 	fileExists: (fileName: string) => boolean;
-	formatFile: (input: {
+	// Kept optional for compatibility with callers from before source edits
+	// replaced the full-file formatting pass.
+	formatFile?: (input: {
 		contents: string;
 		prettierConfigOverride: Record<string, unknown> | null;
 	}) => Promise<{output: string; formatted: boolean}>;
@@ -129,7 +136,7 @@ export const makeInMemoryInsertJsxElementCodemodEnvironment = ({
 	project,
 	svgMarkupToJsx,
 }: {
-	formatFile: InsertJsxElementCodemodEnvironment['formatFile'];
+	formatFile?: InsertJsxElementCodemodEnvironment['formatFile'];
 	project: {files: Record<string, string>; rootDir: string};
 	svgMarkupToJsx: InsertJsxElementCodemodEnvironment['svgMarkupToJsx'];
 }): InsertJsxElementCodemodEnvironment => {
@@ -2082,31 +2089,6 @@ const getLineIndent = (input: string, offset: number) => {
 	return input.slice(lineStart, offset).match(/^\s*/)?.[0] ?? '';
 };
 
-const getIndentationUnit = (
-	input: string,
-	prettierConfigOverride: Record<string, unknown> | null,
-) => {
-	if (/^\t+/m.test(input)) {
-		return '\t';
-	}
-
-	const indentation = input.match(/^([ ]+)\S/m)?.[1].length;
-	if (indentation) {
-		return ' '.repeat(indentation > 1 ? indentation : 2);
-	}
-
-	if (prettierConfigOverride?.useTabs === true) {
-		return '\t';
-	}
-
-	const tabWidth = prettierConfigOverride?.tabWidth;
-	return ' '.repeat(
-		typeof tabWidth === 'number' && Number.isInteger(tabWidth) && tabWidth > 0
-			? tabWidth
-			: 2,
-	);
-};
-
 const renderImportSpecifier = (
 	specifier: NonNullable<ImportDeclaration['specifiers']>[number],
 ) => {
@@ -2493,174 +2475,6 @@ const getSolidInsertionSource = ({
 		...solid.split(/\r?\n/).map((line) => `${unit}${line}`),
 		`</${sequenceName}>`,
 	].join(endOfLine);
-};
-
-const indentInsertedJsx = ({
-	indent,
-	insertion,
-}: {
-	indent: string;
-	insertion: string;
-}) => {
-	return insertion
-		.split(/\r?\n/)
-		.map((line) => `${indent}${line}`)
-		.join(insertion.includes('\r\n') ? '\r\n' : '\n');
-};
-
-const printInsertedJsx = ({
-	element,
-	input,
-	prettierConfigOverride,
-}: {
-	element: namedTypes.JSXElement | namedTypes.JSXFragment;
-	input: string;
-	prettierConfigOverride: Record<string, unknown> | null;
-}): string => {
-	const endOfLine = input.includes('\r\n') ? '\r\n' : '\n';
-	const unit = getIndentationUnit(input, prettierConfigOverride);
-	const printWidth = prettierConfigOverride?.printWidth;
-	const configuredTabWidth = prettierConfigOverride?.tabWidth;
-	const tabWidth =
-		typeof configuredTabWidth === 'number' &&
-		Number.isInteger(configuredTabWidth) &&
-		configuredTabWidth > 0
-			? configuredTabWidth
-			: 2;
-	recast.types.visit(element, {
-		visitObjectProperty(path) {
-			const {node} = path;
-			if (
-				!node.computed &&
-				node.key.type === 'StringLiteral' &&
-				identifierRegex.test(node.key.value)
-			) {
-				node.key = recast.types.builders.identifier(node.key.value);
-			}
-
-			this.traverse(path);
-			return undefined;
-		},
-	});
-	const printNode = (node: namedTypes.Node) => {
-		return recast.prettyPrint(node, {
-			objectCurlySpacing: prettierConfigOverride?.bracketSpacing !== false,
-			quote: prettierConfigOverride?.singleQuote === true ? 'single' : 'double',
-			tabWidth,
-			useTabs: false,
-			wrapColumn: typeof printWidth === 'number' ? printWidth : 80,
-		}).code;
-	};
-
-	const normalizeIndentation = (code: string) => {
-		return code
-			.split(/\r?\n/)
-			.map((line) => {
-				const spaces = line.match(/^ */)?.[0].length ?? 0;
-				const indentationLevels = Math.floor(spaces / tabWidth);
-				const remainingSpaces = spaces % tabWidth;
-				return `${unit.repeat(indentationLevels)}${' '.repeat(remainingSpaces)}${line.slice(spaces)}`;
-			})
-			.join(endOfLine);
-	};
-
-	const printOpeningElement = (opening: namedTypes.JSXOpeningElement) => {
-		const name = printNode(opening.name);
-		const attributes = (opening.attributes ?? []).map((attribute) => {
-			if (
-				attribute.type === 'JSXAttribute' &&
-				attribute.name.type === 'JSXIdentifier' &&
-				attribute.value?.type === 'StringLiteral'
-			) {
-				return `${attribute.name.name}=${JSON.stringify(attribute.value.value)}`;
-			}
-
-			return normalizeIndentation(printNode(attribute));
-		});
-		const suffix = opening.selfClosing ? ' />' : '>';
-		const singleLine = `<${name}${attributes.length === 0 ? '' : ` ${attributes.join(' ')}`}${suffix}`;
-		if (
-			!attributes.some((attribute) => attribute.includes(endOfLine)) &&
-			singleLine.length <= (typeof printWidth === 'number' ? printWidth : 80)
-		) {
-			return singleLine;
-		}
-
-		return [
-			`<${name}`,
-			...attributes.map((attribute) =>
-				indentInsertedJsx({indent: unit, insertion: attribute}),
-			),
-			opening.selfClosing ? '/>' : '>',
-		].join(endOfLine);
-	};
-
-	const printElement = (
-		node: namedTypes.JSXElement | namedTypes.JSXFragment,
-	): string => {
-		if (node.type === 'JSXFragment') {
-			const fragmentChildren = (node.children ?? []).flatMap((child) => {
-				if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
-					return [printElement(child)];
-				}
-
-				if (child.type === 'JSXText' && child.value.trim() === '') {
-					return [];
-				}
-
-				return [normalizeIndentation(printNode(child))];
-			});
-			return [
-				'<>',
-				...fragmentChildren.map((child) =>
-					indentInsertedJsx({indent: unit, insertion: child}),
-				),
-				'</>',
-			].join(endOfLine);
-		}
-
-		const opening = printOpeningElement(node.openingElement);
-		if (node.openingElement.selfClosing) {
-			return opening;
-		}
-
-		const closing = node.closingElement
-			? normalizeIndentation(printNode(node.closingElement))
-			: '';
-		const children = node.children ?? [];
-		if (
-			children.length === 1 &&
-			children[0].type === 'JSXText' &&
-			!children[0].value.includes('\n')
-		) {
-			return `${opening}${children[0].value}${closing}`;
-		}
-
-		const printedChildren = children.flatMap((child) => {
-			if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
-				return [printElement(child)];
-			}
-
-			if (child.type === 'JSXText' && child.value.trim() === '') {
-				return [];
-			}
-
-			return [normalizeIndentation(printNode(child))];
-		});
-		if (printedChildren.length === 0) {
-			return `${opening}${closing}`;
-		}
-
-		return [
-			opening,
-			...printedChildren.map((child) =>
-				indentInsertedJsx({indent: unit, insertion: child}),
-			),
-			closing,
-		].join(endOfLine);
-	};
-
-	return printElement(element);
 };
 
 const getInsertionSource = ({
@@ -3465,7 +3279,7 @@ export const insertJsxElementIntoProjectWithNodePathRemappings = async <
 }: {
 	project: Project;
 	request: InsertJsxElementRequest;
-	formatFile: InsertJsxElementCodemodEnvironment['formatFile'];
+	formatFile?: InsertJsxElementCodemodEnvironment['formatFile'];
 	svgMarkupToJsx: InsertJsxElementCodemodEnvironment['svgMarkupToJsx'];
 	wrapInSequence: {
 		dimensions: {width: number; height: number} | null;

--- a/packages/studio-codemods/src/insert-jsx-element.ts
+++ b/packages/studio-codemods/src/insert-jsx-element.ts
@@ -56,12 +56,6 @@ export type InsertJsxElementCodemodEnvironment = {
 	dirname: (fileName: string) => string;
 	extname: (fileName: string) => string;
 	fileExists: (fileName: string) => boolean;
-	// Kept optional for compatibility with callers from before source edits
-	// replaced the full-file formatting pass.
-	formatFile?: (input: {
-		contents: string;
-		prettierConfigOverride: Record<string, unknown> | null;
-	}) => Promise<{output: string; formatted: boolean}>;
 	isAbsolute: (fileName: string) => boolean;
 	join: (...parts: string[]) => string;
 	pathSeparator: string;
@@ -132,11 +126,9 @@ const relativeVirtualPath = (from: string, to: string) => {
 };
 
 export const makeInMemoryInsertJsxElementCodemodEnvironment = ({
-	formatFile,
 	project,
 	svgMarkupToJsx,
 }: {
-	formatFile?: InsertJsxElementCodemodEnvironment['formatFile'];
 	project: {files: Record<string, string>; rootDir: string};
 	svgMarkupToJsx: InsertJsxElementCodemodEnvironment['svgMarkupToJsx'];
 }): InsertJsxElementCodemodEnvironment => {
@@ -156,7 +148,6 @@ export const makeInMemoryInsertJsxElementCodemodEnvironment = ({
 		},
 		fileExists: (fileName) =>
 			filesByNormalizedPath.has(normalizeVirtualPath(fileName)),
-		formatFile,
 		isAbsolute: (fileName) => fileName.startsWith('/'),
 		join: (...parts) => resolveVirtualPath(...parts),
 		pathSeparator: '/',
@@ -3109,7 +3100,6 @@ export const insertJsxElementIntoComposition = async ({
 	source: string;
 	oldContents: string;
 	output: string;
-	formatted: boolean;
 	logLine: number;
 	nodePathRemappings: SequenceNodePathRemapping[];
 	insertedNodePath: SequenceNodePath | null;
@@ -3244,8 +3234,6 @@ export const insertJsxElementIntoComposition = async ({
 		],
 		input,
 	});
-	const formatted = true;
-
 	const {finalNodePathByNode, nodePathRemappings} = getNodePathRemappings({
 		ast,
 		captured: capturedNodePaths,
@@ -3261,7 +3249,6 @@ export const insertJsxElementIntoComposition = async ({
 		source: location.source,
 		oldContents: input,
 		output,
-		formatted,
 		insertedNodePath,
 		logLine,
 		nodePathRemappings,
@@ -3273,13 +3260,11 @@ export const insertJsxElementIntoProjectWithNodePathRemappings = async <
 >({
 	project,
 	request,
-	formatFile,
 	svgMarkupToJsx,
 	wrapInSequence,
 }: {
 	project: Project;
 	request: InsertJsxElementRequest;
-	formatFile?: InsertJsxElementCodemodEnvironment['formatFile'];
 	svgMarkupToJsx: InsertJsxElementCodemodEnvironment['svgMarkupToJsx'];
 	wrapInSequence: {
 		dimensions: {width: number; height: number} | null;
@@ -3299,7 +3284,6 @@ export const insertJsxElementIntoProjectWithNodePathRemappings = async <
 		compositionId: request.compositionId,
 		element: request.element,
 		environment: makeInMemoryInsertJsxElementCodemodEnvironment({
-			formatFile,
 			project,
 			svgMarkupToJsx,
 		}),

--- a/packages/studio-codemods/src/print-jsx.ts
+++ b/packages/studio-codemods/src/print-jsx.ts
@@ -1,0 +1,197 @@
+import type {namedTypes} from 'ast-types';
+import * as recast from 'recast';
+
+const identifierRegex = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+export const getIndentationUnit = (
+	input: string,
+	prettierConfigOverride: Record<string, unknown> | null,
+) => {
+	if (/^\t+/m.test(input)) {
+		return '\t';
+	}
+
+	const indentation = input.match(/^([ ]+)\S/m)?.[1].length;
+	if (indentation) {
+		return ' '.repeat(indentation > 1 ? indentation : 2);
+	}
+
+	if (prettierConfigOverride?.useTabs === true) {
+		return '\t';
+	}
+
+	const tabWidth = prettierConfigOverride?.tabWidth;
+	return ' '.repeat(
+		typeof tabWidth === 'number' && Number.isInteger(tabWidth) && tabWidth > 0
+			? tabWidth
+			: 2,
+	);
+};
+
+export const indentInsertedJsx = ({
+	indent,
+	insertion,
+}: {
+	indent: string;
+	insertion: string;
+}) => {
+	return insertion
+		.split(/\r?\n/)
+		.map((line) => `${indent}${line}`)
+		.join(insertion.includes('\r\n') ? '\r\n' : '\n');
+};
+
+export const printInsertedJsx = ({
+	element,
+	input,
+	prettierConfigOverride,
+}: {
+	element: namedTypes.JSXElement | namedTypes.JSXFragment;
+	input: string;
+	prettierConfigOverride: Record<string, unknown> | null;
+}): string => {
+	const endOfLine = input.includes('\r\n') ? '\r\n' : '\n';
+	const unit = getIndentationUnit(input, prettierConfigOverride);
+	const printWidth = prettierConfigOverride?.printWidth;
+	const configuredTabWidth = prettierConfigOverride?.tabWidth;
+	const tabWidth =
+		typeof configuredTabWidth === 'number' &&
+		Number.isInteger(configuredTabWidth) &&
+		configuredTabWidth > 0
+			? configuredTabWidth
+			: 2;
+	recast.types.visit(element, {
+		visitObjectProperty(path) {
+			const {node} = path;
+			if (
+				!node.computed &&
+				node.key.type === 'StringLiteral' &&
+				identifierRegex.test(node.key.value)
+			) {
+				node.key = recast.types.builders.identifier(node.key.value);
+			}
+
+			this.traverse(path);
+			return undefined;
+		},
+	});
+	const printNode = (node: namedTypes.Node) => {
+		return recast.prettyPrint(node, {
+			objectCurlySpacing: prettierConfigOverride?.bracketSpacing !== false,
+			quote: prettierConfigOverride?.singleQuote === true ? 'single' : 'double',
+			tabWidth,
+			useTabs: false,
+			wrapColumn: typeof printWidth === 'number' ? printWidth : 80,
+		}).code;
+	};
+
+	const normalizeIndentation = (code: string) => {
+		return code
+			.split(/\r?\n/)
+			.map((line) => {
+				const spaces = line.match(/^ */)?.[0].length ?? 0;
+				const indentationLevels = Math.floor(spaces / tabWidth);
+				const remainingSpaces = spaces % tabWidth;
+				return `${unit.repeat(indentationLevels)}${' '.repeat(remainingSpaces)}${line.slice(spaces)}`;
+			})
+			.join(endOfLine);
+	};
+
+	const printOpeningElement = (opening: namedTypes.JSXOpeningElement) => {
+		const name = printNode(opening.name);
+		const attributes = (opening.attributes ?? []).map((attribute) => {
+			if (
+				attribute.type === 'JSXAttribute' &&
+				attribute.name.type === 'JSXIdentifier' &&
+				attribute.value?.type === 'StringLiteral'
+			) {
+				return `${attribute.name.name}=${JSON.stringify(attribute.value.value)}`;
+			}
+
+			return normalizeIndentation(printNode(attribute));
+		});
+		const suffix = opening.selfClosing ? ' />' : '>';
+		const singleLine = `<${name}${attributes.length === 0 ? '' : ` ${attributes.join(' ')}`}${suffix}`;
+		if (
+			!attributes.some((attribute) => attribute.includes(endOfLine)) &&
+			singleLine.length <= (typeof printWidth === 'number' ? printWidth : 80)
+		) {
+			return singleLine;
+		}
+
+		return [
+			`<${name}`,
+			...attributes.map((attribute) =>
+				indentInsertedJsx({indent: unit, insertion: attribute}),
+			),
+			opening.selfClosing ? '/>' : '>',
+		].join(endOfLine);
+	};
+
+	const printElement = (
+		node: namedTypes.JSXElement | namedTypes.JSXFragment,
+	): string => {
+		if (node.type === 'JSXFragment') {
+			const fragmentChildren = (node.children ?? []).flatMap((child) => {
+				if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+					return [printElement(child)];
+				}
+
+				if (child.type === 'JSXText' && child.value.trim() === '') {
+					return [];
+				}
+
+				return [normalizeIndentation(printNode(child))];
+			});
+			return [
+				'<>',
+				...fragmentChildren.map((child) =>
+					indentInsertedJsx({indent: unit, insertion: child}),
+				),
+				'</>',
+			].join(endOfLine);
+		}
+
+		const opening = printOpeningElement(node.openingElement);
+		if (node.openingElement.selfClosing) {
+			return opening;
+		}
+
+		const closing = node.closingElement
+			? normalizeIndentation(printNode(node.closingElement))
+			: '';
+		const children = node.children ?? [];
+		if (
+			children.length === 1 &&
+			children[0].type === 'JSXText' &&
+			!children[0].value.includes('\n')
+		) {
+			return `${opening}${children[0].value}${closing}`;
+		}
+
+		const printedChildren = children.flatMap((child) => {
+			if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+				return [printElement(child)];
+			}
+
+			if (child.type === 'JSXText' && child.value.trim() === '') {
+				return [];
+			}
+
+			return [normalizeIndentation(printNode(child))];
+		});
+		if (printedChildren.length === 0) {
+			return `${opening}${closing}`;
+		}
+
+		return [
+			opening,
+			...printedChildren.map((child) =>
+				indentInsertedJsx({indent: unit, insertion: child}),
+			),
+			closing,
+		].join(endOfLine);
+	};
+
+	return printElement(element);
+};

--- a/packages/studio-codemods/src/split-jsx-sequence.ts
+++ b/packages/studio-codemods/src/split-jsx-sequence.ts
@@ -394,16 +394,9 @@ export const splitJsxSequence = ({
 	nodePath: SequenceNodePath;
 	sequenceKeys: string[];
 	splitFrame: number;
-	// Kept optional for compatibility with callers from before source edits
-	// replaced the full-file formatting pass.
-	formatFile?: (input: {
-		contents: string;
-		prettierConfigOverride: Record<string, unknown> | null;
-	}) => Promise<{output: string; formatted: boolean}>;
 	prettierConfigOverride?: Record<string, unknown> | null;
 }): Promise<{
 	output: string;
-	formatted: boolean;
 	nodeLabel: string;
 	logLine: number;
 	nodePathRemappings: SequenceNodePathRemapping[];
@@ -505,7 +498,6 @@ export const splitJsxSequence = ({
 
 	return Promise.resolve({
 		output,
-		formatted: true,
 		nodeLabel: getJsxElementTagLabel(jsxElement),
 		logLine:
 			jsxElement.openingElement.loc?.start.line ??

--- a/packages/studio-codemods/src/split-jsx-sequence.ts
+++ b/packages/studio-codemods/src/split-jsx-sequence.ts
@@ -15,6 +15,7 @@ import {
 	hasSequenceTimingTraits,
 	type SequenceNodePathRemapping,
 } from '@remotion/studio-shared';
+import type {namedTypes as AstNamedTypes} from 'ast-types';
 import * as recast from 'recast';
 import type {SequenceNodePath} from 'remotion';
 import {
@@ -25,11 +26,9 @@ import {
 	captureJsxNodePaths,
 	getNodePathRemappings,
 } from './get-node-path-remappings';
-import {
-	parseAst,
-	parseAstForReadOnly,
-	serializeAst,
-} from './sequence-props/parse-ast';
+import {printInsertedJsx} from './print-jsx';
+import {recastLocToOffset} from './recast-loc-to-offset';
+import {parseAst, parseAstForReadOnly} from './sequence-props/parse-ast';
 
 const {builders: b, namedTypes} = recast.types;
 
@@ -330,19 +329,74 @@ const insertAfter = (
 	return false;
 };
 
-export const splitJsxSequence = async ({
+const indentContinuationLines = ({
+	indent,
+	source,
+}: {
+	indent: string;
+	source: string;
+}) => {
+	const endOfLine = source.includes('\r\n') ? '\r\n' : '\n';
+	return source.split(/\r?\n/).join(`${endOfLine}${indent}`);
+};
+
+const getSplitSourceEdit = ({
+	input,
+	left,
+	prettierConfigOverride,
+	right,
+	wrapInFragment,
+}: {
+	input: string;
+	left: JSXElement;
+	prettierConfigOverride: Record<string, unknown> | null;
+	right: JSXElement;
+	wrapInFragment: boolean;
+}) => {
+	if (!left.loc) {
+		throw new Error('Cannot split a JSX sequence without a source location');
+	}
+
+	const start = recastLocToOffset(input, left.loc.start);
+	const end = recastLocToOffset(input, left.loc.end);
+	const lineStart = input.lastIndexOf('\n', start - 1) + 1;
+	const beforeElement = input.slice(lineStart, start);
+	const lineIndent = beforeElement.match(/^\s*/)?.[0] ?? '';
+	const isOnlyElementOnLine = beforeElement.trim() === '';
+	const endOfLine = input.includes('\r\n') ? '\r\n' : '\n';
+	const formattingConfig = prettierConfigOverride ?? null;
+	const print = (element: JSXElement | JSXFragment) =>
+		indentContinuationLines({
+			indent: lineIndent,
+			source: printInsertedJsx({
+				element: element as unknown as
+					| AstNamedTypes.JSXElement
+					| AstNamedTypes.JSXFragment,
+				input,
+				prettierConfigOverride: formattingConfig,
+			}),
+		});
+	const replacement = wrapInFragment
+		? print(makeFragment(left, right))
+		: `${print(left)}${isOnlyElementOnLine ? `${endOfLine}${lineIndent}` : ' '}${print(right)}`;
+
+	return {end, replacement, start};
+};
+
+export const splitJsxSequence = ({
 	input,
 	nodePath,
 	sequenceKeys,
 	splitFrame,
-	formatFile,
 	prettierConfigOverride,
 }: {
 	input: string;
 	nodePath: SequenceNodePath;
 	sequenceKeys: string[];
 	splitFrame: number;
-	formatFile: (input: {
+	// Kept optional for compatibility with callers from before source edits
+	// replaced the full-file formatting pass.
+	formatFile?: (input: {
 		contents: string;
 		prettierConfigOverride: Record<string, unknown> | null;
 	}) => Promise<{output: string; formatted: boolean}>;
@@ -425,29 +479,38 @@ export const splitJsxSequence = async ({
 		throw new Error('Cannot split JSX sequence with no parent');
 	}
 
+	const isJsxChild =
+		namedTypes.JSXElement.check(parentPath.node) ||
+		namedTypes.JSXFragment.check(parentPath.node);
 	if (!insertAfter(parentPath.node, jsxElement, right)) {
 		jsxPath.replace(makeFragment(jsxElement, right));
 	}
 
-	const finalFile = serializeAst(ast);
-	const {output, formatted} = await formatFile({
-		contents: finalFile,
+	const sourceEdit = getSplitSourceEdit({
+		input,
+		left: jsxElement,
 		prettierConfigOverride: prettierConfigOverride ?? null,
+		right,
+		wrapInFragment: !isJsxChild,
 	});
+	const output =
+		input.slice(0, sourceEdit.start) +
+		sourceEdit.replacement +
+		input.slice(sourceEdit.end);
 	const {nodePathRemappings} = getNodePathRemappings({
 		ast,
 		captured: capturedNodePaths,
 		output,
 	});
 
-	return {
+	return Promise.resolve({
 		output,
-		formatted,
+		formatted: true,
 		nodeLabel: getJsxElementTagLabel(jsxElement),
 		logLine:
 			jsxElement.openingElement.loc?.start.line ??
 			jsxElement.loc?.start.line ??
 			1,
 		nodePathRemappings,
-	};
+	});
 };

--- a/packages/studio-codemods/src/test/insert-solid.test.ts
+++ b/packages/studio-codemods/src/test/insert-solid.test.ts
@@ -76,12 +76,7 @@ export const MyComposition = () => {
 
 export const Root = () => <Composition id = "MyComp" component={MyComposition}/>;
 `;
-	let formatCalls = 0;
 	const result = await insertJsxElementIntoProjectWithNodePathRemappings({
-		formatFile: () => {
-			formatCalls++;
-			throw new Error('Prettier should not be called when inserting a Solid');
-		},
 		project: {
 			files: {'/project/src/index.tsx': source},
 			rootDir: '/project',
@@ -105,7 +100,6 @@ export const Root = () => <Composition id = "MyComp" component={MyComposition}/>
 		wrapInSequence: null,
 	});
 
-	expect(formatCalls).toBe(0);
 	expect(result.project.files['/project/src/index.tsx'])
 		.toBe(`import {Composition, AbsoluteFill, Solid} from 'remotion';
 
@@ -137,12 +131,7 @@ test('asset and component insertions also avoid the full-file formatter', async 
 export const MyComposition = () => <><AbsoluteFill /></>;
 export const Root = () => <Composition id="MyComp" component={MyComposition}/>;
 `;
-	let formatCalls = 0;
 	const assetResult = await insertJsxElementIntoProjectWithNodePathRemappings({
-		formatFile: () => {
-			formatCalls++;
-			throw new Error('The full-file formatter should not be called');
-		},
 		project: {
 			files: {'/project/src/index.tsx': source},
 			rootDir: '/project',
@@ -168,10 +157,6 @@ export const Root = () => <Composition id="MyComp" component={MyComposition}/>;
 	});
 	const componentResult =
 		await insertJsxElementIntoProjectWithNodePathRemappings({
-			formatFile: () => {
-				formatCalls++;
-				throw new Error('The full-file formatter should not be called');
-			},
 			project: {
 				files: {'/project/src/index.tsx': source},
 				rootDir: '/project',
@@ -195,7 +180,6 @@ export const Root = () => <Composition id="MyComp" component={MyComposition}/>;
 			wrapInSequence: null,
 		});
 
-	expect(formatCalls).toBe(0);
 	expect(assetResult.project.files['/project/src/index.tsx']).toContain(
 		'<CanvasImage\n',
 	);

--- a/packages/studio-server/src/codemods/split-jsx-sequence.ts
+++ b/packages/studio-server/src/codemods/split-jsx-sequence.ts
@@ -1,6 +1,5 @@
 import {splitJsxSequence as splitJsxSequenceCodemod} from '@remotion/studio-codemods';
 import type {SequenceNodePath} from 'remotion';
-import {formatFileContent} from './format-file-content';
 
 export const splitJsxSequence = ({
 	input,
@@ -20,10 +19,5 @@ export const splitJsxSequence = ({
 		nodePath,
 		sequenceKeys,
 		splitFrame,
-		formatFile: ({contents, prettierConfigOverride: override}) =>
-			formatFileContent({
-				input: contents,
-				prettierConfigOverride: override,
-			}),
 		prettierConfigOverride,
 	});

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -14,7 +14,6 @@ import type {
 	SequenceNodePathRemapping,
 } from '@remotion/studio-shared';
 import type {SequenceNodePath} from 'remotion';
-import {formatFileContent} from '../codemods/format-file-content';
 import {svgMarkupToJsx} from './svg-to-jsx';
 
 const makeCodemodEnvironment = (
@@ -24,8 +23,6 @@ const makeCodemodEnvironment = (
 	extname: path.extname,
 	fileExists: (fileName) =>
 		fs.existsSync(fileName) && fs.statSync(fileName).isFile(),
-	formatFile: ({contents, prettierConfigOverride}) =>
-		formatFileContent({input: contents, prettierConfigOverride}),
 	isAbsolute: path.isAbsolute,
 	join: path.join,
 	pathSeparator: path.sep,

--- a/packages/studio-server/src/helpers/resolve-composition-component.ts
+++ b/packages/studio-server/src/helpers/resolve-composition-component.ts
@@ -95,7 +95,6 @@ export const insertJsxElementIntoComposition = ({
 	source: string;
 	oldContents: string;
 	output: string;
-	formatted: boolean;
 	logLine: number;
 	nodePathRemappings: SequenceNodePathRemapping[];
 	insertedNodePath: SequenceNodePath | null;

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -19,7 +19,6 @@ import {
 	normalizeElementSourceForComparison,
 	validateElementInstallPosition,
 } from './element-install-plan';
-import {warnAboutPrettierOnce} from './log-updates/log-update';
 import {
 	getCodemodTimingPrefix,
 	withSourceFileWriteQueue,
@@ -288,10 +287,6 @@ export const insertElementHandler: ApiHandler<
 				{indent: false, logLevel},
 				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(compositionLocationLabel)} Added <${plan.componentName}>`,
 			);
-			if (!inserted.formatted) {
-				warnAboutPrettierOnce(logLevel);
-			}
-
 			printUndoHint(logLevel);
 
 			return {success: true, nodePathMutation};

--- a/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-jsx-element.ts
@@ -18,7 +18,6 @@ import {
 	pushToUndoStack,
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
-import {warnAboutPrettierOnce} from './log-updates/log-update';
 import {
 	getCodemodTimingPrefix,
 	withSourceFileWriteQueue,
@@ -248,7 +247,6 @@ export const insertJsxElementHandler: ApiHandler<
 				source,
 				oldContents,
 				output,
-				formatted,
 				insertedNodePath,
 				logLine,
 				nodePathRemappings,
@@ -305,13 +303,9 @@ export const insertJsxElementHandler: ApiHandler<
 				{indent: false, logLevel},
 				`${getCodemodTimingPrefix(logLevel)}${RenderInternals.chalk.blueBright(`${locationLabel}`)} Added ${elementLabel}`,
 			);
-			if (!formatted) {
-				warnAboutPrettierOnce(logLevel);
-			}
-
 			RenderInternals.Log.verbose(
 				{indent: false, logLevel},
-				`[insert-jsx-element] Wrote ${source}${formatted ? ' (formatted)' : ''}`,
+				`[insert-jsx-element] Wrote ${source}`,
 			);
 
 			printUndoHint(logLevel);

--- a/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
+++ b/packages/studio-server/src/preview-server/routes/split-jsx-sequence.ts
@@ -15,7 +15,6 @@ import {
 	pushToUndoStack,
 	suppressUndoStackInvalidation,
 } from '../undo-stack';
-import {warnAboutPrettierOnce} from './log-updates/log-update';
 import {
 	getCodemodTimingPrefix,
 	withSourceFileWriteQueue,
@@ -43,7 +42,7 @@ export const splitJsxSequenceHandler: ApiHandler<
 
 			const fileContents = readFileSync(absolutePath, 'utf-8');
 
-			const {output, formatted, nodeLabel, logLine, nodePathRemappings} =
+			const {output, nodeLabel, logLine, nodePathRemappings} =
 				await splitJsxSequence({
 					input: fileContents,
 					nodePath,
@@ -91,15 +90,9 @@ export const splitJsxSequenceHandler: ApiHandler<
 					`${locationLabel}`,
 				)} Split ${nodeLabel}`,
 			);
-			if (!formatted) {
-				warnAboutPrettierOnce(logLevel);
-			}
-
 			RenderInternals.Log.verbose(
 				{indent: false, logLevel},
-				`[split-jsx-sequence] Wrote ${fileRelativeToRoot}${
-					formatted ? ' (formatted)' : ''
-				}`,
+				`[split-jsx-sequence] Wrote ${fileRelativeToRoot}`,
 			);
 
 			printUndoHint(logLevel);

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -132,19 +132,13 @@ export const Comp = () => {
   )
 }
 `;
-	let formatCalls = 0;
 	const {output} = await splitJsxSequenceCodemod({
 		input,
 		nodePath: lineContainingToNodePath(input, '<Sequence'),
 		sequenceKeys: sequenceTimingKeys,
 		splitFrame: 30,
-		formatFile: () => {
-			formatCalls++;
-			throw new Error('Prettier should not be called when splitting a clip');
-		},
 	});
 
-	expect(formatCalls).toBe(0);
 	expect(output).toStartWith(
 		'const deliberatelyUnformatted = {value : true}\n',
 	);

--- a/packages/studio-server/src/test/split-jsx-sequence.test.ts
+++ b/packages/studio-server/src/test/split-jsx-sequence.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'bun:test';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
+import {splitJsxSequence as splitJsxSequenceCodemod} from '@remotion/studio-codemods';
 import {splitJsxSequence} from '../codemods/split-jsx-sequence';
 import {
 	createFileWatcherRegistry,
@@ -111,6 +112,75 @@ test('splitJsxSequence splits finite duration and trimBefore', async () => {
 	expect(output).toContain(
 		'<Sequence from={30} durationInFrames={30} trimBefore={25} />',
 	);
+});
+
+test('splitJsxSequence preserves surrounding formatting without calling Prettier', async () => {
+	const input = `const deliberatelyUnformatted = {value : true}
+
+export const Comp = () => {
+  return (
+    <>
+      <Sequence
+        name="clip"
+        from={0}
+        durationInFrames={50}
+      >
+        <div>Child</div>
+      </Sequence>
+      <Keep prop = {1}/>
+    </>
+  )
+}
+`;
+	let formatCalls = 0;
+	const {output} = await splitJsxSequenceCodemod({
+		input,
+		nodePath: lineContainingToNodePath(input, '<Sequence'),
+		sequenceKeys: sequenceTimingKeys,
+		splitFrame: 30,
+		formatFile: () => {
+			formatCalls++;
+			throw new Error('Prettier should not be called when splitting a clip');
+		},
+	});
+
+	expect(formatCalls).toBe(0);
+	expect(output).toStartWith(
+		'const deliberatelyUnformatted = {value : true}\n',
+	);
+	expect(output).toContain(
+		'<Sequence name="clip" from={0} durationInFrames={30}>\n',
+	);
+	expect(output).toContain(
+		'<Sequence name="clip" from={30} durationInFrames={20} trimBefore={30}>\n',
+	);
+	expect(output).toContain('      <Keep prop = {1}/>');
+	expect(output).toEndWith('  )\n}\n');
+});
+
+test('splitJsxSequence formats a split component root as a fragment', async () => {
+	const input = `export const Comp = () => <Sequence from={0} durationInFrames={50}><span>Hi</span></Sequence>;
+
+const keep = { value : true }
+`;
+	const {output} = await splitJsxSequenceCodemod({
+		input,
+		nodePath: lineContainingToNodePath(input, '<Sequence'),
+		sequenceKeys: sequenceTimingKeys,
+		splitFrame: 30,
+	});
+
+	expect(output).toBe(`export const Comp = () => <>
+  <Sequence from={0} durationInFrames={30}>
+    <span>Hi</span>
+  </Sequence>
+  <Sequence from={30} durationInFrames={20} trimBefore={30}>
+    <span>Hi</span>
+  </Sequence>
+</>;
+
+const keep = { value : true }
+`);
 });
 
 test('splitJsxSequence splits a video with a negative from', async () => {


### PR DESCRIPTION
## Summary

- format split JSX locally instead of running Prettier over the source file
- share the manual JSX printer between split and insertion codemods
- remove Prettier plumbing and warnings from desktop and Browser Studio insertion and split paths

## Tests

- `bun run build`
- `bun test src/test` in `packages/studio-codemods`
- `bun test src/test/split-jsx-sequence.test.ts src/test/resolve-composition-component.test.ts` in `packages/studio-server`
- `bun test src/test/browser-studio-operations.test.ts src/test/browser-studio-project-operations.test.ts` in `packages/browser-studio`
- package formatting and lint checks for `@remotion/studio-codemods`, `@remotion/studio-server`, and `@remotion/browser-studio`

The repository-wide `bun run stylecheck` is blocked by an unrelated, uncommitted formatting change in `packages/example/src/NewVideo.tsx`.
