### PR TITLE
`@remotion/studio`: Fix sequence-relative video config in keyframes

### DIFF
--- a/packages/core/src/CompositionManager.tsx
+++ b/packages/core/src/CompositionManager.tsx
@@ -10,6 +10,7 @@ import type {
 	RuntimeValueSnapshot,
 	RuntimeValueStore,
 } from './runtime-value-store.js';
+import type {VideoConfigValues} from './video-config.js';
 
 export type TComposition<
 	Schema extends AnyZodObject,
@@ -110,6 +111,7 @@ export type JsxComponentIdentity = string;
 export type SequenceRegistrationControls = {
 	schema: InteractivitySchema;
 	runtimeValues: RuntimeValueStore;
+	videoConfigValues: VideoConfigValues | null;
 	overrideId: string;
 	supportsEffects: boolean;
 	componentIdentity: JsxComponentIdentity | null;

--- a/packages/core/src/Sequence.tsx
+++ b/packages/core/src/Sequence.tsx
@@ -416,6 +416,7 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 	const controlsSupportsEffects = controls?.supportsEffects;
 	const controlsComponentIdentity = controls?.componentIdentity;
 	const controlsComponentName = controls?.componentName;
+	const controlsVideoConfigValues = controls?.videoConfigValues;
 	const effectRuntimeValues = useMemo(
 		() =>
 			(
@@ -433,7 +434,8 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 				controlsOverrideId === undefined ||
 				controlsSupportsEffects === undefined ||
 				controlsComponentIdentity === undefined ||
-				controlsComponentName === undefined
+				controlsComponentName === undefined ||
+				controlsVideoConfigValues === undefined
 			) {
 				return null;
 			}
@@ -445,10 +447,12 @@ const RegularSequenceRefForwardingFunction: React.ForwardRefRenderFunction<
 				supportsEffects: controlsSupportsEffects,
 				componentIdentity: controlsComponentIdentity,
 				componentName: controlsComponentName,
+				videoConfigValues: controlsVideoConfigValues,
 			};
 		}, [
 			controlsComponentIdentity,
 			controlsComponentName,
+			controlsVideoConfigValues,
 			controlsOverrideId,
 			controlsRuntimeValues,
 			controlsSchema,

--- a/packages/core/src/SequenceManager.tsx
+++ b/packages/core/src/SequenceManager.tsx
@@ -15,6 +15,7 @@ import type {
 	GetEffectDragOverrides,
 	PropStatuses,
 } from './use-schema.js';
+import type {VideoConfigValues} from './video-config.js';
 
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
@@ -192,12 +193,7 @@ export type SequencePropsSubscriptionKey = {
 	videoConfigValues: VideoConfigValues | null;
 };
 
-export type VideoConfigValues = {
-	durationInFrames: number;
-	fps: number;
-	height: number;
-	width: number;
-};
+export type {VideoConfigValues} from './video-config.js';
 
 const effectDragOverridesKey = (
 	nodePath: SequencePropsSubscriptionKey,

--- a/packages/core/src/test/sequence-register-once.test.tsx
+++ b/packages/core/src/test/sequence-register-once.test.tsx
@@ -343,6 +343,33 @@ test('Interactive runtime values update mounted consumers without re-registering
 	expect(registeredSequences).toHaveLength(1);
 });
 
+test('Interactive controls capture the video config from the surrounding sequence', () => {
+	const registeredSequences: TSequence[] = [];
+	const SequenceChild: React.FC = () => {
+		return <Interactive.Div>Hello</Interactive.Div>;
+	};
+
+	render(
+		<SequenceTestWrapper
+			compositionDurationInFrames={120}
+			currentFrame={30}
+			onRegisterSequence={(sequence) => registeredSequences.push(sequence)}
+		>
+			<Sequence from={30} durationInFrames={60}>
+				<SequenceChild />
+			</Sequence>
+		</SequenceTestWrapper>,
+	);
+
+	const interactiveSequence = registeredSequences.find(
+		(sequence) => sequence.displayName === '<Interactive.Div>',
+	);
+	expect(interactiveSequence?.controls?.videoConfigValues).toMatchObject({
+		durationInFrames: 60,
+		fps: 30,
+	});
+});
+
 test('Interactive runtime values are published only after a render commits', () => {
 	const registeredSequences: TSequence[] = [];
 	const onRegisterSequence = (sequence: TSequence) => {

--- a/packages/core/src/video-config.ts
+++ b/packages/core/src/video-config.ts
@@ -17,3 +17,8 @@ export type VideoConfig = {
 	defaultProResProfile: ProResProfile | null;
 	defaultSampleRate: number | null;
 };
+
+export type VideoConfigValues = Pick<
+	VideoConfig,
+	'durationInFrames' | 'fps' | 'height' | 'width'
+>;

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -34,6 +34,7 @@ import {
 import {useCurrentFrame} from './use-current-frame.js';
 import {useRemotionEnvironment} from './use-remotion-environment.js';
 import {computeEffectiveSchemaValuesDotNotation} from './use-schema.js';
+import {useUnsafeVideoConfig} from './use-unsafe-video-config.js';
 
 export const getNestedValue = (
 	obj: Record<string, unknown>,
@@ -230,6 +231,28 @@ export const withInteractivitySchema = <
 		const nodePathMapping = useContext(OverrideIdsToNodePathsGettersContext);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const frame = useCurrentFrame();
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const videoConfig = useUnsafeVideoConfig();
+		const durationInFrames = videoConfig?.durationInFrames;
+		const fps = videoConfig?.fps;
+		const height = videoConfig?.height;
+		const width = videoConfig?.width;
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const videoConfigValues = useMemo(
+			() =>
+				durationInFrames === undefined ||
+				fps === undefined ||
+				height === undefined ||
+				width === undefined
+					? null
+					: {
+							durationInFrames,
+							fps,
+							height,
+							width,
+						},
+			[durationInFrames, fps, height, width],
+		);
 
 		// If the parent has passed `controls`, we should not override it.
 		// @ts-expect-error
@@ -307,12 +330,18 @@ export const withInteractivitySchema = <
 				schema: schemaWithSequenceName,
 				currentRuntimeValueDotNotation,
 				runtimeValues: runtimeValueStore.store,
+				videoConfigValues,
 				overrideId,
 				supportsEffects,
 				componentIdentity,
 				componentName,
 			};
-		}, [currentRuntimeValueDotNotation, overrideId, runtimeValueStore.store]);
+		}, [
+			currentRuntimeValueDotNotation,
+			overrideId,
+			runtimeValueStore.store,
+			videoConfigValues,
+		]);
 		setStackForControls(controls, internalStack);
 
 		// 3. Apply drag/code overrides on top of the runtime values.

--- a/packages/example/src/Root.tsx
+++ b/packages/example/src/Root.tsx
@@ -319,6 +319,7 @@ import {
 } from './VisualModeTests/InteractiveComponents';
 import {Issue9170} from './VisualModeTests/Issue9170';
 import {OutlineSelectionCases} from './VisualModeTests/OutlineSelectionCases';
+import {SequenceDurationInterpolation} from './VisualModeTests/SequenceDurationInterpolation';
 import {SequenceShiftRepro} from './VisualModeTests/SequenceShiftRepro';
 import {SvgPaintSchema} from './VisualModeTests/SvgPaintSchema';
 import {VideoConfigExpressions} from './VisualModeTests/VideoConfigExpressions';
@@ -3096,6 +3097,14 @@ export const Index: React.FC = () => {
 				<Composition
 					id="issue-9170-duration-subtraction"
 					component={Issue9170}
+					width={1200}
+					height={800}
+					fps={30}
+					durationInFrames={120}
+				/>
+				<Composition
+					id="sequence-duration-interpolation"
+					component={SequenceDurationInterpolation}
 					width={1200}
 					height={800}
 					fps={30}

--- a/packages/example/src/VisualModeTests/SequenceDurationInterpolation.tsx
+++ b/packages/example/src/VisualModeTests/SequenceDurationInterpolation.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	Interactive,
+	interpolate,
+	Sequence,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+const SequenceContent: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames} = useVideoConfig();
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				inset: 0,
+				fontFamily: 'sans-serif',
+			}}
+		>
+			<div
+				style={{
+					position: 'absolute',
+					left: 40,
+					top: 40,
+					fontSize: 32,
+					color: 'white',
+				}}
+			>
+				Sequence frame {frame} / {durationInFrames - 1}; hook duration:{' '}
+				{durationInFrames}
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					left: 50,
+					top: 150,
+					bottom: 90,
+					borderLeft: '4px solid #22c55e',
+				}}
+			/>
+			<div
+				style={{
+					position: 'absolute',
+					left: 50,
+					bottom: 45,
+					color: '#22c55e',
+					fontSize: 24,
+					translate: '-50% 0',
+				}}
+			>
+				Expected final position
+			</div>
+			<Interactive.Div
+				name="Sequence-duration interpolation"
+				style={{
+					position: 'absolute',
+					left: 850,
+					top: 290,
+					width: 280,
+					padding: 32,
+					borderRadius: 20,
+					backgroundColor: '#6366f1',
+					color: 'white',
+					fontSize: 30,
+					fontWeight: 700,
+					textAlign: 'center',
+					translate: interpolate(
+						frame,
+						[0, durationInFrames - 1],
+						['0px -50px', '-800px -50px'],
+					),
+				}}
+			>
+				Should reach the green line
+			</Interactive.Div>
+		</div>
+	);
+};
+
+export const SequenceDurationInterpolation: React.FC = () => {
+	return (
+		<AbsoluteFill style={{backgroundColor: '#111827'}}>
+			<div
+				style={{
+					position: 'absolute',
+					right: 40,
+					top: 40,
+					fontFamily: 'monospace',
+					fontSize: 24,
+					color: '#94a3b8',
+				}}
+			>
+				Composition: 120 frames · Sequence: frames 30–89
+			</div>
+			<Sequence from={30} durationInFrames={60} name="60-frame sequence">
+				<SequenceContent />
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
+++ b/packages/studio/src/components/Timeline/SubscribeToNodePaths.tsx
@@ -3,6 +3,7 @@ import type {
 	EffectDefinition,
 	JsxComponentIdentity,
 	InteractivitySchema,
+	VideoConfigValues,
 } from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
 import {useResolveStackAndReactToChange} from './use-resolved-stack-react-to-change';
@@ -14,7 +15,15 @@ export const SubscribeToNodePaths: FC<{
 	readonly schema: InteractivitySchema;
 	readonly getStack: () => string | null;
 	readonly effects: readonly EffectDefinition<unknown>[];
-}> = ({overrideId, componentIdentity, schema, getStack, effects}) => {
+	readonly videoConfigValues: VideoConfigValues | null;
+}> = ({
+	overrideId,
+	componentIdentity,
+	schema,
+	getStack,
+	effects,
+	videoConfigValues,
+}) => {
 	const {resolvedLocation, stack, preferMappedNodePath} =
 		useResolveStackAndReactToChange(getStack, overrideId);
 
@@ -34,6 +43,7 @@ export const SubscribeToNodePaths: FC<{
 		originalLocation: resolvedLocation,
 		preferMappedNodePath,
 		stack,
+		videoConfigValues,
 	});
 
 	return null;

--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -510,6 +510,7 @@ const TimelineInner: React.FC = () => {
 						schema={sequence.controls.schema}
 						getStack={sequence.getStack}
 						effects={sequence.effects}
+						videoConfigValues={sequence.controls.videoConfigValues}
 					/>
 				);
 			})}

