### PR TITLE
Elements: Show embedded libraries in dark mode

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -222,7 +222,7 @@ const CloseupPlaceholder = () => {
 		}
 	});
 	await context.route(
-		'https://www.remotion.dev/elements?remotion-studio=true',
+		'https://www.remotion.dev/elements?remotion-studio=true&docusaurus-theme=dark',
 		async (route) => {
 			officialLibraryRequests.push(route.request().url());
 			await route.fulfill({
@@ -232,7 +232,7 @@ const CloseupPlaceholder = () => {
 		},
 	);
 	await context.route(
-		`${externalLibraryUrl}?remotion-studio=true`,
+		`${externalLibraryUrl}?remotion-studio=true&docusaurus-theme=dark`,
 		async (route) => {
 			externalLibraryRequests.push(route.request().url());
 			await route.fulfill({
@@ -311,7 +311,7 @@ const CloseupPlaceholder = () => {
 		);
 		await expect(officialElementsIframe).toBeVisible();
 		expect(officialLibraryRequests).toEqual([
-			'https://www.remotion.dev/elements?remotion-studio=true',
+			'https://www.remotion.dev/elements?remotion-studio=true&docusaurus-theme=dark',
 		]);
 		expect(context.pages()).toHaveLength(2);
 		await studioPage.keyboard.press('Escape');
@@ -339,7 +339,7 @@ const CloseupPlaceholder = () => {
 		);
 		await expect(elementsIframe).toHaveAttribute('credentialless', '');
 		expect(externalLibraryRequests).toEqual([
-			`${externalLibraryUrl}?remotion-studio=true`,
+			`${externalLibraryUrl}?remotion-studio=true&docusaurus-theme=dark`,
 		]);
 		expect(context.pages()).toHaveLength(2);
 		const elementsFrame = studioPage.frameLocator(

--- a/packages/studio/src/components/ElementLibraryModal.tsx
+++ b/packages/studio/src/components/ElementLibraryModal.tsx
@@ -13,6 +13,7 @@ const panelStyle: React.CSSProperties = {
 
 const iframeStyle: React.CSSProperties = {
 	border: 0,
+	colorScheme: 'dark',
 	flex: 1,
 	minHeight: 0,
 	width: '100%',
@@ -35,6 +36,7 @@ export const ElementLibraryModal: React.FC<{
 		iframe.setAttribute('credentialless', '');
 		const iframeUrl = new URL(url);
 		iframeUrl.searchParams.set('remotion-studio', 'true');
+		iframeUrl.searchParams.set('docusaurus-theme', 'dark');
 		iframe.src = iframeUrl.toString();
 	}, [url]);
 


### PR DESCRIPTION
## Summary

- request dark browser chrome and color-scheme behavior for embedded Element library iframes
- force Docusaurus-based libraries, including Remotion Elements, to initialize in dark mode
- preserve the dark theme request in existing Element library integration coverage

## Verification

- `bunx oxfmt packages/studio/src/components/ElementLibraryModal.tsx packages/example/e2e/studio-protocol.test.mts --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test e2e/studio-protocol.test.mts`
- headless Chromium check that Remotion Elements initializes with `data-theme="dark"` while the browser prefers light mode
