### PR TITLE
Track the latest player seek in playback state

### DIFF
--- a/packages/core/src/TimelineContext.tsx
+++ b/packages/core/src/TimelineContext.tsx
@@ -33,14 +33,24 @@ export type BufferingState = Readonly<{
 	buffering: boolean;
 }>;
 
+export type LastSeekState = Readonly<{
+	frame: number | null;
+	sequence: number;
+}>;
+
+const initialLastSeekState: LastSeekState = {frame: null, sequence: 0};
+
 export type SetTimelineContextValue = {
 	setFrame: (u: React.SetStateAction<Record<string, number>>) => void;
 	setPlaying: (u: React.SetStateAction<boolean>) => void;
 	setBuffering: (buffering: boolean) => void;
+	setLastSeek: (frame: number) => void;
 	subscribePlaying: (listener: (state: PlayingState) => void) => () => void;
 	subscribeBuffering: (listener: (state: BufferingState) => void) => () => void;
+	subscribeLastSeek: (listener: (state: LastSeekState) => void) => () => void;
 	isPlaying: () => boolean;
 	isBuffering: () => boolean;
+	getLastSeek: () => LastSeekState;
 	frameRef: RefObject<Record<string, number>>;
 	audioAndVideoTags: RefObject<PlayableMediaTag[]>;
 };
@@ -55,10 +65,13 @@ export const SetTimelineContext = createContext<SetTimelineContextValue>({
 	setFrame: missingSetTimelineContext,
 	setPlaying: missingSetTimelineContext,
 	setBuffering: missingSetTimelineContext,
+	setLastSeek: missingSetTimelineContext,
 	subscribePlaying: () => () => undefined,
 	subscribeBuffering: () => () => undefined,
+	subscribeLastSeek: () => () => undefined,
 	isPlaying: () => false,
 	isBuffering: missingSetTimelineContext,
+	getLastSeek: () => initialLastSeekState,
 	frameRef: {current: {}},
 	audioAndVideoTags: {current: []},
 });
@@ -84,7 +97,6 @@ export const TimelineContextProvider: React.FC<{
 		() => createRuntimeValueStore({buffering: false}),
 		[],
 	);
-
 	const [playbackRate, setPlaybackRate] = useState(1);
 	const audioAndVideoTags = useRef<PlayableMediaTag[]>([]);
 	const [_frame, setFrame] = useState<Record<string, number>>(() =>
@@ -103,7 +115,6 @@ export const TimelineContextProvider: React.FC<{
 		() => bufferingStore.store.getSnapshot().buffering,
 		[bufferingStore],
 	);
-
 	const {delayRender, continueRender} = useDelayRender();
 
 	if (typeof window !== 'undefined') {
@@ -171,10 +182,13 @@ export const TimelineContextProvider: React.FC<{
 					bufferingStore.setSnapshot({buffering});
 				}
 			},
+			setLastSeek: () => undefined,
 			subscribePlaying: playingStore.store.subscribe,
 			subscribeBuffering: bufferingStore.store.subscribe,
+			subscribeLastSeek: () => () => undefined,
 			isPlaying: readIsPlaying,
 			isBuffering: readIsBuffering,
+			getLastSeek: () => initialLastSeekState,
 			frameRef,
 			audioAndVideoTags,
 		};

--- a/packages/core/src/test/wrap-sequence-context.tsx
+++ b/packages/core/src/test/wrap-sequence-context.tsx
@@ -20,6 +20,7 @@ import {
 } from '../TimelineContext.js';
 
 const Comp: React.FC = () => null;
+const initialLastSeekState = {frame: null, sequence: 0} as const;
 
 const makeMockCompositionContext = (
 	durationInFrames: number,
@@ -136,10 +137,13 @@ export const WrapSequenceContext: React.FC<{
 					bufferingStore.setSnapshot({buffering});
 				}
 			},
+			setLastSeek: () => undefined,
 			subscribePlaying: () => () => undefined,
 			subscribeBuffering: bufferingStore.store.subscribe,
+			subscribeLastSeek: () => () => undefined,
 			isPlaying: () => false,
 			isBuffering: () => bufferingStore.store.getSnapshot().buffering,
+			getLastSeek: () => initialLastSeekState,
 			frameRef: {current: {}},
 			audioAndVideoTags: {current: []},
 		}),

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -255,6 +255,14 @@ const PlayerFn = <
 		() => Internals.createRuntimeValueStore({buffering: false}),
 		[],
 	);
+	const lastSeekStore = useMemo(
+		() =>
+			Internals.createRuntimeValueStore({
+				frame: null as number | null,
+				sequence: 0,
+			}),
+		[],
+	);
 	const readIsPlaying = useCallback(
 		() => playingStore.store.getSnapshot().playing,
 		[playingStore],
@@ -454,15 +462,22 @@ const PlayerFn = <
 					bufferingStore.setSnapshot({buffering});
 				}
 			},
