### PR TITLE
Elements: Simplify Element install confirmation dialog

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1017,16 +1017,17 @@ export const BrowserElement = () => <Rect width={320} height={180} fill="red" />
 	await canvas.dispatchEvent('drop', coordinates);
 
 	await expect(
-		studio.getByText('Install Element', {exact: true}),
+		studio.getByText('Install Browser Element', {exact: true}),
 	).toBeVisible();
 	await expect(
 		studio.getByText('Unverified drag-and-drop payload'),
 	).toBeVisible();
 	await expect(
-		studio.getByText(
-			'Dependencies are resolved in the browser; package lifecycle scripts do not run.',
-		),
-	).toHaveCount(0);
+		studio.getByText('Packages to install', {exact: true}),
+	).toBeVisible();
+	await expect(
+		studio.getByText('@remotion/shapes', {exact: true}),
+	).toBeVisible();
 	await studio.getByRole('button', {name: /^Install/}).click();
 
 	await expect
@@ -1099,7 +1100,7 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 	await expect(studio.getByTitle('/project').getByText('MyComp')).toBeVisible();
 
 	await expect(
-		studio.getByText('Install Element', {exact: true}),
+		studio.getByText('Install Linked Element', {exact: true}),
 	).toBeVisible();
 	await expect(page).toHaveTitle(
 		'📦 Install Linked Element - Remotion Studio',

--- a/packages/docs/docs/studio-protocol/security.mdx
+++ b/packages/docs/docs/studio-protocol/security.mdx
@@ -19,7 +19,7 @@ Studio reflects only the requesting allowed origin in CORS. It does not use wild
 
 Elements delivered using [`setStudioDragData()`](/docs/studio-protocol/set-studio-drag-data) or [`installInStudio()`](/docs/studio-protocol/install-in-studio) require confirmation in Studio. A successful `installInStudio()` result only means the request reached Studio and is awaiting confirmation.
 
-Before confirming, Studio shows the target composition and destination file, source code, and every declared dependency with its installation status. For an installation request, Studio also shows the requesting website. Drag-and-drop data has no reliable website provenance and is labeled as unverified. Source code and package lifecycle scripts run with the project's file and network access.
+Before confirming, Studio shows the requesting source, destination choice, source code, packages that will be installed, and whether an existing Element source file will be replaced. Drag-and-drop data has no reliable website provenance and is labeled as unverified. Installed source code runs with the project's file and network access. Package lifecycle scripts may also run when packages are installed.
 
 Declining the confirmation does not write source files or install packages.
 

--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -355,13 +355,21 @@ const CloseupPlaceholder = () => {
 		studioProtocolRequests.length = 0;
 		await installInStudio.click();
 
-		const dialog = studioPage.getByRole('dialog');
-		await expect(
-			dialog.getByText('Install Protocol Element', {exact: true}),
-		).toBeVisible();
-		await expect(
-			dialog.getByRole('button', {name: 'Current composition'}),
-		).toHaveAttribute('aria-pressed', 'true');
+		const dialog = studioPage.getByRole('dialog', {
+			name: 'Install Protocol Element',
+		});
+		await expect(dialog).toBeVisible();
+		const currentDestination = dialog.getByRole('radio', {
+			name: 'Current composition',
+		});
+		const newDestination = dialog.getByRole('radio', {
+			name: 'New composition',
+		});
+		await expect(currentDestination).toBeChecked();
+		await currentDestination.press('ArrowRight');
+		await expect(newDestination).toBeChecked();
+		await newDestination.press('ArrowLeft');
+		await expect(currentDestination).toBeChecked();
 		await expect(dialog.getByText(senderUrl, {exact: true})).toBeVisible();
 		await expect(
 			decoyStudioPage.getByText('Install Protocol Element', {exact: true}),
@@ -395,12 +403,12 @@ const CloseupPlaceholder = () => {
 		await senderPage.goto(senderUrl);
 		await senderPage.getByRole('button', {name: 'Install in Studio'}).click();
 		await studioPage.bringToFront();
-		const newCompositionDialog = studioPage.getByRole('dialog');
-		await expect(
-			newCompositionDialog.getByText('Install Protocol Element', {exact: true}),
-		).toBeVisible();
+		const newCompositionDialog = studioPage.getByRole('dialog', {
+			name: 'Install Protocol Element',
+		});
+		await expect(newCompositionDialog).toBeVisible();
 		await newCompositionDialog
-			.getByRole('button', {name: 'New composition'})
+			.getByRole('radio', {name: 'New composition'})
 			.click();
 		await expect(
 			newCompositionDialog.getByPlaceholder('Composition ID'),

--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -356,10 +356,16 @@ const CloseupPlaceholder = () => {
 		await installInStudio.click();
 
 		const dialog = studioPage.getByRole('dialog');
-		await expect(dialog.getByText('Install Element')).toBeVisible();
-		await expect(dialog.getByText(/Protocol Element.*MyComp/)).toBeVisible();
+		await expect(
+			dialog.getByText('Install Protocol Element', {exact: true}),
+		).toBeVisible();
+		await expect(
+			dialog.getByRole('button', {name: 'Current composition'}),
+		).toHaveAttribute('aria-pressed', 'true');
 		await expect(dialog.getByText(senderUrl, {exact: true})).toBeVisible();
-		await expect(decoyStudioPage.getByText('Install Element')).toHaveCount(0);
+		await expect(
+			decoyStudioPage.getByText('Install Protocol Element', {exact: true}),
+		).toHaveCount(0);
 		await expect(elementsIframe).toHaveCount(0);
 		expect(studioProtocolRequests).toEqual([]);
 		await dialog.getByRole('button', {name: /Install/}).click();
@@ -391,7 +397,7 @@ const CloseupPlaceholder = () => {
 		await studioPage.bringToFront();
 		const newCompositionDialog = studioPage.getByRole('dialog');
 		await expect(
-			newCompositionDialog.getByText('Install Element'),
+			newCompositionDialog.getByText('Install Protocol Element', {exact: true}),
 		).toBeVisible();
 		await newCompositionDialog
 			.getByRole('button', {name: 'New composition'})

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -89,8 +89,6 @@ import {useSvgImportDialog} from './SvgImportDialog';
 import {getCurrentFrame} from './Timeline/imperative-state';
 import {useResolvedStack} from './Timeline/use-resolved-stack';
 
-const elementInstallDependencyIgnoreList = ['react', 'react-dom', 'remotion'];
-
 const getCanvasDragPreviewMetadata = (mimeTypes: ArrayLike<string>) => {
 	const composition = getCompositionDragPreviewMetadata(mimeTypes);
 	if (composition !== null) {
@@ -1044,20 +1042,11 @@ export const Canvas: React.FC<{
 					).values(),
 				);
 				const missingPackages = getMissingPackages(declaredDependencies).map(
-					(dependency) => dependency.name,
-				);
-				const ignoredDependencies = declaredDependencies.filter(
 					(dependency) =>
-						elementInstallDependencyIgnoreList.includes(dependency.name) &&
-						!missingPackages.includes(dependency.name),
-				);
-				const dependenciesToReview = declaredDependencies
-					.filter((dependency) => !ignoredDependencies.includes(dependency))
-					.map((dependency) =>
 						dependency.version === null
 							? dependency.name
 							: `${dependency.name}@${dependency.version}`,
-					);
+				);
 				const {source} = activeElementInstallRequest;
 				const sourceLabel =
 					source.type === 'studio-protocol'
@@ -1074,7 +1063,6 @@ export const Canvas: React.FC<{
 				setSelectedModal({
 					type: 'element-install',
 					currentPlan,
-					dependenciesToReview,
 					missingPackages,
 					newPlan: newPreflight.plan,
 					onClose: closeElementInstallDialog,

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -68,7 +68,7 @@ const container: React.CSSProperties = {
 const dialogContent: React.CSSProperties = {
 	...container,
 	padding: 16,
-	width: 'min(600px, calc(100vw - 40px))',
+	width: 'min(520px, calc(100vw - 40px))',
 	maxHeight: 'min(720px, calc(100vh - 140px))',
 	overflowY: 'auto',
 };
@@ -130,6 +130,7 @@ const requestSourceStyle: React.CSSProperties = {
 
 const requestSourceDescriptionStyle: React.CSSProperties = {
 	...metadataDescriptionStyle,
+	color: LIGHT_TEXT,
 	textAlign: 'right',
 };
 
@@ -253,25 +254,31 @@ const destinationControlStyle: React.CSSProperties = {
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'space-between',
-	gap: 16,
+	columnGap: 16,
+	rowGap: 10,
+	flexWrap: 'wrap',
 };
 
 const destinationOptionsStyle: React.CSSProperties = {
 	display: 'flex',
 	overflow: 'hidden',
+	maxWidth: '100%',
+	marginLeft: 'auto',
 	border: `1px solid ${WHITE_ALPHA_12}`,
 	borderRadius: 4,
 };
 
 const destinationOptionStyle: React.CSSProperties = {
 	appearance: 'none',
+	minHeight: 26,
 	border: 0,
 	cursor: 'default',
 	fontFamily: 'sans-serif',
-	fontSize: 11,
+	fontSize: 12,
 	fontWeight: 400,
-	lineHeight: 1.5,
-	padding: '2px 7px',
+	lineHeight: '18px',
+	padding: '4px 8px',
+	whiteSpace: 'nowrap',
 };
 
 const getDestinationOptionStyle = ({
@@ -298,6 +305,8 @@ const footerStyle: React.CSSProperties = {
 const cancelStyle: React.CSSProperties = {
 	minWidth: 90,
 };
+
+const elementInstallTitleId = 'remotion-element-install-title';
 
 const makeSourceControlsVisible = (sourceCode: string) => {
 	return sourceCode.replace(
@@ -397,6 +406,8 @@ export const ElementInstallConfirmation: React.FC<{
 	);
 	const [submitting, setSubmitting] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const currentDestinationRef = useRef<HTMLButtonElement>(null);
+	const newDestinationRef = useRef<HTMLButtonElement>(null);
 	const [newCompositionValues, setNewCompositionValues] =
 		useState<NewCompositionFormValues>(() => {
 			const elementComponentName =
@@ -549,6 +560,7 @@ export const ElementInstallConfirmation: React.FC<{
 	const folderTargetIsReady =
 		selectedFolderStack === null ||
 		(hasResolvedStack(selectedFolderStack) && folderCompositionFile !== null);
+	const title = `Install ${request.element.displayName}${request.element.displayName.endsWith(' Element') ? '' : ' Element'}`;
 	const canSubmit =
 		!submitting &&
 		(mode === 'current-composition'
@@ -630,6 +642,35 @@ export const ElementInstallConfirmation: React.FC<{
 		}
 	}, [onClose, submitting]);
 
+	const onDestinationKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (
+				!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			if (currentPlan === null) {
+				return;
+			}
+
+			const nextMode =
+				mode === 'current-composition'
+					? 'new-composition'
+					: 'current-composition';
+			setMode(nextMode);
+			requestAnimationFrame(() => {
+				if (nextMode === 'current-composition') {
+					currentDestinationRef.current?.focus();
+				} else {
+					newDestinationRef.current?.focus();
+				}
+			});
+		},
+		[currentPlan, mode],
+	);
+
 	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback(
 		(event) => {
 			event.preventDefault();
@@ -639,11 +680,14 @@ export const ElementInstallConfirmation: React.FC<{
 	);
 
 	return createPortal(
-		<ModalContainer onOutsideClick={cancel} onEscape={cancel}>
-			<ModalHeader
-				title={`Install ${request.element.displayName}${request.element.displayName.endsWith(' Element') ? '' : ' Element'}`}
-				onClose={cancel}
-			/>
+		<ModalContainer
+			ariaLabelledBy={elementInstallTitleId}
+			onOutsideClick={cancel}
+			onEscape={cancel}
+		>
+			<div id={elementInstallTitleId}>
+				<ModalHeader title={title} onClose={cancel} />
+			</div>
 			<form onSubmit={onSubmit}>
 				<div style={dialogContent}>
 					<dl style={requestSourceStyle} aria-label="Request source">
@@ -663,29 +707,35 @@ export const ElementInstallConfirmation: React.FC<{
 						<div style={sectionTitleStyle}>Destination</div>
 						<div
 							aria-label="Installation destination"
-							role="group"
+							onKeyDown={onDestinationKeyDown}
+							role="radiogroup"
 							style={destinationOptionsStyle}
 						>
 							<button
-								aria-pressed={mode === 'current-composition'}
+								ref={currentDestinationRef}
+								aria-checked={mode === 'current-composition'}
 								className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 								disabled={currentPlan === null}
 								onClick={() => setMode('current-composition')}
+								role="radio"
 								style={getDestinationOptionStyle({
 									disabled: currentPlan === null,
 									selected: mode === 'current-composition',
 								})}
+								tabIndex={mode === 'current-composition' ? 0 : -1}
 								type="button"
 							>
 								Current composition
 							</button>
 							<button
-								aria-pressed={mode === 'new-composition'}
+								ref={newDestinationRef}
+								aria-checked={mode === 'new-composition'}
 								className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 								onClick={() => {
 									setMode('new-composition');
 									requestAnimationFrame(() => inputRef.current?.select());
 								}}
+								role="radio"
 								style={{
 									...getDestinationOptionStyle({
 										disabled: false,
@@ -693,6 +743,7 @@ export const ElementInstallConfirmation: React.FC<{
 									}),
 									borderLeft: `1px solid ${WHITE_ALPHA_12}`,
 								}}
+								tabIndex={mode === 'new-composition' ? 0 : -1}
 								type="button"
 							>
 								New composition

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -68,7 +68,7 @@ const container: React.CSSProperties = {
 const dialogContent: React.CSSProperties = {
 	...container,
 	padding: 16,
-	width: 'min(640px, calc(100vw - 40px))',
+	width: 'min(600px, calc(100vw - 40px))',
 	maxHeight: 'min(720px, calc(100vh - 140px))',
 	overflowY: 'auto',
 };
@@ -121,8 +121,20 @@ const metadataDescriptionStyle: React.CSSProperties = {
 	overflowWrap: 'anywhere',
 };
 
-const unverifiedSourceStyle: React.CSSProperties = {
+const requestSourceStyle: React.CSSProperties = {
+	display: 'flex',
+	justifyContent: 'space-between',
+	gap: 16,
+	margin: 0,
+};
+
+const requestSourceDescriptionStyle: React.CSSProperties = {
 	...metadataDescriptionStyle,
+	textAlign: 'right',
+};
+
+const unverifiedRequestSourceStyle: React.CSSProperties = {
+	...requestSourceDescriptionStyle,
 	color: WARNING_COLOR,
 };
 
@@ -151,35 +163,13 @@ const dependencyListStyle: React.CSSProperties = {
 	listStyleType: 'none',
 };
 
-const dependencyRowStyle: React.CSSProperties = {
-	display: 'flex',
-	alignItems: 'baseline',
-	justifyContent: 'space-between',
-	gap: 16,
-	minWidth: 0,
-};
-
 const dependencyNameStyle: React.CSSProperties = {
 	minWidth: 0,
 	color: WHITE,
-	fontFamily: 'monospace',
+	fontFamily: 'sans-serif',
 	fontSize: 13,
 	lineHeight: 1.5,
 	overflowWrap: 'anywhere',
-};
-
-const dependencyInstallStatusStyle: React.CSSProperties = {
-	flexShrink: 0,
-	color: WARNING_COLOR,
-	fontFamily: 'sans-serif',
-	fontSize: 13,
-	fontWeight: 500,
-	lineHeight: 1.5,
-};
-
-const dependencyInstalledStatusStyle: React.CSSProperties = {
-	...dependencyInstallStatusStyle,
-	color: LIGHT_TEXT,
 };
 
 const warningStyle: React.CSSProperties = {
@@ -207,6 +197,11 @@ const warningDescriptionStyle: React.CSSProperties = {
 	lineHeight: 1.5,
 };
 
+const installWarningDescriptionStyle: React.CSSProperties = {
+	...warningDescriptionStyle,
+	color: WHITE,
+};
+
 const browseElementsStyle: React.CSSProperties = {
 	color: 'inherit',
 	fontFamily: 'inherit',
@@ -223,7 +218,7 @@ const sourceDetailsStyle: React.CSSProperties = {
 };
 
 const sourceSummaryStyle: React.CSSProperties = {
-	cursor: 'pointer',
+	cursor: 'default',
 	color: WHITE,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
@@ -373,7 +368,6 @@ export const ElementInstallConfirmation: React.FC<{
 }> = ({state}) => {
 	const {
 		currentPlan,
-		dependenciesToReview,
 		missingPackages,
 		newPlan,
 		onClose,
@@ -646,11 +640,27 @@ export const ElementInstallConfirmation: React.FC<{
 
 	return createPortal(
 		<ModalContainer onOutsideClick={cancel} onEscape={cancel}>
-			<ModalHeader title="Install Element" onClose={cancel} />
+			<ModalHeader
+				title={`Install ${request.element.displayName}${request.element.displayName.endsWith(' Element') ? '' : ' Element'}`}
+				onClose={cancel}
+			/>
 			<form onSubmit={onSubmit}>
 				<div style={dialogContent}>
+					<dl style={requestSourceStyle} aria-label="Request source">
+						<dt style={sectionTitleStyle}>From</dt>
+						<dd
+							style={
+								sourceIsUnverified
+									? unverifiedRequestSourceStyle
+									: requestSourceDescriptionStyle
+							}
+						>
+							{sourceLabel}
+						</dd>
+					</dl>
+
 					<div style={destinationControlStyle}>
-						<div style={sectionTitleStyle}>Add to</div>
+						<div style={sectionTitleStyle}>Destination</div>
 						<div
 							aria-label="Installation destination"
 							role="group"
@@ -693,7 +703,7 @@ export const ElementInstallConfirmation: React.FC<{
 					{currentPlan === null ? (
 						<div style={warningStyle} role="status">
 							<WarningTriangle style={warningIconStyle} />
-							<p style={warningDescriptionStyle}>
+							<p style={installWarningDescriptionStyle}>
 								Studio could not find a safe place in “{request.compositionId}”
 								to insert the Element. Install it into a new composition
 								instead.
@@ -721,88 +731,38 @@ export const ElementInstallConfirmation: React.FC<{
 						</section>
 					) : null}
 
-					<dl style={metadataStyle} aria-label="Installation details">
-						<div style={metadataRowStyle}>
-							<dt style={metadataTermStyle}>Element</dt>
-							<dd style={metadataDescriptionStyle}>
-								{request.element.displayName}
-							</dd>
-						</div>
-						<div style={metadataRowStyle}>
-							<dt style={metadataTermStyle}>Request source</dt>
-							<dd
-								style={
-									sourceIsUnverified
-										? unverifiedSourceStyle
-										: metadataDescriptionStyle
-								}
-							>
-								{sourceLabel}
-							</dd>
-						</div>
-						<div style={metadataRowStyle}>
-							<dt style={metadataTermStyle}>Composition</dt>
-							<dd style={metadataDescriptionStyle}>
-								<code style={codeStyle}>
-									{mode === 'current-composition'
-										? request.compositionId
-										: newCompositionValues.id}
-								</code>
-							</dd>
-						</div>
-						<div style={metadataRowStyle}>
-							<dt style={metadataTermStyle}>Destination</dt>
-							<dd style={metadataDescriptionStyle}>
-								<code style={codeStyle}>
-									{selectedPlan?.filePath ?? 'Reviewing destination…'}
-								</code>
-							</dd>
-						</div>
-						{selectedPlan?.expectedFileState.exists ? (
-							<div style={metadataRowStyle}>
-								<dt style={metadataTermStyle}>File change</dt>
-								<dd style={overwriteStyle}>Replace existing source file</dd>
-							</div>
-						) : null}
-					</dl>
+					{selectedPlan?.expectedFileState.exists ? (
+						<p style={overwriteStyle} role="status">
+							This will replace the existing Element source file.
+						</p>
+					) : null}
 
-					{dependenciesToReview.length > 0 ? (
+					{missingPackages.length > 0 ? (
 						<section
 							style={sectionStyle}
 							aria-labelledby="element-install-dependencies"
 						>
 							<h3 id="element-install-dependencies" style={sectionTitleStyle}>
-								Dependencies
+								Packages to install
 							</h3>
 							<ul style={dependencyListStyle} role="list">
-								{dependenciesToReview.map((packageName) => {
-									const willInstall = missingPackages.includes(packageName);
-									return (
-										<li key={packageName} style={dependencyRowStyle}>
-											<div style={dependencyNameStyle}>{packageName}</div>
-											<div
-												style={
-													willInstall
-														? dependencyInstallStatusStyle
-														: dependencyInstalledStatusStyle
-												}
-											>
-												{willInstall ? 'Will be installed' : 'Installed'}
-											</div>
-										</li>
-									);
-								})}
+								{missingPackages.map((packageName) => (
+									<li key={packageName} style={dependencyNameStyle}>
+										{packageName}
+									</li>
+								))}
 							</ul>
 						</section>
 					) : null}
 
 					<div style={warningStyle}>
 						<WarningTriangle style={warningIconStyle} />
-						<p style={warningDescriptionStyle}>
-							This adds executable source code to your project.
-							{usesBrowserDependencyResolution
+						<p style={installWarningDescriptionStyle}>
+							This adds executable source code to your project, with access to
+							your files and the network.
+							{usesBrowserDependencyResolution || missingPackages.length === 0
 								? null
-								: ' Package lifecycle scripts may also run during installation, with access to your files and the network.'}
+								: ' Package lifecycle scripts may also run during installation.'}
 						</p>
 					</div>
 

--- a/packages/studio/src/components/ModalContainer.tsx
+++ b/packages/studio/src/components/ModalContainer.tsx
@@ -39,12 +39,20 @@ const panel: React.CSSProperties = {
 };
 
 export const ModalContainer: React.FC<{
+	readonly ariaLabelledBy?: string;
 	readonly onEscape: () => void;
 	readonly onOutsideClick: () => void;
 	readonly children: React.ReactNode;
 	readonly noZIndex?: boolean;
 	readonly panelStyle?: React.CSSProperties;
-}> = ({children, onEscape, onOutsideClick, noZIndex, panelStyle}) => {
+}> = ({
+	ariaLabelledBy,
+	children,
+	onEscape,
+	onOutsideClick,
+	noZIndex,
+	panelStyle,
+}) => {
 	const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
 		// Prevent deselection of currently selected items
 		e.stopPropagation();
@@ -52,10 +60,11 @@ export const ModalContainer: React.FC<{
 
 	return (
 		<div
-			className="css-reset"
-			style={backgroundOverlay}
-			role="dialog"
+			aria-labelledby={ariaLabelledBy ?? undefined}
 			aria-modal="true"
+			className="css-reset"
+			role="dialog"
+			style={backgroundOverlay}
 			onPointerDown={onPointerDown}
 		>
 			<HigherZIndex

--- a/packages/studio/src/components/ModalHeader.tsx
+++ b/packages/studio/src/components/ModalHeader.tsx
@@ -14,8 +14,12 @@ const container: React.CSSProperties = {
 };
 
 const titleStyle: React.CSSProperties = {
-	fontSize: 14,
 	color: WHITE,
+	fontSize: 14,
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
 };
 
 const icon: React.CSSProperties = {

--- a/packages/studio/src/state/modals.ts
+++ b/packages/studio/src/state/modals.ts
@@ -150,14 +150,12 @@ export type CanvasCaptureImport = {
 
 export type ElementInstallPlan = {
 	readonly compositionFile: string;
-	readonly filePath: string;
 	readonly expectedFileState: ElementInstallExpectedFileState;
 };
 
 export type ElementInstallModalState = {
 	readonly type: 'element-install';
 	readonly currentPlan: ElementInstallPlan | null;
-	readonly dependenciesToReview: string[];
 	readonly missingPackages: string[];
 	readonly newPlan: ElementInstallPlan;
 	readonly onClose: () => void;


### PR DESCRIPTION
## Summary

- simplify the Element installation confirmation dialog around source, destination, and source code
- keep the dialog compact and make the destination selector responsive, easier to target, and keyboard-accessible
- show only packages that need installation while preserving overwrite and security warnings
- include the Element name in the dialog title, expose it as the dialog's accessible name, and keep long titles contained
- update Studio Protocol security documentation and installation E2E coverage

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make --filter='@remotion/studio'`
- `bunx turbo run lint test --filter='@remotion/studio'`
- `cd packages/example && bunx playwright test e2e/studio-protocol.test.mts`
- `cd packages/browser-studio && bunx playwright test e2e/browser-studio.test.ts --grep 'drops and imports an Element payload|confirms and imports an Element payload'`

Closes #10965

## Preview

- [Studio Protocol security](https://remotion-git-elements-install-dialog-layout-remotion.vercel.app/docs/studio-protocol/security)
