### PR TITLE
Elements: Explain denied local network access

### DIFF
--- a/packages/docs/docs/studio-protocol/install-in-studio.mdx
+++ b/packages/docs/docs/studio-protocol/install-in-studio.mdx
@@ -73,6 +73,7 @@ On failure, one of:
 
 - `unsupported-origin`
 - `no-compatible-studio`
+- `loopback-network-permission-denied` <AvailableFrom v="4.0.521" inline />
 - `studio-upgrade-required`
 - `no-installable-target`
 - `unsupported-protocol`

--- a/packages/studio-protocol/src/install-in-studio.ts
+++ b/packages/studio-protocol/src/install-in-studio.ts
@@ -20,6 +20,7 @@ import {
 export type InstallInStudioErrorCode =
 	| 'unsupported-origin'
 	| 'no-compatible-studio'
+	| 'loopback-network-permission-denied'
 	| 'studio-upgrade-required'
 	| 'no-installable-target'
 	| 'unsupported-protocol'
@@ -46,11 +47,18 @@ export type InstallInStudioResult =
 			readonly message: string;
 	  };
 
+type LoopbackPermissionName = 'loopback-network' | 'local-network-access';
+
+type PermissionQueryFn = (descriptor: {
+	readonly name: LoopbackPermissionName;
+}) => Promise<{readonly state: PermissionState}>;
+
 export type InstallInStudioDependencies = {
 	readonly fetchFn: StudioProtocolFetcher;
 	readonly now: () => number;
 	readonly ports: readonly number[];
 	readonly pageOrigin: string | null;
+	readonly permissionQueryFn: PermissionQueryFn | null;
 };
 
 export type StudioProtocolInstallRequest = {
@@ -182,6 +190,27 @@ export const installInStudioWithDependencies = async (
 				'invalid-response',
 				'Remotion Studio returned an invalid Studio Protocol response.',
 			);
+		}
+
+		if (dependencies.permissionQueryFn !== null) {
+			for (const name of [
+				'loopback-network',
+				'local-network-access',
+			] as const) {
+				try {
+					const permission = await dependencies.permissionQueryFn({name});
+					if (permission.state === 'denied') {
+						return failure(
+							'loopback-network-permission-denied',
+							'Access to localhost is blocked by your browser. Open the site settings, allow local network access for this site, then try again.',
+						);
+					}
+
+					break;
+				} catch {
+					// The compatibility alias may still be supported.
+				}
+			}
 		}
 
 		return failure(
@@ -355,6 +384,13 @@ export const installInStudio = async ({
 			typeof globalThis.location === 'undefined'
 				? null
 				: globalThis.location.origin,
+		permissionQueryFn:
+			typeof globalThis.navigator === 'undefined' ||
+			typeof globalThis.navigator.permissions?.query !== 'function'
+				? null
+				: (descriptor) =>
+						// @ts-expect-error Chromium's loopback permission names are not in lib.dom yet.
+						globalThis.navigator.permissions.query(descriptor),
 		ports: studioProtocolProbePorts,
 	});
 };

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -50,6 +50,7 @@ const jsonResponse = (value: unknown, status = 200) =>
 const dependencies = {
 	now: () => 1_000_000,
 	pageOrigin: 'http://localhost:4000',
+	permissionQueryFn: null,
 	ports: [3000, 3001],
 };
 
@@ -192,6 +193,79 @@ test('returns an actionable result when no Studio is running', async () => {
 		'http://localhost:3000/api/studio-protocol',
 		'http://localhost:3001/api/studio-protocol',
 	]);
+});
+
+test('reports when loopback network access is explicitly denied after discovery', async () => {
+	const events: string[] = [];
+	const result = await installInStudioWithDependencies(elementPayload, {
+		...dependencies,
+		fetchFn: (input) => {
+			events.push(String(input));
+			return Promise.resolve(new Response(null, {status: 404}));
+		},
+		permissionQueryFn: ({name}) => {
+			events.push(`permission:${name}`);
+			return Promise.resolve({state: 'denied'});
+		},
+	});
+
+	expect(result).toEqual({
+		success: false,
+		code: 'loopback-network-permission-denied',
+		message:
+			'Access to localhost is blocked by your browser. Open the site settings, allow local network access for this site, then try again.',
+	});
+	expect(events).toEqual([
+		'http://localhost:3000/api/studio-protocol',
+		'http://localhost:3001/api/studio-protocol',
+		'permission:loopback-network',
+	]);
+});
+
+test('uses the legacy local network permission alias when necessary', async () => {
+	const queriedPermissions: string[] = [];
+	const result = await installInStudioWithDependencies(elementPayload, {
+		...dependencies,
+		fetchFn: () => Promise.resolve(new Response(null, {status: 404})),
+		permissionQueryFn: ({name}) => {
+			queriedPermissions.push(name);
+			if (name === 'loopback-network') {
+				return Promise.reject(new TypeError('Unsupported permission name'));
+			}
+
+			return Promise.resolve({state: 'denied'});
+		},
+	});
+
+	expect(result).toEqual({
+		success: false,
+		code: 'loopback-network-permission-denied',
+		message:
+			'Access to localhost is blocked by your browser. Open the site settings, allow local network access for this site, then try again.',
+	});
+	expect(queriedPermissions).toEqual([
+		'loopback-network',
+		'local-network-access',
+	]);
+});
+
+test('keeps the generic result when permission is not definitively denied', async () => {
+	for (const permissionQueryFn of [
+		() => Promise.resolve({state: 'prompt' as const}),
+		() => Promise.reject(new Error('Permissions API failed')),
+	]) {
+		const result = await installInStudioWithDependencies(elementPayload, {
+			...dependencies,
+			fetchFn: () => Promise.resolve(new Response(null, {status: 404})),
+			permissionQueryFn,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			code: 'no-compatible-studio',
+			message: 'Start Remotion Studio and open a composition, then try again.',
+		});
+	}
 });
 
 test('waits for Studio discovery while local network permission is pending', async () => {


### PR DESCRIPTION
## Summary

- detect an explicitly denied loopback network permission after Studio discovery fails
- fall back to the legacy `local-network-access` permission alias when the granular permission name is unavailable
- retain the existing no-Studio result when permission status cannot be determined, and return actionable site-settings guidance when access is denied
- document the new Studio Protocol error code

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run test --filter='@remotion/studio-protocol' --filter='docs'`
- red/green verified for denied loopback permission handling

## Preview

- [`installInStudio()` documentation](https://remotion-git-element-denied-permission-remotion.vercel.app/docs/studio-protocol/install-in-studio)
