### PR TITLE
Elements: Default Browser Studio link imports to new composition

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1130,6 +1130,9 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 			}
 		).__browserStudioInstallPreservedIframe = true;
 	});
+	await expect(
+		studio.getByRole('radio', {name: 'New composition'}),
+	).toBeChecked();
 	await studio.getByRole('button', {name: /^Install/}).click();
 	await expect
 		.poll(() =>
@@ -1140,7 +1143,7 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 				return {
 					composition:
 						browserWindow.__browserStudioProject.files[
-							'/project/src/Composition.tsx'
+							'/project/src/LinkedElementComposition.tsx'
 						],
 					element:
 						browserWindow.__browserStudioProject.files[
@@ -1163,9 +1166,12 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 				).__browserStudioInstallPreservedIframe,
 		),
 	).toBe(true);
-	await expect(page).toHaveTitle('MyComp / template-blank - Remotion Studio', {
-		timeout: 5000,
-	});
+	await expect(page).toHaveTitle(
+		'LinkedElementComposition / template-blank - Remotion Studio',
+		{
+			timeout: 5000,
+		},
+	);
 });
 
 test('reports inline SVG imports as unsupported without changing the project', async ({

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -402,7 +402,9 @@ export const ElementInstallConfirmation: React.FC<{
 	const usesBrowserDependencyResolution = getBrowserStudioOperations() !== null;
 	const {currentZIndex} = useZIndex();
 	const [mode, setMode] = useState<'current-composition' | 'new-composition'>(
-		currentPlan === null ? 'new-composition' : 'current-composition',
+		currentPlan === null || request.source.type === 'browser-studio-link'
+			? 'new-composition'
+			: 'current-composition',
 	);
 	const [submitting, setSubmitting] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
Opening an Element with **Open in Browser Studio** now defaults the import dialog to **New composition**. This uses the existing browser-studio-link request source; regular Studio imports retain their current default and no Studio protocol API change is needed.

Closes #11033

Validation: `bun run build` and `bun run stylecheck` passed. Updated the existing URL-fragment import E2E workflow to verify the new composition default, generated source, and selected composition; the focused Playwright test and test-file lint/formatting checks pass locally.

