### PR TITLE
Elements: Scope asset fields by media type

### DIFF
--- a/packages/docs/elements/audio/mirrored-spectrum/mirrored-spectrum.tsx
+++ b/packages/docs/elements/audio/mirrored-spectrum/mirrored-spectrum.tsx
@@ -24,6 +24,7 @@ const mirroredAudioSpectrumSchema = {
 	...Interactive.baseSchema,
 	audioSrc: {
 		type: 'asset',
+		assetType: 'audio',
 		default:
 			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 		description: 'Audio source',

--- a/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
+++ b/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
@@ -29,6 +29,7 @@ const audioOscilloscopeSchema = {
 	...Interactive.baseSchema,
 	audioSrc: {
 		type: 'asset',
+		assetType: 'audio',
 		default:
 			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 		description: 'Audio source',

--- a/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
+++ b/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
@@ -32,6 +32,7 @@ const audioWaveformProgressSchema = {
 	...Interactive.baseSchema,
 	audioSrc: {
 		type: 'asset',
+		assetType: 'audio',
 		default:
 			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 		description: 'Audio source',

--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -41,6 +41,7 @@ const productCardSchema = {
 	},
 	image: {
 		type: 'asset',
+		assetType: 'image',
 		default:
 			'https://remotion.media/elements/product-collection-cloudline-runner.png',
 		description: 'Product image',

--- a/packages/example/src/mirrored-spectrum.element.tsx
+++ b/packages/example/src/mirrored-spectrum.element.tsx
@@ -24,6 +24,7 @@ const mirroredAudioSpectrumSchema = {
 	...Interactive.baseSchema,
 	audioSrc: {
 		type: 'asset',
+		assetType: 'audio',
 		default:
 			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 		description: 'Audio source',

--- a/packages/example/src/oscilloscope.element.tsx
+++ b/packages/example/src/oscilloscope.element.tsx
@@ -29,6 +29,7 @@ const audioOscilloscopeSchema = {
 	...Interactive.baseSchema,
 	audioSrc: {
 		type: 'asset',
+		assetType: 'audio',
 		default:
 			'https://remotion.media/elements/remotion-made-this-picture-move.mp3',
 		description: 'Audio source',


### PR DESCRIPTION
## Summary

- mark audio Element asset fields as `assetType: 'audio'`
- mark the Product Collection image field as `assetType: 'image'`
- keep the example copies of the audio Elements in sync

## Test plan

- `bun run stylecheck`
- `cd packages/example && bunx tsc --noEmit`

## Stack

1. #11068: public API and built-in Studio integration
2. This PR: Elements and example schemas


## Preview

- [Audio Oscilloscope](https://remotion-git-interactivity-asset-type-elements-remotion.vercel.app/elements/audio/oscilloscope)
- [Audio Waveform Progress](https://remotion-git-interactivity-asset-type-elements-remotion.vercel.app/elements/audio/waveform-progress)
- [Mirrored Audio Spectrum](https://remotion-git-interactivity-asset-type-elements-remotion.vercel.app/elements/audio/mirrored-spectrum)
- [Product Collection](https://remotion-git-interactivity-asset-type-elements-remotion.vercel.app/elements/commerce/product-collection)
