### PR TITLE
`@remotion/studio`: Add persistent frame format for timeline ticks

### DIFF
--- a/packages/studio/src/components/TimeValue.tsx
+++ b/packages/studio/src/components/TimeValue.tsx
@@ -1,17 +1,24 @@
 import {PlayerInternals} from '@remotion/player';
 import React, {
 	useCallback,
+	useContext,
 	useEffect,
 	useImperativeHandle,
 	useRef,
 } from 'react';
 import {Internals, useCurrentFrame} from 'remotion';
-import {LIGHT_TEXT, WHITE} from '../helpers/colors';
+import {LIGHT_TEXT, TRANSPARENT, WHITE} from '../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../helpers/hoverable';
 import {useIsStill} from '../helpers/is-current-selected-still';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {renderFrame} from '../state/render-frame';
 import {Flex, Spacing} from './layout';
 import {InputDragger} from './NewComposition/InputDragger';
+import {TimelineTickFormatContext} from './Timeline/TimelineTickFormatProvider';
 import {TimelineZoomControls} from './Timeline/TimelineZoomControls';
 
 const text: React.CSSProperties = {
@@ -25,7 +32,7 @@ const text: React.CSSProperties = {
 };
 
 const currentTimeTypography: React.CSSProperties = {
-	color: WHITE,
+	color: LIGHT_TEXT,
 	display: 'inline-block',
 	fontSize: 14,
 	fontVariantNumeric: 'tabular-nums',
@@ -36,16 +43,37 @@ const currentTimeTypography: React.CSSProperties = {
 
 const currentTimeInputStyle: React.CSSProperties = {
 	...currentTimeTypography,
-	padding: '4px 6px 4px 0',
+	padding: 0,
 };
 
-const currentTimeButtonStyle: React.CSSProperties = {
-	paddingLeft: 0,
+const currentTimeStack: React.CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'flex-start',
+	lineHeight: 1,
+	padding: '5px 7px 5px 1px',
 	transform: 'translateY(-1px)',
 };
 
+const currentTimeButtonStyle = {
+	display: 'block',
+	padding: 0,
+	border: 'none',
+	lineHeight: '21px',
+	'--remotion-cli-internals-blue-hovered': WHITE,
+} as React.CSSProperties;
+
 const currentTimeSubtitle: React.CSSProperties = {
-	color: LIGHT_TEXT,
+	...hoverableStyle({
+		idleBackground: TRANSPARENT,
+		hoverBackground: TRANSPARENT,
+		idleColor: LIGHT_TEXT,
+		hoverColor: WHITE,
+	}),
+	background: TRANSPARENT,
+	border: 'none',
+	padding: 0,
+	cursor: 'default',
 	display: 'block',
 	fontFamily: 'monospace',
 	fontSize: 10,
@@ -57,6 +85,10 @@ const currentTimeSubtitle: React.CSSProperties = {
 
 export const TimeValue: React.FC = () => {
 	const frame = useCurrentFrame();
+	const {showFrames, setShowFrames} = useContext(TimelineTickFormatContext);
+	const toggleTickFormat = useCallback(() => {
+		setShowFrames((previous) => !previous);
+	}, [setShowFrames]);
 	const config = Internals.useUnsafeVideoConfig();
 	const isStill = useIsStill();
 	const {seek, play, pause, toggle} = PlayerInternals.usePlayerMethods();
@@ -80,10 +112,6 @@ export const TimeValue: React.FC = () => {
 			return config ? renderFrame(Number(value), config.fps) : String(value);
 		},
 		[config],
-	);
-	const formatterSubtitle = useCallback(
-		(value: string | number) => String(value),
-		[],
 	);
 	useImperativeHandle(
 		Internals.timeValueRef,
@@ -127,21 +155,36 @@ export const TimeValue: React.FC = () => {
 
 	return (
 		<div style={text}>
-			<InputDragger
-				ref={ref}
-				aria-label={String(frame)}
-				value={frame}
-				onTextChange={onTextChange}
-				onValueChange={onValueChange}
-				formatter={formatter}
-				formatterStyle={currentTimeTypography}
-				formatterSubtitle={formatterSubtitle}
-				formatterSubtitleStyle={currentTimeSubtitle}
-				buttonStyle={currentTimeButtonStyle}
-				rightAlign={false}
-				status="ok"
-				style={currentTimeInputStyle}
-			/>
+			<div style={currentTimeStack}>
+				<InputDragger
+					ref={ref}
+					aria-label={String(frame)}
+					value={frame}
+					onTextChange={onTextChange}
+					onValueChange={onValueChange}
+					formatter={formatter}
+					formatterStyle={currentTimeTypography}
+					buttonStyle={currentTimeButtonStyle}
+					rightAlign={false}
+					status="ok"
+					style={currentTimeInputStyle}
+				/>
+				<button
+					type="button"
+					className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+					style={currentTimeSubtitle}
+					onClick={toggleTickFormat}
+					aria-label="Show timeline ticks as frames"
+					aria-pressed={showFrames}
+					title={
+						showFrames
+							? 'Show timeline ticks as timecode'
+							: 'Show timeline ticks as frames'
+					}
+				>
+					{frame}
+				</button>
+			</div>
 			<Spacing x={2} />
 			<Flex />
 			<TimelineZoomControls sliderMaxWidth={80} />

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -60,6 +60,7 @@ import {
 } from './TimelineSelection';
 import {SEQUENCE_REORDER_MIME_TYPE} from './TimelineSequenceItem';
 import {TimelineSlider} from './TimelineSlider';
+import {TimelineTickFormatProvider} from './TimelineTickFormatProvider';
 import {
 	TIMELINE_TIME_INDICATOR_HEIGHT,
 	TimelineTimeIndicators,
@@ -553,4 +554,12 @@ const TimelineInner: React.FC = () => {
 	);
 };
 
-export const Timeline = React.memo(TimelineInner);
+const MemoizedTimelineInner = React.memo(TimelineInner);
+
+export const Timeline: React.FC = () => {
+	return (
+		<TimelineTickFormatProvider>
+			<MemoizedTimelineInner />
+		</TimelineTickFormatProvider>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineTickFormatProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTickFormatProvider.tsx
@@ -1,0 +1,26 @@
+import React, {createContext, useEffect, useMemo, useState} from 'react';
+
+const STORAGE_KEY = 'remotion.timelineShowFrames';
+
+export const TimelineTickFormatContext = createContext<{
+	showFrames: boolean;
+	setShowFrames: React.Dispatch<React.SetStateAction<boolean>>;
+}>({showFrames: false, setShowFrames: () => undefined});
+
+export const TimelineTickFormatProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const [showFrames, setShowFrames] = useState(
+		() => localStorage.getItem(STORAGE_KEY) === 'true',
+	);
+	useEffect(() => {
+		localStorage.setItem(STORAGE_KEY, String(showFrames));
+	}, [showFrames]);
+
+	const value = useMemo(() => ({showFrames, setShowFrames}), [showFrames]);
+	return (
+		<TimelineTickFormatContext.Provider value={value}>
+			{children}
+		</TimelineTickFormatContext.Provider>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
+++ b/packages/studio/src/components/Timeline/TimelineTimeIndicators.tsx
@@ -15,6 +15,7 @@ import {TimeValue} from '../TimeValue';
 import {scrollableRef} from './timeline-refs';
 import {getFrameIncrementFromWidth} from './timeline-scroll-logic';
 import {TIMELINE_TICKS_BACKGROUND} from './TimelineSelection';
+import {TimelineTickFormatContext} from './TimelineTickFormatProvider';
 import {TimelineWidthContext} from './TimelineWidthProvider';
 
 export const TIMELINE_TIME_INDICATOR_HEIGHT = 39;
@@ -242,6 +243,7 @@ const TimelineTimeIndicatorsInner = React.memo<{
 	readonly durationInFrames: number;
 }>(({windowWidth, durationInFrames, fps}) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const {showFrames} = useContext(TimelineTickFormatContext);
 
 	useLayoutEffect(() => {
 		const canvas = canvasRef.current;
@@ -260,7 +262,10 @@ const TimelineTimeIndicatorsInner = React.memo<{
 			windowWidth,
 		);
 		const maxTickLabelWidth =
-			renderFrame(durationInFrames - 1, fps).length *
+			(showFrames
+				? `${durationInFrames - 1}f`
+				: renderFrame(durationInFrames - 1, fps)
+			).length *
 			TICK_LABEL_FONT_SIZE *
 			0.6;
 		const tickScale = getTimelineTickScale({
@@ -320,7 +325,7 @@ const TimelineTimeIndicatorsInner = React.memo<{
 					context.font = `${TICK_LABEL_FONT_SIZE}px ${getComputedStyle(canvas).fontFamily}`;
 					context.textBaseline = 'top';
 					context.fillText(
-						renderFrame(frame, fps),
+						showFrames ? `${Math.round(frame)}f` : renderFrame(frame, fps),
 						xForFrame(frame) + TICK_LABEL_MARGIN_LEFT,
 						7,
 					);
@@ -390,7 +395,7 @@ const TimelineTimeIndicatorsInner = React.memo<{
 			scrollable.removeEventListener('scroll', onScroll);
 			resizeObserver.disconnect();
 		};
-	}, [durationInFrames, fps, windowWidth]);
+	}, [durationInFrames, fps, showFrames, windowWidth]);
 
 	const style: React.CSSProperties = useMemo(() => {
 		return {


### PR DESCRIPTION
Clicking the frame number below the Studio timecode now toggles timeline tick labels between timecode and frame counts such as `120f`. The choice persists in localStorage across reloads.

The timecode uses the shared gray palette color and turns white on hover while retaining drag seeking. The frame number is a separate keyboard-accessible button, with the original spacing preserved.

Validation: `bun run build`, `bun run stylecheck`, and all 646 Studio tests pass. Verified both formats, persistence across reloads, drag seeking, hover colors, keyboard focus, and spacing in Studio.
