### PR TITLE
`@remotion/studio`: Fix timeline media jitter when trimming

### DIFF
--- a/packages/studio/src/components/AudioWaveform.tsx
+++ b/packages/studio/src/components/AudioWaveform.tsx
@@ -22,19 +22,17 @@ const getContainerStyle = (height: number): React.CSSProperties => {
 		position: 'relative',
 		width: '100%',
 		height,
+		overflow: 'hidden',
 	};
 };
 
 const waveformCanvasStyle: React.CSSProperties = {
 	pointerEvents: 'none',
-	width: '100%',
-	height: '100%',
+	flexShrink: 0,
 };
 
 const volumeCanvasStyle: React.CSSProperties = {
 	position: 'absolute',
-	width: '100%',
-	height: '100%',
 };
 
 const parseVolume = (volume: string | number): WaveformVolume => {
@@ -161,16 +159,19 @@ const AudioWaveformInner: React.FC<{
 		const pixelRatio = window.devicePixelRatio;
 		const h = Math.ceil(height * pixelRatio);
 		const w = Math.ceil(visualizationWidth * pixelRatio);
+		const drawingWidth = visualizationWidth * pixelRatio;
 
 		canvasElement.width = w;
 		canvasElement.height = h;
+		canvasElement.style.width = w / pixelRatio + 'px';
+		canvasElement.style.height = h / pixelRatio + 'px';
 
 		drawBars({
 			canvas: canvasElement,
 			peaks: portionPeaks ?? EMPTY_PEAKS,
 			color: WHITE_ALPHA_60,
 			volume: visibleVolume,
-			width: w,
+			width: drawingWidth,
 		});
 	}, [height, portionPeaks, visibleVolume, visualizationWidth]);
 
