### PR TITLE
`@remotion/studio`: Clamp timeline layer resizing to composition duration

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -89,6 +89,7 @@ const baseStyle: React.CSSProperties = {
 export type TimelineSequenceDurationDragTarget = {
 	readonly fileName: string;
 	readonly initialDuration: number;
+	readonly maximumDuration: number;
 	readonly minimumDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
 	readonly schema: InteractivitySchema;
@@ -406,12 +407,18 @@ const isFromDraggableSequence = (sequence: TSequence) => {
 export const getTimelineSequenceDurationDragValue = ({
 	initialDuration,
 	deltaFrames,
+	maximumDuration,
 	minimumDuration = 1,
 }: {
 	readonly initialDuration: number;
 	readonly deltaFrames: number;
+	readonly maximumDuration: number;
 	readonly minimumDuration?: number;
-}) => Math.max(minimumDuration, initialDuration + deltaFrames);
+}) =>
+	Math.min(
+		maximumDuration,
+		Math.max(minimumDuration, initialDuration + deltaFrames),
+	);
 
 export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
@@ -531,6 +538,7 @@ export const getTimelineSequenceDurationDragChanges = ({
 		const nextValue = getTimelineSequenceDurationDragValue({
 			initialDuration: target.initialDuration,
 			deltaFrames,
+			maximumDuration: target.maximumDuration,
 			minimumDuration: target.minimumDuration,
 		});
 
@@ -725,12 +733,14 @@ export const getTimelineSequenceDurationDragTargets = ({
 	sequences,
 	overrideIdsToNodePaths,
 	propStatuses,
+	timelineDurationInFrames,
 }: {
 	readonly draggedNodePathInfo: SequenceNodePathInfo;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
 	readonly propStatuses: PropStatuses;
+	readonly timelineDurationInFrames: number;
 }): TimelineSequenceDurationDragTarget[] | null => {
 	const draggedSelectionKey =
 		getTimelineSequenceSelectionKey(draggedNodePathInfo);
@@ -793,14 +803,19 @@ export const getTimelineSequenceDurationDragTargets = ({
 
 		const key = stringifySequenceSubscriptionKey(nodePath);
 		if (!targets.has(key)) {
+			const minimumDuration = Math.max(
+				1 - originalSequence.from,
+				getMinimumSequenceDuration({sequence: originalSequence, sequences}),
+			);
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
 				initialDuration: originalSequence.duration,
-				// A negative start needs enough duration to retain one visible frame.
-				minimumDuration: Math.max(
-					1 - originalSequence.from,
-					getMinimumSequenceDuration({sequence: originalSequence, sequences}),
+				maximumDuration: Math.max(
+					minimumDuration,
+					timelineDurationInFrames - track.cascadedStart,
 				),
+				// A negative start needs enough duration to retain one visible frame.
+				minimumDuration,
 				nodePath,
 				schema: controls.schema,
 			});
@@ -1886,6 +1901,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 						sequences: sequencesRef.current,
 						overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
 						propStatuses: propStatusesRef.current,
+						timelineDurationInFrames,
 					}) ?? [])
 				: [];
 
@@ -1930,6 +1946,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 							getTimelineSequenceDurationDragValue({
 								initialDuration: target.initialDuration,
 								deltaFrames,
+								maximumDuration: target.maximumDuration,
 								minimumDuration: target.minimumDuration,
 							}),
 						),

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1804,9 +1804,11 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 			firstNodePathInfo.sequenceSubscriptionKey,
 			secondNodePathInfo.sequenceSubscriptionKey,
 		]),
+		timelineDurationInFrames: 1000,
 	});
 
 	expect(targets?.map((target) => target.initialDuration)).toEqual([40, 15]);
