### PR TITLE
Internal: Upgrade Zod to 4.5.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1982,7 +1982,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2027,7 +2027,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "twoslash-cdn": "0.3.1",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2087,7 +2087,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2106,7 +2106,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2127,7 +2127,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2153,7 +2153,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2193,7 +2193,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "tailwind-merge": "3.0.1",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2233,7 +2233,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2311,7 +2311,7 @@
         "remotion": "workspace:*",
         "tailwind-merge": "3.4.0",
         "three": "0.178.0",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2353,7 +2353,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@elevenlabs/elevenlabs-js": "2.20.0",
@@ -2398,7 +2398,7 @@
         "tailwindcss": "4.2.0",
         "vite": "7.3.6",
         "vite-tsconfig-paths": "4.3.2",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@react-router/dev": "8.3.0",
@@ -2451,7 +2451,7 @@
         "remotion": "workspace:*",
         "tailwind-merge": "1.14.0",
         "tailwindcss-animate": "1.0.7",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2485,7 +2485,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2510,7 +2510,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2531,7 +2531,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2562,7 +2562,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2586,7 +2586,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "three": "0.178.0",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/eslint-config-flat": "workspace:*",
@@ -2610,7 +2610,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@remotion/captions": "workspace:*",
@@ -2644,7 +2644,7 @@
         "react-dom": "19.2.3",
         "remotion": "workspace:*",
         "tailwind-merge": "3.0.1",
-        "zod": "4.4.3",
+        "zod": "4.5.4",
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.1.0",
@@ -2930,7 +2930,7 @@
     "sharp": "0.34.5",
     "three": "0.178.0",
     "vitest": "4.0.9",
