### PR TITLE
`remotion`: Avoid logging dependencies in hooks

### DIFF
--- a/packages/core/LOGGING_AUDIT.md
+++ b/packages/core/LOGGING_AUDIT.md
@@ -1,0 +1,319 @@
+# Remotion Core Logging Mechanics Audit
+
+Scope: `packages/core`, including browser/runtime code in `src/` and the two
+package-maintenance scripts at the package root. This is a mechanics audit: it
+describes how messages are selected, shaped, emitted, and suppressed. It does
+not evaluate the logging architecture or propose a redesign.
+
+## Executive summary
+
+Core has two independent logging paths:
+
+1. `Log` in `src/log.ts` is the low-level, level-aware path. Most core callers
+   use a bound `Logger` from `src/logger.ts`; imperative callers can construct
+   one explicitly. It filters synchronously, maps the accepted call to a browser
+   console method, and adds renderer-only `Symbol` metadata.
+2. Direct `console.*` calls are used for user-facing warnings, media errors,
+   retry notices, migration output, and a few debugging/error reports. These do
+   not consult the configured log level, do not receive renderer metadata, and
+   use local conditions for suppression where applicable.
+
+`playbackLogging()` is not a separate transport. It formats an elapsed-time and
+topic prefix, then delegates to `Log.trace()`.
+
+### Bound logger
+
+`createLogger({logLevel, mountTime})` binds the repeated logging options and
+exposes `trace`, `verbose`, `info`, `warn`, `error`, and `playback` methods.
+Ordinary methods take a tag followed by console arguments. `playback` takes a
+tag and message and delegates to `playbackLogging()`.
+
+`useLogger()` in `src/use-logger.ts` creates one stable logger per hook instance.
+Its methods read the latest `LogLevelContext` value through a ref, so a log-level
+change affects the next emission without changing logger identity or
+retriggering effects and callbacks merely because logging configuration
+changed. The React hook is separate from the pure factory so `no-react` can
+continue importing `delay-render.ts` without pulling React into that entrypoint.
+
+## 1. Level-aware logger
+
+### Level ordering and filtering
+
+`src/log.ts` defines this ordered list:
+
+```text
+trace < verbose < info < warn < error
+```
+
+`isEqualOrBelowLogLevel(currentLevel, messageLevel)` compares the two array
+indexes. A message is emitted when the configured/current level is less than or
+equal to the message's level. Therefore:
+
+| Configured level | Emitted `Log` methods                       |
+| ---------------- | ------------------------------------------- |
+| `trace`          | `trace`, `verbose`, `info`, `warn`, `error` |
+| `verbose`        | `verbose`, `info`, `warn`, `error`          |
+| `info`           | `info`, `warn`, `error`                     |
+| `warn`           | `warn`, `error`                             |
+| `error`          | `error`                                     |
+
+`Log.error()` is unconditional rather than calling the comparison helper. This
+is mechanically equivalent for the currently valid `LogLevel` values.
+
+There is no runtime validation inside `Log`: callers are expected to supply a
+valid `LogLevel` TypeScript value.
+
+### Console method mapping
+
+| `Log` method | Console method  |
+| ------------ | --------------- |
+| `trace`      | `console.debug` |
+| `verbose`    | `console.debug` |
+| `info`       | `console.log`   |
+| `warn`       | `console.warn`  |
+| `error`      | `console.error` |
+
+Arguments otherwise retain their original types and order. The logger does not
+stringify errors or objects, add timestamps, capture stacks, batch messages, or
+catch console failures.
+
+### Renderer metadata
+
+Before emission, `transformArgs()` can prepend global-registry symbols to the
+argument array. This happens only when both are true:
+
+- `getRemotionEnvironment().isRendering` is true.
+- `getRemotionEnvironment().isClientSideRendering` is false.
+
+The prepended values are:
+
+```text
+Symbol.for("__remotion_level_<message level>")
+Symbol.for("__remotion_tag_<tag>")
+```
+
+The tag symbol is prepended after the level symbol, so a tagged renderer call
+reaches the console in this order:
+
+```text
+[tag symbol, level symbol, ...caller arguments]
+```
+
+No tag symbol is added when `tag` is `null`. The level symbol is always based on
+the method being called, not the configured threshold. Browser Player and
+Studio calls receive neither symbol.
+
+Within core's default environment detector, rendering means browser code with
+`window.process.env.NODE_ENV === "test"`, or production browser code with
+`window.remotion_puppeteerTimeout` defined. Core's detector always reports
+`isClientSideRendering: false`; a scoped environment supplied elsewhere can
+change that second condition.
+
+### Availability
+
+- The public package exports the `LogLevel` type, but not `Log`.
+- `Internals` exposes the existing `Log`, `LogLevelContext`, `useLogLevel`, and
+  `playbackLogging` compatibility surfaces for other Remotion packages.
+- `prefetch()` accepts an optional public `logLevel`; it defaults to `info`.
+- `continueRender()` reads `window.remotion_logLevel`, defaulting to `info`.
+
+## 2. Log-level propagation
+
+`RemotionRootContexts` receives a required `logLevel` and provides this value:
+
+```ts
+{logLevel, mountTime: Date.now()}
+```
+
+through `LogLevelContext`. The context default outside a provider is
+`{logLevel: 'info', mountTime: 0}`. Consequently, `useLogLevel()` does not throw
+when there is no provider; it returns `info`. Its explicit `null` error is only
+reachable if a provider supplies `null`.
+
+`useMountTime()` similarly returns `0` outside a provider. Its null check is
+effectively unreachable with the declared context shape because `mountTime` is
+typed as `number`, not `number | null`.
+
+The context value is memoized on `[logLevel]`. Changing the level creates a new
+`mountTime`, so playback elapsed-time prefixes restart when the configured log
+level changes. The stable logger begins reading the new values immediately but
+does not become an effect dependency. Context-preserving wrappers in
+`wrap-remotion-context.tsx` copy the complete logging context.
+
+Render setup writes the externally selected level to
+`window.remotion_logLevel`; Studio development HTML also initializes that
+global. Most React runtime paths do not read the global directly: their level
+arrives through `RemotionRootContexts` and `useLogLevel()`.
+
+## 3. Playback logging
+
+`playbackLogging({logLevel, tag, message, mountTime})` builds a visible prefix
+and calls:
+
+```ts
+Log.trace({logLevel, tag: null}, `[${tags}]`, message);
+```
+
+The visible `tags` string contains:
+
+- `<elapsed>ms ` when `mountTime` is truthy, calculated with
+  `Date.now() - mountTime` at the time of the call.
+- The supplied topic tag.
+
+Because the function passes `tag: null` to `Log.trace`, the topic is only human
+readable text. It does not become a renderer `__remotion_tag_*` symbol. Calls
+with `mountTime: null` (currently prefetch logging) produce `[prefetch]` without
+elapsed time. A `mountTime` of `0` is also treated as absent.
+
+All playback messages are trace-level and therefore silent at the default
+`info` level. They use `console.debug` when enabled.
+
+Playback topics and triggers are:
+
+| Topic      | Triggered mechanics                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------ |
+| `video`    | A preview video initializes; includes source, core version, and user agent.                      |
+| `play`     | Before calling a media element's `.play()`.                                                      |
+| `pause`    | Before pausing because playback stopped, pre/postmounting is active, or the Player is buffering. |
+| `seek`     | Before assigning `currentTime`; includes old/new time, source, and reason.                       |
+| `buffer`   | Media is marked/unmarked as buffering and its playback block is released.                        |
+| `load`     | `.load()` is called to make a media element acquire future data.                                 |
+| `buffer`   | Media buffering transitions, playback-block release, and first-frame buffering decisions.        |
+| `player`   | The aggregate Player enters or exits its buffer state.                                           |
+| `prefetch` | A prefetch finishes or is freed.                                                                 |
+
+The exact topic names come from the call sites. Several different buffering
+paths intentionally share the `buffer` topic; aggregate Player buffering uses
+the separate `player` topic.
+
+## 4. Other level-aware call sites
+
+| Level     | Tag                | Mechanics                                                                                                                                                                |
+| --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `trace`   | `[buffer-state]`   | Logs buffer-handle add (with a newly captured stack) and first removal. Duplicate `unblock()` calls return before logging.                                               |
+| `trace`   | `audio`            | Logs creation of a shared `AudioContext`.                                                                                                                                |
+| `trace`   | none               | Logs Web Audio amplification start and gain changes.                                                                                                                     |
+| `verbose` | none               | Logs one-time-per-source detection of variable-frame-rate media.                                                                                                         |
+| `verbose` | `delayRender()`    | During rendering only, logs a cleared delay handle with label, token, and elapsed duration.                                                                              |
+| `verbose` | `prefetch`         | Logs the start of a non-rendering prefetch.                                                                                                                              |
+| `verbose` | `audio`            | Logs when `AudioContext.getOutputTimestamp()` proves that resume advanced.                                                                                               |
+| `verbose` | `audio-scheduling` | Logs scheduled/media time ranges, timing lead or delay, latency, state, original timestamp, and start/schedule action. Uses browser `%c` formatting to color mismatches. |
+| `info`    | `<video>`          | After an autoplay failure in Player, explains that video will be muted/retried and points to `onAutoPlayError()`.                                                        |
+| `warn`    | none               | Warns once per loaded module when `AudioContext` is unsupported (browser only).                                                                                          |
+| `warn`    | none               | Emits three Safari volume/playback-rate warnings once per loaded module.                                                                                                 |
+| `warn`    | `audio`            | Reports a rejected `AudioContext.resume()` with the error, then the surrounding code resolves its synchronization wait and swallows the resumed promise rejection.       |
+
+There are no `logger.error()` consumers in current core runtime code;
+error-level output currently uses direct `console.error()`.
+
+## 5. Direct console logging
+
+These calls bypass `Log`. They are emitted regardless of configured log level
+and never receive renderer level/tag symbols.
+
+### Media loading and playback
+
+| File/path                              | Console call      | Exact emission condition                                                                                                                                     |
+| -------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `IFrame.tsx`                           | `error`           | An iframe emits `error` and no `onError` prop was supplied. Supplying `onError` suppresses the console message.                                              |
+| `Img.tsx`                              | `warn`            | An image load fails while its error count is within `maxRetries`; includes exponential backoff.                                                              |
+| `Img.tsx`                              | `info`            | An image later completes after one or more recorded failures.                                                                                                |
+| `Img.tsx`                              | `warn`            | `HTMLImageElement.decode()` rejects before fallback to the `load` event. This can be followed by normal completion.                                          |
+| `canvas-image/CanvasImage.tsx`         | `warn`            | Image decoding/loading fails while retry count is within `maxRetries`; includes exponential backoff.                                                         |
+| `audio/html5-audio.tsx`                | `log`             | Every native audio error, before deciding whether it is fatal. Prints `MediaError` directly.                                                                 |
+| `audio/html5-audio.tsx`                | `warn`            | A non-looping audio tag errors. It is emitted even when `onError` is also called.                                                                            |
+| `video/VideoForPreview.tsx`            | `error`           | A preview video error event has a non-null `current.error`; occurs before custom `onError` handling.                                                         |
+| `video/VideoForRendering.tsx`          | `error`           | A rendering video error event occurs; prints the current media error.                                                                                        |
+| `play-and-handle-not-allowed-error.ts` | `log`             | `.play()` rejects after known pause/abort/source-replacement/unmount cases are filtered out. This happens before custom autoplay handling or mute-and-retry. |
+| `warn-about-non-seekable-media.ts`     | `warn` or `error` | A media element has exactly one seekable range of `0..0`. Mode selects warning, error, or thrown exception. Console modes are deduplicated by source.        |
+
+The image retry delay is `1000 * 2 ** (errorCount - 1)` milliseconds. Retry
+messages are not deduplicated because each retry attempt is intentionally
+reported.
+
+### API usage and compatibility warnings
+
+| File/path                  | Console call       | Suppression and behavior                                                                                                                                                           |
+| -------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config/input-props.ts`    | three `warn` calls | Server-side `getInputProps()` call; once per loaded module. Returns `{}`.                                                                                                          |
+| `get-static-files.ts`      | `warn`             | Server use and Player use have independent once-per-module flags. Returns `[]`.                                                                                                    |
+| `watch-static-file.ts`     | `warn`             | Every call made outside Studio. Returns a no-op cancel handle.                                                                                                                     |
+| `static-file.ts`           | `warn`             | Unsafe encoded-character guidance; deduplicated by the complete message string for the module lifetime.                                                                            |
+| `use-media-in-timeline.ts` | `warn`             | Media/timeline warning; deduplicated by complete message string for the module lifetime.                                                                                           |
+| `prefetch.ts`              | `warn`             | A fetched response lacks a usable media/image content type and no valid override was supplied. The prefetch continues.                                                             |
+| `index.ts` `Config` proxy  | nine `warn` calls  | Calling an extracted legacy CLI config method prints a migration block, then calls `process.exit(1)`. Property reads for known config namespaces return the proxy without logging. |
+
+`warnAboutNonSeekableMedia()` only records its source as warned after it emits
+or throws. Module-level once maps and booleans persist for the lifetime of that
+loaded module instance; they are not persisted across reloads or shared across
+separately bundled copies of core.
+
+## 6. Package-maintenance script output
+
+These files run during core packaging/maintenance rather than normal library
+runtime:
+
+| File                        | Mechanics                                                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bundle.ts`                 | Throws when invoked without production `NODE_ENV`. Uses `console.error()` and exits when the active Bun version does not satisfy `^1.1.7`; uses `console.log('Done.')` after the bundle checks complete. Other failures throw. |
+| `ensure-correct-version.ts` | Logs missing version replacements in each dist file and logs the updated version after processing. It throws if stale-version dist files still exist.                                                                          |
+
+They do not import or use `Log`, and package log-level settings cannot affect
+them.
+
+## 7. Mechanical findings
+
+1. **Configured levels govern only `Log` calls.** All direct console emissions
+   listed above remain visible at `logLevel="error"` or any other setting.
+2. **Renderer metadata exists only on the `Log` path.** Direct console messages
+   have no `__remotion_level_*` or `__remotion_tag_*` symbols for a renderer-side
+   consumer to classify.
+3. **Playback topic tags are visible strings, not metadata tags.** The renderer
+   receives a trace-level symbol for them but no topic/tag symbol because
+   `playbackLogging()` delegates with `tag: null`.
+4. **Changing log level resets elapsed playback timing, but not logging-related
+   effects.** `mountTime` is created in the same memo as `logLevel`, while the
+   stable logger reads the replacement context without changing identity.
+5. **Several handled errors are logged before handling.** Preview video errors,
+   non-looping audio errors, and autoplay rejections can still print even when a
+   user callback handles the condition. Iframe errors are the exception: its
+   direct console error occurs only without an `onError` callback.
+6. **Warning deduplication is local and process/module scoped.** There is no
+   shared registry. The keys differ by implementation: booleans, full message
+   strings, or media source URLs.
+7. **`useLogLevel()`'s missing-provider error is not the fallback behavior.**
+   With the actual context default, a missing provider silently uses `info`.
+
+## 8. End-to-end examples
+
+### Trace playback in Player or Studio
+
+```text
+caller -> logger.playback()
+       -> playbackLogging()
+       -> computes "[123ms seek]"
+       -> Log.trace({logLevel: "trace", tag: null}, prefix, message)
+       -> passes threshold
+       -> console.debug(prefix, message)
+```
+
+### Tagged warning during server rendering
+
+```text
+caller -> Log.warn({logLevel: "info", tag: "audio"}, message, error)
+       -> passes threshold
+       -> transformArgs() prepends level symbol, then tag symbol
+       -> console.warn(tagSymbol, levelSymbol, message, error)
+```
+
+### Direct image retry warning
+
+```text
+image error -> increment per-source attempt count
+            -> compute exponential backoff
+            -> console.warn(message)
+            -> schedule retry
+```
+
+No configured threshold, renderer metadata, or central logger participates in
+the third flow.