@@ -187,6 +188,7 @@ const AudioWaveformInner: React.FC<{
 		const pixelRatio = window.devicePixelRatio;
 		const h = Math.ceil(height * pixelRatio);
 		const w = Math.ceil(visualizationWidth * pixelRatio);
+		const drawingWidth = visualizationWidth * pixelRatio;
 		const context = volumeCanvasElement.getContext('2d');
 		if (!context) {
 			return;
@@ -194,6 +196,8 @@ const AudioWaveformInner: React.FC<{
 
 		volumeCanvasElement.width = w;
 		volumeCanvasElement.height = h;
+		volumeCanvasElement.style.width = w / pixelRatio + 'px';
+		volumeCanvasElement.style.height = h / pixelRatio + 'px';
 
 		context.clearRect(0, 0, w, h);
 		if (!Array.isArray(visibleVolume)) {
@@ -206,7 +210,7 @@ const AudioWaveformInner: React.FC<{
 			const x =
 				visibleVolume.length <= 1
 					? 0
-					: (index / (visibleVolume.length - 1)) * w;
+					: (index / (visibleVolume.length - 1)) * drawingWidth;
 			const y = (1 - v) * (h - TIMELINE_BORDER * 2 * pixelRatio) + pixelRatio;
 			if (index === 0) {
 				context.moveTo(x, y);

--- a/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
+++ b/packages/studio/src/components/Timeline/TimelineVideoInfo.tsx
@@ -37,6 +37,7 @@ const filmstripContainerStyle: React.CSSProperties = {
 	height: TIMELINE_LAYER_FILMSTRIP_HEIGHT,
 	backgroundColor: BLACK_ALPHA_30,
 	display: 'flex',
+	overflow: 'hidden',
 	borderTopLeftRadius: 2,
 	fontSize: 10,
 	fontFamily: 'Arial, Helvetica',
@@ -111,8 +112,8 @@ const TimelineVideoInfoSegment: React.FC<{
 		const canvas = document.createElement('canvas');
 		canvas.width = Math.ceil(visualizationWidth * pixelRatio);
 		canvas.height = Math.ceil(TIMELINE_LAYER_FILMSTRIP_HEIGHT * pixelRatio);
-		canvas.style.width = visualizationWidth + 'px';
-		canvas.style.height = TIMELINE_LAYER_FILMSTRIP_HEIGHT + 'px';
+		canvas.style.width = canvas.width / pixelRatio + 'px';
+		canvas.style.height = canvas.height / pixelRatio + 'px';
 		const ctx = canvas.getContext('2d');
 		if (!ctx) {
 			return;
@@ -251,7 +252,10 @@ const TimelineVideoInfoSegment: React.FC<{
 		const filledSlots = new Map<number, number | undefined>();
 
 		const {fromSeconds, toSeconds} = times;
-		const targetWidth = targetCanvas.width;
+		// Keep the time-to-pixel scale independent of the integer canvas backing size.
+		const targetWidth = tiledLoop
+			? tiledLoop.loopWidth * pixelRatio
+			: visualizationWidth * pixelRatio;
 		const repeatTarget = () => {
 			if (!tiledLoop) {
 				return;

--- a/packages/timeline-utils/src/render-frame-strip.ts
+++ b/packages/timeline-utils/src/render-frame-strip.ts
@@ -132,14 +132,13 @@ export const drawSlot = ({
 	const relativeTimestamp = timestamp - fromSeconds * WEBCODECS_TIMESCALE;
 	const frameIndex = relativeTimestamp / durationOfOneFrame;
 	const thumbnailWidth = frame.displayWidth / devicePixelRatio;
-	const left = Math.floor(frameIndex * thumbnailWidth);
-	const right = Math.ceil((frameIndex + 1) * thumbnailWidth);
+	const left = frameIndex * thumbnailWidth;
 
 	ctx.drawImage(
 		frame,
 		left,
 		0,
-		right - left,
+		thumbnailWidth,
 		frame.displayHeight / devicePixelRatio,
 	);
 	filledSlots.set(timestamp, frame.timestamp);

--- a/packages/timeline-utils/src/test/render-frame-strip.test.ts
+++ b/packages/timeline-utils/src/test/render-frame-strip.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'bun:test';
+import {drawSlot, WEBCODECS_TIMESCALE} from '../render-frame-strip';
+
+test('filmstrip thumbnails keep their global position after a split', () => {
+	const frame = {
+		displayHeight: 52,
+		displayWidth: 92,
+		timestamp: 2 * WEBCODECS_TIMESCALE,
+	} as VideoFrame;
+	const pixelsPerSecond = 133.8;
+	const splitAtSeconds = 1.1;
+	const drawPositions: number[] = [];
+	const ctx = {
+		drawImage: (...args: unknown[]) => {
+			drawPositions.push(args[1] as number);
+		},
+	} as unknown as CanvasRenderingContext2D;
+
+	drawSlot({
+		ctx,
+		devicePixelRatio: 1,
+		filledSlots: new Map(),
+		frame,
+		frameHeight: frame.displayHeight,
+		fromSeconds: 0,
+		segmentDuration: 3,
+		timestamp: frame.timestamp,
+		visualizationWidth: pixelsPerSecond * 3,
+	});
+	drawSlot({
+		ctx,
+		devicePixelRatio: 1,
+		filledSlots: new Map(),
+		frame,
+		frameHeight: frame.displayHeight,
+		fromSeconds: splitAtSeconds,
+		segmentDuration: 3 - splitAtSeconds,
+		timestamp: frame.timestamp,
+		visualizationWidth: pixelsPerSecond * (3 - splitAtSeconds),
+	});
+
+	const [positionBeforeSplit, positionAfterSplit] = drawPositions;
+	expect(positionAfterSplit + splitAtSeconds * pixelsPerSecond).toBeCloseTo(
+		positionBeforeSplit,
+		10,
+	);
+});


### PR DESCRIPTION
## Summary

- keep timeline filmstrip thumbnails aligned while trimming or splitting video layers
- render filmstrip and waveform canvases at a stable device-pixel scale
- keep audio peak and volume-overlay positioning independent of rounded canvas backing dimensions

## Test plan

- `bun run build`
- `bun run stylecheck`
- visually verified video filmstrip and audio waveform continuity in the `NewVideo` Studio testbed
- red/green verified the filmstrip split-position regression test
