### PR TITLE
@remotion/media: Retain video decoders across remounts

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -1,4 +1,4 @@
-import type {Input} from 'mediabunny';
+import type {Input, InputVideoTrack} from 'mediabunny';
 import type {
 	EffectChainState,
 	EffectDefinitionAndStack,
@@ -28,8 +28,63 @@ import {makeNonceManager} from './nonce-manager';
 import {PremountAwareDelayPlayback} from './premount-aware-delay-playback';
 import type {MediaRequestInit} from './request-init';
 import type {SharedAudioContextForMediaPlayer} from './shared-audio-context-for-media-player';
-import type {VideoIteratorManager} from './video-iterator-manager';
+import type {
+	VideoIteratorManager,
+	VideoIteratorPresentation,
+} from './video-iterator-manager';
 import {videoIteratorManager} from './video-iterator-manager';
+
+type VideoIteratorResource = {
+	track: InputVideoTrack;
+	manager: VideoIteratorManager;
+	releaseInput: () => void;
+};
+
+type IdleVideoIteratorResource = VideoIteratorResource & {
+	timer: ReturnType<typeof setTimeout>;
+};
+
+const idleVideoIteratorResources: IdleVideoIteratorResource[] = [];
+
+const destroyVideoIteratorResource = (resource: VideoIteratorResource) => {
+	resource.manager.destroy();
+	resource.releaseInput();
+};
+
+const takeIdleVideoIteratorResource = (track: InputVideoTrack) => {
+	const index = idleVideoIteratorResources.findIndex(
+		(candidate) => candidate.track === track,
+	);
+	if (index === -1) {
+		return null;
+	}
+
+	const [resource] = idleVideoIteratorResources.splice(index, 1);
+	clearTimeout(resource.timer);
+	return resource;
+};
+
+const releaseVideoIteratorResource = (resource: VideoIteratorResource) => {
+	const idleResource: IdleVideoIteratorResource = {
+		...resource,
+		timer: setTimeout(() => {
+			const index = idleVideoIteratorResources.indexOf(idleResource);
+			if (index !== -1) {
+				idleVideoIteratorResources.splice(index, 1);
+				destroyVideoIteratorResource(idleResource);
+			}
+		}, 5000),
+	};
+	idleVideoIteratorResources.push(idleResource);
+
+	while (idleVideoIteratorResources.length > 4) {
+		const oldest = idleVideoIteratorResources.shift();
+		if (oldest) {
+			clearTimeout(oldest.timer);
+			destroyVideoIteratorResource(oldest);
+		}
+	}
+};
 
 export type MediaPlayerInitResult =
 	| {type: 'success'; durationInSeconds: number}
@@ -59,6 +114,9 @@ export class MediaPlayer {
 
 	audioIteratorManager: AudioIteratorManager | null = null;
 	videoIteratorManager: VideoIteratorManager | null = null;
+
+	private videoIteratorResource: VideoIteratorResource | null = null;
+	private inputLeaseOwnedByVideoIterator = false;
 
 	private playing = false;
 	private loop = false;
@@ -344,8 +402,7 @@ export class MediaPlayer {
 					return {type: 'disposed'};
 				}
 
-				this.videoIteratorManager = await videoIteratorManager({
-					videoTrack,
+				const presentation: VideoIteratorPresentation = {
 					delayPlaybackHandleIfNotPremounting:
 						this.delayPlaybackHandleIfNotPremounting,
 					context: this.context,
@@ -359,7 +416,27 @@ export class MediaPlayer {
 					getIsLooping: () => this.loop,
 					getEffects: this.getEffects,
 					getEffectChainState: this.getEffectChainState,
-				});
+				};
+				const idleResource = takeIdleVideoIteratorResource(videoTrack);
+				const resource = idleResource ?? {
+					track: videoTrack,
+					manager: await videoIteratorManager({videoTrack}),
+					releaseInput: this.releaseInput,
+				};
+				if (idleResource) {
+					this.releaseInput();
+				}
+
+				this.inputLeaseOwnedByVideoIterator = true;
+				try {
+					await resource.manager.attach(presentation);
+				} catch (error) {
+					destroyVideoIteratorResource(resource);
+					throw error;
+				}
+
+				this.videoIteratorResource = resource;
+				this.videoIteratorManager = resource.manager;
 			}
 
 			const startTime = this.getTrimmedTime(startTimeUnresolved);
@@ -429,9 +506,13 @@ export class MediaPlayer {
 									this.sharedAudioContext!.audioContext.currentTime,
 							})
 						: Promise.resolve(),
-					this.videoIteratorManager
-						? this.videoIteratorManager.startVideoIterator(startTime, nonce)
-						: Promise.resolve(),
+					this.videoIteratorManager?.resumeAt({
+						newTime: startTime,
+						nonce,
+						fps: this.fps,
+						playbackRate: this.playbackRate,
+						isPlaying: this.playing,
+					}),
 				]);
 			} catch (error) {
 				if (this.isDisposalError()) {
@@ -734,11 +815,19 @@ export class MediaPlayer {
 
 		// Mark all async operations as stale
 		this.nonceManager.createAsyncOperation();
-		this.videoIteratorManager?.destroy();
+		this.videoIteratorResource?.manager.detach();
+		if (this.videoIteratorResource) {
+			releaseVideoIteratorResource(this.videoIteratorResource);
+		}
+
+		this.videoIteratorResource = null;
+		this.videoIteratorManager = null;
 		this.audioIteratorManager?.destroyIterator();
 		// Release our reference to the shared Input; it is only disposed once the
 		// last MediaPlayer using this src releases it.
-		this.releaseInput();
+		if (!this.inputLeaseOwnedByVideoIterator) {
+			this.releaseInput();
+		}
 	}
 
 	private getTargetTime = (

--- a/packages/media/src/video-iterator-manager.ts
+++ b/packages/media/src/video-iterator-manager.ts
@@ -17,6 +17,23 @@ import {
 
 const {runEffectChain} = Internals;
 
+export type VideoIteratorPresentation = {
+	delayPlaybackHandleIfNotPremounting: () => DelayPlaybackIfNotPremounting;
+	context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+	canvas: OffscreenCanvas | HTMLCanvasElement | null;
+	getOnVideoFrameCallback: () => null | ((frame: CanvasImageSource) => void);
+	logLevel: LogLevel;
+	drawDebugOverlay: () => void;
+	getLoopSegmentMediaEndTimestamp: () => number;
+	getStartTime: () => number;
+	getIsLooping: () => boolean;
+	getEffects: () => EffectDefinitionAndStack<unknown>[];
+	getEffectChainState: (
+		width: number,
+		height: number,
+	) => EffectChainState | null;
+};
+
 export const isSequentialMediaTimeAdvance = ({
 	previousTime,
 	newTime,
@@ -41,36 +58,14 @@ export const isSequentialMediaTimeAdvance = ({
 	);
 };
 
-export const videoIteratorManager = async ({
-	delayPlaybackHandleIfNotPremounting,
-	canvas,
-	context,
-	drawDebugOverlay,
-	logLevel,
-	getOnVideoFrameCallback,
-	videoTrack,
-	getLoopSegmentMediaEndTimestamp,
-	getStartTime,
-	getIsLooping,
-	getEffects,
-	getEffectChainState,
-}: {
-	videoTrack: InputVideoTrack;
-	delayPlaybackHandleIfNotPremounting: () => DelayPlaybackIfNotPremounting;
-	context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
-	canvas: OffscreenCanvas | HTMLCanvasElement | null;
-	getOnVideoFrameCallback: () => null | ((frame: CanvasImageSource) => void);
-	logLevel: LogLevel;
-	drawDebugOverlay: () => void;
-	getLoopSegmentMediaEndTimestamp: () => number;
-	getStartTime: () => number;
-	getIsLooping: () => boolean;
-	getEffects: () => EffectDefinitionAndStack<unknown>[];
-	getEffectChainState: (
-		width: number,
-		height: number,
-	) => EffectChainState | null;
-}) => {
+export const videoIteratorManager = async (
+	args:
+		| {videoTrack: InputVideoTrack}
+		| ({videoTrack: InputVideoTrack} & VideoIteratorPresentation),
+) => {
+	const {videoTrack} = args;
+	let presentation: VideoIteratorPresentation | null =
+		'canvas' in args ? args : null;
 	let videoIteratorsCreated = 0;
 	let videoFrameIterator: VideoIterator | null = null;
 	let framesRendered = 0;
@@ -82,14 +77,19 @@ export const videoIteratorManager = async ({
 		lastDrawnFrame = null;
 	};
 
-	if (canvas) {
+	const sizeCanvas = async () => {
+		const canvas = presentation?.canvas;
+		if (!canvas) {
+			return;
+		}
+
 		const displayWidth = await videoTrack.getDisplayWidth();
 		const displayHeight = await videoTrack.getDisplayHeight();
 		if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
 			canvas.width = displayWidth;
 			canvas.height = displayHeight;
 		}
-	}
+	};
 
 	const canvasSink = new CanvasSink(videoTrack, {
 		// Match the preview look-ahead buffer size. CanvasSink may reuse pooled
@@ -103,10 +103,17 @@ export const videoIteratorManager = async ({
 	const prewarmedVideoIteratorCache =
 		makePrewarmedVideoIteratorCache(canvasSink);
 
+	await sizeCanvas();
+
 	const paintFrame = async (frame: WrappedCanvas): Promise<void> => {
+		const canvas = presentation?.canvas;
+		const context = presentation?.context;
 		if (context && canvas) {
-			const effects = getEffects();
-			const chainState = getEffectChainState(canvas.width, canvas.height);
+			const effects = presentation?.getEffects() ?? [];
+			const chainState = presentation?.getEffectChainState(
+				canvas.width,
+				canvas.height,
+			);
 			if (
 				effects.length > 0 &&
 				chainState &&
@@ -133,14 +140,14 @@ export const videoIteratorManager = async ({
 
 		framesRendered++;
 
-		drawDebugOverlay();
-		const callback = getOnVideoFrameCallback();
+		presentation?.drawDebugOverlay();
+		const callback = presentation?.getOnVideoFrameCallback();
 		if (callback) {
 			callback(frame.canvas);
 		}
 
 		Internals.Log.trace(
-			{logLevel, tag: '@remotion/media'},
+			{logLevel: presentation?.logLevel ?? 'info', tag: '@remotion/media'},
 			`[MediaPlayer] Drew frame ${frame.timestamp.toFixed(3)}s`,
 		);
 	};
@@ -152,14 +159,14 @@ export const videoIteratorManager = async ({
 
 		await paintFrame(lastDrawnFrame);
 
-		drawDebugOverlay();
-		const callback = getOnVideoFrameCallback();
+		presentation?.drawDebugOverlay();
+		const callback = presentation?.getOnVideoFrameCallback();
 		if (callback) {
 			callback(lastDrawnFrame.canvas);
 		}
 
 		Internals.Log.trace(
-			{logLevel, tag: '@remotion/media'},
+			{logLevel: presentation?.logLevel ?? 'info', tag: '@remotion/media'},
 			`[MediaPlayer] Redrew frame ${lastDrawnFrame.timestamp.toFixed(3)}s with updated effects`,
 		);
 	};
@@ -170,7 +177,14 @@ export const videoIteratorManager = async ({
 	): Promise<void> => {
 		clearLastDrawnFrame();
 		videoFrameIterator?.destroy();
-		using delayHandle = delayPlaybackHandleIfNotPremounting();
+		videoFrameIterator = null;
+		const activePresentation = presentation;
+		if (!activePresentation) {
+			return;
+		}
+
+		using delayHandle =
+			activePresentation.delayPlaybackHandleIfNotPremounting();
 		currentDelayHandle = delayHandle;
 		currentSeek = timeToSeek;
 
@@ -235,11 +249,11 @@ export const videoIteratorManager = async ({
 		const previousTime = currentSeek;
 		currentSeek = newTime;
 
-		if (getIsLooping()) {
+		if (presentation?.getIsLooping()) {
 			// If less than 1 second from the end away, we pre-warm a new iterator
-			if (getLoopSegmentMediaEndTimestamp() - newTime < 1) {
+			if (presentation.getLoopSegmentMediaEndTimestamp() - newTime < 1) {
 				prewarmedVideoIteratorCache.prewarmIteratorForLooping({
-					timeToSeek: getStartTime(),
+					timeToSeek: presentation.getStartTime(),
 				});
 			}
 		}
@@ -278,14 +292,36 @@ export const videoIteratorManager = async ({
 		await startVideoIterator(newTime, nonce);
 	};
 
+	const resumeAt = async ({
+		newTime,
+		nonce,
+		fps,
+		playbackRate,
+		isPlaying,
+	}: {
+		newTime: number;
+		nonce: Nonce;
+		fps: number;
+		playbackRate: number;
+		isPlaying: boolean;
+	}) => {
+		if (!videoFrameIterator) {
+			await startVideoIterator(newTime, nonce);
+			return;
+		}
+
+		await seek({newTime, nonce, fps, playbackRate, isPlaying});
+	};
+
 	return {
-		startVideoIterator,
-		getVideoIteratorsCreated: () => videoIteratorsCreated,
-		seek,
-		destroy: () => {
-			clearLastDrawnFrame();
-			prewarmedVideoIteratorCache.destroy();
-			videoFrameIterator?.destroy();
+		attach: async (nextPresentation: VideoIteratorPresentation) => {
+			presentation = nextPresentation;
+			await sizeCanvas();
+			await redrawCurrentFrame();
+		},
+		detach: () => {
+			const canvas = presentation?.canvas;
+			const context = presentation?.context;
 			if (context && canvas) {
 				context.clearRect(0, 0, canvas.width, canvas.height);
 			}
@@ -295,6 +331,17 @@ export const videoIteratorManager = async ({
 				currentDelayHandle = null;
 			}
 
+			presentation = null;
+		},
+		startVideoIterator,
+		resumeAt,
+		getVideoIteratorsCreated: () => videoIteratorsCreated,
+		seek,
+		destroy: () => {
+			clearLastDrawnFrame();
+			prewarmedVideoIteratorCache.destroy();
+			videoFrameIterator?.destroy();
+			presentation = null;
 			videoFrameIterator = null;
 		},
 		getVideoFrameIterator: () => videoFrameIterator,


### PR DESCRIPTION
## Summary

- detach video iterator presentation state when a preview media player unmounts
- retain up to four idle iterator/decoder resources for five seconds
- reattach the next canvas and resume the existing iterator instead of cold-starting a decoder
- keep the shared Mediabunny input alive for the retained iterator

## Verification

- `bunx turbo run make --filter='@remotion/media'`
- `bunx turbo run lint --filter='@remotion/media'` (pre-existing warnings only)
- `bunx vitest src/test/video-iterator-manager.test.ts --browser --run` (8 tests passed in Chrome)