### PR TITLE
Elements: Integrate drag handle into install button

### DIFF
--- a/packages/docs/components/layout/Button.tsx
+++ b/packages/docs/components/layout/Button.tsx
@@ -28,14 +28,26 @@ type PrestyledProps = DetailedHTMLProps<
 	MandatoryProps;
 
 export const Button: React.FC<Props> = (props) => {
-	const {children, loading, hoverColor, fullWidth, color, size, ...other} =
-		props;
+	const {
+		children,
+		loading,
+		hoverColor,
+		fullWidth,
+		color,
+		size,
+		className,
+		...other
+	} = props;
 	const actualDisabled = other.disabled || loading;
 
 	return (
 		<button
 			type="button"
-			className={styles.buttoncontainer}
+			className={
+				className
+					? `${styles.buttoncontainer} ${className}`
+					: styles.buttoncontainer
+			}
 			disabled={actualDisabled}
 			{...other}
 			style={{

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -97,23 +97,31 @@
 
 .actionRow {
 	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
+	align-items: flex-start;
 	gap: 10px;
 }
 
+.actionButtons {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 10px;
+	min-width: 0;
+}
+
 .dragHandle {
-	position: relative;
 	display: flex;
 	align-items: center;
-	margin-top: 8px;
-	padding: 8px 40px;
+	justify-content: center;
+	width: 46px;
+	height: 46px;
+	flex: none;
 	border: 1px solid var(--ifm-color-emphasis-300);
-	border-radius: 8px;
+	border-radius: 50%;
 	background: var(--ifm-background-surface-color);
+	box-shadow: 0 2px 5px rgb(0 0 0 / 12%);
 	color: var(--ifm-color-emphasis-800);
 	cursor: grab;
-	font-size: 0.8125rem;
 	user-select: none;
 }
 
@@ -131,29 +139,12 @@
 }
 
 .dragHandleIcon {
-	position: absolute;
-	left: 12px;
-	top: 50%;
 	font-size: 1.5rem;
 	line-height: 1;
-	transform: translateY(-50%);
 }
 
 [data-theme='dark'] .dragHandleIcon {
 	color: var(--ifm-color-emphasis-500);
-}
-
-.dragHandleText {
-	display: flex;
-	flex: 1;
-	flex-direction: column;
-	line-height: 1.3;
-	text-align: center;
-	white-space: nowrap;
-}
-
-.dragHandleText strong {
-	font-weight: 600;
 }
 
 .successStatus,
@@ -171,9 +162,7 @@
 }
 
 .details {
-	margin-top: 16px;
-	padding-top: 16px;
-	border-top: 1px solid var(--ifm-color-emphasis-200);
+	margin-top: 32px;
 }
 
 .description {
@@ -223,11 +212,6 @@
 	max-width: 100%;
 	line-height: 1.45;
 	overflow-wrap: anywhere;
-}
-
-.dependencyList li::marker {
-	color: var(--ifm-color-primary);
-	font-size: 0.85em;
 }
 
 .dependencyList li + li {
@@ -301,7 +285,6 @@
 }
 
 @container actions-column (max-width: 400px) {
-	.actionsColumn .actionRow,
 	.actionsColumn .contributors,
 	.actionsColumn .contributorList {
 		align-items: stretch;
@@ -312,11 +295,6 @@
 @media (max-width: 600px) {
 	.sourceViewportCollapsed {
 		height: 160px;
-	}
-
-	.actionRow {
-		align-items: stretch;
-		flex-direction: column;
 	}
 
 	.contributors {

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -160,7 +160,7 @@
 }
 
 .details {
-	margin-top: 32px;
+	margin-top: 20px;
 }
 
 .description {
@@ -171,7 +171,7 @@
 }
 
 .metadata {
-	margin: 14px 0 0;
+	margin: 16px 0 0;
 	font-size: 0.8125rem;
 }
 
@@ -189,8 +189,8 @@
 
 .metadata dd {
 	margin: 0;
+	color: var(--ifm-color-emphasis-800);
 	font-variant-numeric: tabular-nums;
-	font-weight: 600;
 }
 
 .metadata > .dependenciesMetadata {
@@ -224,7 +224,7 @@
 }
 
 .contributors:not(:first-child) {
-	margin-top: 32px;
+	margin-top: 24px;
 }
 
 .contributorsLabel {
@@ -237,7 +237,7 @@
 .contributorList {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 12px;
+	gap: 8px;
 	min-width: 0;
 }
 

--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -97,16 +97,22 @@
 
 .actionRow {
 	display: flex;
-	align-items: flex-start;
+	flex-direction: column;
 	gap: 10px;
 }
 
-.actionButtons {
+.studioAction {
 	display: flex;
-	flex: 1;
-	flex-direction: column;
-	gap: 10px;
-	min-width: 0;
+	align-items: stretch;
+	width: 100%;
+	border-radius: 8px;
+	background: var(--blue-underlay);
+}
+
+.studioAction .installButtonWithDragHandle {
+	border-top-right-radius: 0;
+	border-right-width: 0;
+	border-bottom-right-radius: 0;
 }
 
 .dragHandle {
@@ -114,37 +120,29 @@
 	align-items: center;
 	justify-content: center;
 	width: 46px;
-	height: 46px;
+	min-height: 46px;
 	flex: none;
-	border: 1px solid var(--ifm-color-emphasis-300);
-	border-radius: 50%;
-	background: var(--ifm-background-surface-color);
-	box-shadow: 0 2px 5px rgb(0 0 0 / 12%);
-	color: var(--ifm-color-emphasis-800);
+	border: 2px solid black;
+	border-bottom-width: 4px;
+	border-left: 1px solid rgb(0 0 0 / 30%);
+	border-radius: 0 8px 8px 0;
+	background: transparent;
+	color: white;
 	cursor: grab;
 	user-select: none;
 }
 
 .dragHandle:hover {
-	background: var(--ifm-color-emphasis-100);
+	background: rgb(0 0 0 / 8%);
 }
 
 .dragHandle:active {
 	cursor: grabbing;
 }
 
-[data-theme='dark'] .dragHandle {
-	border-color: var(--ifm-color-emphasis-200);
-	color: var(--ifm-color-emphasis-700);
-}
-
 .dragHandleIcon {
 	font-size: 1.5rem;
 	line-height: 1;
-}
-
-[data-theme='dark'] .dragHandleIcon {
-	color: var(--ifm-color-emphasis-500);
 }
 
 .successStatus,
@@ -226,9 +224,7 @@
 }
 
 .contributors:not(:first-child) {
-	margin-top: 16px;
-	padding-top: 16px;
-	border-top: 1px solid var(--ifm-color-emphasis-200);
+	margin-top: 32px;
 }
 
 .contributorsLabel {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -214,51 +214,54 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 					{elementPayload === null ? null : (
 						<>
 							<div className={styles.actionRow}>
-								<BlueButton
-									fullWidth
-									loading={installStatus.type === 'installing'}
-									onClick={installElement}
-									size="sm"
-									style={{padding: '7px 12px'}}
-									title="Install in the most recently focused Remotion Studio"
-								>
-									{installStatus.type === 'installing'
-										? 'Finding Studio…'
-										: 'Install in Studio'}
-								</BlueButton>
-								{isBrowserStudioActionVisible ? (
-									<PlainButton
+								<div className={styles.actionButtons}>
+									<BlueButton
 										fullWidth
-										loading={false}
-										onClick={openInBrowserStudio}
+										loading={installStatus.type === 'installing'}
+										onClick={installElement}
 										size="sm"
 										style={{padding: '7px 12px'}}
+										title="Install in the most recently focused Remotion Studio"
 									>
-										Open in Browser Studio
-									</PlainButton>
+										{installStatus.type === 'installing'
+											? 'Finding Studio…'
+											: 'Install in Studio'}
+									</BlueButton>
+									{isBrowserStudioActionVisible ? (
+										<PlainButton
+											fullWidth
+											loading={false}
+											onClick={openInBrowserStudio}
+											size="sm"
+											style={{padding: '7px 12px'}}
+										>
+											Open in Browser Studio
+										</PlainButton>
+									) : null}
+								</div>
+								{isEmbeddedInStudio === false ? (
+									<div
+										aria-label="Drag into Studio"
+										className={styles.dragHandle}
+										draggable
+										onDragStart={(event) => {
+											setStudioDragData({
+												dataTransfer: event.dataTransfer,
+												payload: elementPayload,
+											});
+											setElementDragImage(
+												event.dataTransfer,
+												posterRef.current,
+											);
+										}}
+										title="Drag into your Studio browser tab to choose where the element is placed on the canvas or timeline"
+									>
+										<span aria-hidden="true" className={styles.dragHandleIcon}>
+											⠿
+										</span>
+									</div>
 								) : null}
 							</div>
-							{isEmbeddedInStudio === false ? (
-								<div
-									className={styles.dragHandle}
-									draggable
-									onDragStart={(event) => {
-										setStudioDragData({
-											dataTransfer: event.dataTransfer,
-											payload: elementPayload,
-										});
-										setElementDragImage(event.dataTransfer, posterRef.current);
-									}}
-									title="Drag into your Studio browser tab to choose where the element is placed on the canvas or timeline"
-								>
-									<span aria-hidden="true" className={styles.dragHandleIcon}>
-										⠿
-									</span>
-									<span className={styles.dragHandleText}>
-										<strong>Drag into Studio</strong>
-									</span>
-								</div>
-							) : null}
 							{installStatus.type === 'success' ||
 							installStatus.type === 'error' ? (
 								<p

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -214,8 +214,13 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 					{elementPayload === null ? null : (
 						<>
 							<div className={styles.actionRow}>
-								<div className={styles.actionButtons}>
+								<div className={styles.studioAction}>
 									<BlueButton
+										className={
+											isEmbeddedInStudio === false
+												? styles.installButtonWithDragHandle
+												: undefined
+										}
 										fullWidth
 										loading={installStatus.type === 'installing'}
 										onClick={installElement}
@@ -227,39 +232,42 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 											? 'Finding Studio…'
 											: 'Install in Studio'}
 									</BlueButton>
-									{isBrowserStudioActionVisible ? (
-										<PlainButton
-											fullWidth
-											loading={false}
-											onClick={openInBrowserStudio}
-											size="sm"
-											style={{padding: '7px 12px'}}
+									{isEmbeddedInStudio === false ? (
+										<div
+											aria-label="Drag into Studio"
+											className={styles.dragHandle}
+											draggable
+											onDragStart={(event) => {
+												setStudioDragData({
+													dataTransfer: event.dataTransfer,
+													payload: elementPayload,
+												});
+												setElementDragImage(
+													event.dataTransfer,
+													posterRef.current,
+												);
+											}}
+											title="Drag into your Studio browser tab to choose where the element is placed on the canvas or timeline"
 										>
-											Open in Browser Studio
-										</PlainButton>
+											<span
+												aria-hidden="true"
+												className={styles.dragHandleIcon}
+											>
+												⠿
+											</span>
+										</div>
 									) : null}
 								</div>
-								{isEmbeddedInStudio === false ? (
-									<div
-										aria-label="Drag into Studio"
-										className={styles.dragHandle}
-										draggable
-										onDragStart={(event) => {
-											setStudioDragData({
-												dataTransfer: event.dataTransfer,
-												payload: elementPayload,
-											});
-											setElementDragImage(
-												event.dataTransfer,
-												posterRef.current,
-											);
-										}}
-										title="Drag into your Studio browser tab to choose where the element is placed on the canvas or timeline"
+								{isBrowserStudioActionVisible ? (
+									<PlainButton
+										fullWidth
+										loading={false}
+										onClick={openInBrowserStudio}
+										size="sm"
+										style={{padding: '7px 12px'}}
 									>
-										<span aria-hidden="true" className={styles.dragHandleIcon}>
-											⠿
-										</span>
-									</div>
+										Open in Browser Studio
+									</PlainButton>
 								) : null}
 							</div>
 							{installStatus.type === 'success' ||


### PR DESCRIPTION
## Summary

- integrate the Studio drag handle into the right side of the install button
- preserve the branded button styling, drag tooltip, and existing Browser Studio hotkey gate
- remove the action and contributor separators and restore normal dependency bullet styling
- tighten the sidebar spacing and clarify the metadata hierarchy

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx oxfmt packages/docs/components/layout/Button.tsx packages/docs/src/components/Elements/ElementPage.tsx packages/docs/src/components/Elements/ElementPage.module.css --check`
- `bunx turbo run lint --filter=docs`
- `bunx turbo run test --filter=docs`

Closes #10964
