### PR TITLE
`@remotion/studio`: Distinguish browser and server render modals

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -345,7 +345,7 @@ test('loads Browser Studio, opens external links, and can add, delete, and dupli
 			);
 			await studio.getByRole('button', {name: 'Render on web'}).click();
 			await expect(
-				studio.getByText('Render MyComp', {exact: true}),
+				studio.getByText('Render MyComp in the browser', {exact: true}),
 			).toBeVisible();
 			await studio.locator('body').press('Escape');
 			await expect

--- a/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
@@ -1403,7 +1403,9 @@ const RenderModal: React.FC<
 	}, [availablePixelFormats, pixelFormat]);
 	return (
 		<div style={outerModalStyle}>
-			<ModalHeader title={`Render ${resolvedComposition.id}`} />
+			<ModalHeader
+				title={`Render ${resolvedComposition.id} ${readOnlyStudio ? 'via CLI' : 'on server'}`}
+			/>
 			<div style={container}>
 				<SegmentedControl items={renderTabOptions} needsWrapping={false} />
 				<div style={flexer} />

--- a/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/ServerRenderModal.tsx
@@ -1404,7 +1404,7 @@ const RenderModal: React.FC<
 	return (
 		<div style={outerModalStyle}>
 			<ModalHeader
-				title={`Render ${resolvedComposition.id} ${readOnlyStudio ? 'via CLI' : 'on server'}`}
+				title={`Render ${resolvedComposition.id} ${readOnlyStudio ? 'via CLI' : 'on the server'}`}
 			/>
 			<div style={container}>
 				<SegmentedControl items={renderTabOptions} needsWrapping={false} />

--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -632,7 +632,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 
 	return (
 		<div style={outerModalStyle}>
-			<ModalHeader title={`Render ${resolvedComposition.id} in browser`} />
+			<ModalHeader title={`Render ${resolvedComposition.id} in the browser`} />
 			<div style={containerStyle}>
 				<SegmentedControl items={renderTabOptions} needsWrapping={false} />
 				<div style={flexer} />

--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -632,7 +632,7 @@ const WebRenderModal: React.FC<WebRenderModalProps> = ({
 
 	return (
 		<div style={outerModalStyle}>
-			<ModalHeader title={`Render ${resolvedComposition.id}`} />
+			<ModalHeader title={`Render ${resolvedComposition.id} in browser`} />
 			<div style={containerStyle}>
 				<SegmentedControl items={renderTabOptions} needsWrapping={false} />
 				<div style={flexer} />


### PR DESCRIPTION
## Summary

- distinguish browser and server render modals in their titles
- label read-only rendering as a CLI render
- keep the composition ID prominent in each title

Closes #11027

## Validation

- `bun run build`
- `bun run stylecheck`
