### PR TITLE
`@remotion/studio`: Add persistent collapsing of timeline layer children

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -49,6 +49,10 @@ import {TimelineHeightContainer} from './TimelineHeightContainer';
 import {TimelineInOutDragHandler} from './TimelineInOutDragHandler';
 import {TimelineInOutPointer} from './TimelineInOutPointer';
 import {TimelineKeyframeTracksProvider} from './TimelineKeyframeTracksContext';
+import {
+	TimelineLayerChildrenProvider,
+	useTimelineLayerChildren,
+} from './TimelineLayerChildren';
 import {TimelineList} from './TimelineList';
 import {TimelinePinchZoom} from './TimelinePinchZoom';
 import {TimelinePlayCursorSyncer} from './TimelinePlayCursorSyncer';
@@ -461,14 +465,20 @@ const TimelineInner: React.FC = () => {
 		});
 	}, [filtered]);
 
+	const {visibleTracks, value: layerChildrenValue} = useTimelineLayerChildren(
+		collapsed,
+		sequences,
+		canvasContent?.type === 'composition' ? canvasContent.compositionId : null,
+	);
 	const maxTimelineTracks = getStudioMaxTimelineTracks();
 	const shown = useMemo(() => {
-		return maxTimelineTracks !== null && collapsed.length > maxTimelineTracks
-			? collapsed.slice(0, maxTimelineTracks)
-			: collapsed;
-	}, [collapsed, maxTimelineTracks]);
+		return maxTimelineTracks !== null &&
+			visibleTracks.length > maxTimelineTracks
+			? visibleTracks.slice(0, maxTimelineTracks)
+			: visibleTracks;
+	}, [visibleTracks, maxTimelineTracks]);
 
-	const hasBeenCut = collapsed.length > shown.length;
+	const hasBeenCut = visibleTracks.length > shown.length;
 
 	return (
 		<TimelineContextMenuArea>
@@ -489,66 +499,71 @@ const TimelineInner: React.FC = () => {
 				);
 			})}
 			{isStudioInteractivityEnabled() ? <SequencePropsObserver /> : null}
-			<TimelineKeyframeTracksProvider tracks={filtered}>
-				<TimelineSelectableItemsProvider timeline={shown}>
-					<TimelineVirtualizationProvider
-						hasBeenCut={hasBeenCut}
-						isStill={isStill}
-						timeline={shown}
-					>
-						{isStudioInteractivityEnabled() ? (
-							<TimelineSelectAllKeybindings timeline={shown} />
-						) : null}
-						<TimelineHeightContainer>
-							{isStill ? (
-								<TimelineList />
-							) : (
-								<TimelineWidthProvider>
-									<TimelinePinchZoom />
-									<SplitterContainer
-										orientation="vertical"
-										defaultFlex={0.2}
-										id="names-to-timeline"
-										maxFlex={0.5}
-										minFlex={0.15}
-										maxFlexerSize={null}
-										minFlexerSize={MIN_TIMELINE_LABELS_WIDTH}
-										maxAntiFlexerSize={null}
-										minAntiFlexerSize={null}
-									>
-										<SplitterElement
-											type="flexer"
-											sticky={<TimelineTimePlaceholders />}
+			<TimelineLayerChildrenProvider value={layerChildrenValue}>
+				<TimelineKeyframeTracksProvider tracks={filtered}>
+					<TimelineSelectableItemsProvider timeline={shown}>
+						<TimelineVirtualizationProvider
+							hasBeenCut={hasBeenCut}
+							isStill={isStill}
+							timeline={shown}
+						>
+							{isStudioInteractivityEnabled() ? (
+								<TimelineSelectAllKeybindings timeline={shown} />
+							) : null}
+							<TimelineHeightContainer>
+								{isStill ? (
+									<TimelineList />
+								) : (
+									<TimelineWidthProvider>
+										<TimelinePinchZoom />
+										<SplitterContainer
+											orientation="vertical"
+											defaultFlex={0.2}
+											id="names-to-timeline"
+											maxFlex={0.5}
+											minFlex={0.15}
+											maxFlexerSize={null}
+											minFlexerSize={MIN_TIMELINE_LABELS_WIDTH}
+											maxAntiFlexerSize={null}
+											minAntiFlexerSize={null}
 										>
-											<TimelineList />
-										</SplitterElement>
-										<SplitterHandle onCollapse={noop} allowToCollapse="none" />
-										<SplitterElement
-											type="anti-flexer"
-											sticky={
-												<>
-													<TimelineTimeIndicators />
-													<TimelineSlider />
-												</>
-											}
-										>
-											<TimelineScrollable>
-												<TimelineTracks hasBeenCut={hasBeenCut} />
-												<TimelinePlayCursorSyncer />
-												<TimelineInOutPointer />
-												<TimelineDragHandler />
-												{isStudioInteractivityEnabled() ? (
-													<TimelineInOutDragHandler />
-												) : null}
-											</TimelineScrollable>
-										</SplitterElement>
-									</SplitterContainer>
-								</TimelineWidthProvider>
-							)}
-						</TimelineHeightContainer>
-					</TimelineVirtualizationProvider>
-				</TimelineSelectableItemsProvider>
-			</TimelineKeyframeTracksProvider>
+											<SplitterElement
+												type="flexer"
+												sticky={<TimelineTimePlaceholders />}
+											>
+												<TimelineList />
+											</SplitterElement>
+											<SplitterHandle
+												onCollapse={noop}
+												allowToCollapse="none"
+											/>
+											<SplitterElement
+												type="anti-flexer"
+												sticky={
+													<>
+														<TimelineTimeIndicators />
+														<TimelineSlider />
+													</>
+												}
+											>
+												<TimelineScrollable>
+													<TimelineTracks hasBeenCut={hasBeenCut} />
+													<TimelinePlayCursorSyncer />
+													<TimelineInOutPointer />
+													<TimelineDragHandler />
+													{isStudioInteractivityEnabled() ? (
+														<TimelineInOutDragHandler />
+													) : null}
+												</TimelineScrollable>
+											</SplitterElement>
+										</SplitterContainer>
+									</TimelineWidthProvider>
+								)}
+							</TimelineHeightContainer>
+						</TimelineVirtualizationProvider>
+					</TimelineSelectableItemsProvider>
+				</TimelineKeyframeTracksProvider>
+			</TimelineLayerChildrenProvider>
 		</TimelineContextMenuArea>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineCollapseToggle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineCollapseToggle.tsx
