### PR TITLE
`@remotion/studio`: Expand timeline layer edge hit areas

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -176,6 +176,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly negativeStartClipped: boolean;
 	readonly style: React.CSSProperties;
 	readonly children: React.ReactNode;
+	readonly edgeDragHandles: React.ReactNode;
 	readonly nodePathInfo: SequenceNodePathInfo | null;
 	readonly sequenceFrameOffset: number;
 	readonly fromCanUpdate: boolean;
@@ -195,6 +196,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	negativeStartClipped,
 	style,
 	children,
+	edgeDragHandles,
 	nodePathInfo,
 	sequenceFrameOffset,
 	fromCanUpdate,
@@ -379,8 +381,18 @@ const TimelineSequenceCurrentFrame: React.FC<{
 					</div>
 				</>
 			) : (
-				content
+				<div
+					style={{
+						position: 'absolute',
+						inset: 0,
+						overflow: 'hidden',
+						borderRadius: 'inherit',
+					}}
+				>
+					{content}
+				</div>
 			)}
+			{edgeDragHandles}
 		</div>
 	);
 };
@@ -824,7 +836,8 @@ const TimelineSequenceInner: React.FC<{
 			marginLeft: visibleLayout?.marginLeft ?? 0,
 			width: visibleLayout?.width ?? 0,
 			color: WHITE,
-			overflow: 'hidden',
+			// Edge handles extend outside the layer; media is clipped separately.
+			overflow: 'visible',
 		};
 	}, [negativeStartClipped, s.type, showLeftBorderRadius, visibleLayout]);
 
@@ -870,6 +883,33 @@ const TimelineSequenceInner: React.FC<{
 			frozenFrame={frozenFrame}
 			onMoveDragPointerDown={onMoveDragPointerDown}
 			onPointerDownCapture={dragAwareDoubleClick.beginPointerGesture}
+			edgeDragHandles={
+				<>
+					{showLeftEdgeDragHandle &&
+					visibleLayout.leftEdgeVisible &&
+					negativeStartWidth === 0 &&
+					nodePathInfo &&
+					validatedLocation ? (
+						<TimelineSequenceLeftEdgeDragHandle
+							nodePathInfo={nodePathInfo}
+							windowWidth={windowWidth}
+							timelineDurationInFrames={video.durationInFrames ?? 1}
+							onDragEnd={dragAwareDoubleClick.endPointerGesture}
+						/>
+					) : null}
+					{showRightEdgeDragHandle &&
+					visibleLayout.rightEdgeVisible &&
+					nodePathInfo &&
+					validatedLocation ? (
+						<TimelineSequenceRightEdgeDragHandle
+							nodePathInfo={nodePathInfo}
+							windowWidth={windowWidth}
+							timelineDurationInFrames={video.durationInFrames ?? 1}
+							onDragEnd={dragAwareDoubleClick.endPointerGesture}
+						/>
+					) : null}
+				</>
+			}
 			onDoubleClick={
 				canHandleSequenceDoubleClick ? onSequenceDoubleClick : undefined
 			}
@@ -927,29 +967,6 @@ const TimelineSequenceInner: React.FC<{
 					visibleWidth={visibleLayout.width}
 				/>
 			)}
-			{showLeftEdgeDragHandle &&
-			visibleLayout.leftEdgeVisible &&
-			negativeStartWidth === 0 &&
-			nodePathInfo &&
-			validatedLocation ? (
-				<TimelineSequenceLeftEdgeDragHandle
-					nodePathInfo={nodePathInfo}
-					windowWidth={windowWidth}
-					timelineDurationInFrames={video.durationInFrames ?? 1}
-					onDragEnd={dragAwareDoubleClick.endPointerGesture}
-				/>
-			) : null}
-			{showRightEdgeDragHandle &&
-			visibleLayout.rightEdgeVisible &&
-			nodePathInfo &&
-			validatedLocation ? (
-				<TimelineSequenceRightEdgeDragHandle
-					nodePathInfo={nodePathInfo}
-					windowWidth={windowWidth}
-					timelineDurationInFrames={video.durationInFrames ?? 1}
-					onDragEnd={dragAwareDoubleClick.endPointerGesture}
-				/>
-			) : null}
 		</TimelineSequenceCurrentFrame>
 	);
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -46,14 +46,15 @@ import {
 	type TimelineSelection,
 } from './TimelineSelection';
 
-const HANDLE_WIDTH = 6;
+const HANDLE_INSET = 6;
+const HANDLE_OUTSET = 4;
 export const timelineSequenceFromDragSnapThresholdPx = 10;
 
 const baseStyle: React.CSSProperties = {
 	position: 'absolute',
 	top: 0,
 	bottom: 0,
-	width: HANDLE_WIDTH,
+	width: HANDLE_INSET + HANDLE_OUTSET,
 	cursor: 'ew-resize',
 	zIndex: 1,
 	touchAction: 'none',
@@ -1341,7 +1342,7 @@ const TimelineSequenceLeftEdgeDragHandleInner: React.FC<{
 
 	const style: React.CSSProperties = {
 		...baseStyle,
-		left: 0,
+		left: -HANDLE_OUTSET,
 		background: TRANSPARENT,
 	};
 
@@ -1895,7 +1896,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 
 	const style: React.CSSProperties = {
 		...baseStyle,
-		right: 0,
+		right: -HANDLE_OUTSET,
 		background: TRANSPARENT,
 	};
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -47,14 +47,15 @@ import {
 } from './TimelineSelection';
 
 const HANDLE_INSET = 6;
-const HANDLE_OUTSET = 4;
+const HANDLE_OUTSET = 8;
 export const timelineSequenceFromDragSnapThresholdPx = 10;
 
 const baseStyle: React.CSSProperties = {
 	position: 'absolute',
 	top: 0,
 	bottom: 0,
-	width: HANDLE_INSET + HANDLE_OUTSET,
+	// Keep the middle half of narrow layers available for moving.
+	width: `calc(${HANDLE_OUTSET}px + min(${HANDLE_INSET}px, 25%))`,
 	cursor: 'ew-resize',
 	zIndex: 1,
 	touchAction: 'none',


### PR DESCRIPTION
Timeline layer edge handles previously covered only 6 px inside the layer. Extend both handles 8 px outside, with an inward hit area capped at the smaller of 6 px or 25% of the layer width. This keeps the handles separate on narrow layers and leaves the middle half available for moving. Thumbnails and waveforms remain clipped separately from the handles.

Validation: `bun run build` and `bun run stylecheck` passed. Studio launched successfully; drag interaction has not been browser-tested.
