### PR TITLE
Elements: Open library inside Browser Studio

### DIFF
--- a/packages/studio/src/components/InspectorPanel/ElementLibraryButton.tsx
+++ b/packages/studio/src/components/InspectorPanel/ElementLibraryButton.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useContext, useMemo} from 'react';
-import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
-import {CURRENT_COLOR, LIGHT_TEXT} from '../../helpers/colors';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {BrowseElementsIcon} from '../../icons/browse-elements';
 import {CaretDown} from '../../icons/caret';
 import {SetSelectedModalContext} from '../../state/modals';
@@ -22,14 +21,6 @@ const browseElementsIconContainerStyle: React.CSSProperties = {
 	marginLeft: -2,
 	marginRight: -2,
 	width: 22,
-};
-
-const browseElementsArrowStyle: React.CSSProperties = {
-	display: 'inline-block',
-	height: 12,
-	marginLeft: 4,
-	verticalAlign: -2,
-	width: 12,
 };
 
 const elementLibraryDropdownStyle: React.CSSProperties = {
@@ -68,24 +59,18 @@ const elementLibraryDropdownCaretStyle: React.CSSProperties = {
 export const ElementLibraryButton: React.FC = () => {
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const {studioRuntimeConfig} = useSettings();
-	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const elementLibraries =
 		studioRuntimeConfig?.elementLibraries ?? noElementLibraries;
 
 	const openElementLibrary = useCallback(
 		(name: string, url: string) => {
-			if (isBrowserStudio) {
-				window.open(url, '_blank', 'noopener,noreferrer');
-				return;
-			}
-
 			setSelectedModal({
 				type: 'element-library',
 				name,
 				url,
 			});
 		},
-		[isBrowserStudio, setSelectedModal],
+		[setSelectedModal],
 	);
 
 	const openElementsLibrary = useCallback(() => {
@@ -162,7 +147,7 @@ export const ElementLibraryButton: React.FC = () => {
 		[elementLibraries, openElementLibrary, openElementsLibrary],
 	);
 
-	if (elementLibraries.length > 0 && !isBrowserStudio) {
+	if (elementLibraries.length > 0) {
 		return (
 			<SegmentedButton
 				segments={elementLibraryDropdownSegments}
@@ -180,29 +165,9 @@ export const ElementLibraryButton: React.FC = () => {
 			renderIcon={(color) => (
 				<BrowseElementsIcon color={color} style={browseElementsIconStyle} />
 			)}
-			title={
-				isBrowserStudio
-					? 'Open the Remotion Elements library in a new tab. Install an Element there to send it to this composition.'
-					: 'Browse the Remotion Elements library inside Studio.'
-			}
+			title="Browse the Remotion Elements library inside Studio."
 		>
 			Browse Elements
-			{isBrowserStudio ? (
-				<svg
-					aria-hidden="true"
-					viewBox="0 0 16 16"
-					style={browseElementsArrowStyle}
-				>
-					<path
-						d="M4 12 12 4M6 4h6v6"
-						fill="none"
-						stroke={CURRENT_COLOR}
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						strokeWidth="1.5"
-					/>
-				</svg>
-			) : null}
 		</InspectorQuickAction>
 	);
 };


### PR DESCRIPTION
## Summary

- open the Elements library in the existing Studio iframe modal when running Browser Studio
- remove the new-tab affordance and reuse the same library selection behavior as desktop Studio

## Testing

- `bun run build`
- `bun run stylecheck`
- headless Chromium check that Browser Studio opens the Elements iframe without creating another tab

Closes #11000