-    "zod": "4.4.3",
+    "zod": "4.5.4",
   },
   "packages": {
     "@1natsu/wait-element": ["@1natsu/wait-element@4.2.0", "", { "dependencies": { "defu": "^6.1.4", "many-keys-map": "^3.0.0" } }, "sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw=="],
@@ -9097,7 +9097,7 @@
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "5.0.2", "compress-commons": "6.0.2", "readable-stream": "4.7.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -10035,6 +10035,8 @@
 
     "@floating-ui/react-dom/react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "0.25.0" }, "peerDependencies": { "react": "19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
 
+    "@github/copilot-sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "@google-cloud/common/google-auth-library": ["google-auth-library@9.11.0", "", { "dependencies": { "base64-js": "1.5.1", "ecdsa-sig-formatter": "1.0.11", "gaxios": "6.6.0", "gcp-metadata": "6.1.0", "gtoken": "7.1.0", "jws": "4.0.0" } }, "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw=="],
 
     "@google-cloud/common/html-entities": ["html-entities@2.5.2", "", {}, "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA=="],
@@ -10158,6 +10160,8 @@
     "@mdx-js/react/@types/react": ["@types/react@19.0.0", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg=="],
 
     "@mdx-js/react/react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
+
+    "@microsoft/vally/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -12124,6 +12128,8 @@
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "openai/@types/node": ["@types/node@18.14.6", "", {}, "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="],
+
+    "openai/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -17782,6 +17788,8 @@
     "react-doctor/eslint-plugin-react-hooks/@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
 
     "react-doctor/eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "react-doctor/eslint-plugin-react-hooks/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "react-doctor/magicast/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 			"react-dom": "19.2.3",
 			"eslint": "9.19.0",
 			"prettier": "3.8.1",
-			"zod": "4.4.3",
+			"zod": "4.5.4",
 			"@types/react": "19.2.7",
 			"@types/react-dom": "19.2.3",
 			"@types/node": "20.12.14",

--- a/packages/cli/src/extra-packages.ts
+++ b/packages/cli/src/extra-packages.ts
@@ -6,7 +6,7 @@ export const EXTRA_PACKAGES: Record<string, string> = {
 	'@mediabunny/aac-encoder': '1.55.5',
 	'@mediabunny/flac-encoder': '1.55.5',
 	'@mediabunny/prores': '1.55.5',
-	zod: '4.4.3',
+	zod: '4.5.4',
 };
 
 export const EXTRA_PACKAGES_DOCS: Record<string, string> = {

--- a/packages/cli/src/test/catalog-utils.test.ts
+++ b/packages/cli/src/test/catalog-utils.test.ts
@@ -69,7 +69,7 @@ test('parsePnpmWorkspaceCatalog handles basic, quoted, scoped entries and stops 
 		'  - packages/*',
 		'catalog:',
 		'  react: ^18.3.1',
-		'  zod: 4.4.3',
+		'  zod: 4.5.4',
 		'  "react-dom": "^18.3.1"',
 		"  typescript: '5.8.3'",
 		'  "@remotion/core": 4.0.10',
@@ -81,7 +81,7 @@ test('parsePnpmWorkspaceCatalog handles basic, quoted, scoped entries and stops 
 
 	const result = parsePnpmWorkspaceCatalog(richContent);
 	expect(result.react).toBe('^18.3.1');
-	expect(result.zod).toBe('4.4.3');
+	expect(result.zod).toBe('4.5.4');
 	expect(result['react-dom']).toBe('^18.3.1');
 	expect(result.typescript).toBe('5.8.3');
 	expect(result['@remotion/core']).toBe('4.0.10');
@@ -100,7 +100,7 @@ test('bun-style monorepo: finds workspace root, catalog source, and reads entrie
 				packages: ['packages/*'],
 				catalog: {
 					react: '^19.0.0',
-					zod: '4.4.3',
+					zod: '4.5.4',
 				},
 			},
 		}),
@@ -124,7 +124,7 @@ test('bun-style monorepo: finds workspace root, catalog source, and reads entrie
 
 	expect(getCatalogEntries(tmpDir)).toEqual({
 		react: '^19.0.0',
-		zod: '4.4.3',
+		zod: '4.5.4',
 	});
 });
 
@@ -133,7 +133,7 @@ test('top-level catalog in package.json: finds catalog source and reads entries'
 		path.join(tmpDir, 'package.json'),
 		JSON.stringify({
 			name: 'my-monorepo',
-			catalog: {zod: '4.4.3'},
+			catalog: {zod: '4.5.4'},
 		}),
 	);
 
@@ -144,13 +144,13 @@ test('top-level catalog in package.json: finds catalog source and reads entries'
 		expect(source!.catalogKey).toBe('root');
 	}
 
-	expect(getCatalogEntries(tmpDir)).toEqual({zod: '4.4.3'});
+	expect(getCatalogEntries(tmpDir)).toEqual({zod: '4.5.4'});
 });
 
 test('pnpm monorepo: finds workspace root, catalog source, and reads entries', () => {
 	fs.writeFileSync(
 		path.join(tmpDir, 'pnpm-workspace.yaml'),
-		'packages:\n  - packages/*\ncatalog:\n  zod: 4.4.3\n  react: ^19.0.0\n',
+		'packages:\n  - packages/*\ncatalog:\n  zod: 4.5.4\n  react: ^19.0.0\n',
 	);
 
 	const subPkgDir = path.join(tmpDir, 'packages', 'my-app');
@@ -163,7 +163,7 @@ test('pnpm monorepo: finds workspace root, catalog source, and reads entries', (
 	expect(source!.type).toBe('pnpm-workspace');
 
 	expect(getCatalogEntries(tmpDir)).toEqual({
-		zod: '4.4.3',
+		zod: '4.5.4',
 		react: '^19.0.0',
 	});
 });
@@ -193,7 +193,7 @@ test('updating catalog entries in bun-style package.json', () => {
 					packages: ['packages/*'],
 					catalog: {
 						react: '^18.0.0',
-						zod: '4.4.3',
+						zod: '4.5.4',
 						mediabunny: '1.34.4',
 					},
 				},
@@ -245,7 +245,7 @@ test('updating catalog entries in top-level package.json catalog', () => {
 		JSON.stringify(
 			{
 				name: 'my-monorepo',
-				catalog: {zod: '4.4.3', mediabunny: '1.34.4'},
+				catalog: {zod: '4.5.4', mediabunny: '1.34.4'},
 			},
 			null,
 			'\t',
@@ -263,7 +263,7 @@ test('updating catalog entries in top-level package.json catalog', () => {
 
 	const updated = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 	expect(updated.catalog.mediabunny).toBe('1.35.0');
-	expect(updated.catalog.zod).toBe('4.4.3');
+	expect(updated.catalog.zod).toBe('4.5.4');
 });
 
 test('updating catalog entries in pnpm-workspace.yaml', () => {
@@ -275,7 +275,7 @@ test('updating catalog entries in pnpm-workspace.yaml', () => {
 			'  - packages/*',
 			'catalog:',
 			'  react: ^18.3.1',
-			'  zod: 4.4.3',
+			'  zod: 4.5.4',
 			'  "react-dom": "^18.3.1"',
 			'  "@aws-sdk/client-s3": 3.986.0',
 			'catalogs:',

--- a/packages/cli/src/test/upgrade-protocols.test.ts
+++ b/packages/cli/src/test/upgrade-protocols.test.ts
@@ -133,7 +133,7 @@ test('includes Remotion and extra packages that only exist in pnpm catalog entri
 		targetVersion: '4.0.462',
 		extraPackageVersions: {
 			mediabunny: '1.50.7',
-			zod: '4.4.3',
+			zod: '4.5.4',
 		},
 	});
 
@@ -149,7 +149,7 @@ test('uses the Mediabunny version for extension packages', () => {
 	expect(
 		resolveExtraPackageVersions({
 			mediabunny: '1.50.8',
-			zod: '4.4.3',
+			zod: '4.5.4',
 		}),
 	).toMatchObject({
 		mediabunny: '1.50.8',
@@ -159,7 +159,7 @@ test('uses the Mediabunny version for extension packages', () => {
 		'@mediabunny/aac-encoder': '1.50.8',
 		'@mediabunny/flac-encoder': '1.50.8',
 		'@mediabunny/prores': '1.50.8',
-		zod: '4.4.3',
+		zod: '4.5.4',
 	});
 });
 
@@ -172,7 +172,7 @@ test('end-to-end: updates catalog in bun-style package.json and preserves catalo
 				workspaces: {
 					packages: ['packages/*'],
 					catalog: {
-						zod: '4.4.3',
+						zod: '4.5.4',
 						mediabunny: '1.34.4',
 						react: '19.2.3',
 					},
@@ -239,7 +239,7 @@ test('end-to-end: updates catalog in pnpm-workspace.yaml', () => {
 			'packages:',
 			'  - packages/*',
 			'catalog:',
-			'  zod: 4.4.3',
+			'  zod: 4.5.4',
 			'  mediabunny: 1.34.4',
 			'  react: ^19.0.0',
 			'',

--- a/packages/docs/docs/editor-starter/dependencies.mdx
+++ b/packages/docs/docs/editor-starter/dependencies.mdx
@@ -65,7 +65,7 @@ The following NPM packages are used in the Editor Starter:
   "react-router": "^7.18.1",
   "remotion": "4.0.499",
   "sonner": "^2.0.7",
-  "zod": "4.4.3"
+  "zod": "4.5.4"
 }
 ```
 

--- a/packages/studio-shared/src/package-info.ts
+++ b/packages/studio-shared/src/package-info.ts
@@ -153,7 +153,7 @@ export const extraPackages: ExtraPackage[] = [
 	},
 	{
 		name: 'zod',
-		version: '4.4.3',
+		version: '4.5.4',
 		description: 'TypeScript-first schema validation',
 		docsUrl: 'https://zod.dev',
 	},

--- a/packages/template-audiogram/package.json
+++ b/packages/template-audiogram/package.json
@@ -24,7 +24,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-code-hike/package.json
+++ b/packages/template-code-hike/package.json
@@ -17,7 +17,7 @@
     "remotion": "workspace:*",
     "twoslash-cdn": "0.3.1",
     "polished": "4.3.1",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-helloworld/package.json
+++ b/packages/template-helloworld/package.json
@@ -16,7 +16,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-javascript/package.json
+++ b/packages/template-javascript/package.json
@@ -15,7 +15,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-music-visualization/package.json
+++ b/packages/template-music-visualization/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-next-app-tailwind/package.json
+++ b/packages/template-next-app-tailwind/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "tailwind-merge": "3.0.1",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.0",

--- a/packages/template-next-app/package.json
+++ b/packages/template-next-app/package.json
@@ -23,7 +23,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-next-pages/package.json
+++ b/packages/template-next-pages/package.json
@@ -23,7 +23,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.1.0",

--- a/packages/template-prompt-to-motion-graphics/package.json
+++ b/packages/template-prompt-to-motion-graphics/package.json
@@ -51,7 +51,7 @@
     "remotion": "workspace:*",
     "tailwind-merge": "3.4.0",
     "three": "0.178.0",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.1.0",

--- a/packages/template-prompt-to-video/package.json
+++ b/packages/template-prompt-to-video/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@elevenlabs/elevenlabs-js": "2.20.0",

--- a/packages/template-react-router/package.json
+++ b/packages/template-react-router/package.json
@@ -39,7 +39,7 @@
     "@tailwindcss/vite": "4.2.0",
     "vite": "7.3.6",
     "vite-tsconfig-paths": "4.3.2",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@react-router/dev": "8.3.0",

--- a/packages/template-recorder/package.json
+++ b/packages/template-recorder/package.json
@@ -44,7 +44,7 @@
     "react-dom": "19.2.3",
     "tailwind-merge": "1.14.0",
     "tailwindcss-animate": "1.0.7",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-render-server/package.json
+++ b/packages/template-render-server/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-skia/package.json
+++ b/packages/template-skia/package.json
@@ -19,7 +19,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-stargazer/package.json
+++ b/packages/template-stargazer/package.json
@@ -14,7 +14,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-still/package.json
+++ b/packages/template-still/package.json
@@ -32,7 +32,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-three/package.json
+++ b/packages/template-three/package.json
@@ -20,7 +20,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "three": "0.178.0",
-    "zod": "4.4.3",
+    "zod": "4.5.4",
     "mediabunny": "1.55.5"
   },
   "devDependencies": {

--- a/packages/template-tiktok/package.json
+++ b/packages/template-tiktok/package.json
@@ -20,7 +20,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@remotion/eslint-config-flat": "workspace:*",

--- a/packages/template-vercel/package.json
+++ b/packages/template-vercel/package.json
@@ -29,7 +29,7 @@
     "react-dom": "19.2.3",
     "remotion": "workspace:*",
     "tailwind-merge": "3.0.1",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.0",


### PR DESCRIPTION
## Summary

Upgrades the shared Zod dependency and Remotion templates from 4.4.3 to 4.5.4.

The main motivation is Zod 4.5's major memory reduction: its published benchmarks show roughly 7–10x less retained heap per schema, including `z.string()` dropping from 7.53 KB to 784 B. Zod achieved this by memoizing bound schema methods instead of allocating them eagerly for every schema instance.

https://zod.dev/blog/zod-4-5

Also updates the CLI upgrade metadata, Editor Starter dependency reference, tests, and lockfile.

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/cli/src/test/catalog-utils.test.ts packages/cli/src/test/upgrade-protocols.test.ts`
- `bun test packages/studio/src/test/create-zod-values.test.ts packages/studio/src/test/extract-zod-enums.test.ts packages/studio/src/test/infer-zod-schema-from-value.test.ts packages/studio/src/test/stringify-default-props.test.ts`
- `bun test packages/studio-protocol/src/test`


## Preview

- [Editor Starter dependencies](https://remotion-git-upgrade-zod-4-5-remotion.vercel.app/docs/editor-starter/dependencies)
