### PR TITLE
`@remotion/browser-studio`: Move hosted Studio to /new

### DIFF
--- a/packages/docs/build-browser-studio-standalone.ts
+++ b/packages/docs/build-browser-studio-standalone.ts
@@ -121,11 +121,8 @@ const html = `<!DOCTYPE html>
 </html>
 `;
 
-await Bun.write(
-	path.join(import.meta.dir, 'build', 'experimental_new', 'index.html'),
-	html,
-);
+await Bun.write(path.join(import.meta.dir, 'build', 'new', 'index.html'), html);
 
 process.stdout.write(
-	`Built standalone Browser Studio at /experimental_new with ${output.outputs.length + 4} assets.\n`,
+	`Built standalone Browser Studio at /new with ${output.outputs.length + 4} assets.\n`,
 );

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -40,13 +40,14 @@ export const config: VercelConfig = {
 					'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
 			},
 		]),
-		routes.header('/experimental_new(.*)', browserStudioIsolationHeaders),
+		routes.header('/new(.*)', browserStudioIsolationHeaders),
 		routes.header('/convert/assets/(.*)', [
 			{key: 'Cross-Origin-Embedder-Policy', value: 'require-corp'},
 			{key: 'Cross-Origin-Opener-Policy', value: 'same-origin'},
 		]),
 	],
 	redirects: [
+		routes.redirect('/experimental_new', '/new', {permanent: true}),
 		routes.redirect(
 			'/elements/guidelines',
 			'/elements/contributing#element-guidelines',

--- a/packages/studio-protocol/src/browser-studio-link.ts
+++ b/packages/studio-protocol/src/browser-studio-link.ts
@@ -3,8 +3,7 @@ import type {StudioElementPayload} from './element-payload';
 import {parseStudioElementPayload} from './element-payload';
 
 const browserStudioHashKey = 'remotion-browser-studio';
-const defaultBrowserStudioEndpoint =
-	'https://www.remotion.dev/experimental_new';
+const defaultBrowserStudioEndpoint = 'https://www.remotion.dev/new';
 const maxEncodedPayloadLength = 1_100_000;
 const browserStudioEnvelopeSchema = z.object({
 	type: z.literal('remotion-browser-studio'),

--- a/packages/studio-protocol/src/test/browser-studio-link.test.ts
+++ b/packages/studio-protocol/src/test/browser-studio-link.test.ts
@@ -20,7 +20,7 @@ test('round-trips a payload through the default Browser Studio URL', () => {
 	const parsedUrl = new URL(url);
 
 	expect(parsedUrl.origin).toBe('https://www.remotion.dev');
-	expect(parsedUrl.pathname).toBe('/experimental_new');
+	expect(parsedUrl.pathname).toBe('/new');
 	expect(url).not.toContain('Grüezi');
 	expect(
 		StudioProtocolInternals.parseBrowserStudioHash(parsedUrl.hash),

--- a/packages/studio/src/test/url-state.test.ts
+++ b/packages/studio/src/test/url-state.test.ts
@@ -41,7 +41,7 @@ test('uses query-string routing in Browser Studio', () => {
 			replaceState: (...args: unknown[]) => replaceStateCalls.push(args),
 		},
 		location: {
-			pathname: '/experimental_new',
+			pathname: '/new',
 			search: '?source=release',
 		},
 	};
@@ -61,7 +61,5 @@ test('uses query-string routing in Browser Studio', () => {
 
 	expect(getRoute()).toBe('');
 	replaceUrl('/assets/other.mp4');
-	expect(replaceStateCalls).toEqual([
-		[{}, 'Studio', '/experimental_new?/assets/other.mp4'],
-	]);
+	expect(replaceStateCalls).toEqual([[{}, 'Studio', '/new?/assets/other.mp4']]);
 });


### PR DESCRIPTION
Browser Studio is now hosted at `/new`, with generated Studio links and cross-origin isolation headers updated to match. Permanently redirect `/experimental_new` to `/new` so existing links keep working.

Validation: `bun run build`, `bun run stylecheck`, and all 5 focused Browser Studio URL tests pass.
