### PR TITLE
`@remotion/studio`: Fix timeline layer double-clicks

### DIFF
--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -118,48 +118,14 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 		const movableLayer = page.locator(
 			'[data-timeline-marquee-item][title="Natural end"]',
 		);
-		await movableLayer.dispatchEvent('pointerdown', {
-			button: 2,
-			buttons: 2,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('pointerup', {
-			button: 2,
-			buttons: 0,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('click', {button: 0, detail: 2});
-		await movableLayer.dispatchEvent('dblclick', {button: 0, detail: 2});
-		await page.waitForTimeout(100);
+		await movableLayer.click({button: 'right', position: {x: 30, y: 10}});
+		const contextMenu = page.locator('[data-remotion-menu-tree-id]').last();
+		await expect(contextMenu).toBeVisible();
+		await movableLayer.click({position: {x: 30, y: 10}});
+		await expect(contextMenu).not.toBeVisible();
 		expect(openInEditorRequests).toHaveLength(0);
-
-		await movableLayer.dispatchEvent('pointerdown', {
-			button: 0,
-			buttons: 1,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('pointerup', {
-			button: 0,
-			buttons: 0,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('click', {button: 0, detail: 3});
-		expect(openInEditorRequests).toHaveLength(0);
-		await movableLayer.dispatchEvent('pointerdown', {
-			button: 0,
-			buttons: 1,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('pointerup', {
-			button: 0,
-			buttons: 0,
-			pointerId: 1,
-		});
-		await movableLayer.dispatchEvent('click', {button: 0, detail: 4});
-		await expect.poll(() => openInEditorRequests.length).toBe(1);
-
 		await movableLayer.dblclick({position: {x: 30, y: 10}});
-		await expect.poll(() => openInEditorRequests.length).toBe(2);
+		await expect.poll(() => openInEditorRequests.length).toBe(1);
 
 		const rightEdgeLayer = page.locator(
 			'[data-timeline-marquee-item][title="Explicit fill cutoff"]',

--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -9,6 +9,23 @@ test('handles timeline layer edge geometry and interactions', async ({
 	await startStudio();
 	try {
 		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/default-editor-info', async (route) => {
+			await route.fulfill({
+				json: {
+					success: true,
+					data: {
+						defaultEditor: 'vscode',
+						installedEditors: [
+							{
+								id: 'vscode',
+								name: 'Code',
+								nameWithType: 'VS Code',
+							},
+						],
+					},
+				},
+			});
+		});
 		await page.route('**/api/open-in-editor', async (route) => {
 			openInEditorRequests.push(route.request().postDataJSON());
 			await route.fulfill({json: {success: true, data: {success: true}}});

--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -118,6 +118,30 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 		const movableLayer = page.locator(
 			'[data-timeline-marquee-item][title="Natural end"]',
 		);
+		await movableLayer.dispatchEvent('pointerdown', {
+			button: 2,
+			buttons: 2,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('pointerup', {
+			button: 2,
+			buttons: 0,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('pointerdown', {
+			button: 0,
+			buttons: 1,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('pointerup', {
+			button: 0,
+			buttons: 0,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('dblclick', {button: 0, detail: 2});
+		await page.waitForTimeout(100);
+		expect(openInEditorRequests).toHaveLength(0);
+
 		await movableLayer.dblclick({position: {x: 30, y: 10}});
 		await expect.poll(() => openInEditorRequests.length).toBe(1);
 

--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import {expect, test} from '@playwright/test';
+import fs from 'fs';
 import {rootFile, STUDIO_URL} from './constants.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
@@ -128,6 +128,7 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 			buttons: 0,
 			pointerId: 1,
 		});
+		await movableLayer.dispatchEvent('click', {button: 0, detail: 2});
 		await movableLayer.dispatchEvent('dblclick', {button: 0, detail: 2});
 		await page.waitForTimeout(100);
 		expect(openInEditorRequests).toHaveLength(0);

--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -128,6 +128,10 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 			buttons: 0,
 			pointerId: 1,
 		});
+		await movableLayer.dispatchEvent('dblclick', {button: 0, detail: 2});
+		await page.waitForTimeout(100);
+		expect(openInEditorRequests).toHaveLength(0);
+
 		await movableLayer.dispatchEvent('pointerdown', {
 			button: 0,
 			buttons: 1,
@@ -138,12 +142,23 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 			buttons: 0,
 			pointerId: 1,
 		});
-		await movableLayer.dispatchEvent('dblclick', {button: 0, detail: 2});
-		await page.waitForTimeout(100);
+		await movableLayer.dispatchEvent('click', {button: 0, detail: 3});
 		expect(openInEditorRequests).toHaveLength(0);
+		await movableLayer.dispatchEvent('pointerdown', {
+			button: 0,
+			buttons: 1,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('pointerup', {
+			button: 0,
+			buttons: 0,
+			pointerId: 1,
+		});
+		await movableLayer.dispatchEvent('click', {button: 0, detail: 4});
+		await expect.poll(() => openInEditorRequests.length).toBe(1);
 
 		await movableLayer.dblclick({position: {x: 30, y: 10}});
-		await expect.poll(() => openInEditorRequests.length).toBe(1);
+		await expect.poll(() => openInEditorRequests.length).toBe(2);
 
 		const rightEdgeLayer = page.locator(
 			'[data-timeline-marquee-item][title="Explicit fill cutoff"]',

--- a/packages/example/e2e/timeline-right-edge.test.mts
+++ b/packages/example/e2e/timeline-right-edge.test.mts
@@ -3,11 +3,16 @@ import {expect, test} from '@playwright/test';
 import {rootFile, STUDIO_URL} from './constants.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
-test('rounds inherited endings and squares explicit cutoffs', async ({
+test('handles timeline layer edge geometry and interactions', async ({
 	page,
 }) => {
 	await startStudio();
 	try {
+		const openInEditorRequests: unknown[] = [];
+		await page.route('**/api/open-in-editor', async (route) => {
+			openInEditorRequests.push(route.request().postDataJSON());
+			await route.fulfill({json: {success: true, data: {success: true}}});
+		});
 		fs.writeFileSync(
 			rootFile,
 			`
@@ -109,6 +114,12 @@ export const E2eTestRoot = () => <Composition id="timeline-edges" component={Lay
 			await expect(layer).toHaveCSS('border-top-left-radius', radius);
 			await expect(layer).toHaveCSS('border-bottom-left-radius', radius);
 		}
+
+		const movableLayer = page.locator(
+			'[data-timeline-marquee-item][title="Natural end"]',
+		);
+		await movableLayer.dblclick({position: {x: 30, y: 10}});
+		await expect.poll(() => openInEditorRequests.length).toBe(1);
 
 		const rightEdgeLayer = page.locator(
 			'[data-timeline-marquee-item][title="Explicit fill cutoff"]',

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -515,7 +515,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	);
 	const onClick = React.useCallback(
 		(event: React.MouseEvent<SVGPolygonElement>) => {
-			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(event.detail)) {
+			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(event)) {
 				return;
 			}
 

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -515,17 +515,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 	);
 	const onClick = React.useCallback(
 		(event: React.MouseEvent<SVGPolygonElement>) => {
-			if (!dragAwareDoubleClick.recoverDoubleClick(event.detail)) {
-				return;
-			}
-
-			performDoubleClick(event);
-		},
-		[dragAwareDoubleClick, performDoubleClick],
-	);
-	const onDoubleClick = React.useCallback(
-		(event: React.MouseEvent<SVGPolygonElement>) => {
-			if (!dragAwareDoubleClick.acceptDoubleClick()) {
+			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(event.detail)) {
 				return;
 			}
 
@@ -631,7 +621,6 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			onPointerDown={onPointerDown}
 			onPointerDownCapture={dragAwareDoubleClick.beginPointerGesture}
 			onClick={onClick}
-			onDoubleClick={onDoubleClick}
 			onDragOver={onEffectDragOver}
 			onDragLeave={onEffectDragLeave}
 			onDrop={onEffectDrop}

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -491,12 +491,8 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 		],
 	);
 
-	const onDoubleClick = React.useCallback(
+	const performDoubleClick = React.useCallback(
 		(event: React.MouseEvent<SVGPolygonElement>) => {
-			if (!dragAwareDoubleClick.doubleClickWasPrimary()) {
-				return;
-			}
-
 			const target = getTarget();
 			if (target === undefined) {
 				return;
@@ -516,6 +512,26 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			event.stopPropagation();
 		},
 		[dragAwareDoubleClick, getTarget, onDoubleClickTarget],
+	);
+	const onClick = React.useCallback(
+		(event: React.MouseEvent<SVGPolygonElement>) => {
+			if (!dragAwareDoubleClick.recoverDoubleClick(event.detail)) {
+				return;
+			}
+
+			performDoubleClick(event);
+		},
+		[dragAwareDoubleClick, performDoubleClick],
+	);
+	const onDoubleClick = React.useCallback(
+		(event: React.MouseEvent<SVGPolygonElement>) => {
+			if (!dragAwareDoubleClick.acceptDoubleClick()) {
+				return;
+			}
+
+			performDoubleClick(event);
+		},
+		[dragAwareDoubleClick, performDoubleClick],
 	);
 
 	const onEffectDragOver = React.useCallback(
@@ -614,6 +630,7 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 			}}
 			onPointerDown={onPointerDown}
 			onPointerDownCapture={dragAwareDoubleClick.beginPointerGesture}
+			onClick={onClick}
 			onDoubleClick={onDoubleClick}
 			onDragOver={onEffectDragOver}
 			onDragLeave={onEffectDragLeave}

--- a/packages/studio/src/components/SelectedOutlinePolygon.tsx
+++ b/packages/studio/src/components/SelectedOutlinePolygon.tsx
@@ -493,6 +493,10 @@ const SelectedOutlinePolygonUnmemoized: React.FC<{
 
 	const onDoubleClick = React.useCallback(
 		(event: React.MouseEvent<SVGPolygonElement>) => {
+			if (!dragAwareDoubleClick.doubleClickWasPrimary()) {
+				return;
+			}
+
 			const target = getTarget();
 			if (target === undefined) {
 				return;

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -148,12 +148,8 @@ export const TimelineRowChrome: React.FC<{
 		[onSelect, selected],
 	);
 
-	const onDoubleClickIfNotInteractive = useCallback(
+	const performDoubleClickIfNotInteractive = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!doubleClickTracker.doubleClickWasPrimary()) {
-				return;
-			}
-
 			const {target} = e;
 			if (
 				target instanceof Element &&
@@ -169,7 +165,27 @@ export const TimelineRowChrome: React.FC<{
 
 			onDoubleClick?.(e);
 		},
-		[doubleClickTracker, onDoubleClick],
+		[onDoubleClick],
+	);
+	const onClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!doubleClickTracker.recoverDoubleClick(e.detail)) {
+				return;
+			}
+
+			performDoubleClickIfNotInteractive(e);
+		},
+		[doubleClickTracker, performDoubleClickIfNotInteractive],
+	);
+	const onDoubleClickIfNotInteractive = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!doubleClickTracker.acceptDoubleClick()) {
+				return;
+			}
+
+			performDoubleClickIfNotInteractive(e);
+		},
+		[doubleClickTracker, performDoubleClickIfNotInteractive],
 	);
 
 	const highlightBackground = getTimelineRowHighlightBackground({
@@ -240,6 +256,7 @@ export const TimelineRowChrome: React.FC<{
 				onDrop={onDrop}
 				onPointerDownCapture={doubleClickTracker.beginPointerGesture}
 				onPointerDown={selectable ? onPointerDown : undefined}
+				onClick={onClick}
 				onContextMenu={selectable ? onContextMenu : undefined}
 				onDoubleClick={onDoubleClickIfNotInteractive}
 				onPointerEnter={onPointerEnter}
@@ -257,6 +274,7 @@ export const TimelineRowChrome: React.FC<{
 			onDrop={onDrop}
 			onPointerDownCapture={doubleClickTracker.beginPointerGesture}
 			onPointerDown={selectable ? onPointerDown : undefined}
+			onClick={onClick}
 			onContextMenu={selectable ? onContextMenu : undefined}
 			onDoubleClick={onDoubleClickIfNotInteractive}
 			onPointerEnter={onPointerEnter}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useContext, useMemo} from 'react';
 import {TIMELINE_TRACK_SEPARATOR} from '../../helpers/colors';
+import {createDragAwareDoubleClickTracker} from '../../helpers/drag-aware-double-click';
 import {Padder} from './Padder';
 import {
 	getTimelineRowIndentWidth,
@@ -107,6 +108,10 @@ export const TimelineRowChrome: React.FC<{
 		TimelineRowLayoutContext,
 	);
 	const selectedBackground = useContext(TimelineRowSelectedBackgroundContext);
+	const doubleClickTracker = useMemo(
+		() => createDragAwareDoubleClickTracker(),
+		[],
+	);
 	const indentWidth = getTimelineRowIndentWidth(depth);
 
 	const chromeColumnStyle = useMemo(
@@ -145,6 +150,10 @@ export const TimelineRowChrome: React.FC<{
 
 	const onDoubleClickIfNotInteractive = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!doubleClickTracker.doubleClickWasPrimary()) {
+				return;
+			}
+
 			const {target} = e;
 			if (
 				target instanceof Element &&
@@ -160,7 +169,7 @@ export const TimelineRowChrome: React.FC<{
 
 			onDoubleClick?.(e);
 		},
-		[onDoubleClick],
+		[doubleClickTracker, onDoubleClick],
 	);
 
 	const highlightBackground = getTimelineRowHighlightBackground({
@@ -229,6 +238,7 @@ export const TimelineRowChrome: React.FC<{
 				onDragLeave={onDragLeave}
 				onDragOver={onDragOver}
 				onDrop={onDrop}
+				onPointerDownCapture={doubleClickTracker.beginPointerGesture}
 				onPointerDown={selectable ? onPointerDown : undefined}
 				onContextMenu={selectable ? onContextMenu : undefined}
 				onDoubleClick={onDoubleClickIfNotInteractive}
@@ -245,6 +255,7 @@ export const TimelineRowChrome: React.FC<{
 			onDragLeave={onDragLeave}
 			onDragOver={onDragOver}
 			onDrop={onDrop}
+			onPointerDownCapture={doubleClickTracker.beginPointerGesture}
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onContextMenu={selectable ? onContextMenu : undefined}
 			onDoubleClick={onDoubleClickIfNotInteractive}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -169,17 +169,7 @@ export const TimelineRowChrome: React.FC<{
 	);
 	const onClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!doubleClickTracker.recoverDoubleClick(e.detail)) {
-				return;
-			}
-
-			performDoubleClickIfNotInteractive(e);
-		},
-		[doubleClickTracker, performDoubleClickIfNotInteractive],
-	);
-	const onDoubleClickIfNotInteractive = useCallback(
-		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!doubleClickTracker.acceptDoubleClick()) {
+			if (!doubleClickTracker.acceptClickAsDoubleClick(e.detail)) {
 				return;
 			}
 
@@ -258,7 +248,6 @@ export const TimelineRowChrome: React.FC<{
 				onPointerDown={selectable ? onPointerDown : undefined}
 				onClick={onClick}
 				onContextMenu={selectable ? onContextMenu : undefined}
-				onDoubleClick={onDoubleClickIfNotInteractive}
 				onPointerEnter={onPointerEnter}
 				onPointerLeave={onPointerLeave}
 			>
@@ -276,7 +265,6 @@ export const TimelineRowChrome: React.FC<{
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onClick={onClick}
 			onContextMenu={selectable ? onContextMenu : undefined}
-			onDoubleClick={onDoubleClickIfNotInteractive}
 			onPointerEnter={onPointerEnter}
 			onPointerLeave={onPointerLeave}
 			style={innerRowStyle}

--- a/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
+++ b/packages/studio/src/components/Timeline/TimelineRowChrome.tsx
@@ -169,7 +169,7 @@ export const TimelineRowChrome: React.FC<{
 	);
 	const onClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!doubleClickTracker.acceptClickAsDoubleClick(e.detail)) {
+			if (!doubleClickTracker.acceptClickAsDoubleClick(e)) {
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -581,7 +581,7 @@ const TimelineSequenceInner: React.FC<{
 	);
 	const onSequenceClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(e.detail)) {
+			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(e)) {
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -8,8 +8,8 @@ import {Internals, useCurrentFrame} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {
 	BLUE,
-	TIMELINE_BACKGROUND_COLOR,
 	TIMELINE_AUDIO_GRADIENT,
+	TIMELINE_BACKGROUND_COLOR,
 	TIMELINE_NEGATIVE_START_BACKGROUND_COLOR,
 	TIMELINE_NEGATIVE_START_BORDER_COLOR,
 	TIMELINE_VIDEO_GRADIENT,
@@ -192,7 +192,6 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	) => void;
 	readonly onPointerDownCapture: React.PointerEventHandler<HTMLDivElement>;
 	readonly onClick: React.MouseEventHandler<HTMLDivElement> | null;
-	readonly onDoubleClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }> = ({
 	s,
 	displayDurationInFrames,
@@ -211,7 +210,6 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	onMoveDragPointerDown,
 	onPointerDownCapture,
 	onClick,
-	onDoubleClick,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const {onSelect, selectable, selected, selectionItem} =
@@ -347,7 +345,6 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			onPointerDownCapture={onPointerDownCapture}
 			onPointerDown={selectable ? onPointerDown : undefined}
 			onClick={onClick ?? undefined}
-			onDoubleClick={onDoubleClick}
 		>
 			{negativeStart ? (
 				<>
@@ -584,17 +581,7 @@ const TimelineSequenceInner: React.FC<{
 	);
 	const onSequenceClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!dragAwareDoubleClick.recoverDoubleClick(e.detail)) {
-				return;
-			}
-
-			performSequenceDoubleClick(e);
-		},
-		[dragAwareDoubleClick, performSequenceDoubleClick],
-	);
-	const onSequenceDoubleClick = useCallback(
-		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!dragAwareDoubleClick.acceptDoubleClick()) {
+			if (!dragAwareDoubleClick.acceptClickAsDoubleClick(e.detail)) {
 				return;
 			}
 
@@ -1025,9 +1012,6 @@ const TimelineSequenceInner: React.FC<{
 						/>
 					) : null}
 				</>
-			}
-			onDoubleClick={
-				canHandleSequenceDoubleClick ? onSequenceDoubleClick : undefined
 			}
 		>
 			{s.type === 'audio' && visibleLayout.media ? (

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -191,6 +191,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 		e: React.PointerEvent<HTMLDivElement>,
 	) => void;
 	readonly onPointerDownCapture: React.PointerEventHandler<HTMLDivElement>;
+	readonly onClick: React.MouseEventHandler<HTMLDivElement> | null;
 	readonly onDoubleClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }> = ({
 	s,
@@ -209,6 +210,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	frozenFrame,
 	onMoveDragPointerDown,
 	onPointerDownCapture,
+	onClick,
 	onDoubleClick,
 }) => {
 	const ref = useRef<HTMLDivElement>(null);
@@ -344,6 +346,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			title={s.displayName}
 			onPointerDownCapture={onPointerDownCapture}
 			onPointerDown={selectable ? onPointerDown : undefined}
+			onClick={onClick ?? undefined}
 			onDoubleClick={onDoubleClick}
 		>
 			{negativeStart ? (
@@ -534,13 +537,10 @@ const TimelineSequenceInner: React.FC<{
 			item.type === 'sequence' ? [item.nodePathInfo] : [],
 		);
 	}, [selected, selectedItems]);
-	const onSequenceDoubleClick = useCallback(
+	const performSequenceDoubleClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (isTimelineSelectionModifierEvent(e)) {
 				e.stopPropagation();
-				return;
-			}
-			if (!dragAwareDoubleClick.doubleClickWasPrimary()) {
 				return;
 			}
 
@@ -581,6 +581,26 @@ const TimelineSequenceInner: React.FC<{
 			selectComposition,
 			sequenceFrameOffset,
 		],
+	);
+	const onSequenceClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!dragAwareDoubleClick.recoverDoubleClick(e.detail)) {
+				return;
+			}
+
+			performSequenceDoubleClick(e);
+		},
+		[dragAwareDoubleClick, performSequenceDoubleClick],
+	);
+	const onSequenceDoubleClick = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			if (!dragAwareDoubleClick.acceptDoubleClick()) {
+				return;
+			}
+
+			performSequenceDoubleClick(e);
+		},
+		[dragAwareDoubleClick, performSequenceDoubleClick],
 	);
 	const canHandleSequenceDoubleClick =
 		connectedCompositions.length === 1 || canOpenInEditor;
@@ -974,6 +994,7 @@ const TimelineSequenceInner: React.FC<{
 			frozenFrame={frozenFrame}
 			onMoveDragPointerDown={onMoveDragPointerDown}
 			onPointerDownCapture={dragAwareDoubleClick.beginPointerGesture}
+			onClick={canHandleSequenceDoubleClick ? onSequenceClick : null}
 			edgeDragHandles={
 				<>
 					{showLeftEdgeDragHandle &&

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -190,7 +190,7 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	readonly onMoveDragPointerDown: (
 		e: React.PointerEvent<HTMLDivElement>,
 	) => void;
-	readonly onPointerDownCapture: () => void;
+	readonly onPointerDownCapture: React.PointerEventHandler<HTMLDivElement>;
 	readonly onDoubleClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }> = ({
 	s,
@@ -538,6 +538,9 @@ const TimelineSequenceInner: React.FC<{
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (isTimelineSelectionModifierEvent(e)) {
 				e.stopPropagation();
+				return;
+			}
+			if (!dragAwareDoubleClick.doubleClickWasPrimary()) {
 				return;
 			}
 

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -19,7 +19,10 @@ import {calculateTimeline} from '../../helpers/calculate-timeline';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {TRANSPARENT} from '../../helpers/colors';
 import type {SequenceNodePathInfo} from '../../helpers/get-timeline-sequence-sort-key';
-import {startCapturedPointerSession} from '../../helpers/pointer-session';
+import {
+	startCapturedPointerSession,
+	startDeferredCapturedPointerSession,
+} from '../../helpers/pointer-session';
 import {TIMELINE_PADDING} from '../../helpers/timeline-layout';
 import {EditorSnappingContext} from '../../state/editor-snapping';
 import {
@@ -1620,12 +1623,10 @@ export const useTimelineSequenceFromDrag = ({
 			document.body.style.webkitUserSelect = 'none';
 			// Register before React commits so no pointer move can arrive before
 			// the global session listeners exist.
-			stopPointerSessionRef.current = startCapturedPointerSession({
+			stopPointerSessionRef.current = startDeferredCapturedPointerSession({
 				event: e.nativeEvent,
-				// The bar is removed when it leaves the visible timeline. Capture on
-				// a stable element so the move continues until the pointer is released.
 				captureTarget: e.currentTarget.ownerDocument.body,
-				onMove: (moveEvent) => {
+				onMove: (moveEvent, capturePointer) => {
 					const dragState = dragStateRef.current;
 					if (!dragState) {
 						return;
@@ -1641,6 +1642,10 @@ export const useTimelineSequenceFromDrag = ({
 					});
 					dragState.latestDeltaFrames = deltaFrames;
 					if (deltaFrames !== 0) {
+						// The bar can be removed when it leaves the visible timeline.
+						// Capture only after a real drag starts so clicks and double-clicks
+						// remain targeted at the bar.
+						capturePointer();
 						dragState.didMove = true;
 					}
 

--- a/packages/studio/src/helpers/drag-aware-double-click.ts
+++ b/packages/studio/src/helpers/drag-aware-double-click.ts
@@ -1,16 +1,21 @@
 export type DragAwareDoubleClickTracker = {
-	readonly beginPointerGesture: () => void;
+	readonly beginPointerGesture: (event: Pick<PointerEvent, 'button'>) => void;
 	readonly endPointerGesture: (wasDragged: boolean) => void;
 	readonly consumePointerGestureWasDragged: () => boolean;
+	readonly doubleClickWasPrimary: () => boolean;
 };
 
 export const createDragAwareDoubleClickTracker =
 	(): DragAwareDoubleClickTracker => {
 		let pointerGestureWasDragged = false;
+		let previousPointerButton: number | null = null;
+		let currentPointerButton: number | null = null;
 
 		return {
-			beginPointerGesture: () => {
+			beginPointerGesture: (event) => {
 				pointerGestureWasDragged = false;
+				previousPointerButton = currentPointerButton;
+				currentPointerButton = event.button;
 			},
 			endPointerGesture: (wasDragged) => {
 				pointerGestureWasDragged = wasDragged;
@@ -19,6 +24,9 @@ export const createDragAwareDoubleClickTracker =
 				const wasDragged = pointerGestureWasDragged;
 				pointerGestureWasDragged = false;
 				return wasDragged;
+			},
+			doubleClickWasPrimary: () => {
+				return previousPointerButton === 0 && currentPointerButton === 0;
 			},
 		};
 	};

--- a/packages/studio/src/helpers/drag-aware-double-click.ts
+++ b/packages/studio/src/helpers/drag-aware-double-click.ts
@@ -2,8 +2,7 @@ export type DragAwareDoubleClickTracker = {
 	readonly beginPointerGesture: (event: Pick<PointerEvent, 'button'>) => void;
 	readonly endPointerGesture: (wasDragged: boolean) => void;
 	readonly consumePointerGestureWasDragged: () => boolean;
-	readonly acceptDoubleClick: () => boolean;
-	readonly recoverDoubleClick: (clickCount: number) => boolean;
+	readonly acceptClickAsDoubleClick: (clickCount: number) => boolean;
 };
 
 export const createDragAwareDoubleClickTracker =
@@ -11,7 +10,6 @@ export const createDragAwareDoubleClickTracker =
 		let pointerGestureWasDragged = false;
 		let previousPointerButton: number | null = null;
 		let currentPointerButton: number | null = null;
-		let mixedButtonDoubleClickWasRejected = false;
 
 		return {
 			beginPointerGesture: (event) => {
@@ -27,28 +25,13 @@ export const createDragAwareDoubleClickTracker =
 				pointerGestureWasDragged = false;
 				return wasDragged;
 			},
-			acceptDoubleClick: () => {
-				const isPrimary =
-					previousPointerButton === 0 && currentPointerButton === 0;
-				mixedButtonDoubleClickWasRejected = !isPrimary;
-				return isPrimary;
-			},
-			recoverDoubleClick: (clickCount) => {
-				if (clickCount < 3) {
-					mixedButtonDoubleClickWasRejected = false;
-					return false;
-				}
-
-				if (
-					!mixedButtonDoubleClickWasRejected ||
-					previousPointerButton !== 0 ||
-					currentPointerButton !== 0
-				) {
-					return false;
-				}
-
-				mixedButtonDoubleClickWasRejected = false;
-				return true;
+			acceptClickAsDoubleClick: (clickCount) => {
+				return (
+					clickCount > 0 &&
+					clickCount % 2 === 0 &&
+					previousPointerButton === 0 &&
+					currentPointerButton === 0
+				);
 			},
 		};
 	};

--- a/packages/studio/src/helpers/drag-aware-double-click.ts
+++ b/packages/studio/src/helpers/drag-aware-double-click.ts
@@ -2,7 +2,8 @@ export type DragAwareDoubleClickTracker = {
 	readonly beginPointerGesture: (event: Pick<PointerEvent, 'button'>) => void;
 	readonly endPointerGesture: (wasDragged: boolean) => void;
 	readonly consumePointerGestureWasDragged: () => boolean;
-	readonly doubleClickWasPrimary: () => boolean;
+	readonly acceptDoubleClick: () => boolean;
+	readonly recoverDoubleClick: (clickCount: number) => boolean;
 };
 
 export const createDragAwareDoubleClickTracker =
@@ -10,6 +11,7 @@ export const createDragAwareDoubleClickTracker =
 		let pointerGestureWasDragged = false;
 		let previousPointerButton: number | null = null;
 		let currentPointerButton: number | null = null;
+		let mixedButtonDoubleClickWasRejected = false;
 
 		return {
 			beginPointerGesture: (event) => {
@@ -25,8 +27,28 @@ export const createDragAwareDoubleClickTracker =
 				pointerGestureWasDragged = false;
 				return wasDragged;
 			},
-			doubleClickWasPrimary: () => {
-				return previousPointerButton === 0 && currentPointerButton === 0;
+			acceptDoubleClick: () => {
+				const isPrimary =
+					previousPointerButton === 0 && currentPointerButton === 0;
+				mixedButtonDoubleClickWasRejected = !isPrimary;
+				return isPrimary;
+			},
+			recoverDoubleClick: (clickCount) => {
+				if (clickCount < 3) {
+					mixedButtonDoubleClickWasRejected = false;
+					return false;
+				}
+
+				if (
+					!mixedButtonDoubleClickWasRejected ||
+					previousPointerButton !== 0 ||
+					currentPointerButton !== 0
+				) {
+					return false;
+				}
+
+				mixedButtonDoubleClickWasRejected = false;
+				return true;
 			},
 		};
 	};

--- a/packages/studio/src/helpers/drag-aware-double-click.ts
+++ b/packages/studio/src/helpers/drag-aware-double-click.ts
@@ -2,7 +2,9 @@ export type DragAwareDoubleClickTracker = {
 	readonly beginPointerGesture: (event: Pick<PointerEvent, 'button'>) => void;
 	readonly endPointerGesture: (wasDragged: boolean) => void;
 	readonly consumePointerGestureWasDragged: () => boolean;
-	readonly acceptClickAsDoubleClick: (clickCount: number) => boolean;
+	readonly acceptClickAsDoubleClick: (
+		event: Pick<MouseEvent, 'button' | 'detail'>,
+	) => boolean;
 };
 
 export const createDragAwareDoubleClickTracker =
@@ -25,12 +27,13 @@ export const createDragAwareDoubleClickTracker =
 				pointerGestureWasDragged = false;
 				return wasDragged;
 			},
-			acceptClickAsDoubleClick: (clickCount) => {
+			acceptClickAsDoubleClick: (event) => {
 				return (
-					clickCount > 0 &&
-					clickCount % 2 === 0 &&
-					currentPointerButton === 0 &&
-					(clickCount > 2 || previousPointerButton === 0)
+					event.button === 0 &&
+					event.detail > 0 &&
+					event.detail % 2 === 0 &&
+					(event.detail > 2 ||
+						(previousPointerButton === 0 && currentPointerButton === 0))
 				);
 			},
 		};

--- a/packages/studio/src/helpers/drag-aware-double-click.ts
+++ b/packages/studio/src/helpers/drag-aware-double-click.ts
@@ -29,8 +29,8 @@ export const createDragAwareDoubleClickTracker =
 				return (
 					clickCount > 0 &&
 					clickCount % 2 === 0 &&
-					previousPointerButton === 0 &&
-					currentPointerButton === 0
+					currentPointerButton === 0 &&
+					(clickCount > 2 || previousPointerButton === 0)
 				);
 			},
 		};

--- a/packages/studio/src/helpers/pointer-session.ts
+++ b/packages/studio/src/helpers/pointer-session.ts
@@ -33,12 +33,31 @@ const startPointerSession = ({
 }: {
 	event: PointerSessionEvent;
 	captureTarget: Element | null;
-	onMove?: (event: PointerEvent) => void;
+	onMove?: (
+		event: PointerEvent,
+		capturePointer: (target: Element) => void,
+	) => void;
 	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
 }): (() => void) => {
 	const {pointerId} = event;
 	const buttonMask = getButtonMask(event.button);
 	let ended = false;
+	let activeCaptureTarget: Element | null = null;
+
+	const capturePointer = (target: Element) => {
+		if (activeCaptureTarget !== null) {
+			return;
+		}
+
+		activeCaptureTarget = target;
+		try {
+			target.setPointerCapture?.(pointerId);
+		} catch {
+			// Capture is best-effort for detached targets.
+		}
+
+		target.addEventListener('lostpointercapture', handleLostPointerCapture);
+	};
 
 	const cleanup = () => {
 		window.removeEventListener('pointermove', handleMove);
@@ -46,14 +65,14 @@ const startPointerSession = ({
 		window.removeEventListener('pointercancel', handleCancel);
 		window.removeEventListener('blur', handleBlur);
 		document.removeEventListener('visibilitychange', handleVisibilityChange);
-		captureTarget?.removeEventListener(
+		activeCaptureTarget?.removeEventListener(
 			'lostpointercapture',
 			handleLostPointerCapture,
 		);
 
-		if (captureTarget?.hasPointerCapture?.(pointerId)) {
+		if (activeCaptureTarget?.hasPointerCapture?.(pointerId)) {
 			try {
-				captureTarget.releasePointerCapture(pointerId);
+				activeCaptureTarget.releasePointerCapture(pointerId);
 			} catch {
 				// The browser may already have released capture.
 			}
@@ -83,7 +102,7 @@ const startPointerSession = ({
 			return;
 		}
 
-		onMove?.(moveEvent);
+		onMove?.(moveEvent, capturePointer);
 	}
 
 	function handleUp(upEvent: PointerEvent) {
@@ -115,17 +134,8 @@ const startPointerSession = ({
 		}
 	}
 
-	if (captureTarget) {
-		try {
-			captureTarget.setPointerCapture?.(pointerId);
-		} catch {
-			// Capture is best-effort for detached targets.
-		}
-
-		captureTarget.addEventListener(
-			'lostpointercapture',
-			handleLostPointerCapture,
-		);
+	if (captureTarget !== null) {
+		capturePointer(captureTarget);
 	}
 
 	window.addEventListener('pointermove', handleMove);
@@ -151,6 +161,30 @@ export const startCapturedPointerSession = ({
 	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
 }) => {
 	return startPointerSession({event, captureTarget, onMove, onEnd});
+};
+
+// Use when a click must remain targeted at the element under the pointer, but
+// an actual drag needs a stable capture target. Call `capturePointer()` from
+// `onMove` once the movement qualifies as a drag.
+export const startDeferredCapturedPointerSession = ({
+	event,
+	captureTarget,
+	onMove,
+	onEnd,
+}: {
+	event: PointerSessionEvent;
+	captureTarget: Element;
+	onMove: (event: PointerEvent, capturePointer: () => void) => void;
+	onEnd: (reason: PointerSessionEndReason, event: PointerEvent | null) => void;
+}) => {
+	return startPointerSession({
+		event,
+		captureTarget: null,
+		onMove: (moveEvent, capturePointer) => {
+			onMove(moveEvent, () => capturePointer(captureTarget));
+		},
+		onEnd,
+	});
 };
 
 // Use when observing a gesture that started elsewhere. This deliberately does

--- a/packages/studio/src/test/drag-aware-double-click.test.ts
+++ b/packages/studio/src/test/drag-aware-double-click.test.ts
@@ -39,3 +39,11 @@ test('A mixed-button click succession can recover on the next primary double cli
 	tracker.beginPointerGesture({button: 0});
 	expect(tracker.acceptClickAsDoubleClick(4)).toBe(true);
 });
+
+test('A continued click succession can recover after the tracker remounts', () => {
+	const tracker = createDragAwareDoubleClickTracker();
+
+	tracker.beginPointerGesture({button: 0});
+	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(4)).toBe(true);
+});

--- a/packages/studio/src/test/drag-aware-double-click.test.ts
+++ b/packages/studio/src/test/drag-aware-double-click.test.ts
@@ -16,26 +16,26 @@ test('Drag-aware double clicks consume the drag from the current pointer gesture
 	expect(tracker.consumePointerGestureWasDragged()).toBe(false);
 });
 
-test('Double clicks require two primary-button pointer gestures', () => {
+test('Double clicks require an even click count and two primary-button pointer gestures', () => {
 	const tracker = createDragAwareDoubleClickTracker();
 
 	tracker.beginPointerGesture({button: 2});
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptDoubleClick()).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
 
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptDoubleClick()).toBe(true);
+	expect(tracker.acceptClickAsDoubleClick(1)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(2)).toBe(true);
 });
 
-test('A rejected mixed-button double click can recover within the same click succession', () => {
+test('A mixed-button click succession can recover on the next primary double click', () => {
 	const tracker = createDragAwareDoubleClickTracker();
 
 	tracker.beginPointerGesture({button: 2});
-	expect(tracker.acceptDoubleClick()).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
 
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.recoverDoubleClick(3)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(3)).toBe(false);
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.recoverDoubleClick(4)).toBe(true);
-	expect(tracker.recoverDoubleClick(4)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick(4)).toBe(true);
 });

--- a/packages/studio/src/test/drag-aware-double-click.test.ts
+++ b/packages/studio/src/test/drag-aware-double-click.test.ts
@@ -21,29 +21,29 @@ test('Double clicks require an even click count and two primary-button pointer g
 
 	tracker.beginPointerGesture({button: 2});
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 2})).toBe(false);
 
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptClickAsDoubleClick(1)).toBe(false);
-	expect(tracker.acceptClickAsDoubleClick(2)).toBe(true);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 1})).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 2})).toBe(true);
 });
 
 test('A mixed-button click succession can recover on the next primary double click', () => {
 	const tracker = createDragAwareDoubleClickTracker();
 
 	tracker.beginPointerGesture({button: 2});
-	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 2})).toBe(false);
 
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptClickAsDoubleClick(3)).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 3})).toBe(false);
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptClickAsDoubleClick(4)).toBe(true);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 4})).toBe(true);
 });
 
 test('A continued click succession can recover after the tracker remounts', () => {
 	const tracker = createDragAwareDoubleClickTracker();
 
-	tracker.beginPointerGesture({button: 0});
-	expect(tracker.acceptClickAsDoubleClick(2)).toBe(false);
-	expect(tracker.acceptClickAsDoubleClick(4)).toBe(true);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 2})).toBe(false);
+	expect(tracker.acceptClickAsDoubleClick({button: 0, detail: 4})).toBe(true);
+	expect(tracker.acceptClickAsDoubleClick({button: 2, detail: 4})).toBe(false);
 });

--- a/packages/studio/src/test/drag-aware-double-click.test.ts
+++ b/packages/studio/src/test/drag-aware-double-click.test.ts
@@ -4,14 +4,25 @@ import {createDragAwareDoubleClickTracker} from '../helpers/drag-aware-double-cl
 test('Drag-aware double clicks consume the drag from the current pointer gesture', () => {
 	const tracker = createDragAwareDoubleClickTracker();
 
-	tracker.beginPointerGesture();
+	tracker.beginPointerGesture({button: 0});
 	tracker.endPointerGesture(true);
 	expect(tracker.consumePointerGestureWasDragged()).toBe(true);
 	expect(tracker.consumePointerGestureWasDragged()).toBe(false);
 
-	tracker.beginPointerGesture();
+	tracker.beginPointerGesture({button: 0});
 	tracker.endPointerGesture(true);
-	tracker.beginPointerGesture();
+	tracker.beginPointerGesture({button: 0});
 	tracker.endPointerGesture(false);
 	expect(tracker.consumePointerGestureWasDragged()).toBe(false);
+});
+
+test('Double clicks require two primary-button pointer gestures', () => {
+	const tracker = createDragAwareDoubleClickTracker();
+
+	tracker.beginPointerGesture({button: 2});
+	tracker.beginPointerGesture({button: 0});
+	expect(tracker.doubleClickWasPrimary()).toBe(false);
+
+	tracker.beginPointerGesture({button: 0});
+	expect(tracker.doubleClickWasPrimary()).toBe(true);
 });

--- a/packages/studio/src/test/drag-aware-double-click.test.ts
+++ b/packages/studio/src/test/drag-aware-double-click.test.ts
@@ -21,8 +21,21 @@ test('Double clicks require two primary-button pointer gestures', () => {
 
 	tracker.beginPointerGesture({button: 2});
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.doubleClickWasPrimary()).toBe(false);
+	expect(tracker.acceptDoubleClick()).toBe(false);
 
 	tracker.beginPointerGesture({button: 0});
-	expect(tracker.doubleClickWasPrimary()).toBe(true);
+	expect(tracker.acceptDoubleClick()).toBe(true);
+});
+
+test('A rejected mixed-button double click can recover within the same click succession', () => {
+	const tracker = createDragAwareDoubleClickTracker();
+
+	tracker.beginPointerGesture({button: 2});
+	expect(tracker.acceptDoubleClick()).toBe(false);
+
+	tracker.beginPointerGesture({button: 0});
+	expect(tracker.recoverDoubleClick(3)).toBe(false);
+	tracker.beginPointerGesture({button: 0});
+	expect(tracker.recoverDoubleClick(4)).toBe(true);
+	expect(tracker.recoverDoubleClick(4)).toBe(false);
 });


### PR DESCRIPTION
## Summary

- defer pointer capture for movable timeline layers until a drag actually starts
- preserve stable body capture for drags that leave the visible timeline
- require both presses of a double-click gesture to use the primary button
- recover the next primary-button double-click after a context-menu dismissal
- add browser regression coverage for opening the editor by double-clicking a movable layer

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio/src/test/drag-aware-double-click.test.ts packages/studio/src/test/timeline-selection.test.ts`
- `bunx playwright test e2e/timeline-right-edge.test.mts` (from `packages/example`)
