### PR TITLE
Elements: Select Elements after installation

### DIFF
--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -510,9 +510,15 @@ const CloseupPlaceholder = () => {
 		await expect(studioPage).toHaveURL(/ProtocolElementScene/, {
 			timeout: 30_000,
 		});
+		await expect(
+			studioPage
+				.getByRole('group', {name: 'Inspector source location'})
+				.first(),
+		).toContainText('Protocol Element', {timeout: 30_000});
 
 		await studioPage.bringToFront();
-		await studioPage.mouse.click(500, 300);
+		await studioPage.keyboard.press('Escape');
+		await expect(browseElements).toBeVisible();
 		await expect
 			.poll(() =>
 				fetch(`${studioUrl}/api/studio-protocol`, {

--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -377,6 +377,14 @@ const CloseupPlaceholder = () => {
 		await expect(elementsIframe).toHaveCount(0);
 		expect(studioProtocolRequests).toEqual([]);
 		await dialog.getByRole('button', {name: /Install/}).click();
+		await expect(
+			studioPage
+				.getByRole('group', {name: 'Inspector source location'})
+				.first(),
+		).toContainText('Protocol Element', {timeout: 30_000});
+		await expect(
+			studioPage.getByText('Installed Protocol Element', {exact: true}),
+		).toBeVisible();
 
 		const elementFile = path.join(
 			temporaryProject,

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -368,10 +368,13 @@ const TimelineInner: React.FC = () => {
 
 		const matchesInsertedNodePath = (track: TimelineTrackData) =>
 			track.nodePathInfo !== null &&
-			track.nodePathInfo.sequenceSubscriptionKey.absolutePath ===
-				pendingInsertedElementSelection.nodePath.absolutePath &&
-			JSON.stringify(track.nodePathInfo.sequenceSubscriptionKey.nodePath) ===
-				JSON.stringify(pendingInsertedElementSelection.nodePath.nodePath);
+			(pendingInsertedElementSelection.nodePath === null ||
+				(track.nodePathInfo.sequenceSubscriptionKey.absolutePath ===
+					pendingInsertedElementSelection.nodePath.absolutePath &&
+					JSON.stringify(
+						track.nodePathInfo.sequenceSubscriptionKey.nodePath,
+					) ===
+						JSON.stringify(pendingInsertedElementSelection.nodePath.nodePath)));
 
 		if (
 			pendingSelectionStart.current?.selection !==
@@ -418,6 +421,9 @@ const TimelineInner: React.FC = () => {
 			{reveal: true},
 		);
 		clearInsertedElementSelection(pendingInsertedElementSelection);
+		if (pendingInsertedElementSelection.notification !== null) {
+			showNotification(pendingInsertedElementSelection.notification, 3000);
+		}
 	}, [
 		canvasContent,
 		fastRefreshes,

--- a/packages/studio/src/components/import-assets.ts
+++ b/packages/studio/src/components/import-assets.ts
@@ -697,6 +697,7 @@ const insertCompositionElement = async ({
 		requestInsertedElementSelection({
 			compositionId,
 			nodePath: result.insertedNodePath,
+			notification: null,
 		});
 	}
 
@@ -1355,7 +1356,14 @@ export const insertElement = async ({
 					? response.reason
 					: `Element file changed: ${response.conflict.filePath}`;
 			showNotification(`Could not add Element: ${reason}`, 4000);
+			return;
 		}
+
+		requestInsertedElementSelection({
+			compositionId,
+			nodePath: null,
+			notification: `Installed ${element.displayName}`,
+		});
 	} catch (error) {
 		showNotification(
 			`Could not add Element: ${

--- a/packages/studio/src/helpers/inserted-element-selection.ts
+++ b/packages/studio/src/helpers/inserted-element-selection.ts
@@ -2,10 +2,11 @@ import type {SequenceNodePath} from 'remotion';
 
 export type PendingInsertedElementSelection = {
 	compositionId: string;
+	notification: string | null;
 	nodePath: {
 		absolutePath: string;
 		nodePath: SequenceNodePath;
-	};
+	} | null;
 };
 
 let pendingSelection: PendingInsertedElementSelection | null = null;


### PR DESCRIPTION
## Summary

- automatically select an Element after its new timeline track appears
- show the installation success toast only after the Element has been added to the timeline
- cover selection and success feedback in the Studio Protocol installation workflow

## Verification

- `bunx oxfmt packages/example/e2e/studio-protocol.test.mts packages/studio/src/components/Timeline/Timeline.tsx packages/studio/src/components/import-assets.ts packages/studio/src/helpers/inserted-element-selection.ts --write`
- `bun run build`
- `bun run stylecheck`
- `cd packages/studio && bun test src` (645 tests)
- isolated `cd packages/example && bunx playwright test e2e/studio-protocol.test.mts` through the installation assertions
- `git diff --check`
