### PR TITLE
`@remotion/studio-protocol`: Remove legacy Studio discovery probe

### DIFF
--- a/packages/docs/docs/studio-protocol/install-in-studio.mdx
+++ b/packages/docs/docs/studio-protocol/install-in-studio.mdx
@@ -90,8 +90,6 @@ A human-readable failure message. Use `code` for application logic.
 
 When called outside Studio, ports 3000 through 3009 are probed in parallel. The most recently focused compatible target is selected. Discovery returns a short-lived, single-use token bound to that Studio tab and contextual composition.
 
-Studios older than 4.0.502 are detected and return `studio-upgrade-required`. The Element is not sent through the legacy endpoint.
-
 ## Supported origins
 
 The function supports any HTTPS website. HTTP is supported only on `localhost` and `127.0.0.1` for local development.

--- a/packages/studio-protocol/src/add-element-library-to-studio.ts
+++ b/packages/studio-protocol/src/add-element-library-to-studio.ts
@@ -6,7 +6,6 @@ import {
 	fetchWithTimeout,
 	focusedStudioMaxAge,
 	getAddElementLibraryCapability,
-	hasLegacyStudio,
 	isAbortError,
 	studioProtocolProbePorts,
 } from './studio-discovery';
@@ -151,13 +150,6 @@ export const addElementLibraryToStudioWithDependencies = async (
 			return failure(
 				'unsupported-protocol',
 				'The running Remotion Studio uses an unsupported Studio Protocol version.',
-			);
-		}
-
-		if (await hasLegacyStudio(dependencies)) {
-			return failure(
-				'studio-upgrade-required',
-				'This Remotion Studio cannot add an Element catalog through Studio Protocol. Upgrade Remotion to 4.0.518 or newer.',
 			);
 		}
 

--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -9,7 +9,6 @@ import {
 	fetchWithTimeout,
 	focusedStudioMaxAge,
 	getInstallCapability,
-	hasLegacyStudio,
 	isAbortError,
 	studioProtocolProbePorts,
 } from './studio-discovery';
@@ -175,13 +174,6 @@ export const installInStudioWithDependencies = async (
 			return failure(
 				'unsupported-protocol',
 				'The running Remotion Studio uses an unsupported Studio Protocol version.',
-			);
-		}
-
-		if (await hasLegacyStudio(dependencies)) {
-			return failure(
-				'studio-upgrade-required',
-				'This Remotion Studio does not support the Remotion Studio Protocol. Upgrade Remotion to 4.0.502 or newer.',
 			);
 		}
 

--- a/packages/studio-protocol/src/set-license-key-in-studio.ts
+++ b/packages/studio-protocol/src/set-license-key-in-studio.ts
@@ -6,7 +6,6 @@ import {
 	fetchWithTimeout,
 	focusedStudioMaxAge,
 	getSetLicenseKeyCapability,
-	hasLegacyStudio,
 	isAbortError,
 	studioProtocolProbePorts,
 } from './studio-discovery';
@@ -93,15 +92,6 @@ export const setLicenseKeyInStudioWithDependencies = async (
 				code: 'unsupported-protocol',
 				message:
 					'The running Remotion Studio uses an unsupported Studio Protocol version.',
-			};
-		}
-
-		if (await hasLegacyStudio(dependencies)) {
-			return {
-				success: false,
-				code: 'studio-upgrade-required',
-				message:
-					'This Remotion Studio cannot set a license key through Studio Protocol. Upgrade Remotion to 4.0.504 or newer.',
 			};
 		}
 

--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -114,10 +114,6 @@ const protocolVersionEnvelopeSchema = z.looseObject({
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.unknown(),
 });
-const legacyStudioSchema = z.looseObject({
-	type: z.literal('remotion-studio'),
-});
-
 export const fetchWithTimeout = async ({
 	fetchFn,
 	options,
@@ -265,30 +261,6 @@ export const discoverStudios = async (
 		foundUnsupportedProtocol,
 		foundInvalidResponse,
 	};
-};
-
-export const hasLegacyStudio = async (
-	dependencies: StudioProtocolDiscoveryDependencies,
-): Promise<boolean> => {
-	const results = await Promise.all(
-		dependencies.ports.map(async (port) => {
-			try {
-				const response = await fetchWithTimeout({
-					fetchFn: dependencies.fetchFn,
-					options: {cache: 'no-store'},
-					url: `http://localhost:${port}/api/element-install-target`,
-				});
-				if (!response.ok) {
-					return false;
-				}
-
-				return z.safeParse(legacyStudioSchema, await response.json()).success;
-			} catch {
-				return false;
-			}
-		}),
-	);
-	return results.some(Boolean);
 };
 
 export const isAbortError = (error: unknown): boolean =>

--- a/packages/studio-protocol/src/test/add-element-library-to-studio.test.ts
+++ b/packages/studio-protocol/src/test/add-element-library-to-studio.test.ts
@@ -125,6 +125,30 @@ test('requests confirmation in the most recently focused compatible Studio', asy
 	});
 });
 
