### PR TITLE
Elements: Add getting-started guidance when Studio is unavailable

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.module.css
+++ b/packages/docs/src/components/Elements/ElementPage.module.css
@@ -156,6 +156,44 @@
 	font-weight: 600;
 }
 
+.studioGuidance {
+	margin-top: 12px;
+	padding: 12px;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 8px;
+	background: var(--ifm-color-emphasis-100);
+	font-size: 0.875rem;
+}
+
+.studioGuidanceTitle {
+	margin: 0;
+	font-weight: 600;
+}
+
+.studioGuidanceSteps {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 10px 0 0;
+	padding: 0;
+	list-style: none;
+}
+
+.studioGuidanceSteps li {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	line-height: 1.5;
+}
+
+.studioGuidanceSteps li > div {
+	flex: none;
+}
+
+.studioGuidanceSteps li > span {
+	min-width: 0;
+}
+
 .successStatus,
 .errorStatus {
 	margin: 12px 0 0;
@@ -312,6 +350,10 @@
 @media (max-width: 600px) {
 	.sourceViewportCollapsed {
 		height: 160px;
+	}
+
+	.studioGuidance {
+		font-size: 1rem;
 	}
 
 	.actionRow {

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -16,6 +16,7 @@ import React, {
 	useState,
 	type ReactNode,
 } from 'react';
+import {InlineStep} from '../../../components/InlineStep';
 import {BlueButton, PlainButton} from '../../../components/layout/Button';
 import {Seo} from '../Seo';
 import type {ElementDefinition} from './element-definitions';
@@ -261,8 +262,35 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 									</span>
 								</div>
 							) : null}
-							{installStatus.type === 'success' ||
-							installStatus.type === 'error' ? (
+							{installStatus.type === 'error' &&
+							installStatus.code === 'no-compatible-studio' ? (
+								<div aria-live="polite" className={styles.studioGuidance}>
+									<p className={styles.studioGuidanceTitle}>
+										Connect to Remotion Studio
+									</p>
+									<ol className={styles.studioGuidanceSteps} role="list">
+										<li>
+											<InlineStep>1</InlineStep>
+											<span>
+												Open your Remotion project, or{' '}
+												<a href="/docs/">create a new one</a>.
+											</span>
+										</li>
+										<li>
+											<InlineStep>2</InlineStep>
+											<span>Start Studio and open a composition.</span>
+										</li>
+										<li>
+											<InlineStep>3</InlineStep>
+											<span>
+												Return here and click <strong>Install in Studio</strong>{' '}
+												again.
+											</span>
+										</li>
+									</ol>
+								</div>
+							) : installStatus.type === 'success' ||
+							  installStatus.type === 'error' ? (
 								<p
 									aria-live="polite"
 									className={
@@ -271,18 +299,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 											: styles.errorStatus
 									}
 								>
-									{installStatus.type === 'error' &&
-									installStatus.code === 'no-compatible-studio' ? (
-										<>
-											Remotion Studio needs to be installed and running.{' '}
-											<a href="/docs/">
-												Follow the getting-started instructions
-											</a>
-											, then try again.
-										</>
-									) : (
-										installStatus.message
-									)}
+									{installStatus.message}
 								</p>
 							) : null}
 						</>

--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -1,6 +1,7 @@
 import Head from '@docusaurus/Head';
 import {
 	installInStudio,
+	type InstallInStudioErrorCode,
 	isInsideStudio,
 	setStudioDragData,
 	StudioProtocolInternals,
@@ -40,7 +41,7 @@ type InstallStatus =
 	| {type: 'idle'}
 	| {type: 'installing'}
 	| {type: 'success'; message: string}
-	| {type: 'error'; message: string};
+	| {type: 'error'; code: InstallInStudioErrorCode; message: string};
 
 export const ElementPage: React.FC<ElementPageProps> = ({
 	children,
@@ -114,6 +115,7 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 		if (!result.success) {
 			setInstallStatus({
 				type: 'error',
+				code: result.code,
 				message: result.message,
 			});
 			return;
@@ -269,7 +271,18 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 											: styles.errorStatus
 									}
 								>
-									{installStatus.message}
+									{installStatus.type === 'error' &&
+									installStatus.code === 'no-compatible-studio' ? (
+										<>
+											Remotion Studio needs to be installed and running.{' '}
+											<a href="/docs/">
+												Follow the getting-started instructions
+											</a>
+											, then try again.
+										</>
+									) : (
+										installStatus.message
+									)}
 								</p>
 							) : null}
 						</>


### PR DESCRIPTION
## Summary

- show a welcoming three-step connection card when Element discovery finds no compatible Remotion Studio
- guide existing users to start Studio and newcomers to the existing project setup instructions
- preserve the existing install action so users can retry after opening a composition

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter=docs`
- manually verified the unavailable guidance, getting-started link, and repeated Studio probe flow in a browser
- verified the guidance card on desktop and mobile in light and dark mode

Closes #11042
