### PR TITLE
`@remotion/studio`: Rename web render action to Render in browser

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -273,7 +273,7 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			await secondQuickSwitcherInput.press('Escape');
 
 			await studio.locator('[data-compname="MyComp"]').click();
-			await studio.getByRole('button', {name: 'Render on web'}).click();
+			await studio.getByRole('button', {name: 'Render in browser'}).click();
 			await expect(
 				studio.getByText('Input Props', {exact: true}),
 			).toBeVisible();
@@ -343,7 +343,7 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 				'MyComp / template-blank - Remotion Studio',
 				{timeout: 5000},
 			);
-			await studio.getByRole('button', {name: 'Render on web'}).click();
+			await studio.getByRole('button', {name: 'Render in browser'}).click();
 			await expect(
 				studio.getByText('Render MyComp', {exact: true}),
 			).toBeVisible();

--- a/packages/docs/docs/client-side-rendering/index.mdx
+++ b/packages/docs/docs/client-side-rendering/index.mdx
@@ -61,7 +61,7 @@ const {getBlob} = await renderMediaOnWeb({
 
 ## Remotion Studio
 
-Client-side rendering is always enabled in the Remotion Studio from <AvailableFrom v="4.0.491" inline />. Use the "Render on web" button to render in the browser.
+Client-side rendering is always enabled in the Remotion Studio from <AvailableFrom v="4.0.491" inline />. Use the "Render in browser" button to start a render.
 
 ## Telemetry
 

--- a/packages/docs/docs/contributing/web-renderer.mdx
+++ b/packages/docs/docs/contributing/web-renderer.mdx
@@ -75,7 +75,7 @@ Sloppy, unfiltered AI PRs will not be processed by us.
 
 ## Studio Render Button
 
-In [`packages/example`](/docs/contributing/#testing-your-changes), and in any template, you will see a "Render on web" button.
+In [`packages/example`](/docs/contributing/#testing-your-changes), and in any template, you will see a "Render in browser" button.
 
 ## See also
 

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -303,7 +303,7 @@ const RenderButtonInner: React.FC<{
 				{
 					type: 'item' as const,
 					id: 'client-render',
-					label: 'Render on web',
+					label: 'Render in browser',
 					value: 'client-render',
 					onClick: () => handleRenderTypeChange('client-render'),
 					keyHint: null,
@@ -360,7 +360,7 @@ const RenderButtonInner: React.FC<{
 			? 'Render'
 			: renderType === 'render-command'
 				? 'Render via CLI'
-				: 'Render on web';
+				: 'Render in browser';
 	const showRenderLabel = !narrow || renderType !== 'server-render';
 	const segments = useMemo((): SegmentedButtonSegment[] => {
 		return [

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -264,7 +264,7 @@ const getRenderMenuItems = ({
 		{
 			id: 'render-on-web',
 			value: 'render-on-web',
-			label: 'Render on web...',
+			label: 'Render in browser...',
 			onClick: () => {
 				closeMenu();
 
@@ -278,7 +278,7 @@ const getRenderMenuItems = ({
 			keyHint: null,
 			leftItem: null,
 			subMenu: null,
-			quickSwitcherLabel: 'Render on web...',
+			quickSwitcherLabel: 'Render in browser...',
 		},
 		{
 			type: 'divider' as const,


### PR DESCRIPTION
## Summary

- rename the Studio client-side rendering action from “Render on web” to “Render in browser”
- update the command menu, Browser Studio end-to-end locators, and documentation to use the new wording

## Verification

- `bun run build`
- `bun run stylecheck`


## Preview

- [Client-side rendering](https://remotion-git-codex-rename-browser-render-button-remotion.vercel.app/docs/client-side-rendering)
- [Contributing to client-side rendering](https://remotion-git-codex-rename-browser-render-button-remotion.vercel.app/docs/contributing/web-renderer)
