### PR TITLE
`@remotion/bundler`: Enable incremental chunk graph builds

### DIFF
--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -85,6 +85,7 @@ export const rspackConfig = async ({
 		experiments: {
 			...sharedBaseConfig.experiments,
 			...(environment === 'development'
+				// Makes the first HMR event faster. 
 				? {incremental: {buildChunkGraph: true}}
 				: {}),
 		},

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -79,8 +79,15 @@ export const rspackConfig = async ({
 		},
 	};
 
+	const sharedBaseConfig = getBaseConfig(environment, poll);
 	const baseConfig = {
-		...getBaseConfig(environment, poll),
+		...sharedBaseConfig,
+		experiments: {
+			...sharedBaseConfig.experiments,
+			...(environment === 'development'
+				? {incremental: {buildChunkGraph: true}}
+				: {}),
+		},
 		// Remove once https://github.com/huggingface/transformers.js/issues/1759 is resolved.
 		ignoreWarnings: [
 			{

--- a/packages/bundler/src/test/override-order.test.ts
+++ b/packages/bundler/src/test/override-order.test.ts
@@ -59,6 +59,17 @@ test('applies the shared override before the Rspack override', async () => {
 	expect(config.name).toBe('shared-rspack-rspack');
 });
 
+test('enables incremental chunk graphs for Rspack development builds', async () => {
+	const [, config] = await rspackConfig({
+		...baseOptions,
+		environment: 'development',
+		bundlerOverride: (configuration) => configuration,
+		rspackOverride: (configuration) => configuration,
+	});
+
+	expect(config.experiments?.incremental).toEqual({buildChunkGraph: true});
+});
+
 test('includes React Scan only in an explicitly enabled development bundle', async () => {
 	const previousEndpoint = process.env.REMOTION_REACT_SCAN_ENDPOINT;
 	const previousEntryPoint = process.env.REMOTION_REACT_SCAN_ENTRY_POINT;

--- a/packages/bundler/src/test/override-order.test.ts
+++ b/packages/bundler/src/test/override-order.test.ts
@@ -59,17 +59,6 @@ test('applies the shared override before the Rspack override', async () => {
 	expect(config.name).toBe('shared-rspack-rspack');
 });
 
-test('enables incremental chunk graphs for Rspack development builds', async () => {
-	const [, config] = await rspackConfig({
-		...baseOptions,
-		environment: 'development',
-		bundlerOverride: (configuration) => configuration,
-		rspackOverride: (configuration) => configuration,
-	});
-
-	expect(config.experiments?.incremental).toEqual({buildChunkGraph: true});
-});
-
 test('includes React Scan only in an explicitly enabled development bundle', async () => {
 	const previousEndpoint = process.env.REMOTION_REACT_SCAN_ENDPOINT;
 	const previousEntryPoint = process.env.REMOTION_REACT_SCAN_ENTRY_POINT;


### PR DESCRIPTION
## Summary

- enable Rspack's incremental chunk graph for development builds
- leave Webpack and production bundling unchanged
- verify the development configuration with a focused regression test

## Motivation

The first Studio rebuild after splitting a `<Video>` took 1,759 ms without incremental chunk graph reuse. With `buildChunkGraph` enabled, the same rebuild took 392 ms, a reduction of about 78%.

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test src` from `packages/bundler`
- manually split and undo a `<Video>` in a freshly started Studio