--- a/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
+++ b/packages/studio/src/components/Timeline/use-sequence-props-subscription.ts
@@ -7,6 +7,7 @@ import type {
 	JsxComponentIdentity,
 	SequencePropsSubscriptionKey,
 	InteractivitySchema,
+	VideoConfigValues,
 } from 'remotion';
 import {Internals} from 'remotion';
 import type {OriginalPosition} from '../../error-overlay/react-overlay/utils/get-source-map';
@@ -26,6 +27,7 @@ export const useSequencePropsSubscription = ({
 	effects,
 	preferMappedNodePath,
 	stack,
+	videoConfigValues,
 }: {
 	overrideId: string;
 	componentIdentity: JsxComponentIdentity | null;
@@ -34,6 +36,7 @@ export const useSequencePropsSubscription = ({
 	originalLocation: OriginalPosition | null;
 	preferMappedNodePath: boolean;
 	stack: string | null;
+	videoConfigValues: VideoConfigValues | null;
 }) => {
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {setOverrideIdToNodePath} = useContext(
@@ -52,8 +55,6 @@ export const useSequencePropsSubscription = ({
 	const overrideIdToNodePathMappingsRef = useRef(overrideIdToNodePathMappings);
 	overrideIdToNodePathMappingsRef.current = overrideIdToNodePathMappings;
 	const clientId = state.type === 'connected' ? state.clientId : undefined;
-	const videoConfig = Internals.useUnsafeVideoConfig();
-
 	const effectsSignature = useMemo(
 		() =>
 			effects.map((effect) => getAllSchemaKeys(effect).join('\0')).join('\0\0'),
@@ -94,7 +95,7 @@ export const useSequencePropsSubscription = ({
 			!locationLine ||
 			locationColumn === null ||
 			!schema ||
-			videoConfig === null
+			videoConfigValues === null
 		) {
 			return;
 		}
@@ -114,12 +115,7 @@ export const useSequencePropsSubscription = ({
 				: null,
 			clientId,
 			stack,
-			videoConfigValues: {
-				durationInFrames: videoConfig.durationInFrames,
-				fps: videoConfig.fps,
-				height: videoConfig.height,
-				width: videoConfig.width,
-			},
+			videoConfigValues,
 			applyOnce: (result) => {
 				if (!result.success) {
 					return;
@@ -175,6 +171,6 @@ export const useSequencePropsSubscription = ({
 		setPropStatuses,
 		setOverrideIdToNodePath,
 		stack,
-		videoConfig,
+		videoConfigValues,
 	]);
 };

--- a/packages/studio/src/test/split-selected-timeline-item.test.ts
+++ b/packages/studio/src/test/split-selected-timeline-item.test.ts
@@ -157,6 +157,7 @@ test('getTimelineSequenceSplitEligibility rejects non-editable sequence shapes',
 				controls: {
 					schema: {},
 					runtimeValues: makeRuntimeValueStore({}),
+					videoConfigValues: null,
 					overrideId: 'override',
 					supportsEffects: true,
 					componentIdentity: 'dev.remotion.remotion.Solid',

--- a/packages/studio/src/test/timeline-keyframes.test.ts
+++ b/packages/studio/src/test/timeline-keyframes.test.ts
@@ -41,6 +41,7 @@ const makeControls = (
 ): NonNullable<TSequence['controls']> => ({
 	schema: {},
 	runtimeValues: makeRuntimeValueStore({}),
+	videoConfigValues: null,
 	overrideId,
 	supportsEffects: false,
 	componentIdentity: null,

--- a/packages/studio/src/test/timeline-video-info.test.ts
+++ b/packages/studio/src/test/timeline-video-info.test.ts
@@ -76,6 +76,7 @@ const makeSequenceControls = ({
 	componentIdentity: null,
 	componentName: 'Test',
 	runtimeValues: makeRuntimeValueStore(currentRuntimeValueDotNotation),
+	videoConfigValues: null,
 	overrideId: 'test',
 	schema,
 	supportsEffects: false,


### PR DESCRIPTION
## Summary

- capture video config values at the interactive component's runtime location
- pass sequence-relative values to Studio keyframe source subscriptions
- add a regression composition and registration test

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun test src/test/sequence-register-once.test.tsx` (from `packages/core`)
- `bun test src/test/split-selected-timeline-item.test.ts src/test/timeline-keyframes.test.ts src/test/timeline-video-info.test.ts` (from `packages/studio`)
- verified `sequence-duration-interpolation` at frame 89 resolves to `translate: -800px -50px` in Studio
