### PR TITLE
`@remotion/studio`: Fix context menu actions triggering on right-click

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1665,19 +1665,9 @@ test.describe('visual mode', () => {
 					exact: true,
 				}),
 			).toBeVisible();
-			const deleteSelected = contextMenu.getByRole('button', {
-				name: 'Delete selected',
-				exact: true,
-			});
-			await deleteSelected.dispatchEvent('pointerup', {button: 2});
-			await expect(deleteSelected).toBeVisible();
-			expect(fs.readFileSync(sequenceShiftFile, 'utf-8')).toContain(
-				'name="Outer frame descendant"',
-			);
-			expect(fs.readFileSync(sequenceShiftFile, 'utf-8')).toContain(
-				'name="Local frame descendant"',
-			);
-			await deleteSelected.click();
+			await contextMenu
+				.getByRole('button', {name: 'Delete selected', exact: true})
+				.click();
 
 			await expect
 				.poll(() => {

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1665,9 +1665,19 @@ test.describe('visual mode', () => {
 					exact: true,
 				}),
 			).toBeVisible();
-			await contextMenu
-				.getByRole('button', {name: 'Delete selected', exact: true})
-				.click();
+			const deleteSelected = contextMenu.getByRole('button', {
+				name: 'Delete selected',
+				exact: true,
+			});
+			await deleteSelected.dispatchEvent('pointerup', {button: 2});
+			await expect(deleteSelected).toBeVisible();
+			expect(fs.readFileSync(sequenceShiftFile, 'utf-8')).toContain(
+				'name="Outer frame descendant"',
+			);
+			expect(fs.readFileSync(sequenceShiftFile, 'utf-8')).toContain(
+				'name="Local frame descendant"',
+			);
+			await deleteSelected.click();
 
 			await expect
 				.poll(() => {

--- a/packages/studio/src/components/Menu/MenuSubItem.tsx
+++ b/packages/studio/src/components/Menu/MenuSubItem.tsx
@@ -107,7 +107,7 @@ export const MenuSubItem: React.FC<{
 
 	const onPointerUp = useCallback(
 		(e: PointerEvent<HTMLDivElement>) => {
-			if (disabled) {
+			if (disabled || e.button !== 0) {
 				return;
 			}
 


### PR DESCRIPTION
## Summary

- Ignore non-primary pointer releases on Studio menu items
- Cover secondary-click behavior in the existing timeline context menu E2E workflow

## Testing

- `bunx playwright test e2e/studio.test.mts --grep "should apply a timeline context menu action to multiple selected sequences"`
- `bun run build`
- `bun run stylecheck`
