### PR TITLE
`@remotion/serverless`: Fix warm Lambda exits after flaky renderer errors

### DIFF
--- a/packages/lambda/src/functions/aws-server-implementation.ts
+++ b/packages/lambda/src/functions/aws-server-implementation.ts
@@ -1,6 +1,7 @@
 import {LambdaClientInternals, type AwsProvider} from '@remotion/lambda-client';
 import type {InsideFunctionSpecifics} from '@remotion/serverless';
 import {
+	closeBrowserInstanceImplementation,
 	forgetBrowserEventLoopImplementation,
 	getBrowserInstanceImplementation,
 	invokeWebhook,
@@ -17,6 +18,7 @@ export const serverAwsImplementation: InsideFunctionSpecifics<AwsProvider> = {
 		? 'veryfast'
 		: null,
 	forgetBrowserEventLoop: forgetBrowserEventLoopImplementation,
+	closeBrowserInstance: closeBrowserInstanceImplementation,
 	getBrowserInstance: getBrowserInstanceImplementation,
 	timer,
 	getCurrentRegionInFunction: getCurrentRegionInFunctionImplementation,

--- a/packages/lambda/src/test/mock-implementation.ts
+++ b/packages/lambda/src/test/mock-implementation.ts
@@ -44,6 +44,10 @@ export const mockServerImplementation: InsideFunctionSpecifics<AwsProvider> = {
 		);
 		launchedBrowser.instance.close({silent: false});
 	},
+	closeBrowserInstance: async ({launchedBrowser}) => {
+		browsersOpen.delete(launchedBrowser.instance.id);
+		await launchedBrowser.instance.close({silent: true});
+	},
 	getCurrentRegionInFunction: () => 'eu-central-1',
 	getBrowserInstance,
 	timer: () => ({

--- a/packages/serverless/src/get-browser-instance.ts
+++ b/packages/serverless/src/get-browser-instance.ts
@@ -128,51 +128,54 @@ export const getBrowserInstanceImplementation: GetBrowserInstance = async <
 		);
 		launching = true;
 
-		const execPath = providerSpecifics.getChromiumPath();
+		try {
+			const execPath = providerSpecifics.getChromiumPath();
 
-		const instance = await RenderInternals.internalOpenBrowser({
-			browser: 'chrome',
-			browserExecutable: execPath,
-			chromiumOptions: actualChromiumOptions,
-			forceDeviceScaleFactor: undefined,
-			indent: false,
-			viewport: null,
-			logLevel,
-			onBrowserDownload: () => {
-				throw new Error('Should not download a browser in serverless');
-			},
-			chromeMode: 'headless-shell',
-		});
-		const launchedBrowser = {
-			instance,
-			configurationString,
-		};
-		_browserInstance = launchedBrowser;
-		instance.on('disconnected', () => {
-			if (_browserInstance !== launchedBrowser) {
-				return;
-			}
-
-			_browserInstance = null;
-			RenderInternals.Log.info(
-				{indent: false, logLevel},
-				'Browser disconnected or crashed.',
-			);
-			insideFunctionSpecifics.forgetBrowserEventLoop({
+			const instance = await RenderInternals.internalOpenBrowser({
+				browser: 'chrome',
+				browserExecutable: execPath,
+				chromiumOptions: actualChromiumOptions,
+				forceDeviceScaleFactor: undefined,
+				indent: false,
+				viewport: null,
 				logLevel,
-				launchedBrowser,
+				onBrowserDownload: () => {
+					throw new Error('Should not download a browser in serverless');
+				},
+				chromeMode: 'headless-shell',
 			});
-			launchedBrowser.instance.close({silent: true}).catch((err) => {
+			const launchedBrowser = {
+				instance,
+				configurationString,
+			};
+			_browserInstance = launchedBrowser;
+			instance.on('disconnected', () => {
+				if (_browserInstance !== launchedBrowser) {
+					return;
+				}
+
+				_browserInstance = null;
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
-					'Could not close browser instance',
-					err,
+					'Browser disconnected or crashed.',
 				);
+				insideFunctionSpecifics.forgetBrowserEventLoop({
+					logLevel,
+					launchedBrowser,
+				});
+				launchedBrowser.instance.close({silent: true}).catch((err) => {
+					RenderInternals.Log.info(
+						{indent: false, logLevel},
+						'Could not close browser instance',
+						err,
+					);
+				});
 			});
-		});
 
-		launching = false;
-		return launchedBrowser;
+			return launchedBrowser;
+		} finally {
+			launching = false;
+		}
 	}
 
 	if (_browserInstance.configurationString !== configurationString) {

--- a/packages/serverless/src/get-browser-instance.ts
+++ b/packages/serverless/src/get-browser-instance.ts
@@ -7,6 +7,7 @@ import type {
 } from '@remotion/serverless-client';
 import {VERSION} from '@remotion/serverless-client';
 import type {
+	CloseBrowserInstance,
 	ForgetBrowserEventLoop,
 	GetBrowserInstance,
 	InsideFunctionSpecifics,
@@ -62,6 +63,16 @@ export const forgetBrowserEventLoopImplementation: ForgetBrowserEventLoop = ({
 	);
 	launchedBrowser.instance.runner.forgetEventLoop();
 	launchedBrowser.instance.runner.deleteBrowserCaches();
+};
+
+export const closeBrowserInstanceImplementation: CloseBrowserInstance = async ({
+	launchedBrowser,
+}) => {
+	if (_browserInstance === launchedBrowser) {
+		_browserInstance = null;
+	}
+
+	await launchedBrowser.instance.close({silent: true});
 };
 
 export const getBrowserInstanceImplementation: GetBrowserInstance = async <
@@ -132,31 +143,36 @@ export const getBrowserInstanceImplementation: GetBrowserInstance = async <
 			},
 			chromeMode: 'headless-shell',
 		});
+		const launchedBrowser = {
+			instance,
+			configurationString,
+		};
+		_browserInstance = launchedBrowser;
 		instance.on('disconnected', () => {
+			if (_browserInstance !== launchedBrowser) {
+				return;
+			}
+
+			_browserInstance = null;
 			RenderInternals.Log.info(
 				{indent: false, logLevel},
 				'Browser disconnected or crashed.',
 			);
 			insideFunctionSpecifics.forgetBrowserEventLoop({
 				logLevel,
-				launchedBrowser: _browserInstance as LaunchedBrowser,
+				launchedBrowser,
 			});
-			_browserInstance?.instance?.close({silent: true}).catch((err) => {
+			launchedBrowser.instance.close({silent: true}).catch((err) => {
 				RenderInternals.Log.info(
 					{indent: false, logLevel},
 					'Could not close browser instance',
 					err,
 				);
 			});
-			_browserInstance = null;
 		});
-		_browserInstance = {
-			instance,
-			configurationString,
-		};
 
 		launching = false;
-		return _browserInstance;
+		return launchedBrowser;
 	}
 
 	if (_browserInstance.configurationString !== configurationString) {

--- a/packages/serverless/src/handlers/renderer.ts
+++ b/packages/serverless/src/handlers/renderer.ts
@@ -583,32 +583,34 @@ export const rendererHandler = async <Provider extends CloudProvider>({
 		});
 	} finally {
 		stopCancellationPolling();
-		if (executionMode === 'direct') {
-			if (!shouldKeepBrowserOpen && instance) {
-				await instance.instance.close({silent: true});
+		if (!shouldKeepBrowserOpen && instance) {
+			try {
+				await insideFunctionSpecifics.closeBrowserInstance({
+					launchedBrowser: instance,
+				});
+			} catch (err) {
+				RenderInternals.Log.info(
+					{indent: false, logLevel: params.logLevel},
+					'Could not close browser instance after flaky error',
+					err,
+				);
 			}
-		} else if (shouldKeepBrowserOpen && instance) {
+		} else if (
+			executionMode === 'invoked' &&
+			shouldKeepBrowserOpen &&
+			instance
+		) {
 			insideFunctionSpecifics.forgetBrowserEventLoop({
 				logLevel: params.logLevel,
 				launchedBrowser: instance,
 			});
-		} else {
+		}
+
+		if (!shouldKeepBrowserOpen) {
 			RenderInternals.Log.info(
 				{indent: false, logLevel: params.logLevel},
 				'Function did not succeed with flaky error, not keeping browser open.',
 			);
-			RenderInternals.Log.info(
-				{indent: false, logLevel: params.logLevel},
-				'Waiting 2 seconds to allow for response to be sent',
-			);
-
-			setTimeout(() => {
-				RenderInternals.Log.info(
-					{indent: false, logLevel: params.logLevel},
-					'Quitting Function forcefully now to force not keeping the Function warm.',
-				);
-				process.exit(0);
-			}, 2000);
 		}
 
 		if (ENABLE_SLOW_LEAK_DETECTION) {

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -1,5 +1,6 @@
 export * from '@remotion/serverless-client';
 export {
+	closeBrowserInstanceImplementation,
 	forgetBrowserEventLoopImplementation,
 	getBrowserInstanceImplementation,
 } from './get-browser-instance';

--- a/packages/serverless/src/provider-implementation.ts
+++ b/packages/serverless/src/provider-implementation.ts
@@ -49,6 +49,10 @@ export type ForgetBrowserEventLoop = (options: {
 	launchedBrowser: LaunchedBrowser;
 }) => void;
 
+export type CloseBrowserInstance = (options: {
+	launchedBrowser: LaunchedBrowser;
+}) => Promise<void>;
+
 export type GenerateRenderId = (options: {
 	deleteAfter: DeleteAfter | null;
 	randomHashFn: () => string;
@@ -123,6 +127,7 @@ export type InsideFunctionSpecifics<Provider extends CloudProvider> = {
 	defaultX264Preset: X264Preset | null;
 	getBrowserInstance: GetBrowserInstance;
 	forgetBrowserEventLoop: ForgetBrowserEventLoop;
+	closeBrowserInstance: CloseBrowserInstance;
 	timer: DebuggingTimer;
 	generateRandomId: GenerateRenderId;
 	deleteTmpDir: () => Promise<void>;

--- a/packages/serverless/src/test/renderer-lifecycle.test.ts
+++ b/packages/serverless/src/test/renderer-lifecycle.test.ts
@@ -1,4 +1,7 @@
 import {expect, mock, spyOn, test} from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {RenderInternals} from '@remotion/renderer';
 import type {
 	CloudProvider,
@@ -22,77 +25,157 @@ type MockProvider = CloudProvider<
 	Record<string, never>
 >;
 
-test('a flaky renderer invocation cannot terminate the next invocation', async () => {
-	const previousNodeEnv = process.env.NODE_ENV;
-	const scheduledCallbacks: Array<() => void> = [];
-	let currentInvocation = 'A';
-	const exits: string[] = [];
-	const timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
-		callback: (...args: never[]) => void,
-	) => {
-		scheduledCallbacks.push(callback);
-
-		return 0 as unknown as ReturnType<typeof setTimeout>;
-	}) as unknown as typeof setTimeout);
-	const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
-		exits.push(currentInvocation);
-	}) as typeof process.exit);
-	const streamedMessages: StreamingPayload<MockProvider>[] = [];
-
-	try {
-		process.env.NODE_ENV = 'production';
-		await rendererHandler<MockProvider>({
-			params: {
-				type: 'renderer',
-				chromiumOptions: {gl: null},
-				launchFunctionConfig: {version: `${VERSION}-mismatch`},
-				logLevel: 'error',
-				retriesLeft: 1,
-				attempt: 1,
-				chunk: 0,
-				enableCancellation: false,
-			} as never,
-			options: {expectedBucketOwner: 'owner', isWarm: true},
-			onStream: (message) => {
-				streamedMessages.push(message);
-				return Promise.resolve();
-			},
-			providerSpecifics: {
-				isFlakyError: () => true,
-			} as unknown as ProviderSpecifics<MockProvider>,
-			requestContext: {
-				awsRequestId: 'invocation-a',
-				invokedFunctionArn: 'arn',
-				getRemainingTimeInMillis: () => 120_000,
-			},
-			insideFunctionSpecifics:
-				{} as unknown as InsideFunctionSpecifics<MockProvider>,
-			onMediaFiles: null,
-			executionMode: 'invoked',
-		});
-
-		expect(streamedMessages).toHaveLength(1);
-		expect(streamedMessages[0]).toMatchObject({
-			type: 'error-occurred',
-			payload: {shouldRetry: true},
-		});
-
-		currentInvocation = 'B';
-		for (const callback of scheduledCallbacks) {
-			callback();
+test.each(['browser launch', 'Chromium path lookup'] as const)(
+	'a failed %s allows the next renderer invocation to complete without exiting',
+	async (failure) => {
+		const previousNodeEnv = process.env.NODE_ENV;
+		const testRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'renderer-lifecycle-'),
+		);
+		const tmpDirSpy = spyOn(RenderInternals, 'tmpDir').mockImplementation(() =>
+			fs.mkdtempSync(path.join(testRoot, 'render-')),
+		);
+		const launchError = new Error(`Failed ${failure}`);
+		const browser = {
+			on: mock(() => undefined),
+			close: mock(() => Promise.resolve()),
+		};
+		// Fake Chromium startup and rendering: a real connection timeout is
+		// nondeterministic. Keep the handler and browser cache implementation real.
+		const openBrowserSpy = spyOn(RenderInternals, 'internalOpenBrowser');
+		if (failure === 'browser launch') {
+			openBrowserSpy.mockRejectedValueOnce(launchError);
 		}
 
-		expect(exits).toEqual([]);
-	} finally {
-		timeoutSpy.mockRestore();
-		exitSpy.mockRestore();
-		if (previousNodeEnv === undefined) {
-			delete process.env.NODE_ENV;
-		} else {
-			process.env.NODE_ENV = previousNodeEnv;
+		openBrowserSpy.mockResolvedValue(browser as never);
+		const renderMediaSpy = spyOn(
+			RenderInternals,
+			'internalRenderMedia',
+		).mockResolvedValue({
+			slowestFrames: [],
+		} as never);
+		const onMediaFiles = mock(() => Promise.resolve());
+		const forgetBrowserEventLoop = mock(() => undefined);
+		let launchedBrowser: LaunchedBrowser | null = null;
+		const scheduledCallbacks: Array<() => void> = [];
+		let currentInvocation = 'A';
+		const exits: string[] = [];
+		const timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
+			callback: (...args: never[]) => void,
+		) => {
+			scheduledCallbacks.push(callback);
+
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		}) as unknown as typeof setTimeout);
+		const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+			exits.push(currentInvocation);
+		}) as typeof process.exit);
+		const streamedMessages: StreamingPayload<MockProvider>[] = [];
+
+		try {
+			process.env.NODE_ENV = 'production';
+			const invoke = () =>
+				rendererHandler<MockProvider>({
+					params: {
+						type: 'renderer',
+						chromiumOptions: {gl: null},
+						launchFunctionConfig: {version: VERSION},
+						inputProps: {type: 'payload', payload: '{}'},
+						resolvedProps: {type: 'payload', payload: '{}'},
+						bucketName: 'bucket',
+						forcePathStyle: false,
+						frameRange: [0, 0],
+						everyNthFrame: 1,
+						codec: 'h264',
+						muted: true,
+						framesPerLambda: 1,
+						logLevel: 'error',
+						retriesLeft: 1,
+						attempt: 1,
+						chunk: 0,
+						enableCancellation: false,
+					} as never,
+					options: {expectedBucketOwner: 'owner', isWarm: true},
+					onStream: (message) => {
+						streamedMessages.push(message);
+						return Promise.resolve();
+					},
+					providerSpecifics: {
+						isFlakyError: (err: Error) => err === launchError,
+						getChromiumPath: () => {
+							if (
+								failure === 'Chromium path lookup' &&
+								currentInvocation === 'A'
+							) {
+								throw launchError;
+							}
+
+							return '/mock-chrome';
+						},
+					} as unknown as ProviderSpecifics<MockProvider>,
+					requestContext: {
+						awsRequestId: currentInvocation,
+						invokedFunctionArn: 'arn',
+						getRemainingTimeInMillis: () => 120_000,
+					},
+					insideFunctionSpecifics: {
+						getCurrentRegionInFunction: () => 'mock-region',
+						getBrowserInstance: async (options) => {
+							launchedBrowser = await getBrowserInstanceImplementation(options);
+							return launchedBrowser;
+						},
+						closeBrowserInstance: closeBrowserInstanceImplementation,
+						forgetBrowserEventLoop,
+						timer: () => ({end: () => undefined}),
+					} satisfies Partial<
+						InsideFunctionSpecifics<MockProvider>
+					> as unknown as InsideFunctionSpecifics<MockProvider>,
+					onMediaFiles,
+					executionMode: 'invoked',
+				});
+
+			await invoke();
+			expect(streamedMessages).toHaveLength(1);
+			expect(streamedMessages[0]).toMatchObject({
+				type: 'error-occurred',
+				payload: {shouldRetry: true, errorInfo: {message: launchError.message}},
+			});
+
+			currentInvocation = 'B';
+			const nextInvocation = invoke();
+			for (const callback of [...scheduledCallbacks]) {
+				callback();
+			}
+
+			await nextInvocation;
+			expect(streamedMessages).toHaveLength(2);
+			expect(streamedMessages[1]).toMatchObject({type: 'chunk-complete'});
+			expect(openBrowserSpy).toHaveBeenCalledTimes(
+				failure === 'browser launch' ? 2 : 1,
+			);
+			expect(renderMediaSpy).toHaveBeenCalledTimes(1);
+			expect(onMediaFiles).toHaveBeenCalledTimes(1);
+			expect(forgetBrowserEventLoop).toHaveBeenCalledTimes(1);
+			expect(exits).toEqual([]);
+		} finally {
+			if (launchedBrowser) {
+				await closeBrowserInstanceImplementation({launchedBrowser});
+			}
+
+			tmpDirSpy.mockRestore();
+			openBrowserSpy.mockRestore();
+			renderMediaSpy.mockRestore();
+			fs.rmSync(testRoot, {recursive: true, force: true});
+			timeoutSpy.mockRestore();
+			exitSpy.mockRestore();
+			if (previousNodeEnv === undefined) {
+				delete process.env.NODE_ENV;
+			} else {
+				process.env.NODE_ENV = previousNodeEnv;
+			}
 		}
-	}
-});
+	},
+);
 
 test('a flaky renderer invocation closes its browser before returning', async () => {
 	const previousNodeEnv = process.env.NODE_ENV;
@@ -113,6 +196,7 @@ test('a flaky renderer invocation closes its browser before returning', async ()
 	const closing = new Promise<void>((_resolve, reject) => {
 		failClosing = () => reject(new Error('Could not close browser'));
 	});
+	const streamedMessages: StreamingPayload<MockProvider>[] = [];
 	const closeBrowserInstance = mock(() => {
 		notifyCloseStarted();
 		return closing;
@@ -135,7 +219,10 @@ test('a flaky renderer invocation closes its browser before returning', async ()
 				enableCancellation: false,
 			} as never,
 			options: {expectedBucketOwner: 'owner', isWarm: true},
-			onStream: () => Promise.resolve(),
+			onStream: (message) => {
+				streamedMessages.push(message);
+				return Promise.resolve();
+			},
 			providerSpecifics: {
 				isFlakyError: () => true,
 			} as unknown as ProviderSpecifics<MockProvider>,
@@ -174,6 +261,18 @@ test('a flaky renderer invocation closes its browser before returning', async ()
 		failClosing();
 		await handlerPromise;
 		expect(handlerReturned).toBe(true);
+		expect(streamedMessages).toHaveLength(1);
+		expect(streamedMessages[0]).toMatchObject({
+			type: 'error-occurred',
+			payload: {
+				shouldRetry: true,
+				errorInfo: {
+					message: 'must pass chunk',
+					willRetry: true,
+					isFatal: false,
+				},
+			},
+		});
 	} finally {
 		failClosing();
 		await Promise.resolve();

--- a/packages/serverless/src/test/renderer-lifecycle.test.ts
+++ b/packages/serverless/src/test/renderer-lifecycle.test.ts
@@ -1,0 +1,256 @@
+import {expect, mock, spyOn, test} from 'bun:test';
+import {RenderInternals} from '@remotion/renderer';
+import type {
+	CloudProvider,
+	ProviderSpecifics,
+	StreamingPayload,
+} from '@remotion/serverless-client';
+import {VERSION} from '@remotion/serverless-client';
+import {
+	closeBrowserInstanceImplementation,
+	getBrowserInstanceImplementation,
+} from '../get-browser-instance';
+import type {LaunchedBrowser} from '../get-browser-instance';
+import {rendererHandler} from '../handlers/renderer';
+import type {InsideFunctionSpecifics} from '../provider-implementation';
+
+type MockProvider = CloudProvider<
+	'mock-region',
+	Record<string, never>,
+	Record<string, never>,
+	'normal',
+	Record<string, never>
+>;
+
+test('a flaky renderer invocation cannot terminate the next invocation', async () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	const scheduledCallbacks: Array<() => void> = [];
+	let currentInvocation = 'A';
+	const exits: string[] = [];
+	const timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
+		callback: (...args: never[]) => void,
+	) => {
+		scheduledCallbacks.push(callback);
+
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as unknown as typeof setTimeout);
+	const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+		exits.push(currentInvocation);
+	}) as typeof process.exit);
+	const streamedMessages: StreamingPayload<MockProvider>[] = [];
+
+	try {
+		process.env.NODE_ENV = 'production';
+		await rendererHandler<MockProvider>({
+			params: {
+				type: 'renderer',
+				chromiumOptions: {gl: null},
+				launchFunctionConfig: {version: `${VERSION}-mismatch`},
+				logLevel: 'error',
+				retriesLeft: 1,
+				attempt: 1,
+				chunk: 0,
+				enableCancellation: false,
+			} as never,
+			options: {expectedBucketOwner: 'owner', isWarm: true},
+			onStream: (message) => {
+				streamedMessages.push(message);
+				return Promise.resolve();
+			},
+			providerSpecifics: {
+				isFlakyError: () => true,
+			} as unknown as ProviderSpecifics<MockProvider>,
+			requestContext: {
+				awsRequestId: 'invocation-a',
+				invokedFunctionArn: 'arn',
+				getRemainingTimeInMillis: () => 120_000,
+			},
+			insideFunctionSpecifics:
+				{} as unknown as InsideFunctionSpecifics<MockProvider>,
+			onMediaFiles: null,
+			executionMode: 'invoked',
+		});
+
+		expect(streamedMessages).toHaveLength(1);
+		expect(streamedMessages[0]).toMatchObject({
+			type: 'error-occurred',
+			payload: {shouldRetry: true},
+		});
+
+		currentInvocation = 'B';
+		for (const callback of scheduledCallbacks) {
+			callback();
+		}
+
+		expect(exits).toEqual([]);
+	} finally {
+		timeoutSpy.mockRestore();
+		exitSpy.mockRestore();
+		if (previousNodeEnv === undefined) {
+			delete process.env.NODE_ENV;
+		} else {
+			process.env.NODE_ENV = previousNodeEnv;
+		}
+	}
+});
+
+test('a flaky renderer invocation closes its browser before returning', async () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	const tmpDirSpy = spyOn(RenderInternals, 'tmpDir').mockImplementation(
+		() => '/tmp/remotion-renderer-lifecycle-test',
+	);
+	const browser = {
+		instance: {
+			close: mock(() => Promise.resolve()),
+		},
+		configurationString: 'configuration',
+	};
+	let notifyCloseStarted: () => void = () => undefined;
+	const closeStarted = new Promise<void>((resolve) => {
+		notifyCloseStarted = resolve;
+	});
+	let failClosing: () => void = () => undefined;
+	const closing = new Promise<void>((_resolve, reject) => {
+		failClosing = () => reject(new Error('Could not close browser'));
+	});
+	const closeBrowserInstance = mock(() => {
+		notifyCloseStarted();
+		return closing;
+	});
+
+	try {
+		process.env.NODE_ENV = 'production';
+		const handlerPromise = rendererHandler<MockProvider>({
+			params: {
+				type: 'renderer',
+				chromiumOptions: {gl: null},
+				launchFunctionConfig: {version: VERSION},
+				inputProps: {type: 'payload', payload: '{}'},
+				resolvedProps: {type: 'payload', payload: '{}'},
+				bucketName: 'bucket',
+				forcePathStyle: false,
+				logLevel: 'error',
+				retriesLeft: 1,
+				attempt: 1,
+				enableCancellation: false,
+			} as never,
+			options: {expectedBucketOwner: 'owner', isWarm: true},
+			onStream: () => Promise.resolve(),
+			providerSpecifics: {
+				isFlakyError: () => true,
+			} as unknown as ProviderSpecifics<MockProvider>,
+			requestContext: {
+				awsRequestId: 'invocation-a',
+				invokedFunctionArn: 'arn',
+				getRemainingTimeInMillis: () => 120_000,
+			},
+			insideFunctionSpecifics: {
+				getCurrentRegionInFunction: () => 'mock-region',
+				getBrowserInstance: () => Promise.resolve(browser as never),
+				closeBrowserInstance,
+			} as unknown as InsideFunctionSpecifics<MockProvider>,
+			onMediaFiles: null,
+			executionMode: 'invoked',
+		});
+
+		expect(
+			await Promise.race([
+				closeStarted.then(() => 'close-started'),
+				handlerPromise.then(() => 'handler-returned'),
+			]),
+		).toBe('close-started');
+		expect(closeBrowserInstance).toHaveBeenCalledTimes(1);
+		expect(closeBrowserInstance).toHaveBeenCalledWith({
+			launchedBrowser: browser,
+		});
+
+		let handlerReturned = false;
+		handlerPromise.then(() => {
+			handlerReturned = true;
+		});
+		await Promise.resolve();
+		expect(handlerReturned).toBe(false);
+
+		failClosing();
+		await handlerPromise;
+		expect(handlerReturned).toBe(true);
+	} finally {
+		failClosing();
+		await Promise.resolve();
+		tmpDirSpy.mockRestore();
+		if (previousNodeEnv === undefined) {
+			delete process.env.NODE_ENV;
+		} else {
+			process.env.NODE_ENV = previousNodeEnv;
+		}
+	}
+});
+
+test('closing a cached browser makes the next invocation launch a new one', async () => {
+	const makeBrowser = (id: string) => {
+		let onDisconnected: (() => void) | null = null;
+
+		return {
+			id,
+			on: mock((event: string, callback: () => void) => {
+				if (event === 'disconnected') {
+					onDisconnected = callback;
+				}
+			}),
+			close: mock(() => {
+				onDisconnected?.();
+				return Promise.resolve();
+			}),
+		};
+	};
+
+	const firstBrowser = makeBrowser('first');
+	const secondBrowser = makeBrowser('second');
+	const openBrowserSpy = spyOn(
+		RenderInternals,
+		'internalOpenBrowser',
+	).mockImplementationOnce(() => Promise.resolve(firstBrowser as never));
+	openBrowserSpy.mockImplementationOnce(() =>
+		Promise.resolve(secondBrowser as never),
+	);
+	const providerSpecifics = {
+		getChromiumPath: () => '/mock-chrome',
+	} as unknown as ProviderSpecifics<MockProvider>;
+	const insideFunctionSpecifics = {
+		getBrowserInstance: getBrowserInstanceImplementation,
+	} as unknown as InsideFunctionSpecifics<MockProvider>;
+	let first: LaunchedBrowser | null = null;
+	let second: LaunchedBrowser | null = null;
+
+	try {
+		first = await getBrowserInstanceImplementation({
+			logLevel: 'error',
+			indent: false,
+			chromiumOptions: {},
+			providerSpecifics,
+			insideFunctionSpecifics,
+		});
+		await closeBrowserInstanceImplementation({launchedBrowser: first});
+		second = await getBrowserInstanceImplementation({
+			logLevel: 'error',
+			indent: false,
+			chromiumOptions: {},
+			providerSpecifics,
+			insideFunctionSpecifics,
+		});
+
+		expect(openBrowserSpy).toHaveBeenCalledTimes(2);
+		expect(first.instance as unknown).toBe(firstBrowser);
+		expect(second.instance as unknown).toBe(secondBrowser);
+	} finally {
+		if (second) {
+			await closeBrowserInstanceImplementation({launchedBrowser: second});
+		}
+
+		if (first) {
+			await closeBrowserInstanceImplementation({launchedBrowser: first});
+		}
+
+		openBrowserSpy.mockRestore();
+	}
+});