@@ -15,7 +15,7 @@ const Icon: React.FC<
 	}
 > = ({color, ...props}) => {
 	return (
-		<svg viewBox="0 0 8 10" {...props} style={{height: 10, width: 8}}>
+		<svg viewBox="0 0 8 10" {...props} style={{height: 8, width: 6.4}}>
 			<path d="M 0 0 L 8 5 L 0 10 z" fill={color} />
 		</svg>
 	);

--- a/packages/studio/src/components/Timeline/TimelineLayerChildren.tsx
+++ b/packages/studio/src/components/Timeline/TimelineLayerChildren.tsx
@@ -1,0 +1,187 @@
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from 'react';
+import type {TSequence} from 'remotion';
+import {LIGHT_TEXT, TRANSPARENT, WHITE} from '../../helpers/colors';
+import type {TimelineTrackData} from '../../helpers/get-timeline-sequence-sort-key';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../../helpers/hoverable';
+import {toggleBooleanMapKey} from '../../helpers/persist-boolean-map';
+import {timelineNodePathInfoToKey} from '../../helpers/timeline-node-path-key';
+import {TimelineCollapseToggle} from './TimelineCollapseToggle';
+import {TimelineExpandArrowSpacer} from './TimelineExpandArrowButton';
+
+const STORAGE_KEY = 'remotion.editor.collapsedLayerChildren.v1';
+
+const TimelineLayerChildrenContext = createContext<{
+	readonly collapsed: Record<string, boolean>;
+	readonly keys: Map<string, string>;
+	readonly parents: Set<string>;
+	readonly toggle: (key: string) => void;
+} | null>(null);
+
+export const TimelineLayerChildrenProvider =
+	TimelineLayerChildrenContext.Provider;
+
+export const useTimelineLayerChildren = (
+	tracks: TimelineTrackData[],
+	sequences: TSequence[],
+	compositionId: string | null,
+) => {
+	const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
+		try {
+			const parsed: unknown = JSON.parse(
+				window.localStorage.getItem(STORAGE_KEY) ?? '{}',
+			);
+			if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+				return {};
+			}
+
+			return Object.fromEntries(
+				Object.entries(parsed).filter(
+					([, storedValue]) => storedValue === true,
+				),
+			);
+		} catch {
+			return {};
+		}
+	});
+	const toggle = useCallback((key: string) => {
+		setCollapsed((previous) => {
+			const next = toggleBooleanMapKey(previous, key);
+			try {
+				window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+			} catch {
+				// Keep the control usable when storage is unavailable.
+			}
+
+			return next;
+		});
+	}, []);
+	const hierarchy = useMemo(() => {
+		const byId = new Map(sequences.map((sequence) => [sequence.id, sequence]));
+		const siblingIndices = new Map<string, number>();
+		const siblingCounts = new Map<string | null, number>();
+		for (const sequence of sequences) {
+			const index = siblingCounts.get(sequence.parent) ?? 0;
+			siblingIndices.set(sequence.id, index);
+			siblingCounts.set(sequence.parent, index + 1);
+		}
+
+		const keys = new Map<string, string>();
+		const parents = new Set<string>();
+		const ancestors = new Map<string, string[]>();
+		for (const track of tracks) {
+			const parentIds: string[] = [];
+			let {parent} = track.sequence;
+			while (parent !== null && !parentIds.includes(parent)) {
+				parentIds.push(parent);
+				parents.add(parent);
+				parent = byId.get(parent)?.parent ?? null;
+			}
+
+			ancestors.set(track.sequence.id, parentIds);
+			// Source identity survives remounts. For layers without source metadata,
+			// use the structural position instead of the ephemeral sequence ID.
+			const identity = track.nodePathInfo
+				? ['source', timelineNodePathInfoToKey(track.nodePathInfo)]
+				: [
+						'position',
+						...[...parentIds]
+							.reverse()
+							.concat(track.sequence.id)
+							.map((id) => siblingIndices.get(id)),
+					];
+			keys.set(track.sequence.id, JSON.stringify([compositionId, identity]));
+		}
+
+		return {keys, parents, ancestors};
+	}, [compositionId, sequences, tracks]);
+	const visibleTracks = useMemo(
+		() =>
+			tracks.filter((track) => {
+				return !(hierarchy.ancestors.get(track.sequence.id) ?? []).some(
+					(id) => {
+						const key = hierarchy.keys.get(id);
+						return key !== undefined && collapsed[key];
+					},
+				);
+			}),
+		[hierarchy, collapsed, tracks],
+	);
+	const value = useMemo(
+		() => ({
+			collapsed,
+			keys: hierarchy.keys,
+			parents: hierarchy.parents,
+			toggle,
+		}),
+		[collapsed, hierarchy, toggle],
+	);
+	return {visibleTracks, value};
+};
+
+export const TimelineLayerChildrenToggle: React.FC<{
+	readonly sequence: TSequence;
+}> = ({sequence}) => {
+	const context = useContext(TimelineLayerChildrenContext);
+	const key = context?.keys.get(sequence.id);
+	const isCollapsed = key !== undefined && Boolean(context?.collapsed[key]);
+	const onClick = useCallback(
+		(event: React.MouseEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+			if (key !== undefined) {
+				context?.toggle(key);
+			}
+		},
+		[context, key],
+	);
+	const stopPropagation = useCallback(
+		(event: React.SyntheticEvent) => event.stopPropagation(),
+		[],
+	);
+	if (!context?.parents.has(sequence.id) || key === undefined) {
+		return <TimelineExpandArrowSpacer />;
+	}
+
+	const label = `${isCollapsed ? 'Expand' : 'Collapse'} children of ${sequence.displayName}`;
+	return (
+		<button
+			type="button"
+			className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+			aria-label={label}
+			aria-expanded={!isCollapsed}
+			title={label}
+			onClick={onClick}
+			onPointerDown={stopPropagation}
+			onDoubleClick={stopPropagation}
+			style={{
+				...hoverableStyle({
+					idleBackground: TRANSPARENT,
+					hoverBackground: TRANSPARENT,
+					idleColor: LIGHT_TEXT,
+					hoverColor: WHITE,
+				}),
+				border: 'none',
+				padding: 0,
+				cursor: 'default',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				width: 12,
+				height: 16,
+				marginRight: 0,
+				flexShrink: 0,
+			}}
+		>
+			<TimelineCollapseToggle collapsed={isCollapsed} color="currentColor" />
+		</button>
+	);
+};

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -76,6 +76,7 @@ import {
 	TimelineExpandArrowSpacer,
 } from './TimelineExpandArrowButton';
 import {TimelineExpandedSection} from './TimelineExpandedSection';
+import {TimelineLayerChildrenToggle} from './TimelineLayerChildren';
 import {TimelineLayerEye, TimelineLayerEyeSpacer} from './TimelineLayerEye';
 import {TimelineMediaInfo} from './TimelineMediaInfo';
 import {TimelineRowChrome} from './TimelineRowChrome';
@@ -1266,7 +1267,7 @@ const TimelineSequenceItemInner: React.FC<{
 					<TimelineLayerEyeSpacer />
 				)
 			}
-			arrow={<TimelineExpandArrowSpacer />}
+			arrow={<TimelineLayerChildrenToggle sequence={sequence} />}
 			style={rowStyle}
 			selected={selected}
 			selectable={selectable}


### PR DESCRIPTION
Adds a filled triangle before parent timeline layer names to expand or collapse their descendants in both the layer list and timeline tracks. Collapse choices persist per composition across reloads, including nested choices when a parent is reopened. Property expansion remains independent.

The triangle uses a smaller icon and no right margin, with its click target preserved.

Validation: `bun run build`, `bun run stylecheck`, and all 646 Studio tests. Verified nested collapse, reload persistence, independent property expansion, hover styling, and keyboard focus in Studio.
