### PR TITLE
`remotion`: Fix playback rate resetting on media reload

### DIFF
--- a/packages/core/src/use-media-playback.ts
+++ b/packages/core/src/use-media-playback.ts
@@ -164,6 +164,14 @@ export const useMediaPlayback = ({
 	// and it is also in a useLayoutEffect.
 	useLayoutEffect(() => {
 		const playbackRateToSet = Math.max(0, playbackRate);
+		// Loading a resource resets playbackRate to defaultPlaybackRate.
+		if (
+			mediaRef.current &&
+			mediaRef.current.defaultPlaybackRate !== playbackRateToSet
+		) {
+			mediaRef.current.defaultPlaybackRate = playbackRateToSet;
+		}
+
 		if (
 			mediaRef.current &&
 			mediaRef.current.playbackRate !== playbackRateToSet

--- a/packages/media/src/test/html5-playback-rate.test.tsx
+++ b/packages/media/src/test/html5-playback-rate.test.tsx
@@ -1,0 +1,46 @@
+import {Player} from '@remotion/player';
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import {Html5Video} from 'remotion';
+import {expect, test} from 'vitest';
+
+test('preserves the Player media playback rate across source changes and reloads', async () => {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = createRoot(container);
+	const Composition: React.FC<{readonly src: string}> = ({src}) => (
+		<Html5Video src={src} playbackRate={0.6} />
+	);
+
+	try {
+		for (const [index, globalRate] of [1, 0.5].entries()) {
+			root.render(
+				<Player
+					acknowledgeRemotionLicense
+					component={Composition}
+					compositionHeight={720}
+					compositionWidth={1280}
+					durationInFrames={100}
+					fps={30}
+					initiallyMuted
+					playbackRate={globalRate}
+					inputProps={{src: `/bigbuckbunny.mp4?source=${index}`}}
+				/>,
+			);
+			await expect
+				.poll(() => container.querySelector('video')?.readyState)
+				.toBe(4);
+			const video = container.querySelector('video')!;
+			await expect.poll(() => video.playbackRate).toBe(0.6 * globalRate);
+
+			// Loading a new resource resets playbackRate to defaultPlaybackRate.
+			video.src = `/bigbuckbunny.mp4?reload=${index}`;
+			video.load();
+			await expect.poll(() => video.readyState).toBe(4);
+			expect(video.playbackRate).toBe(0.6 * globalRate);
+		}
+	} finally {
+		root.unmount();
+		container.remove();
+	}
+});


### PR DESCRIPTION
When a preview media element loads a new resource, the browser resets its playback rate to `defaultPlaybackRate`. We only set `playbackRate`, so a video configured at 0.6× can return to 1× and drift ahead of the timeline.

Set `defaultPlaybackRate` to the combined local and Player playback rate alongside `playbackRate`. This preserves the intended rate through resource reloads without additional event listeners.

Validation: a Chrome browser integration test mounts the real Player and Html5Video with representative media and checks resource reloads at 0.6× and a combined 0.3× rate. No modules are mocked. Red/green verified: the original code returns 1 instead of 0.6; the fix passes. Full build, stylecheck, and all 674 core tests pass.

Closes #11061
