### PR TITLE
Elements: Center Elements installed into compositions

### DIFF
--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -74,6 +74,7 @@ import {
 } from './element-install-request';
 import {handleDrop} from './handle-drop';
 import {
+	getElementPositionForDrop,
 	getFromForDrop,
 	hasSvgFile,
 	importAssets,
@@ -925,23 +926,37 @@ export const Canvas: React.FC<{
 
 	useEffect(() => {
 		return subscribeToElementInstallRequests((request) => {
-			const requestWithFrom =
-				request.source.type === 'drag-and-drop' || request.from !== null
-					? request
-					: {
-							...request,
-							from: getFromForDrop({
+			const isDragAndDrop = request.source.type === 'drag-and-drop';
+			const requestWithDefaults = isDragAndDrop
+				? request
+				: {
+						...request,
+						from:
+							request.from ??
+							getFromForDrop({
 								durationInFrames: request.element.durationInFrames,
 								from: getCurrentFrame(),
 								preferCompositionStart: true,
 							}),
-						};
+						position:
+							request.position ??
+							getElementPositionForDrop({
+								dimensions: request.element.dimensions,
+								dropPosition:
+									contentDimensions === null || contentDimensions === 'none'
+										? null
+										: {
+												centerX: contentDimensions.width / 2,
+												centerY: contentDimensions.height / 2,
+											},
+							}),
+					};
 			setPendingElementInstallRequests((requests) => [
 				...requests,
-				requestWithFrom,
+				requestWithDefaults,
 			]);
 		});
-	}, []);
+	}, [contentDimensions]);
 
 	useEffect(() => {
 		if (


### PR DESCRIPTION
## Summary

- center fixed-size Elements when they are installed into the active composition
- preserve explicit positions and drag-and-drop placement
- keep dimensionless Elements at their existing default position

## Verification

- `bun test packages/studio/src/test/import-assets.test.ts`
- `bunx turbo run make --filter='@remotion/studio'`
- `bun run build`
- `bun run stylecheck`
- `bunx oxfmt packages/studio/src/components/Canvas.tsx --write`
- `git diff --check`
