### PR TITLE
Add NULLFRAME to the list of templates

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -28,6 +28,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - Docker Build & Render ([Source code](https://github.com/scotthavird/remotion-docker-template))
 - [Template for deploying Remotion on Railway](https://railway.com/deploy/remotion-on-rails) ([Blog](https://medium.com/@viveknathani/remotion-on-rails-0852acc9595e))
 - [Multiple shared Remotion components in a Monorepo template](https://github.com/Takamasa045/remotion-studio-monorepo)
+- [NULLFRAME - locked template and prompt so a coding agent fills in content instead of rewriting the composition](https://getnullframe.com) (paid, [free in-browser demo](https://getnullframe.com/demo/))
 
 ## SaaS starter Kits
 


### PR DESCRIPTION
Adds one line to the Templates section.

NULLFRAME is a Remotion template kit sold with a master prompt: the composition code stays fixed and tested, and a coding agent (Claude Code or Codex) only writes a per-video brief, instead of regenerating sequencing, timing and audio wiring on every render.

It is a paid product, and the entry says so rather than leaving people to find out after clicking. There is a free demo at getnullframe.com/demo that transcribes and plays back an edit entirely in the browser — Whisper via WebAssembly, no upload, no signup — so the output can be judged before spending anything.

Happy to move it to Products, reword it, or drop it if it is not a fit for the list.