### PR TITLE
`@remotion/browser-studio`: Add confirmation before leaving

### DIFF
--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -182,6 +182,18 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	);
 
 	useEffect(() => {
+		const onBeforeUnload = (event: BeforeUnloadEvent) => {
+			event.preventDefault();
+			event.returnValue = true;
+		};
+
+		window.addEventListener('beforeunload', onBeforeUnload);
+		return () => {
+			window.removeEventListener('beforeunload', onBeforeUnload);
+		};
+	}, []);
+
+	useEffect(() => {
 		return () => publicFileManager.dispose();
 	}, [publicFileManager]);
 	const hmrAssetManager = useMemo(


### PR DESCRIPTION
Request the browser’s default confirmation when closing, refreshing, or leaving Browser Studio, regardless of whether the project has been edited. Register the handler while Browser Studio is mounted and remove it on unmount.

Validation: `bun run build` and `bun run stylecheck` pass.

Closes #11074
