### PR TITLE
`@remotion/studio`: Fix timeline drags snapping back on mouse release

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -1303,6 +1303,8 @@ const TimelineSequenceLeftEdgeDragHandleInner: React.FC<{
 				return;
 			}
 
+			// Include the release position even if the final pointermove was skipped.
+			onMove(e);
 			finishDrag(true);
 		};
 
@@ -1326,7 +1328,9 @@ const TimelineSequenceLeftEdgeDragHandleInner: React.FC<{
 			onMove,
 			onEnd: (reason, endEvent) => {
 				if (
-					(reason === 'pointerup' || reason === 'buttons-released') &&
+					(reason === 'pointerup' ||
+						reason === 'buttons-released' ||
+						(reason === 'lostpointercapture' && endEvent?.buttons === 0)) &&
 					endEvent
 				) {
 					onUp(endEvent);
@@ -1613,7 +1617,9 @@ export const useTimelineSequenceFromDrag = ({
 				onEnd: (reason, endEvent) => {
 					stopPointerSessionRef.current = null;
 					finishDrag(
-						(reason === 'pointerup' || reason === 'buttons-released') &&
+						(reason === 'pointerup' ||
+							reason === 'buttons-released' ||
+							(reason === 'lostpointercapture' && endEvent?.buttons === 0)) &&
 							endEvent !== null,
 					);
 				},
@@ -1857,6 +1863,8 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 				return;
 			}
 
+			// Include the release position even if the final pointermove was skipped.
+			onMove(e);
 			finishDrag(true);
 		};
 
@@ -1880,7 +1888,9 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 			onMove,
 			onEnd: (reason, endEvent) => {
 				if (
-					(reason === 'pointerup' || reason === 'buttons-released') &&
+					(reason === 'pointerup' ||
+						reason === 'buttons-released' ||
+						(reason === 'lostpointercapture' && endEvent?.buttons === 0)) &&
 					endEvent
 				) {
 					onUp(endEvent);


### PR DESCRIPTION
Fast timeline drags could snap back on mouse release when the browser delivered `lostpointercapture` with `buttons: 0` without a preceding `pointerup`. Studio treated the release as cancellation and discarded the previewed edit.

Commit sequence moves and edge resizes in that case, and apply the final release coordinates before saving an edge resize.

Validation: reproduced the failure twice with diagnostic event logging; the user repeated the gesture with the fix and confirmed the value stays. Temporary logging has been removed. `bun run build`, `bun run stylecheck`, and the existing pointer-session and drag-aware double-click tests pass (3 tests).
