### PR TITLE
`remotion`: Reduce canvas effect WebGL context usage

### DIFF
--- a/packages/core/src/effects/canvas-pool.ts
+++ b/packages/core/src/effects/canvas-pool.ts
@@ -1,8 +1,7 @@
 import type {Backend} from './effect-types.js';
 import {createWebGL2ContextError} from './webgl2-context-error.js';
 
-// A pair of scratch canvases for ping-ponging within a same-backend run.
-type CanvasPair = readonly [HTMLCanvasElement, HTMLCanvasElement];
+type CanvasSlots = [HTMLCanvasElement | null, HTMLCanvasElement | null];
 
 // Per-chain canvas pool. Each chain owns its own pool; pools are not shared
 // across chains because dimensions are chain-specific.
@@ -14,36 +13,67 @@ type CanvasPair = readonly [HTMLCanvasElement, HTMLCanvasElement];
 export class CanvasPool {
 	private readonly width: number;
 	private readonly height: number;
-	private readonly pairs: Map<Backend, CanvasPair> = new Map();
+	private readonly canvases: Map<Backend, CanvasSlots> = new Map();
 	private readonly lostContexts: Set<HTMLCanvasElement> = new Set();
+	private disposed = false;
 
 	public constructor(width: number, height: number) {
 		this.width = width;
 		this.height = height;
 	}
 
-	public getPair(backend: Backend): CanvasPair {
-		const existing = this.pairs.get(backend);
+	public getCanvas(backend: Backend, slot: 0 | 1): HTMLCanvasElement {
+		if (this.disposed) {
+			throw new Error('Cannot allocate a canvas from a disposed effect pool');
+		}
+
+		const canvases = this.canvases.get(backend) ?? [null, null];
+		const existing = canvases[slot];
 		if (existing) {
 			return existing;
 		}
 
-		const pair = [
-			this.allocateCanvas(backend),
-			this.allocateCanvas(backend),
-		] as const;
-		this.pairs.set(backend, pair);
-		return pair;
+		const canvas = this.allocateCanvas(backend);
+		canvases[slot] = canvas;
+		this.canvases.set(backend, canvases);
+		return canvas;
 	}
 
 	public assertContextNotLost(canvas: HTMLCanvasElement): void {
-		if (this.lostContexts.has(canvas)) {
+		const context = canvas.getContext('webgl2');
+		if (!context || context.isContextLost() || this.lostContexts.has(canvas)) {
 			throw new Error(
 				'WebGL context was lost during canvas effect rendering. ' +
 					'This typically happens in headless or memory-constrained environments (e.g. Remotion Lambda). ' +
 					'Try reducing concurrency or increasing the Lambda function memory.',
 			);
 		}
+	}
+
+	public dispose(): void {
+		if (this.disposed) {
+			return;
+		}
+
+		this.disposed = true;
+		for (const [backend, canvases] of this.canvases) {
+			for (const canvas of canvases) {
+				if (!canvas) {
+					continue;
+				}
+
+				if (backend === 'webgl2') {
+					const context = canvas.getContext('webgl2');
+					context?.getExtension('WEBGL_lose_context')?.loseContext();
+				}
+
+				canvas.width = 0;
+				canvas.height = 0;
+			}
+		}
+
+		this.canvases.clear();
+		this.lostContexts.clear();
 	}
 
 	private allocateCanvas(backend: Backend): HTMLCanvasElement {
@@ -74,10 +104,18 @@ export class CanvasPool {
 				}
 
 				canvas.addEventListener('webglcontextlost', (e) => {
+					if (this.disposed) {
+						return;
+					}
+
 					e.preventDefault();
 					this.lostContexts.add(canvas);
 				});
 				canvas.addEventListener('webglcontextrestored', () => {
+					if (this.disposed) {
+						return;
+					}
+
 					this.lostContexts.delete(canvas);
 				});
 

--- a/packages/core/src/effects/run-effect-chain.ts
+++ b/packages/core/src/effects/run-effect-chain.ts
@@ -31,8 +31,12 @@ export const createEffectChainState = (
 
 export const cleanupEffectChainState = (state: EffectChainState): void => {
 	state.currentRunId++;
-	for (const entry of state.cleanupRegistry) {
-		entry.definition.cleanup(entry.state);
+	try {
+		for (const entry of state.cleanupRegistry) {
+			entry.definition.cleanup(entry.state);
+		}
+	} finally {
+		state.pool.dispose();
 	}
 };
 
@@ -130,13 +134,14 @@ export const runEffectChain = async ({
 	// texture coordinates match clip-space output. `ImageBitmap` bridges below
 	// opt out because they are already oriented for upload.
 	let flipWebGLSourceY = true;
+	let lastRunWasWebGl2 = false;
 
 	for (let runIndex = 0; runIndex < runs.length; runIndex++) {
 		const run = runs[runIndex];
-		const [a, b] = state.pool.getPair(run.backend);
+		const a = state.pool.getCanvas(run.backend, 0);
 		let dst = a;
 
-		for (const eff of run.effects) {
+		for (const [effectIndex, eff] of run.effects.entries()) {
 			const def = eff.definition as EffectDefinition<unknown, unknown>;
 			const setupState = ensureSetup(state, def, dst);
 
@@ -160,10 +165,13 @@ export const runEffectChain = async ({
 			}
 
 			currentImage = dst;
-			dst = dst === a ? b : a;
+			if (effectIndex < run.effects.length - 1) {
+				dst = dst === a ? state.pool.getCanvas(run.backend, 1) : a;
+			}
 		}
 
 		lastTarget = (currentImage as HTMLCanvasElement | null) ?? lastTarget;
+		lastRunWasWebGl2 = run.backend === 'webgl2';
 
 		const nextRun = runs[runIndex + 1];
 		if (nextRun && nextRun.backend !== run.backend && lastTarget) {
@@ -195,6 +203,10 @@ export const runEffectChain = async ({
 
 	if (!lastTarget) {
 		return true;
+	}
+
+	if (lastRunWasWebGl2) {
+		state.pool.assertContextNotLost(lastTarget);
 	}
 
 	const outCtx = output.getContext('2d');

--- a/packages/core/src/test/canvas-pool.test.ts
+++ b/packages/core/src/test/canvas-pool.test.ts
@@ -1,0 +1,183 @@
+import {afterEach, beforeEach, expect, test} from 'bun:test';
+import {CanvasPool} from '../effects/canvas-pool.js';
+import type {
+	Backend,
+	EffectDefinitionAndStack,
+} from '../effects/effect-types.js';
+import {
+	cleanupEffectChainState,
+	createEffectChainState,
+	runEffectChain,
+} from '../effects/run-effect-chain.js';
+
+type CanvasRecord = {
+	canvas: HTMLCanvasElement;
+	contextLost: boolean;
+	loseContextCalls: number;
+};
+
+const originalDocument = globalThis.document;
+let canvases: CanvasRecord[] = [];
+
+beforeEach(() => {
+	canvases = [];
+	Object.defineProperty(globalThis, 'document', {
+		configurable: true,
+		value: {
+			createElement: (tag: string) => {
+				expect(tag).toBe('canvas');
+				const record = {
+					canvas: null,
+					contextLost: false,
+					loseContextCalls: 0,
+				} as unknown as CanvasRecord;
+				const webGlContext = {
+					UNPACK_PREMULTIPLY_ALPHA_WEBGL: 0x9241,
+					getExtension: (name: string) =>
+						name === 'WEBGL_lose_context'
+							? {
+									loseContext: () => {
+										record.loseContextCalls++;
+									},
+								}
+							: null,
+					isContextLost: () => record.contextLost,
+					pixelStorei: () => undefined,
+				};
+				const twoDContext = {
+					clearRect: () => undefined,
+					drawImage: () => undefined,
+				};
+				record.canvas = {
+					width: 0,
+					height: 0,
+					addEventListener: () => undefined,
+					getContext: (type: string) =>
+						type === 'webgl2' ? webGlContext : twoDContext,
+				} as unknown as HTMLCanvasElement;
+				canvases.push(record);
+				return record.canvas;
+			},
+		},
+	});
+});
+
+afterEach(() => {
+	Object.defineProperty(globalThis, 'document', {
+		configurable: true,
+		value: originalDocument,
+	});
+});
+
+const makeEffect = (
+	type: string,
+	backend: Backend,
+): EffectDefinitionAndStack<unknown> => ({
+	definition: {
+		type,
+		label: type,
+		documentationLink: null,
+		backend,
+		calculateKey: () => type,
+		setup: () => null,
+		apply: () => undefined,
+		cleanup: () => undefined,
+		schema: {},
+		validateParams: () => undefined,
+	},
+	params: {},
+	effectKey: type,
+	memoized: true,
+});
+
+const makeOutput = (): HTMLCanvasElement =>
+	({
+		getContext: () => ({
+			clearRect: () => undefined,
+			drawImage: () => undefined,
+		}),
+	}) as unknown as HTMLCanvasElement;
+
+test('allocates effect canvases by slot', () => {
+	const pool = new CanvasPool(1920, 1080);
+	const first = pool.getCanvas('webgl2', 0);
+
+	expect(first).toBe(pool.getCanvas('webgl2', 0));
+	expect(canvases).toHaveLength(1);
+
+	pool.getCanvas('webgl2', 1);
+	expect(canvases).toHaveLength(2);
+});
+
+test('allocates one canvas for one effect and two for ping-ponging', async () => {
+	const oneEffectState = createEffectChainState(1920, 1080);
+	await runEffectChain({
+		state: oneEffectState,
+		source: {} as CanvasImageSource,
+		effects: [makeEffect('first', 'webgl2')],
+		output: makeOutput(),
+		width: 1920,
+		height: 1080,
+	});
+	expect(canvases).toHaveLength(1);
+	cleanupEffectChainState(oneEffectState);
+
+	canvases = [];
+	const twoEffectState = createEffectChainState(1920, 1080);
+	await runEffectChain({
+		state: twoEffectState,
+		source: {} as CanvasImageSource,
+		effects: [makeEffect('first', 'webgl2'), makeEffect('second', 'webgl2')],
+		output: makeOutput(),
+		width: 1920,
+		height: 1080,
+	});
+	expect(canvases).toHaveLength(2);
+	cleanupEffectChainState(twoEffectState);
+});
+
+test('detects context loss before the browser event fires', () => {
+	const pool = new CanvasPool(1920, 1080);
+	const canvas = pool.getCanvas('webgl2', 0);
+	canvases[0].contextLost = true;
+
+	expect(() => pool.assertContextNotLost(canvas)).toThrow(
+		'WebGL context was lost',
+	);
+});
+
+test('releases allocated contexts during chain cleanup', () => {
+	const state = createEffectChainState(1920, 1080);
+	state.pool.getCanvas('webgl2', 0);
+	state.pool.getCanvas('webgl2', 1);
+
+	cleanupEffectChainState(state);
+
+	for (const {canvas, loseContextCalls} of canvases) {
+		expect(loseContextCalls).toBe(1);
+		expect(canvas.width).toBe(0);
+		expect(canvas.height).toBe(0);
+	}
+
+	expect(() => state.pool.getCanvas('webgl2', 0)).toThrow(
+		'disposed effect pool',
+	);
+});
+
+test('releases contexts when effect cleanup throws', () => {
+	const state = createEffectChainState(1920, 1080);
+	const effect = makeEffect('throws-on-cleanup', 'webgl2');
+	state.pool.getCanvas('webgl2', 0);
+	state.cleanupRegistry.push({
+		definition: {
+			...effect.definition,
+			cleanup: () => {
+				throw new Error('cleanup failed');
+			},
+		},
+		state: null,
+	});
+
+	expect(() => cleanupEffectChainState(state)).toThrow('cleanup failed');
+	expect(canvases[0].loseContextCalls).toBe(1);
+});


### PR DESCRIPTION
## Summary

- allocate canvas-effect scratch targets by slot so a single-pass backend uses one canvas instead of a pair
- explicitly release WebGL contexts when an effect chain is discarded
- detect a lost WebGL context synchronously before accepting the final output
- add focused allocation, context-loss, and cleanup tests

## Motivation

Each effect chain currently allocates two canvases as soon as it uses a backend, even when the run contains only one effect. For WebGL effects this doubles context usage. Cleanup releases effect-owned resources but leaves the pool's WebGL contexts alive until garbage collection.

Together, those behaviors can put compositions with several effects-bearing videos near Chromium's live-context limit. Context loss is currently tracked only through the asynchronous `webglcontextlost` event, so a loss can also occur before the pool observes the event.

## Tradeoffs

Cleanup uses `WEBGL_lose_context` when available. This deliberately makes a disposed pool unusable; `getCanvas()` now throws if code tries to reuse one. The extension is optional, and canvases are also resized to zero and dereferenced from the pool.

This reduces context pressure and makes detected loss fail loudly. It does not introduce a global shared context pool or serialize effects across chains.

## Test plan

- `bun test src/test`
- `bunx turbo run lint --filter=remotion`
- `bunx turbo run make --filter=remotion`
- `bunx turbo run formatting --filter=remotion`
- Chromium probe confirmed `WEBGL_lose_context` transitions `isContextLost()` and emits `webglcontextlost`

Made with [Cursor](https://cursor.com)