### PR TITLE
Elements: Explain local network access during Studio discovery

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -156,10 +156,15 @@
 	font-weight: 600;
 }
 
+.installingStatus,
 .successStatus,
 .errorStatus {
 	margin: 12px 0 0;
 	font-size: 0.875rem;
+}
+
+.installingStatus {
+	color: var(--ifm-color-emphasis-700);
 }
 
 .successStatus {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -51,6 +51,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const [installStatus, setInstallStatus] = useState<InstallStatus>({
 		type: 'idle',
 	});
+	const [isInstallHintVisible, setIsInstallHintVisible] = useState(false);
 	const [isSourceVisible, setIsSourceVisible] = useState(false);
 	const [isBrowserStudioActionVisible, setIsBrowserStudioActionVisible] =
 		useState(false);
@@ -71,6 +72,17 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	useLayoutEffect(() => {
 		setIsEmbeddedInStudio(isInsideStudio());
 	}, []);
+
+	useEffect(() => {
+		if (installStatus.type !== 'installing') {
+			return;
+		}
+
+		const timeout = window.setTimeout(() => {
+			setIsInstallHintVisible(true);
+		}, 1000);
+		return () => window.clearTimeout(timeout);
+	}, [installStatus.type]);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
@@ -109,6 +121,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 			return;
 		}
 
+		setIsInstallHintVisible(false);
 		setInstallStatus({type: 'installing'});
 		const result = await installInStudio({payload: elementPayload});
 		if (!result.success) {
@@ -259,17 +272,21 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									</span>
 								</div>
 							) : null}
-							{installStatus.type === 'success' ||
-							installStatus.type === 'error' ? (
+							{installStatus.type !== 'idle' &&
+							(installStatus.type !== 'installing' || isInstallHintVisible) ? (
 								<p
 									aria-live="polite"
 									className={
-										installStatus.type === 'success'
-											? styles.successStatus
-											: styles.errorStatus
+										installStatus.type === 'installing'
+											? styles.installingStatus
+											: installStatus.type === 'success'
+												? styles.successStatus
+												: styles.errorStatus
 									}
 								>
-									{installStatus.message}
+									{installStatus.type === 'installing'
+										? 'If your browser prompts you, allow local network access so this page can find Remotion Studio.'
+										: installStatus.message}
 								</p>
 							) : null}
 						</>

--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -202,12 +202,13 @@ export const discoverStudios = async (
 }> => {
 	let foundUnsupportedProtocol = false;
 	let foundInvalidResponse = false;
+	const {fetchFn} = dependencies;
 	const studios = await Promise.all(
 		dependencies.ports.map(async (port): Promise<DiscoveredStudio | null> => {
 			const origin = `http://localhost:${port}`;
 			let response: Response;
 			try {
-				response = await dependencies.fetchFn(`${origin}/api/studio-protocol`, {
+				response = await fetchFn(`${origin}/api/studio-protocol`, {
 					cache: 'no-store',
 				});
 			} catch {

--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -211,10 +211,8 @@ export const discoverStudios = async (
 			const origin = `http://localhost:${port}`;
 			let response: Response;
 			try {
-				response = await fetchWithTimeout({
-					fetchFn: dependencies.fetchFn,
-					options: {cache: 'no-store'},
-					url: `${origin}/api/studio-protocol`,
+				response = await dependencies.fetchFn(`${origin}/api/studio-protocol`, {
+					cache: 'no-store',
 				});
 			} catch {
 				return null;

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -186,6 +186,65 @@ test('returns an actionable result when no Studio is running', async () => {
 	});
 });
 
+test('waits for Studio discovery while local network permission is pending', async () => {
+	const fetchFn = (input: string | URL | Request, options?: RequestInit) => {
+		const url = String(input);
+		if (url === 'http://localhost:3000/api/studio-protocol') {
+			return new Promise<Response>((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					resolve(
+						jsonResponse(
+							descriptor({
+								compositionId: 'Main',
+								lastFocusedAt: 950_000,
+								projectName: 'Project',
+								targetId: 'target',
+							}),
+						),
+					);
+				}, 2100);
+				options?.signal?.addEventListener(
+					'abort',
+					() => {
+						clearTimeout(timeout);
+						reject(options.signal?.reason);
+					},
+					{once: true},
+				);
+			});
+		}
+
+		if (url === 'http://localhost:3000/api/studio-protocol/install') {
+			return Promise.resolve(
+				jsonResponse({
+					protocol: 'remotion-studio-protocol',
+					protocolVersion: 1,
+					status: 'awaiting-confirmation',
+				}),
+			);
+		}
+
+		return Promise.resolve(new Response(null, {status: 404}));
+	};
+
+	expect(
+		await installInStudioWithDependencies(elementPayload, {
+			...dependencies,
+			ports: [3000],
+			fetchFn,
+		}),
+	).toEqual({
+		success: true,
+		status: 'awaiting-confirmation',
+		target: {
+			projectName: 'Project',
+			compositionId: 'Main',
+			studioOrigin: 'http://localhost:3000',
+			studioVersion: '4.0.502',
+		},
+	});
+});
+
 test('reports malformed discovery JSON as an invalid response', async () => {
 	const fetchFn = (input: string | URL | Request) => {
 		if (String(input) === 'http://localhost:3000/api/studio-protocol') {

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -195,7 +195,12 @@ test('returns an actionable result when no Studio is running', async () => {
 });
 
 test('waits for Studio discovery while local network permission is pending', async () => {
-	const fetchFn = (input: string | URL | Request, options?: RequestInit) => {
+	const fetchFn = function (
+		this: void,
+		input: string | URL | Request,
+		options?: RequestInit,
+	) {
+		expect(this).toBeUndefined();
 		const url = String(input);
 		if (url === 'http://localhost:3000/api/studio-protocol') {
 			return new Promise<Response>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- show local network access guidance when Studio discovery takes longer than one second
- wait for the browser's local network permission decision instead of aborting discovery after two seconds
- keep quick Studio installations free of transient guidance and announce pending guidance to assistive technology

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/studio-protocol && bun test`
- red/green verified for delayed Studio discovery

Closes #11043
