### PR TITLE
Elements: Avoid drag handle flicker in embedded viewer

### DIFF
--- a/packages/docs/src/components/Elements/ElementPage.tsx
+++ b/packages/docs/src/components/Elements/ElementPage.tsx
@@ -57,7 +57,9 @@ export const ElementPage: React.FC<ElementPageProps> = ({
 	const [isSourceVisible, setIsSourceVisible] = useState(false);
 	const [isBrowserStudioActionVisible, setIsBrowserStudioActionVisible] =
 		useState(false);
-	const [isEmbeddedInStudio, setIsEmbeddedInStudio] = useState(false);
+	const [isEmbeddedInStudio, setIsEmbeddedInStudio] = useState<boolean | null>(
+		null,
+	);
 	const posterRef = useRef<HTMLImageElement>(null);
 	const sourceId = useId();
 	const {height: previewHeight, width: previewWidth} =

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -14,3 +14,7 @@ Config.addElementLibrary({
 	url: 'https://remocn.dev/docs/typography',
 	displayName: 'Remocn',
 });
+Config.addElementLibrary({
+	url: 'http://localhost:3002/elements',
+	displayName: 'Local Elements',
+});


### PR DESCRIPTION
## Summary

- keep the Elements embedding state unknown until the client-side Studio check completes
- render the drag handle only after confirming the page is outside Studio
- register the local docs Elements page in the example Studio config for embedded viewer development

## Testing

- `bun run build`
- `bun run stylecheck`

Closes #11053