### PR DESCRIPTION
## Summary

Fixes a Lambda warm-container lifecycle race after a renderer invocation returns a retryable error.

Previously, the invocation scheduled `process.exit(0)` two seconds after returning. AWS could freeze the environment before that timer fired, then thaw it for a later invocation, allowing the stale timer to terminate the new request with `Runtime.ExitError`.

This change:

- removes the delayed process exit
- closes and evicts the browser before the flaky invocation returns
- keeps browser cleanup failures from replacing the original retryable response
- ignores delayed `disconnected` events from browser instances that have already been discarded

## Tests

- Added renderer lifecycle coverage for stale timers across invocations.
- Added coverage that browser cleanup is awaited without replacing the renderer response.
- Added coverage that a closed browser is evicted and a delayed disconnect cannot affect the next browser.
- `bun run build`
- `bun run stylecheck`
- `bun run --cwd packages/serverless test`
- `bun run --cwd packages/lambda test`

## AWS E2E

Validated with an isolated Remotion 4.0.520 test Lambda in `us-east-1`:

- triggered retryable renderer failures and verified subsequent requests reused the same warm environment without `Runtime.ExitError`
- verified each post-failure renderer invocation launched a fresh browser
- rendered a 10-second, 300-frame H.264 MP4 in a single Lambda invocation
