### PR TITLE
`@remotion/studio-protocol`: Ignore non-Studio responses during discovery

### DIFF
--- a/packages/studio-protocol/src/studio-discovery.ts
+++ b/packages/studio-protocol/src/studio-discovery.ts
@@ -110,6 +110,9 @@ const descriptorSchema = z
 			return new Set(capabilityTypes).size === capabilityTypes.length;
 		}),
 	);
+const protocolEnvelopeSchema = z.looseObject({
+	protocol: z.literal('remotion-studio-protocol'),
+});
 const protocolVersionEnvelopeSchema = z.looseObject({
 	protocol: z.literal('remotion-studio-protocol'),
 	protocolVersion: z.unknown(),
@@ -223,7 +226,11 @@ export const discoverStudios = async (
 			try {
 				value = await response.json();
 			} catch {
-				foundInvalidResponse = true;
+				return null;
+			}
+
+			const protocolEnvelope = z.safeParse(protocolEnvelopeSchema, value);
+			if (!protocolEnvelope.success) {
 				return null;
 			}
 
@@ -231,10 +238,12 @@ export const discoverStudios = async (
 				protocolVersionEnvelopeSchema,
 				value,
 			);
-			if (
-				protocolVersionEnvelope.success &&
-				protocolVersionEnvelope.data.protocolVersion !== 1
-			) {
+			if (!protocolVersionEnvelope.success) {
+				foundInvalidResponse = true;
+				return null;
+			}
+
+			if (protocolVersionEnvelope.data.protocolVersion !== 1) {
 				foundUnsupportedProtocol = true;
 				return null;
 			}

--- a/packages/studio-protocol/src/test/install-in-studio.test.ts
+++ b/packages/studio-protocol/src/test/install-in-studio.test.ts
@@ -194,6 +194,25 @@ test('returns an actionable result when no Studio is running', async () => {
 	]);
 });
 
+test('ignores a non-Studio development server on a probed port', async () => {
+	const result = await installInStudioWithDependencies(elementPayload, {
+		...dependencies,
+		ports: [3000],
+		fetchFn: () =>
+			Promise.resolve(
+				new Response('<!doctype html><html><body>Remotion docs</body></html>', {
+					headers: {'Content-Type': 'text/html'},
+				}),
+			),
+	});
+
+	expect(result).toEqual({
+		success: false,
+		code: 'no-compatible-studio',
+		message: 'Start Remotion Studio and open a composition, then try again.',
+	});
+});
+
 test('waits for Studio discovery while local network permission is pending', async () => {
 	const fetchFn = function (
 		this: void,
@@ -258,12 +277,13 @@ test('waits for Studio discovery while local network permission is pending', asy
 	});
 });
 
-test('reports malformed discovery JSON as an invalid response', async () => {
+test('reports malformed Studio Protocol data as an invalid response', async () => {
 	const fetchFn = (input: string | URL | Request) => {
 		if (String(input) === 'http://localhost:3000/api/studio-protocol') {
 			return Promise.resolve(
-				new Response('not JSON', {
-					headers: {'Content-Type': 'application/json'},
+				jsonResponse({
+					protocol: 'remotion-studio-protocol',
+					protocolVersion: 1,
 				}),
 			);
 		}


### PR DESCRIPTION
## Summary

- ignore successful responses from probed local ports unless they identify themselves as Remotion Studio Protocol
- preserve invalid-response errors for malformed data that does carry the Studio Protocol marker
- add regression coverage for a docs-like local development server returning HTML

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter='@remotion/studio-protocol'`