+test('returns an actionable result when no Studio is running', async () => {
+	const requests: string[] = [];
+	const result = await addElementLibraryToStudioWithDependencies(
+		{url: 'https://catalog.example.com', displayName: null},
+		{
+			...dependencies,
+			fetchFn: (input) => {
+				requests.push(String(input));
+				return Promise.resolve(new Response(null, {status: 404}));
+			},
+		},
+	);
+
+	expect(result).toEqual({
+		success: false,
+		code: 'no-compatible-studio',
+		message: 'Start Remotion Studio, focus it, and try again.',
+	});
+	expect(requests).toEqual([
+		'http://localhost:3000/api/studio-protocol',
+		'http://localhost:3001/api/studio-protocol',
+	]);
+});
+
 test('validates the request before probing localhost', async () => {
 	for (const request of [
 		{url: '/relative', displayName: null},

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -174,9 +174,13 @@ test('distinguishes a compatible Studio without an installable target', async ()
 });
 
 test('returns an actionable result when no Studio is running', async () => {
+	const requests: string[] = [];
 	const result = await installInStudioWithDependencies(elementPayload, {
 		...dependencies,
-		fetchFn: () => Promise.resolve(new Response(null, {status: 404})),
+		fetchFn: (input) => {
+			requests.push(String(input));
+			return Promise.resolve(new Response(null, {status: 404}));
+		},
 	});
 
 	expect(result).toEqual({
@@ -184,6 +188,10 @@ test('returns an actionable result when no Studio is running', async () => {
 		code: 'no-compatible-studio',
 		message: 'Start Remotion Studio and open a composition, then try again.',
 	});
+	expect(requests).toEqual([
+		'http://localhost:3000/api/studio-protocol',
+		'http://localhost:3001/api/studio-protocol',
+	]);
 });
 
 test('reports malformed discovery JSON as an invalid response', async () => {
@@ -210,36 +218,6 @@ test('reports malformed discovery JSON as an invalid response', async () => {
 		code: 'invalid-response',
 		message: 'Remotion Studio returned an invalid Studio Protocol response.',
 	});
-});
-
-test('reports a legacy Studio as requiring an upgrade without sending a payload', async () => {
-	const requests: string[] = [];
-	const fetchFn = (input: string | URL | Request) => {
-		const url = String(input);
-		requests.push(url);
-		if (url === 'http://localhost:3000/api/element-install-target') {
-			return Promise.resolve(
-				jsonResponse({type: 'remotion-studio', canInstall: true}),
-			);
-		}
-
-		return Promise.resolve(new Response(null, {status: 404}));
-	};
-
-	expect(
-		await installInStudioWithDependencies(elementPayload, {
-			...dependencies,
-			fetchFn,
-		}),
-	).toEqual({
-		success: false,
-		code: 'studio-upgrade-required',
-		message:
-			'This Remotion Studio does not support the Remotion Studio Protocol. Upgrade Remotion to 4.0.502 or newer.',
-	});
-	expect(
-		requests.some((url) => url.endsWith('/api/request-element-install')),
-	).toBe(false);
 });
 
 test('returns a structured error when the selected target expired', async () => {

--- a/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/set-license-key-in-studio.test.ts
@@ -121,6 +121,27 @@ test('requests confirmation in the most recently focused Studio project', async 
 	});
 });
 
+test('returns an actionable result when no Studio is running', async () => {
+	const requests: string[] = [];
+	const result = await setLicenseKeyInStudioWithDependencies(licenseKey, {
+		...dependencies,
+		fetchFn: (input) => {
+			requests.push(String(input));
+			return Promise.resolve(new Response(null, {status: 404}));
+		},
+	});
+
+	expect(result).toEqual({
+		success: false,
+		code: 'no-compatible-studio',
+		message: 'Start Remotion Studio, focus it, and try again.',
+	});
+	expect(requests).toEqual([
+		'http://localhost:3000/api/studio-protocol',
+		'http://localhost:3001/api/studio-protocol',
+	]);
+});
+
 test('rejects malformed keys before discovery', async () => {
 	let requests = 0;
 	const fetchFn = () => {


### PR DESCRIPTION
## Summary

- remove the legacy `/api/element-install-target` compatibility probe from Studio Protocol discovery
- return `no-compatible-studio` when modern discovery finds no Studio while preserving invalid-response and unsupported-protocol handling
- keep capability-based upgrade results for modern Studios and update tests and documentation

Current Remotion Studio no longer serves the legacy endpoint. Removing this probe avoids a redundant second scan across localhost ports when modern discovery finds nothing.

## Validation

- `bun test packages/studio-protocol/src/test`
- `cd packages/studio-protocol && bun run lint && bun run formatting && bun run make`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