+			setLastSeek: (newFrame) => {
+				const {sequence} = lastSeekStore.store.getSnapshot();
+				lastSeekStore.setSnapshot({frame: newFrame, sequence: sequence + 1});
+			},
 			subscribePlaying: playingStore.store.subscribe,
 			subscribeBuffering: bufferingStore.store.subscribe,
+			subscribeLastSeek: lastSeekStore.store.subscribe,
 			isPlaying: readIsPlaying,
 			isBuffering: readIsBuffering,
+			getLastSeek: lastSeekStore.store.getSnapshot,
 			frameRef,
 			audioAndVideoTags,
 		};
 	}, [
 		bufferingStore,
+		lastSeekStore,
 		setFrame,
 		frameRef,
 		playingStore,

--- a/packages/player/src/Thumbnail.tsx
+++ b/packages/player/src/Thumbnail.tsx
@@ -30,6 +30,8 @@ import {PLAYER_COMP_ID, SharedPlayerContexts} from './SharedPlayerContext.js';
 import ThumbnailUI from './ThumbnailUI.js';
 import type {PropsIfHasProps} from './utils/props-if-has-props.js';
 
+const initialLastSeekState = {frame: null, sequence: 0} as const;
+
 export type ThumbnailProps<
 	Schema extends AnyZodObject,
 	Props extends Record<string, unknown>,
@@ -121,10 +123,13 @@ const ThumbnailFn = <
 					bufferingStore.setSnapshot({buffering});
 				}
 			},
+			setLastSeek: () => undefined,
 			subscribePlaying: () => () => undefined,
 			subscribeBuffering: bufferingStore.store.subscribe,
+			subscribeLastSeek: () => () => undefined,
 			isPlaying: () => false,
 			isBuffering: () => bufferingStore.store.getSnapshot().buffering,
+			getLastSeek: () => initialLastSeekState,
 			frameRef,
 			audioAndVideoTags,
 		};

