### PR TITLE
`@remotion/studio`: Show checkmark after copying

### DIFF
--- a/packages/studio/src/components/CopyButton.tsx
+++ b/packages/studio/src/components/CopyButton.tsx
@@ -1,6 +1,8 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback} from 'react';
 import {CURRENT_COLOR, WHITE} from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
+import {useCopyFeedback} from '../helpers/use-copy-feedback';
+import {CopyIcon} from '../icons/copy';
 import {Button} from './Button';
 import {Spacing} from './layout';
 import {showNotification} from './Notifications/NotificationCenter';
@@ -16,25 +18,6 @@ const buttonContainerStyle: React.CSSProperties = {
 	minWidth: '114px',
 };
 
-const copyIcon = (
-	<svg
-		aria-hidden="true"
-		focusable="false"
-		data-prefix="far"
-		data-icon="clipboard"
-		className="svg-inline--fa fa-clipboard fa-w-12"
-		role="img"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 384 512"
-		style={iconStyle}
-	>
-		<path
-			fill={CURRENT_COLOR}
-			d="M336 64h-80c0-35.3-28.7-64-64-64s-64 28.7-64 64H48C21.5 64 0 85.5 0 112v352c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48V112c0-26.5-21.5-48-48-48zM192 40c13.3 0 24 10.7 24 24s-10.7 24-24 24-24-10.7-24-24 10.7-24 24-24zm144 418c0 3.3-2.7 6-6 6H54c-3.3 0-6-2.7-6-6V118c0-3.3 2.7-6 6-6h42v36c0 6.6 5.4 12 12 12h168c6.6 0 12-5.4 12-12v-36h42c3.3 0 6 2.7 6 6z"
-		/>
-	</svg>
-);
-
 const labelStyle: React.CSSProperties = {
 	fontSize: 14,
 };
@@ -44,30 +27,19 @@ export const CopyButton: React.FC<{
 	readonly label: string;
 	readonly labelWhenCopied: string;
 }> = ({textToCopy, label, labelWhenCopied}) => {
-	const [copied, setCopied] = useState<false | number>(false);
+	const {copied, markCopied} = useCopyFeedback();
 
 	const onClick = useCallback(() => {
 		copyText(textToCopy)
-			.then(() => {
-				setCopied(Date.now());
-			})
+			.then(markCopied)
 			.catch((err) => {
 				showNotification(`Could not copy: ${err.message}`, 2000);
 			});
-	}, [textToCopy]);
-
-	useEffect(() => {
-		if (!copied) {
-			return;
-		}
-
-		const to = setTimeout(() => setCopied(false), 2000);
-		return () => clearTimeout(to);
-	}, [copied]);
+	}, [markCopied, textToCopy]);
 
 	return (
 		<Button onClick={onClick} buttonContainerStyle={buttonContainerStyle}>
-			{copyIcon}
+			<CopyIcon copied={copied} color={CURRENT_COLOR} style={iconStyle} />
 			<Spacing x={1.5} />{' '}
 			<span style={labelStyle}>{copied ? labelWhenCopied : label}</span>
 		</Button>

--- a/packages/studio/src/components/FixComputedValueModal.tsx
+++ b/packages/studio/src/components/FixComputedValueModal.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback} from 'react';
 import {LIGHT_TEXT, SELECTED_BACKGROUND, WHITE} from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
-import {ClipboardIcon} from '../icons/clipboard';
+import {useCopyFeedback} from '../helpers/use-copy-feedback';
+import {CopyIcon} from '../icons/copy';
 import type {ModalState} from '../state/modals';
 import {CodingAgentButton} from './CodingAgentButton';
 import type {RenderInlineAction} from './InlineAction';