--- a/packages/core/src/audio/AudioForPreview.tsx
+++ b/packages/core/src/audio/AudioForPreview.tsx
@@ -10,7 +10,6 @@ import React, {
 	useState,
 } from 'react';
 import {getCrossOriginValue} from '../get-cross-origin-value.js';
-import {useLogLevel} from '../log-level-context.js';
 import {usePreload} from '../prefetch.js';
 import {random} from '../random.js';
 import {SequenceContext} from '../SequenceContext.js';
@@ -51,8 +50,6 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 			'Cannot change the behavior for pre-mounting audio tags dynamically.',
 		);
 	}
-
-	const logLevel = useLogLevel();
 
 	const {
 		volume,
@@ -218,7 +215,6 @@ const AudioForDevelopmentForwardRefFunction: React.ForwardRefRenderFunction<
 	});
 
 	useVolume({
-		logLevel,
 		mediaRef: audioRef,
 		source: mediaElementSourceNode,
 		volume: userPreferredVolume,

--- a/packages/core/src/audio/shared-audio-tags.tsx
+++ b/packages/core/src/audio/shared-audio-tags.tsx
@@ -9,9 +9,8 @@ import React, {
 	useState,
 	type AudioHTMLAttributes,
 } from 'react';
-import {useLogLevel, useMountTime} from '../log-level-context.js';
-import {Log} from '../log.js';
 import {playAndHandleNotAllowedError} from '../play-and-handle-not-allowed-error.js';
+import {useLogger} from '../use-logger.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import type {SharedElementSourceNode} from './shared-element-source-node.js';
 import {makeSharedElementSourceNode} from './shared-element-source-node.js';
@@ -197,7 +196,7 @@ export const SharedAudioContextProvider: React.FC<{
 	readonly audioEnabled: boolean;
 	readonly previewSampleRate: number | null;
 }> = ({children, audioLatencyHint, audioEnabled, previewSampleRate}) => {
-	const logLevel = useLogLevel();
+	const logger = useLogger();
 	const sampleRate = previewSampleRate ?? 48000;
 
 	useEffect(() => {
@@ -209,7 +208,6 @@ export const SharedAudioContextProvider: React.FC<{
 	}, [sampleRate]);
 
 	const ctxAndGain = useSingletonAudioContext({
-		logLevel,
 		latencyHint: audioLatencyHint,
 		audioEnabled,
 		sampleRate,
@@ -306,8 +304,8 @@ export const SharedAudioContextProvider: React.FC<{
 				prev.mediaEndTime !== null &&
 				Math.abs(mediaTime - prev.mediaEndTime) > 0.001;
 
-			Log.verbose(
-				{logLevel, tag: 'audio-scheduling'},
+			logger.verbose(
+				'audio-scheduling',
 				'scheduled %c%s%c %s %c%s%c %s %c%s%c %s %s %s %s %s',
 				scheduledMismatch ? 'color: red; font-weight: bold' : '',
 				scheduledTime.toFixed(4),
@@ -351,7 +349,9 @@ export const SharedAudioContextProvider: React.FC<{
 						reason: 'missed ' + Math.abs(offset).toFixed(2) + 's',
 					};
 		};
-	}, [ctxAndGain, logLevel]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ctxAndGain]);
 
 	const resume = useCallback(() => {
 		if (!ctxAndGain) {
@@ -384,10 +384,10 @@ export const SharedAudioContextProvider: React.FC<{
 		const resumePromise = ctxAndGain.resume();
 
 		isResuming.current = new Promise<void>((resolve) => {
-			waitUntilActuallyResumed(ctxAndGain.audioContext, logLevel).then(resolve);
+			waitUntilActuallyResumed(ctxAndGain.audioContext, logger).then(resolve);
 			resumePromise.catch((err) => {
-				Log.warn(
-					{logLevel, tag: 'audio'},
+				logger.warn(
+					'audio',
 					'AudioContext resume rejected, continuing without audio sync',
 					err,
 				);
@@ -401,7 +401,9 @@ export const SharedAudioContextProvider: React.FC<{
 			// Already logged above; swallow to avoid unhandled rejection
 			// since callers (e.g. use-playback.ts) do not await this.
 		});
-	}, [ctxAndGain, logLevel]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ctxAndGain]);
 
 	const getIsResumingAudioContext = useCallback(() => {
 		return isResuming.current;
@@ -464,8 +466,7 @@ export const SharedAudioTagsContextProvider: React.FC<{
 		);
 	}
 
-	const logLevel = useLogLevel();
-	const mountTime = useMountTime();
+	const logger = useLogger();
 	const env = useRemotionEnvironment();
 	const audioCtx = useContext(SharedAudioContext);
 	const audioContext = audioCtx?.audioContext ?? null;
@@ -675,14 +676,15 @@ export const SharedAudioTagsContextProvider: React.FC<{
 				mediaRef: ref.ref,
 				mediaType: 'audio',
 				onAutoPlayError: null,
-				logLevel,
-				mountTime,
+				logger,
 				reason: 'playing all audios',
 				isPlayer: env.isPlayer,
 			});
 		});
 		resume?.();
-	}, [logLevel, mountTime, refs, env.isPlayer, resume]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [refs, env.isPlayer, resume]);
 
 	const audioTagsValue: SharedAudioTagsContextValue = useMemo(() => {
 		return {

--- a/packages/core/src/audio/use-audio-context.ts
+++ b/packages/core/src/audio/use-audio-context.ts
@@ -1,6 +1,6 @@
 import {useMemo, useRef} from 'react';
-import type {LogLevel} from '../log';
-import {Log} from '../log';
+import type {Logger} from '../logger.js';
+import {useLogger} from '../use-logger.js';
 import {useRemotionEnvironment} from '../use-remotion-environment';
 
 // The native AudioContext.state can be 'closed' | 'interrupted' | 'running' | 'suspended'.
@@ -13,7 +13,7 @@ export type RemotionAudioContextState =
 
 let warned = false;
 
-const warnOnce = (logLevel: LogLevel) => {
+const warnOnce = (logger: Logger) => {
 	if (warned) {
 		return;
 	}
@@ -22,24 +22,20 @@ const warnOnce = (logLevel: LogLevel) => {
 
 	// Don't pullute logs if in SSR
 	if (typeof window !== 'undefined') {
-		Log.warn(
-			{logLevel, tag: null},
-			'AudioContext is not supported in this browser',
-		);
+		logger.warn(null, 'AudioContext is not supported in this browser');
 	}
 };
 
 export const useSingletonAudioContext = ({
-	logLevel,
 	latencyHint,
 	audioEnabled,
 	sampleRate,
 }: {
-	logLevel: LogLevel;
 	latencyHint: AudioContextLatencyCategory;
 	audioEnabled: boolean;
 	sampleRate: number;
 }) => {
+	const logger = useLogger();
 	const env = useRemotionEnvironment();
 	const initialSampleRate = useRef(sampleRate);
 
@@ -59,7 +55,7 @@ export const useSingletonAudioContext = ({
 		}
 
 		if (typeof AudioContext === 'undefined') {
-			warnOnce(logLevel);
+			warnOnce(logger);
 			return null;
 		}
 
@@ -73,7 +69,7 @@ export const useSingletonAudioContext = ({
 
 		const gainNode = audioContext.createGain();
 		gainNode.connect(audioContext.destination);
-		Log.trace({logLevel, tag: 'audio'}, 'Creating new audio context');
+		logger.trace('audio', 'Creating new audio context');
 
 		audioContext.suspend();
 
@@ -128,7 +124,9 @@ export const useSingletonAudioContext = ({
 			resume,
 			suspend,
 		};
-	}, [logLevel, latencyHint, env.isRendering, audioEnabled, sampleRate]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [latencyHint, env.isRendering, audioEnabled, sampleRate]);
 
 	return context;
 };

--- a/packages/core/src/audio/wait-until-actually-resumed.ts
+++ b/packages/core/src/audio/wait-until-actually-resumed.ts
@@ -1,8 +1,8 @@
-import {Log, type LogLevel} from '../log.js';
+import type {Logger} from '../logger.js';
 
 export const waitUntilActuallyResumed = (
 	audioContext: AudioContext,
-	logLevel: LogLevel,
+	logger: Logger,
 ): Promise<void> => {
 	return new Promise((resolve) => {
 		const startCurrentTime = audioContext.currentTime;
@@ -22,8 +22,8 @@ export const waitUntilActuallyResumed = (
 				outputTimestamp.contextTime !== undefined &&
 				outputTimestamp.contextTime > startCurrentTime
 			) {
-				Log.verbose(
-					{logLevel, tag: 'audio'},
+				logger.verbose(
+					'audio',
 					`waitUntilActuallyResumed: getOutputTimestamp.performanceTime advanced from ${startOutputPerformanceTime.toFixed(
 						6,
 					)} to ${outputTimestamp.performanceTime.toFixed(

--- a/packages/core/src/buffer-until-first-frame.ts
+++ b/packages/core/src/buffer-until-first-frame.ts
@@ -1,7 +1,6 @@
 import {useCallback, useMemo, useRef} from 'react';
-import type {LogLevel} from './log';
-import {playbackLogging} from './playback-logging';
 import {useBufferState} from './use-buffer-state';
+import {useLogger} from './use-logger.js';
 
 const isSafariWebkit = () => {
 	const isSafari = /^((?!chrome|android).)*safari/i.test(
@@ -15,18 +14,15 @@ export const useBufferUntilFirstFrame = ({
 	mediaType,
 	onVariableFpsVideoDetected,
 	pauseWhenBuffering,
-	logLevel,
-	mountTime,
 }: {
 	mediaRef: React.RefObject<HTMLVideoElement | HTMLAudioElement | null>;
 	mediaType: 'video' | 'audio';
 	onVariableFpsVideoDetected: () => void;
 	pauseWhenBuffering: boolean;
-	logLevel: LogLevel;
-	mountTime: number | null;
 }) => {
 	const bufferingRef = useRef<boolean>(false);
 	const {delayPlayback} = useBufferState();
+	const logger = useLogger();
 
 	const bufferUntilFirstFrame = useCallback(
 		(requestedTime: number) => {
@@ -45,33 +41,27 @@ export const useBufferUntilFirstFrame = ({
 			}
 
 			if (current.readyState >= current.HAVE_FUTURE_DATA && !isSafariWebkit()) {
-				playbackLogging({
-					logLevel,
-					message: `Not using buffer until first frame, because readyState is ${current.readyState} and is not Safari or Desktop Chrome`,
-					mountTime,
-					tag: 'buffer',
-				});
+				logger.playback(
+					'buffer',
+					`Not using buffer until first frame, because readyState is ${current.readyState} and is not Safari or Desktop Chrome`,
+				);
 				return;
 			}
 
 			if (!current.requestVideoFrameCallback) {
-				playbackLogging({
-					logLevel,
-					message: `Not using buffer until first frame, because requestVideoFrameCallback is not supported`,
-					mountTime,
-					tag: 'buffer',
-				});
+				logger.playback(
+					'buffer',
+					'Not using buffer until first frame, because requestVideoFrameCallback is not supported',
+				);
 				return;
 			}
 
 			bufferingRef.current = true;
 
-			playbackLogging({
-				logLevel,
-				message: `Buffering ${mediaRef.current?.src} until the first frame is received`,
-				mountTime,
-				tag: 'buffer',
-			});
+			logger.playback(
+				'buffer',
+				`Buffering ${mediaRef.current?.src} until the first frame is received`,
+			);
 
 			const playback = delayPlayback();
 
@@ -109,12 +99,12 @@ export const useBufferUntilFirstFrame = ({
 				once: true,
 			});
 		},
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			delayPlayback,
-			logLevel,
 			mediaRef,
 			mediaType,
-			mountTime,
 			onVariableFpsVideoDetected,
 			pauseWhenBuffering,
 		],

--- a/packages/core/src/buffering.tsx
+++ b/packages/core/src/buffering.tsx
@@ -1,15 +1,12 @@
 import React, {
 	useCallback,
-	useContext,
 	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
 } from 'react';
-import type {LogLevel} from './log';
-import {LogLevelContext} from './log-level-context';
-import {playbackLogging} from './playback-logging';
+import {useLogger} from './use-logger.js';
 import {useRemotionEnvironment} from './use-remotion-environment';
 
 type Block = {
@@ -38,10 +35,7 @@ type BufferManager = {
 	buffering: React.RefObject<boolean>;
 };
 
-const useBufferManager = (
-	logLevel: LogLevel,
-	mountTime: number | null,
-): BufferManager => {
+const useBufferManager = (): BufferManager => {
 	const [blocks, setBlocks] = useState<Block[]>([]);
 	const [onBufferingCallbacks, setOnBufferingCallbacks] = useState<
 		OnBufferingCallback[]
@@ -51,6 +45,7 @@ const useBufferManager = (
 	>([]);
 
 	const env = useRemotionEnvironment();
+	const logger = useLogger();
 	const rendering = env.isRendering;
 
 	const buffering = useRef(false);
@@ -124,12 +119,7 @@ const useBufferManager = (
 		if (blocks.length > 0 && !buffering.current) {
 			buffering.current = true;
 			onBufferingCallbacks.forEach((c) => c());
-			playbackLogging({
-				logLevel,
-				message: 'Player is entering buffer state',
-				mountTime,
-				tag: 'player',
-			});
+			logger.playback('player', 'Player is entering buffer state');
 		}
 
 		// Intentionally only firing when blocks change, not the callbacks
@@ -152,12 +142,7 @@ const useBufferManager = (
 			if (blocks.length === 0 && buffering.current) {
 				buffering.current = false;
 				onResumeCallbacks.forEach((c) => c());
-				playbackLogging({
-					logLevel,
-					message: 'Player is exiting buffer state',
-					mountTime,
-					tag: 'player',
-				});
+				logger.playback('player', 'Player is exiting buffer state');
 			}
 			// Intentionally only firing when blocks change, not the callbacks
 			// otherwise a resume callback might remove itself after being called
@@ -178,8 +163,7 @@ export const BufferingContextReact = React.createContext<BufferManager | null>(
 export const BufferingProvider: React.FC<{
 	readonly children: React.ReactNode;
 }> = ({children}) => {
-	const {logLevel, mountTime} = useContext(LogLevelContext);
-	const bufferManager = useBufferManager(logLevel ?? 'info', mountTime);
+	const bufferManager = useBufferManager();
 
 	return (
 		<BufferingContextReact.Provider value={bufferManager}>

--- a/packages/core/src/delay-render.ts
+++ b/packages/core/src/delay-render.ts
@@ -3,8 +3,7 @@ import {
 	getErrorStackWithMessage,
 } from './cancel-render.js';
 import {getRemotionEnvironment} from './get-remotion-environment.js';
-import type {LogLevel} from './log.js';
-import {Log} from './log.js';
+import {createLogger, type Logger} from './logger.js';
 import type {RemotionEnvironment} from './remotion-environment-context.js';
 import {truthy} from './truthy.js';
 
@@ -141,14 +140,14 @@ type ContinueRenderInternalOptions = {
 	scope: DelayRenderScope;
 	handle: number;
 	environment: RemotionEnvironment;
-	logLevel: LogLevel;
+	logger: Logger;
 };
 
 export const continueRenderInternal = ({
 	scope,
 	handle,
 	environment,
-	logLevel,
+	logger,
 }: ContinueRenderInternalOptions): void => {
 	if (typeof handle === 'undefined') {
 		throw new TypeError(
@@ -175,7 +174,7 @@ export const continueRenderInternal = ({
 		]
 			.filter(truthy)
 			.join(' ');
-		Log.verbose({logLevel, tag: 'delayRender()'}, message);
+		logger.verbose('delayRender()', message);
 		delete scope.remotion_delayRenderTimeouts[handle];
 	}
 
@@ -201,6 +200,9 @@ export const continueRender = (handle: number): void => {
 		scope: window,
 		handle,
 		environment: getRemotionEnvironment(),
-		logLevel: window.remotion_logLevel ?? 'info',
+		logger: createLogger({
+			logLevel: window.remotion_logLevel ?? 'info',
+			mountTime: null,
+		}),
 	});
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -194,6 +194,7 @@ import {
 } from './use-current-scale.js';
 import {DelayRenderContextType} from './use-delay-render.js';
 import {useLazyComponent} from './use-lazy-component.js';
+import {useLogger} from './use-logger.js';
 import {useAudioEnabled, useVideoEnabled} from './use-media-enabled.js';
 import {
 	useBasicMediaInTimeline,
@@ -373,6 +374,7 @@ export const Internals = {
 	Log,
 	LogLevelContext,
 	useLogLevel,
+	useLogger,
 	playbackLogging,
 	timeValueRef,
 	compositionSelectorRef,

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -4,6 +4,7 @@ import {getRemotionEnvironment} from './get-remotion-environment';
 export const logLevels = ['trace', 'verbose', 'info', 'warn', 'error'] as const;
 
 export type LogLevel = (typeof logLevels)[number];
+export type LogArgs = Parameters<typeof console.log>;
 
 const getNumberForLogLevel = (level: LogLevel) => {
 	return logLevels.indexOf(level);
@@ -21,7 +22,7 @@ const transformArgs = ({
 	logLevel,
 	tag,
 }: {
-	args: Parameters<typeof console.log>;
+	args: LogArgs;
 	logLevel: LogLevel;
 	tag: string | null;
 }) => {
@@ -49,7 +50,7 @@ type Options = {
 	tag: string | null;
 };
 
-const verbose = (options: Options, ...args: Parameters<typeof console.log>) => {
+const verbose = (options: Options, ...args: LogArgs) => {
 	if (isEqualOrBelowLogLevel(options.logLevel, 'verbose')) {
 		return console.debug(
 			...transformArgs({args, logLevel: 'verbose', tag: options.tag}),
@@ -57,7 +58,7 @@ const verbose = (options: Options, ...args: Parameters<typeof console.log>) => {
 	}
 };
 
-const trace = (options: Options, ...args: Parameters<typeof console.log>) => {
+const trace = (options: Options, ...args: LogArgs) => {
 	if (isEqualOrBelowLogLevel(options.logLevel, 'trace')) {
 		return console.debug(
 			...transformArgs({args, logLevel: 'trace', tag: options.tag}),
@@ -65,7 +66,7 @@ const trace = (options: Options, ...args: Parameters<typeof console.log>) => {
 	}
 };
 
-const info = (options: Options, ...args: Parameters<typeof console.log>) => {
+const info = (options: Options, ...args: LogArgs) => {
 	if (isEqualOrBelowLogLevel(options.logLevel, 'info')) {
 		return console.log(
 			...transformArgs({args, logLevel: 'info', tag: options.tag}),
@@ -73,7 +74,7 @@ const info = (options: Options, ...args: Parameters<typeof console.log>) => {
 	}
 };
 
-const warn = (options: Options, ...args: Parameters<typeof console.log>) => {
+const warn = (options: Options, ...args: LogArgs) => {
 	if (isEqualOrBelowLogLevel(options.logLevel, 'warn')) {
 		return console.warn(
 			...transformArgs({args, logLevel: 'warn', tag: options.tag}),
@@ -81,7 +82,7 @@ const warn = (options: Options, ...args: Parameters<typeof console.log>) => {
 	}
 };
 
-const error = (options: Options, ...args: Parameters<typeof console.log>) => {
+const error = (options: Options, ...args: LogArgs) => {
 	return console.error(
 		...transformArgs({args, logLevel: 'error', tag: options.tag}),
 	);

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,40 @@
+import {Log, type LogArgs, type LogLevel} from './log.js';
+import {playbackLogging} from './playback-logging.js';
+
+export type Logger = {
+	trace: (tag: string | null, ...args: LogArgs) => void;
+	verbose: (tag: string | null, ...args: LogArgs) => void;
+	info: (tag: string | null, ...args: LogArgs) => void;
+	warn: (tag: string | null, ...args: LogArgs) => void;
+	error: (tag: string | null, ...args: LogArgs) => void;
+	playback: (tag: string, message: string) => void;
+};
+
+type LoggerOptions = {
+	logLevel: LogLevel;
+	mountTime: number | null;
+};
+
+export const createLoggerFromOptions = (
+	getOptions: () => LoggerOptions,
+): Logger => {
+	return {
+		trace: (tag, ...args) =>
+			Log.trace({logLevel: getOptions().logLevel, tag}, ...args),
+		verbose: (tag, ...args) =>
+			Log.verbose({logLevel: getOptions().logLevel, tag}, ...args),
+		info: (tag, ...args) =>
+			Log.info({logLevel: getOptions().logLevel, tag}, ...args),
+		warn: (tag, ...args) =>
+			Log.warn({logLevel: getOptions().logLevel, tag}, ...args),
+		error: (tag, ...args) =>
+			Log.error({logLevel: getOptions().logLevel, tag}, ...args),
+		playback: (tag, message) => {
+			const {logLevel, mountTime} = getOptions();
+			playbackLogging({logLevel, tag, message, mountTime});
+		},
+	};
+};
+
+export const createLogger = (options: LoggerOptions): Logger =>
+	createLoggerFromOptions(() => options);

--- a/packages/core/src/play-and-handle-not-allowed-error.ts
+++ b/packages/core/src/play-and-handle-not-allowed-error.ts
@@ -1,21 +1,18 @@
 import type {RefObject} from 'react';
-import {Log, type LogLevel} from './log';
-import {playbackLogging} from './playback-logging';
+import type {Logger} from './logger.js';
 
 export const playAndHandleNotAllowedError = ({
 	mediaRef,
 	mediaType,
 	onAutoPlayError,
-	logLevel,
-	mountTime,
+	logger,
 	reason,
 	isPlayer,
 }: {
 	mediaRef: RefObject<HTMLVideoElement | HTMLAudioElement | null>;
 	mediaType: 'audio' | 'video';
 	onAutoPlayError: null | (() => void);
-	logLevel: LogLevel;
-	mountTime: number;
+	logger: Logger;
 	reason: string;
 	isPlayer: boolean;
 }) => {
@@ -24,12 +21,10 @@ export const playAndHandleNotAllowedError = ({
 		return;
 	}
 
-	playbackLogging({
-		logLevel,
-		tag: 'play',
-		message: `Attempting to play ${current.src}. Reason: ${reason}`,
-		mountTime,
-	});
+	logger.playback(
+		'play',
+		`Attempting to play ${current.src}. Reason: ${reason}`,
+	);
 	const prom = current.play();
 	if (!prom.catch) {
 		return;
@@ -88,13 +83,13 @@ export const playAndHandleNotAllowedError = ({
 			}
 
 			if (mediaType === 'video' && isPlayer) {
-				Log.info(
-					{logLevel, tag: '<' + mediaType + '>'},
+				logger.info(
+					'<' + mediaType + '>',
 					`The video will be muted and we'll retry playing it.`,
 				);
 
-				Log.info(
-					{logLevel, tag: '<' + mediaType + '>'},
+				logger.info(
+					'<' + mediaType + '>',
 					'Use onAutoPlayError() to handle this error yourself.',
 				);
 				current.muted = true;

--- a/packages/core/src/prefetch.ts
+++ b/packages/core/src/prefetch.ts
@@ -1,8 +1,7 @@
 import {useContext} from 'react';
 import {getRemotionEnvironment} from './get-remotion-environment.js';
 import type {LogLevel} from './log.js';
-import {Log} from './log.js';
-import {playbackLogging} from './playback-logging.js';
+import {createLogger} from './logger.js';
 import {PreloadContext, setPreloads} from './prefetch-state.js';
 
 export const removeAndGetHashFragment = (src: string) => {
@@ -122,6 +121,7 @@ export const prefetch = (
 ): FetchAndPreload => {
 	const method = options?.method ?? 'blob-url';
 	const logLevel = options?.logLevel ?? 'info';
+	const logger = createLogger({logLevel, mountTime: null});
 	const srcWithoutHash = getSrcWithoutHash(src);
 
 	if (getRemotionEnvironment().isRendering) {
@@ -131,10 +131,7 @@ export const prefetch = (
 		};
 	}
 
-	Log.verbose(
-		{logLevel, tag: 'prefetch'},
-		`Starting prefetch ${srcWithoutHash}`,
-	);
+	logger.verbose('prefetch', `Starting prefetch ${srcWithoutHash}`);
 
 	let canceled = false;
 	let objectUrl: string | null = null;
@@ -215,12 +212,10 @@ export const prefetch = (
 				return;
 			}
 
-			playbackLogging({
-				logLevel,
-				tag: 'prefetch',
-				message: `Finished prefetch ${srcWithoutHash} with method ${method}`,
-				mountTime: null,
-			});
+			logger.playback(
+				'prefetch',
+				`Finished prefetch ${srcWithoutHash} with method ${method}`,
+			);
 
 			objectUrl = url as string;
 
@@ -240,12 +235,7 @@ export const prefetch = (
 
 	return {
 		free: () => {
-			playbackLogging({
-				logLevel,
-				tag: 'prefetch',
-				message: `Freeing ${srcWithoutHash}`,
-				mountTime: null,
-			});
+			logger.playback('prefetch', `Freeing ${srcWithoutHash}`);
 			if (objectUrl) {
 				if (method === 'blob-url') {
 					URL.revokeObjectURL(objectUrl);

--- a/packages/core/src/seek.ts
+++ b/packages/core/src/seek.ts
@@ -1,29 +1,24 @@
-import type {LogLevel} from './log';
-import {playbackLogging} from './playback-logging';
+import type {Logger} from './logger.js';
 import {isIosSafari} from './video/video-fragment';
 
 export const seek = ({
 	mediaRef,
 	time,
-	logLevel,
+	logger,
 	why,
-	mountTime,
 }: {
 	mediaRef: HTMLVideoElement | HTMLAudioElement;
 	time: number;
-	logLevel: LogLevel;
+	logger: Logger;
 	why: string;
-	mountTime: number;
 }): number => {
 	// iOS seeking does not support multiple decimals
 	const timeToSet = isIosSafari() ? Number(time.toFixed(1)) : time;
 
-	playbackLogging({
-		logLevel,
-		tag: 'seek',
-		message: `Seeking from ${mediaRef.currentTime} to ${timeToSet}. src= ${mediaRef.src} Reason: ${why}`,
-		mountTime,
-	});
+	logger.playback(
+		'seek',
+		`Seeking from ${mediaRef.currentTime} to ${timeToSet}. src= ${mediaRef.src} Reason: ${why}`,
+	);
 
 	mediaRef.currentTime = timeToSet;
 	return timeToSet;

--- a/packages/core/src/test/logger.test.tsx
+++ b/packages/core/src/test/logger.test.tsx
@@ -1,0 +1,82 @@
+import {
+	afterEach,
+	describe,
+	expect,
+	restoreAllMocks,
+	spyOn,
+	test,
+} from 'bun:test';
+import {cleanup, render} from '@testing-library/react';
+import type React from 'react';
+import {useEffect} from 'react';
+import {LogLevelContext} from '../log-level-context.js';
+import type {Logger} from '../logger.js';
+import {useLogger} from '../use-logger.js';
+
+afterEach(() => {
+	cleanup();
+	restoreAllMocks();
+});
+
+const LoggerProbe: React.FC<{
+	onLogger: (logger: Logger) => void;
+}> = ({onLogger}) => {
+	const logger = useLogger();
+
+	useEffect(() => {
+		onLogger(logger);
+	}, [logger, onLogger]);
+
+	return null;
+};
+
+describe('useLogger()', () => {
+	test('keeps loggers isolated between roots', () => {
+		const debug = spyOn(console, 'debug').mockImplementation(() => undefined);
+		let traceLogger!: Logger;
+		let errorLogger!: Logger;
+
+		render(
+			<>
+				<LogLevelContext.Provider value={{logLevel: 'trace', mountTime: 0}}>
+					<LoggerProbe onLogger={(logger) => (traceLogger = logger)} />
+				</LogLevelContext.Provider>
+				<LogLevelContext.Provider value={{logLevel: 'error', mountTime: 0}}>
+					<LoggerProbe onLogger={(logger) => (errorLogger = logger)} />
+				</LogLevelContext.Provider>
+			</>,
+		);
+
+		traceLogger.trace(null, 'visible');
+		errorLogger.trace(null, 'hidden');
+
+		expect(debug).toHaveBeenCalledTimes(1);
+		expect(debug.mock.calls[0]?.at(-1)).toBe('visible');
+	});
+
+	test('keeps its identity while reading the latest level', () => {
+		const debug = spyOn(console, 'debug').mockImplementation(() => undefined);
+		let logger!: Logger;
+		const onLogger = (newLogger: Logger) => {
+			logger = newLogger;
+		};
+
+		const result = render(
+			<LogLevelContext.Provider value={{logLevel: 'trace', mountTime: 0}}>
+				<LoggerProbe onLogger={onLogger} />
+			</LogLevelContext.Provider>,
+		);
+		const initialLogger = logger;
+
+		logger.trace(null, 'visible');
+		result.rerender(
+			<LogLevelContext.Provider value={{logLevel: 'error', mountTime: 0}}>
+				<LoggerProbe onLogger={onLogger} />
+			</LogLevelContext.Provider>,
+		);
+		logger.trace(null, 'hidden');
+
+		expect(logger).toBe(initialLogger);
+		expect(debug).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/test/ready-manager.test.ts
+++ b/packages/core/src/test/ready-manager.test.ts
@@ -5,6 +5,7 @@ import {
 	continueRenderInternal,
 	delayRender,
 } from '../delay-render.js';
+import {createLogger} from '../logger.js';
 
 describe('Ready Manager tests', () => {
 	let handle: number;
@@ -57,7 +58,7 @@ describe('Ready Manager tests', () => {
 				isStudio: false,
 			},
 			handle: unknownHandle,
-			logLevel: 'info',
+			logger: createLogger({logLevel: 'info', mountTime: null}),
 			scope,
 		});
 

--- a/packages/core/src/use-amplification.ts
+++ b/packages/core/src/use-amplification.ts
@@ -2,8 +2,8 @@ import {useContext, useLayoutEffect, useRef, type RefObject} from 'react';
 import {SharedAudioContext} from './audio/shared-audio-tags';
 import type {SharedElementSourceNode} from './audio/shared-element-source-node';
 import {isApproximatelyTheSame} from './is-approximately-the-same';
-import type {LogLevel} from './log';
-import {Log} from './log';
+import type {Logger} from './logger.js';
+import {useLogger} from './use-logger.js';
 import {isSafari} from './video/video-fragment';
 
 type AudioItems = {
@@ -12,23 +12,19 @@ type AudioItems = {
 
 let warned = false;
 
-const warnSafariOnce = (logLevel: LogLevel) => {
+const warnSafariOnce = (logger: Logger) => {
 	if (warned) {
 		return;
 	}
 
 	warned = true;
-	Log.warn(
-		{logLevel, tag: null},
+	logger.warn(
+		null,
 		'In Safari, setting a volume and a playback rate at the same time is buggy.',
 	);
-	Log.warn(
-		{logLevel, tag: null},
-		'In Desktop Safari, only volumes <= 1 will be applied.',
-	);
-	Log.warn(
-		{logLevel, tag: null},
-		logLevel,
+	logger.warn(null, 'In Desktop Safari, only volumes <= 1 will be applied.');
+	logger.warn(
+		null,
 		'In Mobile Safari, the volume will be ignored and set to 1 if a playbackRate is set.',
 	);
 };
@@ -41,17 +37,16 @@ const warnSafariOnce = (logLevel: LogLevel) => {
 export const useVolume = ({
 	mediaRef,
 	volume,
-	logLevel,
 	source,
 	shouldUseWebAudioApi,
 }: {
 	mediaRef: RefObject<HTMLAudioElement | HTMLVideoElement | null>;
 	source: SharedElementSourceNode | null;
 	volume: number;
-	logLevel: LogLevel;
 	shouldUseWebAudioApi: boolean;
 }) => {
 	const audioStuffRef = useRef<AudioItems | null>(null);
+	const logger = useLogger();
 	const currentVolumeRef = useRef(volume);
 	currentVolumeRef.current = volume;
 
@@ -81,7 +76,7 @@ export const useVolume = ({
 
 			// [1]
 			if (mediaRef.current.playbackRate !== 1 && isSafari()) {
-				warnSafariOnce(logLevel);
+				warnSafariOnce(logger);
 				return;
 			}
 
@@ -104,8 +99,8 @@ export const useVolume = ({
 				gainNode,
 			};
 
-			Log.trace(
-				{logLevel, tag: null},
+			logger.trace(
+				null,
 				`Starting to amplify ${mediaRef.current?.src}. Gain = ${currentVolumeRef.current}, playbackRate = ${mediaRef.current?.playbackRate}`,
 			);
 
@@ -114,14 +109,9 @@ export const useVolume = ({
 				gainNode.disconnect();
 				source.get().disconnect();
 			};
-		}, [
-			logLevel,
-			mediaRef,
-			audioContext,
-			source,
-			shouldUseWebAudioApi,
-			masterGainNode,
-		]);
+			// The logger has stable identity and reads the latest context.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [mediaRef, audioContext, source, shouldUseWebAudioApi, masterGainNode]);
 	}
 
 	if (audioStuffRef.current) {
@@ -133,8 +123,8 @@ export const useVolume = ({
 			)
 		) {
 			audioStuffRef.current.gainNode.gain.value = valueToSet;
-			Log.trace(
-				{logLevel, tag: null},
+			logger.trace(
+				null,
 				`Setting gain to ${valueToSet} for ${mediaRef.current?.src}`,
 			);
 		}

--- a/packages/core/src/use-buffer-state.ts
+++ b/packages/core/src/use-buffer-state.ts
@@ -1,7 +1,6 @@
 import {useContext, useMemo} from 'react';
 import {BufferingContextReact} from './buffering';
-import {Log} from './log';
-import {useLogLevel} from './log-level-context';
+import {useLogger} from './use-logger.js';
 
 export type DelayPlaybackHandle = {
 	unblock: () => void;
@@ -13,7 +12,7 @@ export type UseBufferState = {
 
 export const useBufferState = (): UseBufferState => {
 	const buffer = useContext(BufferingContextReact);
-	const logLevel = useLogLevel();
+	const logger = useLogger();
 
 	// Allows <Img> tag to be rendered without a context
 	// https://github.com/remotion-dev/remotion/issues/4007
@@ -28,8 +27,8 @@ export const useBufferState = (): UseBufferState => {
 					);
 				}
 
-				Log.trace(
-					{logLevel, tag: '[buffer-state]'},
+				logger.trace(
+					'[buffer-state]',
 					'Adding buffer handle',
 					new Error().stack,
 				);
@@ -47,15 +46,14 @@ export const useBufferState = (): UseBufferState => {
 						}
 
 						unblocked = true;
-						Log.trace(
-							{logLevel, tag: '[buffer-state]'},
-							'Removing buffer handle',
-						);
+						logger.trace('[buffer-state]', 'Removing buffer handle');
 						unblock();
 					},
 				};
 			},
 		}),
-		[addBlock, logLevel],
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[addBlock],
 	);
 };

--- a/packages/core/src/use-delay-render.tsx
+++ b/packages/core/src/use-delay-render.tsx
@@ -3,7 +3,7 @@ import type {cancelRender as cancelRenderOriginal} from './cancel-render.js';
 import {cancelRenderInternal} from './cancel-render.js';
 import type {DelayRenderOptions, DelayRenderScope} from './delay-render.js';
 import {continueRenderInternal, delayRenderInternal} from './delay-render.js';
-import {useLogLevel} from './log-level-context.js';
+import {useLogger} from './use-logger.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
 
 type DelayRenderFn = (label?: string, options?: DelayRenderOptions) => number;
@@ -23,7 +23,7 @@ export const useDelayRender = (): {
 	const scope =
 		useContext(DelayRenderContextType) ??
 		(typeof window !== 'undefined' ? window : undefined);
-	const logLevel = useLogLevel();
+	const logger = useLogger();
 
 	const delayRender = useCallback<DelayRenderFn>(
 		(label?: string, options?: DelayRenderOptions) => {
@@ -38,6 +38,8 @@ export const useDelayRender = (): {
 				options: options ?? {},
 			});
 		},
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[environment, scope],
 	);
 
@@ -51,10 +53,10 @@ export const useDelayRender = (): {
 				scope,
 				handle,
 				environment,
-				logLevel,
+				logger,
 			});
 		},
-		[environment, logLevel, scope],
+		[environment, scope],
 	);
 
 	const cancelRender = useCallback<CancelRenderFn>(

--- a/packages/core/src/use-logger.ts
+++ b/packages/core/src/use-logger.ts
@@ -1,0 +1,30 @@
+import {useContext, useRef} from 'react';
+import {
+	LogLevelContext,
+	type LoggingContextValue,
+} from './log-level-context.js';
+import {createLoggerFromOptions, type Logger} from './logger.js';
+
+export const useLogger = (): Logger => {
+	const logging = useContext(LogLevelContext);
+	if (logging.logLevel === null) {
+		throw new Error('useLogger must be used within a LogLevelProvider');
+	}
+
+	const loggingRef = useRef<LoggingContextValue>(logging);
+	loggingRef.current = logging;
+	const loggerRef = useRef<Logger | null>(null);
+
+	if (loggerRef.current === null) {
+		loggerRef.current = createLoggerFromOptions(() => {
+			const {logLevel, mountTime} = loggingRef.current;
+			if (logLevel === null) {
+				throw new Error('useLogger must be used within a LogLevelProvider');
+			}
+
+			return {logLevel, mountTime};
+		});
+	}
+
+	return loggerRef.current;
+};

--- a/packages/core/src/use-media-buffering.ts
+++ b/packages/core/src/use-media-buffering.ts
@@ -1,27 +1,23 @@
 import type React from 'react';
 import {useEffect, useState} from 'react';
-import type {LogLevel} from './log';
-import {playbackLogging} from './playback-logging';
 import {useBufferState} from './use-buffer-state';
+import {useLogger} from './use-logger.js';
 
 export const useMediaBuffering = ({
 	element,
 	shouldBuffer,
 	isPremounting,
 	isPostmounting,
-	logLevel,
-	mountTime,
 	src,
 }: {
 	element: React.RefObject<HTMLVideoElement | HTMLAudioElement | null>;
 	shouldBuffer: boolean;
 	isPremounting: boolean;
 	isPostmounting: boolean;
-	logLevel: LogLevel;
-	mountTime: number;
 	src: string | null;
 }) => {
 	const buffer = useBufferState();
+	const logger = useLogger();
 	const [isBuffering, setIsBuffering] = useState(false);
 
 	// Buffer state based on `waiting` and `canplay`
@@ -52,12 +48,10 @@ export const useMediaBuffering = ({
 				current.readyState < current.HAVE_FUTURE_DATA
 			) {
 				if (!navigator.userAgent.includes('Firefox/')) {
-					playbackLogging({
-						logLevel,
-						message: `Calling .load() on ${current.src} because readyState is ${current.readyState} and it is not Firefox. Element is premounted ${current.playbackRate}`,
-						tag: 'load',
-						mountTime,
-					});
+					logger.playback(
+						'load',
+						`Calling .load() on ${current.src} because readyState is ${current.readyState} and it is not Firefox. Element is premounted ${current.playbackRate}`,
+					);
 					const previousPlaybackRate = current.playbackRate;
 					current.load();
 					current.playbackRate = previousPlaybackRate;
@@ -83,23 +77,19 @@ export const useMediaBuffering = ({
 				return false;
 			});
 			if (didDoSomething) {
-				playbackLogging({
-					logLevel,
-					message: `Unmarking as buffering: ${current.src}. Reason: ${reason}`,
-					tag: 'buffer',
-					mountTime,
-				});
+				logger.playback(
+					'buffer',
+					`Unmarking as buffering: ${current.src}. Reason: ${reason}`,
+				);
 			}
 		};
 
 		const blockMedia = (reason: string) => {
 			setIsBuffering(true);
-			playbackLogging({
-				logLevel,
-				message: `Marking as buffering: ${current.src}. Reason: ${reason}`,
-				tag: 'buffer',
-				mountTime,
-			});
+			logger.playback(
+				'buffer',
+				`Marking as buffering: ${current.src}. Reason: ${reason}`,
+			);
 			const {unblock} = buffer.delayPlayback();
 			const onCanPlay = () => {
 				cleanup('"canplay" was fired');
@@ -127,12 +117,10 @@ export const useMediaBuffering = ({
 				current.removeEventListener('error', onError);
 			});
 			cleanupFns.push((cleanupReason) => {
-				playbackLogging({
-					logLevel,
-					message: `Unblocking ${current.src} from buffer. Reason: ${cleanupReason}`,
-					tag: 'buffer',
-					mountTime,
-				});
+				logger.playback(
+					'buffer',
+					`Unblocking ${current.src} from buffer. Reason: ${cleanupReason}`,
+				);
 				unblock();
 			});
 		};
@@ -153,12 +141,10 @@ export const useMediaBuffering = ({
 
 				// Breaks on Firefox though: https://github.com/remotion-dev/remotion/issues/3915
 				if (!navigator.userAgent.includes('Firefox/')) {
-					playbackLogging({
-						logLevel,
-						message: `Calling .load() on ${src} because readyState is ${current.readyState} and it is not Firefox. ${current.playbackRate}`,
-						tag: 'load',
-						mountTime,
-					});
+					logger.playback(
+						'load',
+						`Calling .load() on ${src} because readyState is ${current.readyState} and it is not Firefox. ${current.playbackRate}`,
+					);
 
 					const previousPlaybackRate = current.playbackRate;
 					current.load();
@@ -187,16 +173,9 @@ export const useMediaBuffering = ({
 		// it gives the chance to load the new source.
 
 		// https://github.com/remotion-dev/remotion/issues/5218
-	}, [
-		buffer,
-		src,
-		element,
-		isPremounting,
-		isPostmounting,
-		logLevel,
-		shouldBuffer,
-		mountTime,
-	]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [buffer, src, element, isPremounting, isPostmounting, shouldBuffer]);
 
 	return isBuffering;
 };

--- a/packages/core/src/use-media-playback.ts
+++ b/packages/core/src/use-media-playback.ts
@@ -10,11 +10,8 @@ import {useMediaStartsAt} from './audio/use-audio-frame.js';
 import {useBufferUntilFirstFrame} from './buffer-until-first-frame.js';
 import {BufferingContextReact, useIsPlayerBuffering} from './buffering.js';
 import {getMediaSyncAction} from './get-media-sync-action.js';
-import {useLogLevel, useMountTime} from './log-level-context.js';
-import {Log} from './log.js';
 import {useCurrentTimeOfMediaTagWithUpdateTimeStamp} from './media-tag-current-time-timestamp.js';
 import {playAndHandleNotAllowedError} from './play-and-handle-not-allowed-error.js';
-import {playbackLogging} from './playback-logging.js';
 import {seek} from './seek.js';
 import {
 	usePlayingState,
@@ -22,6 +19,7 @@ import {
 	useTimelinePosition,
 } from './timeline-position-state.js';
 import {useCurrentFrame} from './use-current-frame.js';
+import {useLogger} from './use-logger.js';
 import {useMediaBuffering} from './use-media-buffering.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
 import {useRequestVideoCallbackTime} from './use-request-video-callback-time.js';
@@ -63,8 +61,7 @@ export const useMediaPlayback = ({
 	const mediaStartsAt = useMediaStartsAt();
 	const lastSeekDueToShift = useRef<number | null>(null);
 	const lastSeek = useRef<number | null>(null);
-	const logLevel = useLogLevel();
-	const mountTime = useMountTime();
+	const logger = useLogger();
 
 	if (!buffering) {
 		throw new Error(
@@ -83,13 +80,15 @@ export const useMediaPlayback = ({
 			return;
 		}
 
-		Log.verbose(
-			{logLevel, tag: null},
+		logger.verbose(
+			null,
 			`Detected ${src} as a variable FPS video. Disabling buffering while seeking.`,
 		);
 
 		isVariableFpsVideoMap.current[src] = true;
-	}, [logLevel, src]);
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [src]);
 
 	const rvcCurrentTime = useRequestVideoCallbackTime({
 		mediaRef,
@@ -113,8 +112,6 @@ export const useMediaPlayback = ({
 		shouldBuffer: pauseWhenBuffering,
 		isPremounting,
 		isPostmounting,
-		logLevel,
-		mountTime,
 		src: src ?? null,
 	});
 
@@ -123,8 +120,6 @@ export const useMediaPlayback = ({
 		mediaType,
 		onVariableFpsVideoDetected,
 		pauseWhenBuffering,
-		logLevel,
-		mountTime,
 	});
 
 	const playbackRate = localPlaybackRate * globalPlaybackRate;
@@ -158,12 +153,10 @@ export const useMediaPlayback = ({
 		}
 
 		if (!playing) {
-			playbackLogging({
-				logLevel,
-				tag: 'pause',
-				message: `Pausing ${mediaRef.current?.src} because ${isPremounting ? 'media is premounting' : isPostmounting ? 'media is postmounting' : 'Player is not playing'}`,
-				mountTime,
-			});
+			logger.playback(
+				'pause',
+				`Pausing ${mediaRef.current?.src} because ${isPremounting ? 'media is premounting' : isPostmounting ? 'media is postmounting' : 'Player is not playing'}`,
+			);
 			mediaRef.current?.pause();
 			return;
 		}
@@ -172,24 +165,22 @@ export const useMediaPlayback = ({
 
 		const playerBufferingNotStateButLive = buffering.buffering.current;
 		if (playerBufferingNotStateButLive && !isMediaTagBufferingOrStalled) {
-			playbackLogging({
-				logLevel,
-				tag: 'pause',
-				message: `Pausing ${mediaRef.current?.src} because player is buffering but media tag is not`,
-				mountTime,
-			});
+			logger.playback(
+				'pause',
+				`Pausing ${mediaRef.current?.src} because player is buffering but media tag is not`,
+			);
 			mediaRef.current?.pause();
 		}
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		isBuffering,
 		isMediaTagBuffering,
 		buffering,
 		isPlayerBuffering,
 		isPremounting,
-		logLevel,
 		mediaRef,
 		mediaType,
-		mountTime,
 		playing,
 		isPostmounting,
 	]);
@@ -258,9 +249,8 @@ export const useMediaPlayback = ({
 			lastSeek.current = seek({
 				mediaRef: current,
 				time: action.shouldBeTime,
-				logLevel,
+				logger,
 				why: action.why,
-				mountTime,
 			});
 			lastSeekDueToShift.current = lastSeek.current;
 
@@ -273,8 +263,7 @@ export const useMediaPlayback = ({
 					mediaRef,
 					mediaType,
 					onAutoPlayError,
-					logLevel,
-					mountTime,
+					logger,
 					reason: action.playReason,
 					isPlayer: env.isPlayer,
 				});
@@ -292,9 +281,8 @@ export const useMediaPlayback = ({
 				lastSeek.current = seek({
 					mediaRef: current,
 					time: action.shouldBeTime,
-					logLevel,
+					logger,
 					why: action.why,
-					mountTime,
 				});
 			}
 
@@ -306,9 +294,8 @@ export const useMediaPlayback = ({
 			lastSeek.current = seek({
 				mediaRef: current,
 				time: action.shouldBeTime,
-				logLevel,
+				logger,
 				why: action.why,
-				mountTime,
 			});
 		}
 
@@ -316,21 +303,21 @@ export const useMediaPlayback = ({
 			mediaRef,
 			mediaType,
 			onAutoPlayError,
-			logLevel,
-			mountTime,
+			logger,
 			reason: action.playReason,
 			isPlayer: env.isPlayer,
 		});
 		if (action.bufferUntilFirstFrame) {
 			bufferUntilFirstFrame(action.shouldBeTime);
 		}
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		absoluteFrame,
 		acceptableTimeShiftButLessThanDuration,
 		bufferUntilFirstFrame,
 		buffering.buffering,
 		rvcCurrentTime,
-		logLevel,
 		desiredUnclampedTime,
 		isBuffering,
 		isMediaTagBuffering,
@@ -344,7 +331,6 @@ export const useMediaPlayback = ({
 		isPremounting,
 		isPostmounting,
 		pauseWhenBuffering,
-		mountTime,
 		mediaTagCurrentTime,
 		env.isPlayer,
 	]);

--- a/packages/core/src/use-media-tag.ts
+++ b/packages/core/src/use-media-tag.ts
@@ -1,9 +1,9 @@
 import type {RefObject} from 'react';
 import {useEffect} from 'react';
-import {useLogLevel, useMountTime} from './log-level-context.js';
 import {playAndHandleNotAllowedError} from './play-and-handle-not-allowed-error.js';
 import type {PlayableMediaTag} from './timeline-position-state.js';
 import {useTimelineContext} from './timeline-position-state.js';
+import {useLogger} from './use-logger.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
 
 export const useMediaTag = ({
@@ -22,8 +22,7 @@ export const useMediaTag = ({
 	isPostmounting: boolean;
 }) => {
 	const {audioAndVideoTags, imperativePlaying} = useTimelineContext();
-	const logLevel = useLogLevel();
-	const mountTime = useMountTime();
+	const logger = useLogger();
 	const env = useRemotionEnvironment();
 
 	useEffect(() => {
@@ -43,8 +42,7 @@ export const useMediaTag = ({
 					mediaRef,
 					mediaType,
 					onAutoPlayError,
-					logLevel,
-					mountTime,
+					logger,
 					reason,
 					isPlayer: env.isPlayer,
 				});
@@ -57,6 +55,8 @@ export const useMediaTag = ({
 				(a) => a.id !== id,
 			);
 		};
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		audioAndVideoTags,
 		id,
@@ -66,8 +66,6 @@ export const useMediaTag = ({
 		imperativePlaying,
 		isPremounting,
 		isPostmounting,
-		logLevel,
-		mountTime,
 		env.isPlayer,
 	]);
 };

--- a/packages/core/src/video/VideoForPreview.tsx
+++ b/packages/core/src/video/VideoForPreview.tsx
@@ -13,11 +13,10 @@ import {SharedAudioContext} from '../audio/shared-audio-tags.js';
 import {makeSharedElementSourceNode} from '../audio/shared-element-source-node.js';
 import {useFrameForVolumeProp} from '../audio/use-audio-frame.js';
 import {getCrossOriginValue} from '../get-cross-origin-value.js';
-import {useLogLevel, useMountTime} from '../log-level-context.js';
-import {playbackLogging} from '../playback-logging.js';
 import {usePreload} from '../prefetch.js';
 import {SequenceContext} from '../SequenceContext.js';
 import {useVolume} from '../use-amplification.js';
+import {useLogger} from '../use-logger.js';
 import {useMediaInTimeline} from '../use-media-in-timeline.js';
 import {useMediaPlayback} from '../use-media-playback.js';
 import {useMediaTag} from '../use-media-tag.js';
@@ -134,8 +133,7 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	);
 	const {fps, durationInFrames} = useVideoConfig();
 	const parentSequence = useContext(SequenceContext);
-	const logLevel = useLogLevel();
-	const mountTime = useMountTime();
+	const logger = useLogger();
 
 	const [timelineId] = useState(() => String(Math.random()));
 
@@ -205,7 +203,6 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	});
 
 	useVolume({
-		logLevel,
 		mediaRef: videoRef,
 		volume: userPreferredVolume,
 		source: sharedSource,
@@ -231,14 +228,12 @@ const VideoForDevelopmentRefForwardingFunction: React.ForwardRefRenderFunction<
 	}, []);
 
 	useState(() =>
-		playbackLogging({
-			logLevel,
-			message: `Mounting video with source = ${actualSrc}, v=${VERSION}, user agent=${
+		logger.playback(
+			'video',
+			`Mounting video with source = ${actualSrc}, v=${VERSION}, user agent=${
 				typeof navigator === 'undefined' ? 'server' : navigator.userAgent
 			}`,
-			tag: 'video',
-			mountTime,
-		}),
+		),
 	);
 
 	useEffect(() => {

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -14,13 +14,13 @@ import {
 	useMediaStartsAt,
 } from '../audio/use-audio-frame.js';
 import {isApproximatelyTheSame} from '../is-approximately-the-same.js';
-import {useLogLevel, useMountTime} from '../log-level-context.js';
 import {random} from '../random.js';
 import {RenderAssetManager} from '../RenderAssetManager.js';
 import {SequenceContext} from '../SequenceContext.js';
 import {useTimelinePosition} from '../timeline-position-state.js';
 import {useCurrentFrame} from '../use-current-frame.js';
 import {useDelayRender} from '../use-delay-render.js';
+import {useLogger} from '../use-logger.js';
 import {useRemotionEnvironment} from '../use-remotion-environment.js';
 import {useUnsafeVideoConfig} from '../use-unsafe-video-config.js';
 import {evaluateVolume} from '../volume-prop.js';
@@ -70,8 +70,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 	const sequenceContext = useContext(SequenceContext);
 	const mediaStartsAt = useMediaStartsAt();
 	const environment = useRemotionEnvironment();
-	const logLevel = useLogLevel();
-	const mountTime = useMountTime();
+	const logger = useLogger();
 	const {delayRender, continueRender} = useDelayRender();
 
 	const {registerRenderAsset, unregisterRenderAsset} =
@@ -211,8 +210,7 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			element: current,
 			desiredTime: currentTime,
 			fps: videoConfig.fps,
-			logLevel,
-			mountTime,
+			logger,
 		});
 
 		seek.prom.then(() => {
@@ -252,6 +250,8 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 			current.removeEventListener('error', errorHandler);
 			continueRender(handle);
 		};
+		// The logger has stable identity and reads the latest context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		volumePropsFrame,
 		props.src,
@@ -262,8 +262,6 @@ const VideoForRenderingForwardFunction: React.ForwardRefRenderFunction<
 		onError,
 		delayRenderRetries,
 		delayRenderTimeoutInMilliseconds,
-		logLevel,
-		mountTime,
 		continueRender,
 		delayRender,
 	]);

--- a/packages/core/src/video/seek-until-right.ts
+++ b/packages/core/src/video/seek-until-right.ts
@@ -1,5 +1,5 @@
 import {isApproximatelyTheSame} from '../is-approximately-the-same';
-import {type LogLevel} from '../log';
+import type {Logger} from '../logger.js';
 import {seek} from '../seek';
 
 const roundTo6Commas = (num: number) => {
@@ -9,13 +9,11 @@ const roundTo6Commas = (num: number) => {
 export const seekToTime = ({
 	element,
 	desiredTime,
-	logLevel,
-	mountTime,
+	logger,
 }: {
 	element: HTMLVideoElement;
 	desiredTime: number;
-	logLevel: LogLevel;
-	mountTime: number;
+	logger: Logger;
 }) => {
 	if (isApproximatelyTheSame(element.currentTime, desiredTime)) {
 		return {
@@ -25,11 +23,10 @@ export const seekToTime = ({
 	}
 
 	seek({
-		logLevel,
+		logger,
 		mediaRef: element,
 		time: desiredTime,
 		why: 'Seeking during rendering',
-		mountTime,
 	});
 
 	let cancel: number;
@@ -77,14 +74,12 @@ export const seekToTimeMultipleUntilRight = ({
 	element,
 	desiredTime,
 	fps,
-	logLevel,
-	mountTime,
+	logger,
 }: {
 	element: HTMLVideoElement;
 	desiredTime: number;
 	fps: number;
-	logLevel: LogLevel;
-	mountTime: number;
+	logger: Logger;
 }) => {
 	const threshold = 1 / fps / 2;
 	let currentCancel: () => void = () => undefined;
@@ -104,8 +99,7 @@ export const seekToTimeMultipleUntilRight = ({
 		const firstSeek = seekToTime({
 			element,
 			desiredTime: desiredTime + threshold,
-			logLevel,
-			mountTime,
+			logger,
 		});
 		firstSeek.wait.then((seekedTo) => {
 			const difference = Math.abs(desiredTime - seekedTo);
@@ -119,8 +113,7 @@ export const seekToTimeMultipleUntilRight = ({
 			const newSeek = seekToTime({
 				element,
 				desiredTime: seekedTo + threshold * sign,
-				logLevel,
-				mountTime,
+				logger,
 			});
 			currentCancel = newSeek.cancel;
 			newSeek.wait
@@ -134,8 +127,7 @@ export const seekToTimeMultipleUntilRight = ({
 					const thirdSeek = seekToTime({
 						element,
 						desiredTime: desiredTime + threshold,
-						logLevel,
-						mountTime,
+						logger,
 					});
 					currentCancel = thirdSeek.cancel;
 					return thirdSeek.wait


### PR DESCRIPTION
## Summary

- bind core logging to the active React logging context through a stable `useLogger()` hook
- remove `logLevel`, `mountTime`, and logger identity from playback and audio hook dependencies
- keep pure and imperative boundaries explicit without pulling React into the `no-react` bundle
- document the current logging mechanics and add focused logger isolation tests

## Verification

- `bunx oxfmt --write <changed files>`
- `git diff --check`
- pure `createLogger()` filtering and playback smoke test
- bundled `packages/core/src/no-react.ts` and verified it contains no React imports or hooks

Full `bun run build`, `bun run stylecheck`, and React-based tests were not available because this worktree has no installed dependencies (`turbo`, `eslint`, React, and Happy DOM are missing).