+	expect(targets?.map((target) => target.maximumDuration)).toEqual([1000, 990]);
 	expect(
 		getTimelineSequenceDurationDragChanges({
 			targets: targets ?? [],
@@ -1840,6 +1842,7 @@ test('Timeline duration drag uses the declared duration for negative from values
 		propStatuses: makeDurationPropStatuses([
 			nodePathInfo.sequenceSubscriptionKey,
 		]),
+		timelineDurationInFrames: 1000,
 	});
 
 	expect(targets?.map((target) => target.initialDuration)).toEqual([36]);
@@ -1849,6 +1852,37 @@ test('Timeline duration drag uses the declared duration for negative from values
 			deltaFrames: 0,
 		}),
 	).toEqual([]);
+});
+
+test('Timeline duration drag clamps to the composition end', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const targets = getTimelineSequenceDurationDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema,
+				duration: 40,
+				from: 30,
+			}),
+		],
+		overrideIdsToNodePaths: {
+			override: nodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeDurationPropStatuses([
+			nodePathInfo.sequenceSubscriptionKey,
+		]),
+		timelineDurationInFrames: 180,
+	});
+
+	expect(targets?.[0].maximumDuration).toBe(150);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 200,
+		})[0].value,
+	).toBe(150);
 });
 
 test('Timeline duration drag supports interactive video clips', () => {
@@ -1871,11 +1905,13 @@ test('Timeline duration drag supports interactive video clips', () => {
 			propStatuses: makeDurationPropStatuses([
 				nodePathInfo.sequenceSubscriptionKey,
 			]),
+			timelineDurationInFrames: 1000,
 		}),
 	).toEqual([
 		{
 			fileName: nodePathInfo.sequenceSubscriptionKey.absolutePath,
 			initialDuration: 78,
+			maximumDuration: 1000,
 			minimumDuration: 1,
 			nodePath: nodePathInfo.sequenceSubscriptionKey,
 			schema: Internals.baseSchema,
@@ -1914,6 +1950,7 @@ test('Timeline duration drag rejects media without an explicit duration', () => 
 					effects: [],
 				},
 			},
+			timelineDurationInFrames: 1000,
 		}),
 	).toBe(null);
 });
@@ -1959,12 +1996,14 @@ test('Timeline duration drag clamps each selected sequence to one frame', () => 
 		getTimelineSequenceDurationDragValue({
 			initialDuration: 4,
 			deltaFrames: -10,
+			maximumDuration: 1000,
 		}),
 	).toBe(1);
 	expect(
 		getTimelineSequenceDurationDragValue({
 			initialDuration: 20,
 			deltaFrames: -10,
+			maximumDuration: 1000,
 		}),
 	).toBe(10);
 });
@@ -2017,6 +2056,7 @@ test('TransitionSeries.Sequence resize clamps to adjacent transition durations',
 		sequences,
 		overrideIdsToNodePaths,
 		propStatuses,
+		timelineDurationInFrames: 1000,
 	});
 
 	expect(durationTargets?.[0].minimumDuration).toBe(12);
@@ -2092,6 +2132,7 @@ test('Timeline duration drag is blocked if one selected sequence cannot update d
 				second: secondNodePathInfo.sequenceSubscriptionKey,
 			},
 			propStatuses,
+			timelineDurationInFrames: 1000,
 		}),
 	).toBe(null);
 });
@@ -2153,6 +2194,7 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 				second: secondNodePathInfo.sequenceSubscriptionKey,
 			},
 			propStatuses,
+			timelineDurationInFrames: 1000,
 		}),
 	).toBe(null);
 });
@@ -2200,6 +2242,7 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 			secondNodePathInfo.sequenceSubscriptionKey,
 			thirdNodePathInfo.sequenceSubscriptionKey,
 		]),
+		timelineDurationInFrames: 1000,
 	});
 
 	expect(targets?.map((target) => target.nodePath)).toEqual([


### PR DESCRIPTION
## Summary

- Clamp timeline right-edge resizing to the composition end
- Account for each selected layer's absolute timeline start
- Add regression coverage for dragging beyond the last timeline tick

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #11095
