### PR TITLE
`@remotion/studio`: Add timeline zoom to audio asset previews

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -401,16 +401,32 @@ test.describe('visual mode', () => {
 		await mediaTrack.dblclick();
 		await expect(page.getByRole('textbox')).toHaveCount(0);
 
-		await page.goto(`${STUDIO_URL}/assets/whip.mp3`);
+		await page.goto(`${STUDIO_URL}/assets/podcast.wav`);
 		await expect(
 			page.getByRole('img', {name: 'Audio asset', exact: true}),
 		).toBeVisible();
 		await expect(page.getByTestId('asset-media-preview')).not.toBeInViewport();
 		await expect(page.locator('[data-timeline-scrollable]')).toBeVisible();
-		await expect(page.getByTitle('whip.mp3').last()).toBeVisible();
+		await expect(page.getByTitle('podcast.wav').last()).toBeVisible();
 		await expect(
 			page.getByRole('button', {name: 'Play', exact: true}),
 		).toBeEnabled();
+		const audioTimelineZoom = page.getByTitle(/^Timeline zoom \(/);
+		await expect(audioTimelineZoom).toBeVisible();
+		const audioTimelineScrubber = page.locator('[data-timeline-scrubber]');
+		const audioTimelineWidthBeforeZoom = await audioTimelineScrubber.evaluate(
+			(element) => element.getBoundingClientRect().width,
+		);
+		await page
+			.getByRole('button', {name: 'Zoom in timeline', exact: true})
+			.click();
+		await expect
+			.poll(() =>
+				audioTimelineScrubber.evaluate(
+					(element) => element.getBoundingClientRect().width,
+				),
+			)
+			.toBeGreaterThan(audioTimelineWidthBeforeZoom);
 		await expect(checkerboardToggle).toHaveCount(0);
 		await expect(rulersToggle).toHaveCount(0);
 		await expect(horizontalRuler).toHaveCount(0);

--- a/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDragHandler.tsx
@@ -77,6 +77,7 @@ export const TimelineDragHandler: React.FC = () => {
 	const {canvasContent, currentAssetMetadata} = useContext(
 		Internals.CompositionManager,
 	);
+	const videoId = video?.id;
 
 	const containerStyle: React.CSSProperties = useMemo(() => {
 		if (!canvasContent) {
@@ -88,17 +89,20 @@ export const TimelineDragHandler: React.FC = () => {
 			durationInFrames,
 			timelineViewportWidth:
 				timelineSize?.width ?? scrollableRef.current?.clientWidth ?? 0,
-			zoom:
-				canvasContent.type === 'composition'
-					? (zoomMap[canvasContent.compositionId] ?? null)
-					: null,
+			zoom: videoId ? (zoomMap[videoId] ?? null) : null,
 		});
 		return {
 			...container,
 			width: getTimelineWidth({durationInFrames, zoom}),
 			height: TIMELINE_TIME_INDICATOR_HEIGHT,
 		};
-	}, [canvasContent, timelineSize?.width, video?.durationInFrames, zoomMap]);
+	}, [
+		canvasContent,
+		timelineSize?.width,
+		video?.durationInFrames,
+		videoId,
+		zoomMap,
+	]);
 
 	const hasPlayableContent =
 		canvasContent?.type === 'composition' ||

--- a/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePinchZoom.tsx
@@ -23,7 +23,6 @@ type WebKitGestureEvent = UIEvent & {
 export const TimelinePinchZoom: FC = () => {
 	const isVideoComposition = useIsVideoComposition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
-	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {zoom, setZoom} = useContext(TimelineZoomCtx);
 	const {editorZoomGestures} = useContext(EditorZoomGesturesContext);
 
@@ -68,10 +67,6 @@ export const TimelinePinchZoom: FC = () => {
 				return;
 			}
 
-			if (!canvasContent || canvasContent.type !== 'composition') {
-				return;
-			}
-
 			const scrollEl = scrollableRef.current;
 			if (!scrollEl) {
 				return;
@@ -92,18 +87,12 @@ export const TimelinePinchZoom: FC = () => {
 			}
 
 			setZoom(
-				canvasContent.compositionId,
+				videoConfig.id,
 				(z) => z * Math.exp(-scaledDeltaY * ZOOM_WHEEL_SENSITIVITY),
 				{anchorFrame: null, anchorContentX},
 			);
 		},
-		[
-			editorZoomGestures,
-			isVideoComposition,
-			videoConfig,
-			canvasContent,
-			setZoom,
-		],
+		[editorZoomGestures, isVideoComposition, videoConfig, setZoom],
 	);
 
 	const supportsWebKitPinch =
@@ -142,10 +131,6 @@ export const TimelinePinchZoom: FC = () => {
 				return;
 			}
 
-			if (!canvasContent || canvasContent.type !== 'composition') {
-				return;
-			}
-
 			const scrollEl = scrollableRef.current;
 			if (!scrollEl) {
 				return;
@@ -154,9 +139,7 @@ export const TimelinePinchZoom: FC = () => {
 			e.preventDefault();
 			suppressWheelFromWebKitPinchRef.current = true;
 
-			pinchBaseZoomRef.current = getCurrentTimelineZoom(
-				canvasContent.compositionId,
-			);
+			pinchBaseZoomRef.current = getCurrentTimelineZoom(videoConfig.id);
 		};
 
 		const onGestureChange = (event: Event) => {
@@ -168,10 +151,6 @@ export const TimelinePinchZoom: FC = () => {
 				!videoConfig ||
 				videoConfig.durationInFrames < 2
 			) {
-				return;
-			}
-
-			if (!canvasContent || canvasContent.type !== 'composition') {
 				return;
 			}
 
@@ -187,7 +166,7 @@ export const TimelinePinchZoom: FC = () => {
 				scrollEl,
 			});
 
-			setZoom(canvasContent.compositionId, () => base * e.scale, {
+			setZoom(videoConfig.id, () => base * e.scale, {
 				anchorFrame: null,
 				anchorContentX,
 			});
@@ -213,7 +192,6 @@ export const TimelinePinchZoom: FC = () => {
 		supportsWebKitPinch,
 		isVideoComposition,
 		videoConfig,
-		canvasContent,
 		getCurrentTimelineZoom,
 		setZoom,
 	]);
@@ -238,10 +216,6 @@ export const TimelinePinchZoom: FC = () => {
 				return;
 			}
 
-			if (!canvasContent || canvasContent.type !== 'composition') {
-				return;
-			}
-
 			const [t0, t1] = [event.touches[0], event.touches[1]];
 			const initialDistance = Math.hypot(
 				t1.clientX - t0.clientX,
@@ -253,7 +227,7 @@ export const TimelinePinchZoom: FC = () => {
 
 			touchPinchRef.current = {
 				initialDistance,
-				initialZoom: getCurrentTimelineZoom(canvasContent.compositionId),
+				initialZoom: getCurrentTimelineZoom(videoConfig.id),
 			};
 		};
 
@@ -265,10 +239,6 @@ export const TimelinePinchZoom: FC = () => {
 				!videoConfig ||
 				videoConfig.durationInFrames < 2
 			) {
-				return;
-			}
-
-			if (!canvasContent || canvasContent.type !== 'composition') {
 				return;
 			}
 
@@ -289,7 +259,7 @@ export const TimelinePinchZoom: FC = () => {
 				scrollEl,
 			});
 
-			setZoom(canvasContent.compositionId, () => pinch.initialZoom * ratio, {
+			setZoom(videoConfig.id, () => pinch.initialZoom * ratio, {
 				anchorFrame: null,
 				anchorContentX,
 			});
@@ -316,7 +286,6 @@ export const TimelinePinchZoom: FC = () => {
 		editorZoomGestures,
 		isVideoComposition,
 		videoConfig,
-		canvasContent,
 		getCurrentTimelineZoom,
 		setZoom,
 	]);

--- a/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
+++ b/packages/studio/src/components/Timeline/TimelinePlayCursorSyncer.tsx
@@ -34,19 +34,12 @@ export const TimelinePlayCursorSyncer: React.FC = () => {
 	const timelinePosition = Internals.Timeline.useTimelinePosition();
 	const playing = Internals.usePlaying();
 	const {playbackRate} = Internals.usePlaybackRate();
-	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
 
-	const compositionId =
-		canvasContent && canvasContent.type === 'composition'
-			? canvasContent.compositionId
-			: null;
-	// Asset previews have a synthetic video config, but no composition ID
-	// with which to look up a persisted timeline zoom.
 	const zoom = getTimelineZoom({
 		durationInFrames: video?.durationInFrames ?? 1,
 		timelineViewportWidth: scrollableRef.current?.clientWidth ?? 0,
-		zoom: compositionId ? (zoomMap[compositionId] ?? null) : null,
+		zoom: video ? (zoomMap[video.id] ?? null) : null,
 	});
 
 	if (video) {

--- a/packages/studio/src/components/Timeline/TimelineSlider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSlider.tsx
@@ -82,16 +82,12 @@ const TimelineSliderInner: React.FC = () => {
 	const ref = useRef<HTMLDivElement>(null);
 	const timelineWidth = useContext(TimelineWidthContext);
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
-	const {canvasContent} = useContext(Internals.CompositionManager);
 
 	if (timelineWidth === null) {
 		throw new Error('Unexpectedly did not have timeline width');
 	}
 
-	const zoomLevel =
-		canvasContent?.type === 'composition'
-			? (zoomMap[canvasContent.compositionId] ?? null)
-			: null;
+	const zoomLevel = zoomMap[videoConfig.id] ?? null;
 
 	useLayoutEffect(() => {
 		const el = ref.current;

--- a/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
+++ b/packages/studio/src/components/Timeline/TimelineWidthProvider.tsx
@@ -21,7 +21,6 @@ export const TimelineWidthProvider: React.FC<{
 		shouldApplyCssTransforms: true,
 	});
 	const {zoom: zoomMap} = useContext(TimelineZoomCtx);
-	const {canvasContent} = useContext(Internals.CompositionManager);
 	const videoConfig = Internals.useUnsafeVideoConfig();
 
 	const width = useMemo(() => {
@@ -34,14 +33,11 @@ export const TimelineWidthProvider: React.FC<{
 		const zoom = getTimelineZoom({
 			durationInFrames,
 			timelineViewportWidth: scrollableWidth,
-			zoom:
-				canvasContent?.type === 'composition'
-					? (zoomMap[canvasContent.compositionId] ?? null)
-					: null,
+			zoom: videoConfig ? (zoomMap[videoConfig.id] ?? null) : null,
 		});
 
 		return getTimelineWidth({durationInFrames, zoom});
-	}, [canvasContent, size?.width, videoConfig?.durationInFrames, zoomMap]);
+	}, [size?.width, videoConfig, zoomMap]);
 
 	return (
 		<TimelineWidthContext.Provider value={width}>

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -9,7 +9,7 @@ import {
 	TIMELINE_ZOOM_SLIDER_PROPS,
 	timelineZoomToSliderValue,
 } from '../../helpers/get-timeline-max-zoom';
-import {useIsStill} from '../../helpers/is-current-selected-still';
+import {useIsVideoComposition} from '../../helpers/is-current-selected-still';
 import {CanvasZoomIcon, CanvasZoomOutIcon} from '../../icons/canvas-zoom';
 import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
@@ -35,20 +35,19 @@ const TimelineZoomSlider: React.FC<{
 	readonly minZoom: number;
 	readonly timelineViewportWidth: number;
 }> = ({maxWidth, minZoom, timelineViewportWidth}) => {
-	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom, zoom: zoomMap} = useContext(TimelineZoomCtx);
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const {tabIndex} = useZIndex();
-	const isStill = useIsStill();
+	const isVideoComposition = useIsVideoComposition();
 
 	const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
 		(e) => {
-			if (canvasContent === null || canvasContent.type !== 'composition') {
+			if (videoConfig === null) {
 				return;
 			}
 
 			setZoom(
-				canvasContent.compositionId,
+				videoConfig.id,
 				() =>
 					sliderValueToTimelineZoom({
 						sliderValue: Number(e.target.value),
@@ -60,21 +59,17 @@ const TimelineZoomSlider: React.FC<{
 				},
 			);
 		},
-		[canvasContent, minZoom, setZoom],
+		[minZoom, setZoom, videoConfig],
 	);
 
-	if (
-		isStill ||
-		canvasContent === null ||
-		canvasContent.type !== 'composition'
-	) {
+	if (!isVideoComposition || videoConfig === null) {
 		return null;
 	}
 
 	const zoom = getTimelineZoom({
 		durationInFrames: videoConfig?.durationInFrames ?? 1,
 		timelineViewportWidth,
-		zoom: zoomMap[canvasContent.compositionId] ?? null,
+		zoom: zoomMap[videoConfig.id] ?? null,
 	});
 	const roundedZoom = Math.round(zoom * 100) / 100;
 
@@ -98,7 +93,6 @@ const TimelineZoomSlider: React.FC<{
 const TimelineZoomControlsInner: React.FC<{
 	readonly sliderMaxWidth?: number;
 }> = ({sliderMaxWidth}) => {
-	const {canvasContent} = useContext(Internals.CompositionManager);
 	const {setZoom} = useContext(TimelineZoomCtx);
 	const videoConfig = Internals.useUnsafeVideoConfig();
 	const timelineSize = PlayerInternals.useElementSize(scrollableRef, {
@@ -113,36 +107,30 @@ const TimelineZoomControlsInner: React.FC<{
 	});
 
 	const onMinusClicked = useCallback(() => {
-		if (canvasContent === null || canvasContent.type !== 'composition') {
+		if (videoConfig === null) {
 			return;
 		}
 
-		setZoom(
-			canvasContent.compositionId,
-			(z) => z / TIMELINE_ZOOM_BUTTON_FACTOR,
-			{anchorFrame: null, anchorContentX: null},
-		);
-	}, [canvasContent, setZoom]);
+		setZoom(videoConfig.id, (z) => z / TIMELINE_ZOOM_BUTTON_FACTOR, {
+			anchorFrame: null,
+			anchorContentX: null,
+		});
+	}, [setZoom, videoConfig]);
 
 	const onPlusClicked = useCallback(() => {
-		if (canvasContent === null || canvasContent.type !== 'composition') {
+		if (videoConfig === null) {
 			return;
 		}
 
-		setZoom(
-			canvasContent.compositionId,
-			(z) => z * TIMELINE_ZOOM_BUTTON_FACTOR,
-			{anchorFrame: null, anchorContentX: null},
-		);
-	}, [canvasContent, setZoom]);
+		setZoom(videoConfig.id, (z) => z * TIMELINE_ZOOM_BUTTON_FACTOR, {
+			anchorFrame: null,
+			anchorContentX: null,
+		});
+	}, [setZoom, videoConfig]);
 
-	const isStill = useIsStill();
+	const isVideoComposition = useIsVideoComposition();
 
-	if (
-		isStill ||
-		canvasContent === null ||
-		canvasContent.type !== 'composition'
-	) {
+	if (!isVideoComposition || videoConfig === null) {
 		return null;
 	}
 

--- a/packages/studio/src/components/ZoomPersistor.tsx
+++ b/packages/studio/src/components/ZoomPersistor.tsx
@@ -26,10 +26,13 @@ export const ZoomPersistor: React.FC = () => {
 
 	const isActive =
 		urlState &&
-		urlState.type === 'composition' &&
 		canvasContent &&
-		canvasContent.type === 'composition' &&
-		urlState.compositionId === canvasContent.compositionId;
+		((urlState.type === 'composition' &&
+			canvasContent.type === 'composition' &&
+			urlState.compositionId === canvasContent.compositionId) ||
+			(urlState.type === 'asset' &&
+				canvasContent.type === 'asset' &&
+				urlState.asset === canvasContent.asset));
 
 	useEffect(() => {
 		if (!isActive) {

--- a/packages/studio/src/state/timeline-zoom.tsx
+++ b/packages/studio/src/state/timeline-zoom.tsx
@@ -20,7 +20,7 @@ export type TimelineSetZoomOptions = {
 export const TimelineZoomCtx = createContext<{
 	zoom: Record<string, number>;
 	setZoom: (
-		compositionId: string,
+		videoId: string,
 		prev: (prevZoom: number) => number,
 		options?: TimelineSetZoomOptions,
 	) => void;
@@ -40,7 +40,7 @@ export const TimelineZoomContext: React.FC<{
 
 	const setZoom = useCallback(
 		(
-			compositionId: string,
+			videoId: string,
 			callback: (prevZoomLevel: number) => number,
 			options?: TimelineSetZoomOptions,
 		) => {
@@ -59,7 +59,7 @@ export const TimelineZoomContext: React.FC<{
 					const previousZoom = getTimelineZoom({
 						durationInFrames,
 						timelineViewportWidth,
-						zoom: prevZoomMap[compositionId] ?? null,
+						zoom: prevZoomMap[videoId] ?? null,
 					});
 					const newZoom = clampTimelineZoom({
 						zoom: callback(previousZoom),
@@ -67,7 +67,7 @@ export const TimelineZoomContext: React.FC<{
 						timelineViewportWidth,
 					});
 
-					return {...prevZoomMap, [compositionId]: newZoom};
+					return {...prevZoomMap, [videoId]: newZoom};
 				});
 			});
 


### PR DESCRIPTION
## Summary

- show timeline zoom controls for playable asset previews
- use the active video ID consistently for timeline width, playhead, wheel/pinch gestures, and persisted zoom
- extend the media asset Playwright workflow to verify an audio timeline grows when zoomed

## Testing

- `bunx turbo run lint test --filter='@remotion/studio'`
- `bunx playwright test e2e/studio.test.mts --grep 'should preview media assets as a non-interactive timeline'`
- `bun run build`
- `bun run stylecheck`

Closes https://github.com/remotion-dev/remotion/issues/11112
