### PR TITLE
`@remotion/studio`: Fix custom asset values missing from Inspector

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineAssetField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineAssetField.tsx
@@ -88,13 +88,11 @@ export const TimelineAssetField: React.FC<TimelineAssetFieldProps> = ({
 		AssetSelectionContext,
 	);
 	const inlineSourceAction = useMemo(() => {
-		if (field.key !== 'src') {
-			return null;
+		if (typeof effectiveValue === 'string') {
+			return getSourceAction(effectiveValue);
 		}
 
-		return typeof effectiveValue === 'string'
-			? getSourceAction(effectiveValue)
-			: sourceAction;
+		return field.key === 'src' ? sourceAction : null;
 	}, [effectiveValue, field.key, getSourceAction, sourceAction]);
 
 	const onSelect = useCallback(


### PR DESCRIPTION
## Summary

- display the current value for every interactivity field with `type: 'asset'`
- keep the media-specific fallback limited to fields named `src`
- fix custom asset properties such as `audioSrc` appearing blank in the Studio Inspector

## Context

The original asset-field implementation displayed all asset values. The later media-source picker refactor restricted the display to properties named exactly `src`, even though asset schemas support arbitrary property names.

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx oxfmt packages/studio/src/components/Timeline/TimelineAssetField.tsx --write`
- `git diff --check`