--- a/packages/player/src/test/index.test.ts
+++ b/packages/player/src/test/index.test.ts
@@ -79,14 +79,25 @@ const PlayerMethodsProbe = React.memo(
 test('Imperative player methods do not rerender when the frame changes', () => {
 	const playerRef = createRef<PlayerRef>();
 	const methodsRef: {current: UsePlayerMethods | null} = {current: null};
+	let getLastSeek = () => ({frame: null as number | null, sequence: 0});
 	let methodRenders = 0;
 	const onRender = (methods: UsePlayerMethods) => {
 		methodsRef.current = methods;
 		methodRenders++;
 	};
 
+	const LastSeekProbe = () => {
+		getLastSeek = React.useContext(Internals.SetTimelineContext).getLastSeek;
+		return null;
+	};
+
 	const renderCustomControls = () =>
-		React.createElement(PlayerMethodsProbe, {onRender});
+		React.createElement(
+			React.Fragment,
+			null,
+			React.createElement(PlayerMethodsProbe, {onRender}),
+			React.createElement(LastSeekProbe),
+		);
 	const Composition = () => null;
 
 	render(
@@ -104,6 +115,7 @@ test('Imperative player methods do not rerender when the frame changes', () => {
 	);
 
 	expect(methodsRef.current?.getCurrentFrame()).toBe(12);
+	expect(getLastSeek()).toEqual({frame: null, sequence: 0});
 	const rendersAfterMount = methodRenders;
 
 	act(() => {
@@ -112,13 +124,18 @@ test('Imperative player methods do not rerender when the frame changes', () => {
 
 	expect(playerRef.current?.getCurrentFrame()).toBe(30);
 	expect(methodsRef.current?.getCurrentFrame()).toBe(30);
+	expect(getLastSeek()).toEqual({frame: 30, sequence: 1});
 	expect(methodRenders).toBe(rendersAfterMount);
 
 	act(() => {
 		methodsRef.current?.frameForward(5);
 		expect(methodsRef.current?.getCurrentFrame()).toBe(35);
+		expect(getLastSeek()).toEqual({frame: 35, sequence: 2});
 		methodsRef.current?.frameBack(2);
 		expect(methodsRef.current?.getCurrentFrame()).toBe(33);
+		expect(getLastSeek()).toEqual({frame: 33, sequence: 3});
+		methodsRef.current?.seek(33);
+		expect(getLastSeek()).toEqual({frame: 33, sequence: 4});
 	});
 
 	expect(playerRef.current?.getCurrentFrame()).toBe(33);

--- a/packages/player/src/use-player-methods.ts
+++ b/packages/player/src/use-player-methods.ts
@@ -20,10 +20,10 @@ export type UsePlayerMethods = {
 };
 
 export const usePlayerMethods = (): UsePlayerMethods => {
-	const setFrame = Internals.Timeline.useTimelineSetFrame();
 	const setTimelinePosition = Internals.Timeline.useTimelineSetFrame();
 	const {
 		setPlaying,
+		setLastSeek,
 		frameRef,
 		audioAndVideoTags,
 		isPlaying: readIsPlaying,
@@ -65,6 +65,28 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 		);
 	}, [environment.isPlayer, frameRef, video]);
 
+	const setFrameFromSeek = useCallback(
+		(newFrame: number, compositionId: string | undefined) => {
+			fallbackFrame.current = newFrame;
+			setLastSeek(newFrame);
+
+			if (!compositionId) {
+				return;
+			}
+
+			if (frameRef.current[compositionId] !== newFrame) {
+				frameRef.current = {...frameRef.current, [compositionId]: newFrame};
+			}
+
+			setTimelinePosition((currentFrames) =>
+				currentFrames[compositionId] === newFrame
+					? currentFrames
+					: {...currentFrames, [compositionId]: newFrame},
+			);
+		},
+		[frameRef, setLastSeek, setTimelinePosition],
+	);
+
 	const seek = useCallback(
 		(newFrame: number) => {
 			const frameToSeekTo = config
@@ -74,26 +96,11 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 					)
 				: Math.max(0, newFrame);
 
-			fallbackFrame.current = frameToSeekTo;
-
-			if (video?.id) {
-				if (frameRef.current[video.id] !== frameToSeekTo) {
-					frameRef.current = {
-						...frameRef.current,
-						[video.id]: frameToSeekTo,
-					};
-				}
-
-				setTimelinePosition((currentFrames) =>
-					currentFrames[video.id] === frameToSeekTo
-						? currentFrames
-						: {...currentFrames, [video.id]: frameToSeekTo},
-				);
-			}
+			setFrameFromSeek(frameToSeekTo, video?.id);
 
 			emitter.dispatchSeek(frameToSeekTo);
 		},
-		[config, emitter, frameRef, setTimelinePosition, video?.id],
+		[config, emitter, setFrameFromSeek, video?.id],
 	);
 
 	const play = useCallback(
@@ -163,27 +170,12 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 	const pauseAndReturnToPlayStart = useCallback(() => {
 		if (readIsPlaying()) {
 			setPlaying(false);
-			fallbackFrame.current = playStart.current;
+			setFrameFromSeek(playStart.current, config?.id);
 			if (config) {
-				frameRef.current = {
-					...frameRef.current,
-					[config.id]: playStart.current,
-				};
-				setTimelinePosition((currentFrames) => ({
-					...currentFrames,
-					[config.id]: playStart.current,
-				}));
 				emitter.dispatchPause();
 			}
 		}
-	}, [
-		config,
-		emitter,
-		frameRef,
-		readIsPlaying,
-		setPlaying,
-		setTimelinePosition,
-	]);
+	}, [config, emitter, readIsPlaying, setFrameFromSeek, setPlaying]);
 
 	const videoId = video?.id;
 	const lastFrame = (config?.durationInFrames ?? 1) - 1;
@@ -205,17 +197,9 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 				return;
 			}
 
-			frameRef.current = {
-				...frameRef.current,
-				[videoId]: newFrame,
-			};
-			setFrame((currentFrames) =>
-				currentFrames[videoId] === newFrame
-					? currentFrames
-					: {...currentFrames, [videoId]: newFrame},
-			);
+			setFrameFromSeek(newFrame, videoId);
 		},
-		[frameRef, readIsPlaying, setFrame, videoId],
+		[frameRef, readIsPlaying, setFrameFromSeek, videoId],
 	);
 
 	const frameForward = useCallback(
@@ -235,17 +219,9 @@ export const usePlayerMethods = (): UsePlayerMethods => {
 				return;
 			}
 
-			frameRef.current = {
-				...frameRef.current,
-				[videoId]: newFrame,
-			};
-			setFrame((currentFrames) =>
-				currentFrames[videoId] === newFrame
-					? currentFrames
-					: {...currentFrames, [videoId]: newFrame},
-			);
+			setFrameFromSeek(newFrame, videoId);
 		},
-		[frameRef, lastFrame, readIsPlaying, setFrame, videoId],
+		[frameRef, lastFrame, readIsPlaying, setFrameFromSeek, videoId],
 	);
 
 	const toggle = useCallback(


### PR DESCRIPTION
## Summary

"last seeked" is now core remotion state, tracked canonically at the source. This allows us to delete a bunch of complex react hook callback code, have a single "dumb" owner, and pull some complexity away from native handling of DOM refs

## Detailed

- add the latest explicit player seek as canonical, independently subscribable state
- represent each seek as `{frame, sequence}`, so repeated seeks to the same frame remain observable
- increment `sequence` for every explicit seek, frame step, and pause-and-return
- keep the latest explicit seek during ordinary playback rather than resetting it
- consolidate explicit player frame jumps behind one writer
- preserve the element-local seek bookkeeping required for DOM seek de-duplication and variable-FPS detection
- keep automatic playback advancement out of seek state

## Validation

- `bun run --filter remotion lint`
- `bun run --filter remotion make`
- `bun run --filter remotion test` (674 passed)
- `bun run --filter @remotion/player make`
- `cd packages/player && bun test src/test/index.test.ts` (8 passed)