### PR TITLE
`@remotion/studio`: Add composition menu to title bar

### DIFF
--- a/packages/studio/src/components/MenuBuildIndicator.tsx
+++ b/packages/studio/src/components/MenuBuildIndicator.tsx
@@ -7,7 +7,7 @@ import {Spinner} from './Spinner';
 
 const cwd: React.CSSProperties = {
 	fontSize: 13,
-	opacity: 0.8,
+	color: WHITE_ALPHA_80,
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'center',
@@ -18,8 +18,14 @@ const cwd: React.CSSProperties = {
 const spinnerSize = 14;
 
 const spinner: React.CSSProperties = {
+	opacity: 0.8,
 	position: 'relative',
 	width: spinnerSize,
+};
+
+const openInEditor: React.CSSProperties = {
+	display: 'flex',
+	opacity: 0.8,
 };
 
 const noSpinner: React.CSSProperties = {
@@ -60,7 +66,12 @@ export const MenuBuildIndicator: React.FC<{
 			{window.remotion_projectName}
 			<MenuCompositionName />
 			<Spacing x={1} />
-			<InspectorOpenInEditor location={folderLocation} locationType="folder" />
+			<div style={openInEditor}>
+				<InspectorOpenInEditor
+					location={folderLocation}
+					locationType="folder"
+				/>
+			</div>
 			{mobileLayout ? null : <Spacing x={0.5} />}
 			{mobileLayout ? (
 				isBuilding ? (

--- a/packages/studio/src/components/MenuCompositionName.tsx
+++ b/packages/studio/src/components/MenuCompositionName.tsx
@@ -1,23 +1,65 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
-import {LIGHT_TEXT} from '../helpers/colors';
+import {StudioServerConnectionCtx} from '../helpers/client-id';
+import {
+	LIGHT_TEXT,
+	TRANSPARENT,
+	WHITE,
+	WHITE_ALPHA_80,
+} from '../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	NO_HOVER_BACKGROUND_STYLE,
+} from '../helpers/hoverable';
+import {noop} from '../helpers/noop';
+import {SetSelectedModalContext} from '../state/modals';
+import {getCompositionContextMenuItems} from './composition-menu-items';
+import {ContextMenu} from './ContextMenu';
+import {InlineDropdown} from './InlineDropdown';
+import {useResolvedStack} from './Timeline/use-resolved-stack';
+import {useEditorOpening} from './use-default-editor-info';
 
 const baseStyle: React.CSSProperties = {
-	color: 'inherit',
+	cursor: 'default',
 	textDecoration: 'none',
 	fontSize: 'inherit',
 	textUnderlineOffset: 2,
 	whiteSpace: 'nowrap',
 };
 
+const assetNameStyle: React.CSSProperties = {
+	...baseStyle,
+	color: WHITE_ALPHA_80,
+};
+
+const contextMenuStyle: React.CSSProperties = {
+	alignItems: 'center',
+	color: 'inherit',
+	display: 'flex',
+	fontFamily: 'inherit',
+	fontSize: 'inherit',
+	lineHeight: 'inherit',
+};
+
 const compositionNameStyle: React.CSSProperties = {
 	...baseStyle,
-	cursor: 'default',
+	appearance: 'none',
+	border: 'none',
+	backgroundColor: TRANSPARENT,
+	fontFamily: 'inherit',
+	fontSize: 13,
+	height: 'auto',
+	lineHeight: 1.5,
+	margin: 0,
+	padding: 0,
+	width: 'auto',
+	...NO_HOVER_BACKGROUND_STYLE,
 };
 
 const slashStyle: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	marginInline: 4,
+	opacity: 0.8,
 	position: 'relative',
 	top: 1,
 };
@@ -36,6 +78,33 @@ export const MenuCompositionName: React.FC = () => {
 		);
 	}, [canvasContent, compositions]);
 	const asset = canvasContent?.type === 'asset' ? canvasContent.asset : null;
+	const {setSelectedModal} = useContext(SetSelectedModalContext);
+	const connectionStatus = useContext(StudioServerConnectionCtx)
+		.previewServerState.type;
+	const {defaultEditorId, defaultEditorName} = useEditorOpening(
+		connectionStatus === 'connected',
+	);
+	const resolvedLocation = useResolvedStack(composition?.stack ?? null);
+	const getContextMenuItems = useCallback(() => {
+		return getCompositionContextMenuItems({
+			closeMenu: noop,
+			composition,
+			connectionStatus,
+			editorId: defaultEditorId,
+			editorName: defaultEditorName,
+			includeCompositionManagementItems: true,
+			resolvedLocation,
+			setSelectedModal,
+			readOnlyStudio: window.remotion_isReadOnlyStudio,
+		});
+	}, [
+		composition,
+		connectionStatus,
+		defaultEditorId,
+		defaultEditorName,
+		resolvedLocation,
+		setSelectedModal,
+	]);
 
 	if (!composition && asset === null) {
 		return null;
@@ -46,7 +115,23 @@ export const MenuCompositionName: React.FC = () => {
 	return (
 		<>
 			<span style={slashStyle}>/</span>
-			<span style={compositionNameStyle}>{name}</span>
+			{composition ? (
+				<ContextMenu getItems={getContextMenuItems} style={contextMenuStyle}>
+					<InlineDropdown
+						aria-label="Open composition menu"
+						className={FOCUS_VISIBLE_ONLY_CLASS_NAME}
+						getItems={getContextMenuItems}
+						hoveredColor={WHITE}
+						renderAction={() => composition.id}
+						style={compositionNameStyle}
+						title="Open composition menu"
+						unhoveredColor={WHITE_ALPHA_80}
+						variant={null}
+					/>
+				</ContextMenu>
+			) : (
+				<span style={assetNameStyle}>{name}</span>
+			)}
 		</>
 	);
 };

--- a/packages/studio/src/components/composition-menu-items.ts
+++ b/packages/studio/src/components/composition-menu-items.ts
@@ -263,7 +263,7 @@ export const getCompositionMenuItems = ({
 				navigator.clipboard
 					.writeText(composition.id)
 					.then(() => {
-						showNotification('Copied to clipboard', 1000);
+						showNotification('Copied composition name', 1000);
 					})
 					.catch((err) => {
 						showNotification(


### PR DESCRIPTION
## Summary

- make the title-bar composition name open the existing composition menu on click or right-click
- preserve the title's original idle appearance and brighten it on hover
- clarify the composition copy notification

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make lint test --filter='@remotion/studio'`
- verified left-click, right-click, hover styling, clipboard output, and notification in Studio
