### PR TITLE
`create-video`: Add Nub package manager support

### DIFF
--- a/packages/create-video/src/pkg-managers.ts
+++ b/packages/create-video/src/pkg-managers.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import {Log} from './log';
 import type {Template} from './templates';
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'nub';
 
 const shouldUseBun = (): boolean => {
 	if (
@@ -41,6 +41,10 @@ const shouldUsePnpm = (): boolean => {
 };
 
 export const selectPackageManager = (): PackageManager => {
+	if (process.env.npm_config_user_agent?.includes('nub/')) {
+		return 'nub';
+	}
+
 	if (shouldUseYarn()) {
 		return 'yarn';
 	}
@@ -72,6 +76,10 @@ export const getInstallCommand = (manager: PackageManager) => {
 	if (manager === 'bun') {
 		return `bun install`;
 	}
+
+	if (manager === 'nub') {
+		return `nub install`;
+	}
 };
 
 const getStartCommand = (manager: PackageManager) => {
@@ -90,6 +98,10 @@ const getStartCommand = (manager: PackageManager) => {
 	if (manager === 'bun') {
 		return `bun run dev`;
 	}
+
+	if (manager === 'nub') {
+		return `nub run dev`;
+	}
 };
 
 export const getRunCommand = (manager: PackageManager) => {
@@ -107,6 +119,10 @@ export const getRunCommand = (manager: PackageManager) => {
 
 	if (manager === 'bun') {
 		return `bun run`;
+	}
+
+	if (manager === 'nub') {
+		return `nub run`;
 	}
 
 	throw new TypeError('unknown package manager');
@@ -129,6 +145,10 @@ export const getRenderCommand = (manager: PackageManager) => {
 		return `bunx remotion render`;
 	}
 
+	if (manager === 'nub') {
+		return `nubx remotion render`;
+	}
+
 	throw new TypeError('unknown package manager');
 };
 
@@ -147,6 +167,10 @@ export const getUpgradeCommand = (manager: PackageManager) => {
 
 	if (manager === 'bun') {
 		return `bunx remotion upgrade`;
+	}
+
+	if (manager === 'nub') {
+		return `nubx remotion upgrade`;
 	}
 
 	throw new TypeError('unknown package manager');

--- a/packages/create-video/src/test/patch-package-json.test.ts
+++ b/packages/create-video/src/test/patch-package-json.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from 'bun:test';
 import {patchPackageJson} from '../patch-package-json';
 import type {PackageManager} from '../pkg-managers';
 
-const packageManagers: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+const packageManagers: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun', 'nub'];
 
 for (const packageManager of packageManagers) {
 	test(`Using ${packageManager} package manager provides the correct "packageManager" entry in package.json`, () => {

--- a/packages/create-video/src/test/pkg-managers.test.ts
+++ b/packages/create-video/src/test/pkg-managers.test.ts
@@ -1,0 +1,63 @@
+import {expect, test} from 'bun:test';
+import {
+	getDevCommand,
+	getInstallCommand,
+	getRenderCommand,
+	getRunCommand,
+	getUpgradeCommand,
+	selectPackageManager,
+} from '../pkg-managers';
+import {FEATURED_TEMPLATES} from '../templates';
+
+test('detects Nub and uses Nub commands', () => {
+	const previousUserAgent = process.env.npm_config_user_agent;
+	const previousExecPath = process.env.npm_execpath;
+	const previousArgv = process.env.npm_config_argv;
+
+	try {
+		process.env.npm_config_user_agent = 'nub/0.8.2 yarn/1.22.22';
+		process.env.npm_execpath = '/path/to/yarn.js';
+		process.env.npm_config_argv = JSON.stringify({remain: ['dlx']});
+
+		expect(selectPackageManager()).toBe('nub');
+
+		const blankTemplate = FEATURED_TEMPLATES.find(
+			(template) => template.cliId === 'blank',
+		);
+		if (!blankTemplate) {
+			throw new Error('Blank template not found');
+		}
+
+		expect([
+			getInstallCommand('nub'),
+			getDevCommand('nub', blankTemplate),
+			getRunCommand('nub'),
+			getRenderCommand('nub'),
+			getUpgradeCommand('nub'),
+		]).toEqual([
+			'nub install',
+			'nub run dev',
+			'nub run',
+			'nubx remotion render',
+			'nubx remotion upgrade',
+		]);
+	} finally {
+		if (previousUserAgent === undefined) {
+			delete process.env.npm_config_user_agent;
+		} else {
+			process.env.npm_config_user_agent = previousUserAgent;
+		}
+
+		if (previousExecPath === undefined) {
+			delete process.env.npm_execpath;
+		} else {
+			process.env.npm_execpath = previousExecPath;
+		}
+
+		if (previousArgv === undefined) {
+			delete process.env.npm_config_argv;
+		} else {
+			process.env.npm_config_argv = previousArgv;
+		}
+	}
+});

--- a/packages/docs/docs/getting-started.mdx
+++ b/packages/docs/docs/getting-started.mdx
@@ -57,6 +57,7 @@ values={[
 { label: 'bun', value: 'bun', },
 { label: 'pnpm', value: 'pnpm', },
 { label: 'yarn', value: 'yarn', },
+{ label: 'nub', value: 'nub', },
 ]
 }>
 <TabItem value="npm">
@@ -78,6 +79,14 @@ pnpm create video
 
 ```bash title="Use Yarn as the package manager"
 yarn create video
+```
+
+  </TabItem>
+
+  <TabItem value="nub">
+
+```bash title="Use Nub as the package manager"
+nubx create-video@latest
 ```
 
   </TabItem>

--- a/packages/renderer/src/options/package-manager.tsx
+++ b/packages/renderer/src/options/package-manager.tsx
@@ -14,7 +14,7 @@ export const packageManagerOption = {
 				auto-detect the package manager based on your lockfile.
 				<br />
 				Acceptable values are <code>npm</code>, <code>yarn</code>,{' '}
-				<code>pnpm</code> and <code>bun</code>.
+				<code>pnpm</code>, <code>bun</code> and <code>nub</code>.
 			</>
 		);
 	},

--- a/packages/studio-server/src/helpers/install-command.ts
+++ b/packages/studio-server/src/helpers/install-command.ts
@@ -25,6 +25,7 @@ export const getInstallCommand = ({
 		pnpm: ['i', ...additionalArgs, ...pkgList],
 		yarn: ['add', '--exact', ...additionalArgs, ...pkgList],
 		bun: ['i', ...additionalArgs, ...pkgList],
+		nub: ['add', ...additionalArgs, ...pkgList],
 	};
 
 	return commands[manager];

--- a/packages/studio-server/src/preview-server/get-package-manager.ts
+++ b/packages/studio-server/src/preview-server/get-package-manager.ts
@@ -31,6 +31,12 @@ export const lockFilePaths: LockfilePath[] = [
 		startCommand: 'pnpm exec remotion studio',
 	},
 	{
+		path: 'nub.lock',
+		manager: 'nub',
+		installCommand: 'nub add',
+		startCommand: 'nubx remotion studio',
+	},
+	{
 		path: 'bun.lock',
 		manager: 'bun',
 		installCommand: 'bun i',

--- a/packages/studio-server/src/test/install-dependency.test.ts
+++ b/packages/studio-server/src/test/install-dependency.test.ts
@@ -89,6 +89,7 @@ test('installs without running dependency lifecycle scripts', async () => {
 		pnpm: 'pnpm-lock.yaml',
 		yarn: 'yarn.lock',
 		bun: 'bun.lock',
+		nub: 'nub.lock',
 	};
 	const temporaryDirectories: string[] = [];
 
@@ -125,6 +126,11 @@ test('installs without running dependency lifecycle scripts', async () => {
 			expect(spawnCalls).toHaveLength(1);
 			const [call] = spawnCalls;
 			expect(call.command).toBe(manager);
+			expect(call.args).toContain('lodash@4.17.21');
+			if (manager === 'nub') {
+				expect(call.args[0]).toBe('add');
+			}
+
 			if (manager === 'yarn') {
 				expect(call.args).not.toContain('--ignore-scripts');
 				expect(call.options.env?.YARN_ENABLE_SCRIPTS).toBe('false');

--- a/packages/studio-shared/src/package-manager.ts
+++ b/packages/studio-shared/src/package-manager.ts
@@ -1,1 +1,1 @@
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'nub';

--- a/packages/studio/src/components/UpdatesSettings.tsx
+++ b/packages/studio/src/components/UpdatesSettings.tsx
@@ -107,6 +107,7 @@ const commands: {
 	yarn: 'yarn remotion upgrade',
 	pnpm: 'pnpm exec remotion upgrade',
 	bun: 'bun remotion upgrade',
+	nub: 'nubx remotion upgrade',
 	unknown: 'npx remotion upgrade',
 };
 


### PR DESCRIPTION
## Summary

- detect Nub when scaffolding projects and print Nub-specific commands
- detect `nub.lock` in Studio and use Nub for dependency installation and upgrades
- document Nub in CLI help and the project creation guide

## Verification

- `bun test packages/create-video/src/test/pkg-managers.test.ts packages/create-video/src/test/patch-package-json.test.ts`
- `bun test packages/studio-server/src/test/install-dependency.test.ts`
- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && bun run build-docs`

Closes #11037

## Preview

- [Creating a new project](https://remotion-git-support-nub-package-manager-remotion.vercel.app/docs/)