@@ -76,22 +77,45 @@ export const FixComputedValueModal: React.FC<{
 	const installCommand = 'npx remotion skills add';
 	const hasCodingAgent =
 		(codingAgentInfo?.installedCodingAgents.length ?? 0) > 0;
+	const {copied: promptCopied, markCopied: markPromptCopied} =
+		useCopyFeedback();
+	const {copied: installCommandCopied, markCopied: markInstallCommandCopied} =
+		useCopyFeedback();
 
 	const onCopyPrompt = useCallback(() => {
-		copyText(prompt).catch((err) => {
-			showNotification(`Could not copy: ${err.message}`, 2000);
-		});
-	}, [prompt]);
+		copyText(prompt)
+			.then(markPromptCopied)
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [markPromptCopied, prompt]);
 
 	const onCopyInstallCommand = useCallback(() => {
-		copyText(installCommand).catch((err) => {
-			showNotification(`Could not copy: ${err.message}`, 2000);
-		});
-	}, [installCommand]);
+		copyText(installCommand)
+			.then(markInstallCommandCopied)
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [installCommand, markInstallCommandCopied]);
 
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon color={color} style={copyIcon} />;
-	}, []);
+	const renderPromptCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return <CopyIcon copied={promptCopied} color={color} style={copyIcon} />;
+		},
+		[promptCopied],
+	);
+	const renderInstallCommandCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return (
+				<CopyIcon
+					copied={installCommandCopied}
+					color={color}
+					style={copyIcon}
+				/>
+			);
+		},
+		[installCommandCopied],
+	);
 
 	return (
 		<DismissableModal panelStyle={panelStyle}>
@@ -105,7 +129,7 @@ export const FixComputedValueModal: React.FC<{
 							<InlineAction
 								variant={null}
 								onClick={onCopyInstallCommand}
-								renderAction={renderCopyAction}
+								renderAction={renderInstallCommandCopyAction}
 								title="Copy command"
 							/>
 						</div>
@@ -126,7 +150,7 @@ export const FixComputedValueModal: React.FC<{
 					<InlineAction
 						variant={null}
 						onClick={onCopyPrompt}
-						renderAction={renderCopyAction}
+						renderAction={renderPromptCopyAction}
 						title="Copy prompt"
 					/>
 				</div>

--- a/packages/studio/src/components/InspectorLocationCopy.tsx
+++ b/packages/studio/src/components/InspectorLocationCopy.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import type {OriginalPosition} from '../error-overlay/react-overlay/utils/get-source-map';
 import {formatContextForAgents} from '../helpers/format-file-location';
-import {ClipboardIcon} from '../icons/clipboard';
+import {useCopyFeedback} from '../helpers/use-copy-feedback';
+import {CopyIcon} from '../icons/copy';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {InspectorOpenInEditor} from './InspectorOpenInEditor';
@@ -46,6 +47,7 @@ export const InspectorLocationCopy: React.FC<{
 }> = ({children, location, name, openInEditorLocation}) => {
 	const [hovered, setHovered] = useState(false);
 	const [focusedWithin, setFocusedWithin] = useState(false);
+	const {copied, markCopied} = useCopyFeedback();
 	const contextForAgents = useMemo(() => {
 		return formatContextForAgents({
 			location,
@@ -54,9 +56,12 @@ export const InspectorLocationCopy: React.FC<{
 		});
 	}, [location, name]);
 
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon style={icon} color={color} />;
-	}, []);
+	const renderCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return <CopyIcon copied={copied} style={icon} color={color} />;
+		},
+		[copied],
+	);
 
 	const onCopy: React.MouseEventHandler<HTMLButtonElement> = useCallback(
 		(event) => {
@@ -65,14 +70,17 @@ export const InspectorLocationCopy: React.FC<{
 				return;
 			}
 
-			navigator.clipboard.writeText(contextForAgents).catch((err) => {
-				showNotification(
-					`Could not copy to clipboard: ${(err as Error).message}`,
-					2000,
-				);
-			});
+			navigator.clipboard
+				.writeText(contextForAgents)
+				.then(markCopied)
+				.catch((err) => {
+					showNotification(
+						`Could not copy to clipboard: ${(err as Error).message}`,
+						2000,
+					);
+				});
 		},
-		[contextForAgents],
+		[contextForAgents, markCopied],
 	);
 
 	const showAction = hovered || focusedWithin;

--- a/packages/studio/src/components/RenderModal/CliCopyButton.tsx
+++ b/packages/studio/src/components/RenderModal/CliCopyButton.tsx
@@ -1,19 +1,13 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {LIGHT_TEXT, WHITE} from '../../helpers/colors';
-import {ClipboardIcon} from '../../icons/clipboard';
+import {copyText} from '../../helpers/copy-text';
+import {useCopyFeedback} from '../../helpers/use-copy-feedback';
+import {CopyIcon} from '../../icons/copy';
+import {showNotification} from '../Notifications/NotificationCenter';
 const svgStyle: React.CSSProperties = {
 	width: 16,
 	height: 16,
 	verticalAlign: 'sub',
-};
-
-const copiedStyle: React.CSSProperties = {
-	fontSize: '14px',
-	minHeight: '30px',
-	minWidth: '30px',
-	display: 'flex',
-	alignItems: 'center',
-	justifyContent: 'center',
 };
 
 const buttonStyle: React.CSSProperties = {
@@ -29,26 +23,15 @@ const buttonStyle: React.CSSProperties = {
 export const CliCopyButton: React.FC<{valueToCopy: string}> = ({
 	valueToCopy,
 }) => {
-	const [copied, setCopied] = useState<boolean>(false);
+	const {copied, markCopied} = useCopyFeedback();
 	const [hovered, setHovered] = useState<boolean>(false);
 
 	const fillColor = useMemo(() => {
 		return hovered ? WHITE : LIGHT_TEXT;
 	}, [hovered]);
 
-	const clipboardIcon = <ClipboardIcon color={fillColor} style={svgStyle} />;
-
-	const checkSvg = (
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			viewBox="0 0 448 512"
-			style={svgStyle}
-		>
-			<path
-				fill={fillColor}
-				d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"
-			/>
-		</svg>
+	const copyIcon = (
+		<CopyIcon copied={copied} color={fillColor} style={svgStyle} />
 	);
 
 	const onPointerEnter = useCallback(() => {
@@ -59,34 +42,21 @@ export const CliCopyButton: React.FC<{valueToCopy: string}> = ({
 		setHovered(false);
 	}, []);
 
-	useEffect(() => {
-		if (!copied) {
-			return;
-		}
-
-		const handleClear = () => {
-			setCopied(false);
-			setHovered(false);
-		};
-
-		const to = setTimeout(() => handleClear(), 2000);
-		return () => clearTimeout(to);
-	}, [copied]);
-
-	return copied ? (
-		<span style={copiedStyle}>{checkSvg}</span>
-	) : (
+	return (
 		<button
 			type="button"
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 			style={buttonStyle}
 			onClick={() => {
-				navigator.clipboard.writeText(valueToCopy);
-				setCopied(true);
+				copyText(valueToCopy)
+					.then(markCopied)
+					.catch((err) => {
+						showNotification(`Could not copy: ${err.message}`, 2000);
+					});
 			}}
 		>
-			{clipboardIcon}
+			{copyIcon}
 		</button>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
@@ -2,7 +2,8 @@ import type {RenderJob} from '@remotion/studio-shared';
 import {useCallback} from 'react';
 import {CURRENT_COLOR} from '../../helpers/colors';
 import {remotion_outputsBase} from '../../helpers/get-asset-metadata';
-import {ClipboardIcon} from '../../icons/clipboard';
+import {useCopyFeedback} from '../../helpers/use-copy-feedback';
+import {CopyIcon} from '../../icons/copy';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -35,9 +36,13 @@ export const supportsCopyingToClipboard = (job: RenderJob) => {
 export const RenderQueueCopyToClipboard: React.FC<{
 	job: RenderJob;
 }> = ({job}) => {
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon style={revealIconStyle} color={color} />;
-	}, []);
+	const {copied, markCopied} = useCopyFeedback();
+	const renderCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return <CopyIcon copied={copied} style={revealIconStyle} color={color} />;
+		},
+		[copied],
+	);
 
 	const onClick: React.MouseEventHandler = useCallback(
 		async (e) => {
@@ -58,6 +63,7 @@ export const RenderQueueCopyToClipboard: React.FC<{
 						[contentType]: blob,
 					}),
 				]);
+				markCopied();
 				showNotification('Copied to clipboard!', 1000);
 			} catch (err) {
 				showNotification(
@@ -66,7 +72,7 @@ export const RenderQueueCopyToClipboard: React.FC<{
 				);
 			}
 		},
-		[job.outName],
+		[job.outName, markCopied],
 	);
 
 	return (

--- a/packages/studio/src/components/SkillsSettings.tsx
+++ b/packages/studio/src/components/SkillsSettings.tsx
@@ -6,8 +6,9 @@ import {
 	WHITE,
 } from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
+import {useCopyFeedback} from '../helpers/use-copy-feedback';
 import {CheckCircleFilled} from '../icons/check-circle-filled';
-import {ClipboardIcon} from '../icons/clipboard';
+import {CopyIcon} from '../icons/copy';
 import {Minus} from '../icons/minus';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
@@ -109,6 +110,7 @@ const loading: React.CSSProperties = {
 
 export const SkillsSettings: React.FC = () => {
 	const {error, remotionSkillsInfo} = useSettings();
+	const {copied, markCopied} = useCopyFeedback();
 	const installedSkills = useMemo(() => {
 		return (
 			remotionSkillsInfo?.skills.filter(
@@ -121,13 +123,18 @@ export const SkillsSettings: React.FC = () => {
 		(remotionSkillsInfo?.skills.length ?? 0) - installedSkills;
 
 	const onCopy = useCallback(() => {
-		copyText(INSTALL_COMMAND).catch((err) => {
-			showNotification(`Could not copy: ${err.message}`, 2000);
-		});
-	}, []);
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon color={color} style={copyIcon} />;
-	}, []);
+		copyText(INSTALL_COMMAND)
+			.then(markCopied)
+			.catch((err) => {
+				showNotification(`Could not copy: ${err.message}`, 2000);
+			});
+	}, [markCopied]);
+	const renderCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return <CopyIcon copied={copied} color={color} style={copyIcon} />;
+		},
+		[copied],
+	);
 
 	return (
 		<div style={container}>

--- a/packages/studio/src/components/UpdatesSettings.tsx
+++ b/packages/studio/src/components/UpdatesSettings.tsx
@@ -5,14 +5,15 @@ import type {
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
 	BACKGROUND,
-	BORDER_WHITE_ALPHA_12,
 	BLUE,
+	BORDER_WHITE_ALPHA_12,
 	LIGHT_TEXT,
 	SELECTED_BACKGROUND,
 	WHITE,
 } from '../helpers/colors';
 import {copyText} from '../helpers/copy-text';
-import {ClipboardIcon} from '../icons/clipboard';
+import {useCopyFeedback} from '../helpers/use-copy-feedback';
+import {CopyIcon} from '../icons/copy';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {KnownBugs} from './KnownBugs';
@@ -292,20 +293,26 @@ export const UpdatesSettings: React.FC = () => {
 	const updateActionType = remotionSkillsInfo?.remotionUpgradeSkillAvailable
 		? 'skill'
 		: 'command';
+	const {copied, markCopied} = useCopyFeedback();
 
 	const onClick = useCallback(() => {
 		if (updateAction === null) {
 			return;
 		}
 
-		copyText(updateAction).catch((err) => {
-			showNotification('Could not copy: ' + err.message, 2000);
-		});
-	}, [updateAction]);
+		copyText(updateAction)
+			.then(markCopied)
+			.catch((err) => {
+				showNotification('Could not copy: ' + err.message, 2000);
+			});
+	}, [markCopied, updateAction]);
 
-	const renderCopyAction: RenderInlineAction = useCallback((color) => {
-		return <ClipboardIcon color={color} style={copyIcon} />;
-	}, []);
+	const renderCopyAction: RenderInlineAction = useCallback(
+		(color) => {
+			return <CopyIcon copied={copied} color={color} style={copyIcon} />;
+		},
+		[copied],
+	);
 
 	const onUpgrade = useCallback(() => {
 		if (info) {

--- a/packages/studio/src/helpers/copy-text.ts
+++ b/packages/studio/src/helpers/copy-text.ts
@@ -6,8 +6,7 @@ export const copyText = (cmd: string) => {
 			.query({name: permissionName})
 			.then((result) => {
 				if (result.state === 'granted' || result.state === 'prompt') {
-					navigator.clipboard.writeText(cmd);
-					resolve();
+					navigator.clipboard.writeText(cmd).then(resolve).catch(reject);
 				} else {
 					reject(new Error('Permission to copy not granted'));
 				}

--- a/packages/studio/src/helpers/use-copy-feedback.ts
+++ b/packages/studio/src/helpers/use-copy-feedback.ts
@@ -1,0 +1,20 @@
+import {useCallback, useEffect, useState} from 'react';
+
+export const useCopyFeedback = () => {
+	const [copyCount, setCopyCount] = useState(0);
+
+	useEffect(() => {
+		if (copyCount === 0) {
+			return;
+		}
+
+		const timeout = setTimeout(() => setCopyCount(0), 2000);
+		return () => clearTimeout(timeout);
+	}, [copyCount]);
+
+	const markCopied = useCallback(() => {
+		setCopyCount((currentCopyCount) => currentCopyCount + 1);
+	}, []);
+
+	return {copied: copyCount > 0, markCopied};
+};

--- a/packages/studio/src/icons/copy.tsx
+++ b/packages/studio/src/icons/copy.tsx
@@ -1,0 +1,19 @@
+import type {SVGProps} from 'react';
+import {ClipboardIcon} from './clipboard';
+
+export const CopyIcon: React.FC<
+	SVGProps<SVGSVGElement> & {readonly copied: boolean; readonly color?: string}
+> = ({copied, color, style, ...props}) => {
+	if (copied) {
+		return (
+			<svg viewBox="0 0 512 512" style={style} {...props}>
+				<path
+					fill={color}
+					d="M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z"
+				/>
+			</svg>
+		);
+	}
+
+	return <ClipboardIcon color={color} style={style} {...props} />;
+};


### PR DESCRIPTION
## Summary

- show a temporary checkmark after clipboard actions succeed in Studio
- share the two-second copy feedback state across copy button implementations
- wait for clipboard writes to finish before showing successful feedback

## Testing

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run lint test --filter=@remotion/studio`

Closes #11100
