### PR TITLE
`@remotion/browser-studio`: Fix stuck timeline outlines after pointer exit

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1260,6 +1260,17 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 	await expect
 		.poll(() => getBackgroundColor(addSolid))
 		.toBe('rgba(255, 255, 255, 0.06)');
+	const neutralArea = studio.locator('[data-sidebar-toggle="right"]');
+
+	await addSolid.click();
+	const solid = studio.getByText('<Solid>', {exact: true});
+	await expect(solid).toBeVisible();
+	await expect(studio.locator('svg[viewBox="0 0 24 16"]')).toBeVisible();
+	await solid.hover();
+	const hoveredOutline = studio.locator(
+		'polygon[data-remotion-studio-selected-outline-key]',
+	);
+	await expect(hoveredOutline).toHaveCount(1);
 
 	// Browsers can fail to deliver pointer leave events when the pointer
 	// exits the Studio <iframe>. Simulate this by suppressing them before
@@ -1278,7 +1289,9 @@ test('clears hover backgrounds even if pointer leave events are lost', async ({
 		}
 	});
 
-	const neutralArea = studio.locator('[data-sidebar-toggle="right"]');
+	await page.locator('iframe').dispatchEvent('pointerout');
+	await expect(hoveredOutline).toHaveCount(0, {timeout: 5000});
+	await neutralArea.hover();
 
 	await studio.getByRole('button', {name: 'Assets', exact: true}).click();
 	const assetFolder = studio.getByTitle('hover-folder', {exact: true});

--- a/packages/browser-studio/src/BrowserStudio.tsx
+++ b/packages/browser-studio/src/BrowserStudio.tsx
@@ -46,6 +46,7 @@ const localVendorEntry = new URL(
 	import.meta.url,
 ).href;
 const localVendorEntryWithMarker = `${localVendorEntry}?browserStudioVendor`;
+const browserStudioPointerLeaveEvent = 'remotion-browser-studio-pointerleave';
 
 type BrowserStudioContentWindow = Window & {
 	remotion_browserStudioHmr: BrowserStudioHmrBridge;
@@ -168,6 +169,10 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 	const initialElementRef = useRef(initialElement);
 	const lastSentProjectRef = useRef<BrowserStudioProps['project'] | null>(null);
 	const bundleUrlRef = useRef<string | null>(null);
+	const notifyStudioOfPointerLeave = useCallback(() => {
+		const contentWindow = iframeRef.current?.contentWindow;
+		contentWindow?.dispatchEvent(new Event(browserStudioPointerLeaveEvent));
+	}, []);
 	const onCompileStateChangeRef = useRef(onCompileStateChange);
 	onCompileStateChangeRef.current = onCompileStateChange;
 	const dependencyResolverRef = useRef(dependencyResolver);
@@ -823,6 +828,7 @@ export const BrowserStudio: React.FC<BrowserStudioProps> = ({
 					ref={iframeRef}
 					allow="cross-origin-isolated"
 					onLoad={() => setIframeLoaded(true)}
+					onPointerOut={notifyStudioOfPointerLeave}
 					sandbox="allow-scripts allow-same-origin allow-downloads allow-popups allow-popups-to-escape-sandbox"
 					src={iframeSrc ?? 'about:blank'}
 					style={iframeStyle}

--- a/packages/studio/src/components/ShowOutlinesProvider.tsx
+++ b/packages/studio/src/components/ShowOutlinesProvider.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {
 	EditorShowOutlinesContext,
 	loadEditorShowOutlinesOption,
@@ -8,6 +8,8 @@ import {
 	createTimelineSequenceHoverStore,
 	TimelineSequenceHoverContext,
 } from '../state/timeline-sequence-hover';
+
+const browserStudioPointerLeaveEvent = 'remotion-browser-studio-pointerleave';
 
 export const ShowOutlinesProvider: React.FC<{
 	readonly children: React.ReactNode;
@@ -19,7 +21,23 @@ export const ShowOutlinesProvider: React.FC<{
 		() => createTimelineSequenceHoverStore(),
 		[],
 	);
+	useEffect(() => {
+		const onPointerLeave = () => {
+			timelineSequenceHoverStore.setHoveredSequence((hover) =>
+				hover?.source === 'timeline' ? null : hover,
+			);
+		};
 
+		window.addEventListener('pointerleave', onPointerLeave);
+		window.addEventListener(browserStudioPointerLeaveEvent, onPointerLeave);
+		return () => {
+			window.removeEventListener('pointerleave', onPointerLeave);
+			window.removeEventListener(
+				browserStudioPointerLeaveEvent,
+				onPointerLeave,
+			);
+		};
+	}, [timelineSequenceHoverStore]);
 	const setEditorShowOutlines = useCallback(
 		(newValue: (prevState: boolean) => boolean) => {
 			setEditorShowOutlinesState((prevState) => {


### PR DESCRIPTION
## Summary

- forward iframe pointer exits from Browser Studio into the embedded Studio
- clear timeline-originated hover state when the pointer leaves the Studio window
- cover the lost-pointer-leave case with a Browser Studio end-to-end regression test

## Testing

- `bun run build`
- `bun run stylecheck`
- `bun run testbrowserstudio --grep "clears hover backgrounds even if pointer leave events are lost"`
