### PR TITLE
`@remotion/cli`: Add `setKeyboardShortcuts()` for Studio commands

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -22,6 +22,7 @@ import type {
 import type {HardwareAccelerationOption} from '@remotion/renderer/client';
 import {BrowserSafeApis} from '@remotion/renderer/client';
 import {StudioServerInternals} from '@remotion/studio-server';
+import type {StudioKeyboardShortcuts} from '@remotion/studio-shared';
 import {getBrowser} from './browser';
 import {
 	getBufferStateDelayInMilliseconds,
@@ -44,6 +45,11 @@ import {
 	setFfmpegOverrideFunction,
 } from './ffmpeg-override';
 import {getShouldOutputImageSequence} from './image-sequence';
+import {
+	getKeyboardShortcuts,
+	resetKeyboardShortcuts,
+	setKeyboardShortcuts,
+} from './keyboard-shortcuts';
 import {getMetadata, resetMetadata, setMetadata} from './metadata';
 import {
 	getOutputLocation,
@@ -81,6 +87,7 @@ export type {
 	Concurrency,
 	RspackConfiguration,
 	RspackOverrideFn,
+	StudioKeyboardShortcuts,
 	WebpackConfiguration,
 	WebpackOverrideFn,
 };
@@ -628,6 +635,11 @@ type FlatConfig = RemotionConfigObject &
 		 */
 		addElementLibrary: (options: AddElementLibraryOptions) => void;
 		/**
+		 * Override keyboard shortcuts in the Remotion Studio.
+		 * Omitted actions use their default shortcut. Set an action to null to disable it.
+		 */
+		setKeyboardShortcuts: (shortcuts: StudioKeyboardShortcuts) => void;
+		/**
 		 * Set the audio codec to use for the output video.
 		 * See the Encoding guide in the docs for defaults and available options.
 		 */
@@ -769,6 +781,7 @@ export const Config: FlatConfig = {
 	addElementLibrary,
 	setMaxTimelineTracks: StudioServerInternals.setMaxTimelineTracks,
 	setKeyboardShortcutsEnabled: keyboardShortcutsOption.setConfig,
+	setKeyboardShortcuts,
 	setInteractivityEnabled: interactivityOption.setConfig,
 	setAllowHtmlInCanvasEnabled: allowHtmlInCanvasOption.setConfig,
 	setRspack: rspackOption.setConfig,
@@ -929,6 +942,7 @@ const resetConfigOptions = () => {
 	StudioServerInternals.resetMaxTimelineTracks();
 	resetBufferStateDelayInMilliseconds();
 	resetElementLibraries();
+	resetKeyboardShortcuts();
 	resetEntryPoint();
 	resetFfmpegOverrideFunction();
 	resetMetadata();
@@ -963,6 +977,7 @@ export const ConfigInternals = {
 	getWebpackPolling,
 	getBufferStateDelayInMilliseconds,
 	getElementLibraries,
+	getKeyboardShortcuts,
 	getOutputCodecOrUndefined: BrowserSafeApis.getOutputCodecOrUndefined,
 	resetConfigOptions,
 };

--- a/packages/cli/src/config/keyboard-shortcuts.ts
+++ b/packages/cli/src/config/keyboard-shortcuts.ts
@@ -1,0 +1,21 @@
+import {
+	type StudioKeyboardShortcuts,
+	validateStudioKeyboardShortcuts,
+} from '@remotion/studio-shared';
+
+let keyboardShortcuts: StudioKeyboardShortcuts | null = null;
+
+export const setKeyboardShortcuts = (value: StudioKeyboardShortcuts) => {
+	const error = validateStudioKeyboardShortcuts(value);
+	if (error !== null) {
+		throw new Error(error);
+	}
+
+	keyboardShortcuts = value;
+};
+
+export const getKeyboardShortcuts = () => keyboardShortcuts;
+
+export const resetKeyboardShortcuts = () => {
+	keyboardShortcuts = null;
+};

--- a/packages/cli/src/studio.ts
+++ b/packages/cli/src/studio.ts
@@ -160,6 +160,7 @@ export const studioCommand = async (
 
 		return {
 			maxTimelineTracks: ConfigInternals.getMaxTimelineTracks(),
+			keyboardShortcuts: ConfigInternals.getKeyboardShortcuts(),
 			askAIEnabled: askAIOption.getValue({
 				commandLine: parsedCli,
 			}).value,

--- a/packages/cli/src/test/config-file-change.test.ts
+++ b/packages/cli/src/test/config-file-change.test.ts
@@ -46,6 +46,12 @@ test('classifies runtime config changes', () => {
 			prepare('Config.addElementLibrary({url: "https://two.example.com"});'),
 		),
 	).toBe('runtime');
+	expect(
+		classify(
+			prepare('Config.setKeyboardShortcuts({playPause: {key: "Space"}});'),
+			prepare('Config.setKeyboardShortcuts({playPause: {key: "p"}});'),
+		),
+	).toBe('runtime');
 });
 
 test('classifies changes that require a page reload', () => {

--- a/packages/cli/src/test/config-reset.test.ts
+++ b/packages/cli/src/test/config-reset.test.ts
@@ -86,6 +86,10 @@ test('reset config options restores defaults before reloading config', async () 
 	Config.setEnableCrossSiteIsolation(true);
 	Config.setInteractivityEnabled(false);
 	Config.setKeyboardShortcutsEnabled(false);
+	Config.setKeyboardShortcuts({
+		playPause: {key: 'p'},
+		quickSwitcher: null,
+	});
 	Config.setLogLevel('verbose');
 	Config.setNumberOfSharedAudioTags(2);
 	Config.setRspack(true);
@@ -115,6 +119,10 @@ test('reset config options restores defaults before reloading config', async () 
 			url: 'https://example.com/elements',
 		},
 	]);
+	expect(ConfigInternals.getKeyboardShortcuts()).toEqual({
+		playPause: {key: 'p'},
+		quickSwitcher: null,
+	});
 	expect(
 		BrowserSafeApis.options.glOption.getValue({commandLine: {}}).value,
 	).toBe('angle');
@@ -219,6 +227,7 @@ test('reset config options restores defaults before reloading config', async () 
 	expect(
 		BrowserSafeApis.options.keyboardShortcutsOption.getConfigValue(),
 	).toBeNull();
+	expect(ConfigInternals.getKeyboardShortcuts()).toBeNull();
 	expect(BrowserSafeApis.options.logLevelOption.getConfigValue()).toBeNull();
 	expect(
 		BrowserSafeApis.options.numberOfSharedAudioTagsOption.getConfigValue(),

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -236,7 +236,7 @@ The [command line flag](/docs/cli/studio#--disable-keyboard-shortcuts) `--disabl
 
 ## `setKeyboardShortcuts()`<AvailableFrom v="4.0.523" />
 
-Override keyboard shortcuts for Studio commands. Shortcuts that are omitted keep their default binding. Set a command to `null` to disable its shortcut.
+Override keyboard shortcuts for Studio commands. Shortcuts that are omitted keep their default binding. Set a command to `null` to disable its shortcut. See [Keyboard shortcuts](/docs/studio/shortcuts) for the available action IDs and defaults.
 
 ```ts twoslash title="remotion.config.ts"
 import {Config} from '@remotion/cli/config';

--- a/packages/docs/docs/config.mdx
+++ b/packages/docs/docs/config.mdx
@@ -234,6 +234,25 @@ Config.setKeyboardShortcutsEnabled(false);
 
 The [command line flag](/docs/cli/studio#--disable-keyboard-shortcuts) `--disable-keyboard-shortcuts` will take precedence over this option.
 
+## `setKeyboardShortcuts()`<AvailableFrom v="4.0.523" />
+
+Override keyboard shortcuts for Studio commands. Shortcuts that are omitted keep their default binding. Set a command to `null` to disable its shortcut.
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setKeyboardShortcuts({
+	playPause: {key: 'q'},
+	quickSwitcher: {key: 'p', commandOrControl: true},
+	toggleSnapping: {key: 's', shift: true},
+	render: null,
+});
+```
+
+The `commandOrControl` modifier uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported. Pass an array to assign multiple bindings to one command.
+
+Studio can also update these values from the Keyboard Shortcuts settings screen. Changes made there are written to `remotion.config.ts`.
+
 ## `setInteractivityEnabled()`<AvailableFrom v="4.0.487" />
 
 <Options id="disable-interactivity" />

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -1,423 +1,91 @@
 ---
 image: /generated/articles-docs-studio-shortcuts.png
-title: Keyboard navigation
+title: Keyboard shortcuts
 crumb: 'Remotion Studio'
 ---
 
-## Shortcuts
+Open the Shortcuts tab in the Studio settings to see the shortcuts for the current project. You can also press <kbd>?</kbd> to open this tab.
 
-You can always find the list of keyboard shortcuts by pressing <kbd>?</kbd> in the Studio.
+## Customizing shortcuts<AvailableFrom v="4.0.523" />
 
-### Playback
+Select a shortcut in the settings and press a new key combination. The Studio writes the override to `remotion.config.ts` using [`Config.setKeyboardShortcuts()`](/docs/config#setkeyboardshortcuts).
 
-<table>
-<tr>
-<td>
-  <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M48.048 304h73.798v128c0 26.51 21.49 48 48 48h108.308c26.51 0 48-21.49 48-48V304h73.789c42.638 0 64.151-51.731 33.941-81.941l-175.943-176c-18.745-18.745-49.137-18.746-67.882 0l-175.952 176C-16.042 252.208 5.325 304 48.048 304zM224 80l176 176H278.154v176H169.846V256H48L224 80z"
-      ></path>
-    </svg>
-  </kbd>
-  <div style={{ width: 2, display: "inline-block" }} />
-  <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M257.5 445.1l-22.2 22.2c-9.4 9.4-24.6 9.4-33.9 0L7 273c-9.4-9.4-9.4-24.6 0-33.9L201.4 44.7c9.4-9.4 24.6-9.4 33.9 0l22.2 22.2c9.5 9.5 9.3 25-.4 34.3L136.6 216H424c13.3 0 24 10.7 24 24v32c0 13.3-10.7 24-24 24H136.6l120.5 114.8c9.8 9.3 10 24.8.4 34.3z"
-      ></path>
-    </svg>
-  </kbd>{" "}
-  </td>
-  <td>
-  Move 1 second back{" "}
-  </td>
-  </tr>
-  <tr>
-  <td>
-  <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M257.5 445.1l-22.2 22.2c-9.4 9.4-24.6 9.4-33.9 0L7 273c-9.4-9.4-9.4-24.6 0-33.9L201.4 44.7c9.4-9.4 24.6-9.4 33.9 0l22.2 22.2c9.5 9.5 9.3 25-.4 34.3L136.6 216H424c13.3 0 24 10.7 24 24v32c0 13.3-10.7 24-24 24H136.6l120.5 114.8c9.8 9.3 10 24.8.4 34.3z"
-      ></path>
-    </svg>
-  </kbd>{" "}
-    </td>
-  <td>
-Move 1 frame back
-  </td>
-  </tr>
-<tr>
-<td>
-  <kbd>Space</kbd> 
-</td>
-<td>Play / Pause</td>
+You can also edit the configuration file directly:
 
-</tr>
-<tr>
-<td>
-  <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"
-      ></path>
-    </svg>
-  </kbd>{" "}
-</td>
-<td>
-  Move 1 frame forward
-</td>
-</tr>
-<tr>
-<td> <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M48.048 304h73.798v128c0 26.51 21.49 48 48 48h108.308c26.51 0 48-21.49 48-48V304h73.789c42.638 0 64.151-51.731 33.941-81.941l-175.943-176c-18.745-18.745-49.137-18.746-67.882 0l-175.952 176C-16.042 252.208 5.325 304 48.048 304zM224 80l176 176H278.154v176H169.846V256H48L224 80z"
-      ></path>
-    </svg>
-  </kbd>
-  <div style={{ width: 2, display: "inline-block" }} />
-  <kbd>
-    <svg viewBox="0 0 448 512" style={{ width: 10, display: "inline" }}>
-      <path
-        fill="currentColor"
-        d="M190.5 66.9l22.2-22.2c9.4-9.4 24.6-9.4 33.9 0L441 239c9.4 9.4 9.4 24.6 0 33.9L246.6 467.3c-9.4 9.4-24.6 9.4-33.9 0l-22.2-22.2c-9.5-9.5-9.3-25 .4-34.3L311.4 296H24c-13.3 0-24-10.7-24-24v-32c0-13.3 10.7-24 24-24h287.4L190.9 101.2c-9.8-9.3-10-24.8-.4-34.3z"
-      ></path>
-    </svg>
-  </kbd>
-</td>
-<td>
-  Move 1 second forward
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setKeyboardShortcuts({
+	playPause: {key: 'q'},
+	quickSwitcher: {key: 'p', commandOrControl: true},
+	toggleSnapping: {key: 's', shift: true},
+	render: null,
+});
+```
 
-</td>
-</tr>
+Omitted actions keep their default shortcut. Set an action to `null` to disable it, or pass an array to assign multiple shortcuts.
 
-<tr>
-<td>
-<kbd>A</kbd>
-</td>
-<td>
-Jump to beginning
-</td>
-</tr>
-<tr>
-<td>
-<kbd>E</kbd>
-</td>
-<td>
-Jump to end
-</td>
-</tr>
-<tr>
-<td>
-<kbd>J</kbd>
-</td>
-<td>
-Play in reverse
-</td>
-</tr>
-<tr>
-<td>
-<kbd>K</kbd>
-</td>
-<td>
-Pause
-</td>
-</tr>
-<tr>
-<td>
-<kbd>L</kbd>
-</td>
-<td>
-Play (press repeatedly to increase speed)
-</td>
-</tr>
-<tr>
-<td>
-<kbd>G</kbd>
-</td>
-<td>
-Jump to frame
-</td>
-</tr>
-<tr>
-<td>
-<kbd>Enter</kbd>
-</td>
-<td>
-Pause and return to where playback started
-</td>
-</tr>
-</table>
+`commandOrControl` uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported.
 
-### Sidebars
+## Available actions
 
-<table>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>B</kbd>
-    </td>
-    <td>Toggle left sidebar</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>J</kbd>
-    </td>
-    <td>Toggle right sidebar</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>G</kbd>
-    </td>
-    <td>Toggle both sidebars</td>
-  </tr>
-</table>
+| Action ID                       | Default                                    | Action                                                         |
+| ------------------------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| `playPause`                     | `Space`                                    | Play or pause                                                  |
+| `jumpToBeginning`               | `A`                                        | Jump to the beginning                                          |
+| `jumpToEnd`                     | `E`                                        | Jump to the end                                                |
+| `reversePlayback`               | `J`                                        | Play in reverse                                                |
+| `pausePlayback`                 | `K`                                        | Pause playback                                                 |
+| `playForward`                   | `L`                                        | Play forward; press repeatedly to increase speed               |
+| `goToFrame`                     | `G`                                        | Open the frame input                                           |
+| `pauseAndReturnToPlaybackStart` | `Enter`                                    | Pause and return to where playback started                     |
+| `toggleLeftSidebar`             | `Cmd/Ctrl+B`                               | Toggle the left sidebar                                        |
+| `toggleRightSidebar`            | `Cmd/Ctrl+J`                               | Toggle the right sidebar                                       |
+| `toggleBothSidebars`            | `Cmd/Ctrl+G`                               | Toggle both sidebars                                           |
+| `enterFullscreen`               | `F`                                        | Enter fullscreen                                               |
+| `toggleSnapping`                | `Shift+M`                                  | Enable or disable snapping                                     |
+| `previousComposition`           | `PageUp`                                   | Select the previous composition                                |
+| `nextComposition`               | `PageDown`                                 | Select the next composition                                    |
+| `showKeyboardShortcuts`         | `?`                                        | Open the Shortcuts settings                                    |
+| `quickSwitcher`                 | `Cmd/Ctrl+K`                               | Open the Quick Switcher                                        |
+| `render`                        | `R`                                        | Open the Render dialog unless a sequence property is selected  |
+| `toggleCheckerboard`            | `T`                                        | Toggle the checkerboard unless a sequence property is selected |
+| `setInPoint`                    | `I`                                        | Set the playback In Point                                      |
+| `setOutPoint`                   | `O`                                        | Set the playback Out Point                                     |
+| `clearInOutPoints`              | `X`                                        | Clear the playback In and Out Points                           |
+| `zoomIn`                        | `+`                                        | Zoom into the preview                                          |
+| `zoomOut`                       | `-`                                        | Zoom out of the preview                                        |
+| `resetZoom`                     | `0`                                        | Reset the preview zoom                                         |
+| `undo`                          | `Cmd/Ctrl+Z`                               | Undo the last props edit                                       |
+| `redo`                          | `Cmd+Shift+Z` on macOS, `Ctrl+Y` otherwise | Redo the last props edit                                       |
+| `selectAllSequenceRows`         | `Cmd/Ctrl+A`                               | Select all sequence rows                                       |
+| `selectTranslateProp`           | `P`                                        | Select the `style.translate` property                          |
+| `selectOpacityProp`             | `T`                                        | Select the `style.opacity` property                            |
+| `selectRotateProp`              | `R`                                        | Select the `style.rotate` property                             |
+| `selectScaleProp`               | `S`                                        | Select the `style.scale` property                              |
+| `duplicateSequences`            | `Cmd/Ctrl+D`                               | Duplicate selected sequences                                   |
+| `copyEffectsAndValues`          | `Cmd/Ctrl+C`                               | Copy selected effects or property values                       |
+| `cutEffects`                    | `Cmd/Ctrl+X`                               | Cut selected effects                                           |
+| `deleteSelection`               | `Backspace` or `Delete`                    | Delete or reset the selection                                  |
+| `askAI`                         | `Cmd/Ctrl+I`                               | Open Ask AI when it is enabled                                 |
 
-### View
+## Fixed shortcuts
 
-<table>
-  <tr>
-    <td>
-      <kbd>F</kbd>
-    </td>
-    <td>Enter fullscreen</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>Esc</kbd>
-    </td>
-    <td>Exit fullscreen</td>
-  </tr>
-</table>
+Some shortcuts are context-sensitive interactions or browser events and cannot yet be overridden:
 
-### Playback range
-
-<table>
-  <tr>
-    <td>
-      <kbd>I</kbd>
-    </td>
-    <td>Set In Point - video will only play from this point</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>O</kbd>
-    </td>
-    <td>Set Out Point - video will only play until this point</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>X</kbd>
-    </td>
-    <td>Clear both In and Out points</td>
-  </tr>
-</table>
-
-### Zoom
-
-<table>
-  <tr>
-    <td>
-      <kbd>+</kbd>
-    </td>
-    <td>Zoom in</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>-</kbd>
-    </td>
-    <td>Zoom out</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>0</kbd>
-    </td>
-    <td>Reset zoom</td>
-  </tr>
-</table>
-
-### Props editor
-
-<table>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>Z</kbd>
-    </td>
-    <td>Undo</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>Y</kbd>
-    </td>
-    <td>Redo</td>
-  </tr>
-</table>
-
-### Interactivity
-
-<table>
-  <tr>
-    <td>
-      <kbd>Shift</kbd>
-    </td>
-    <td>Select a range of timeline items</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-    </td>
-    <td>Toggle timeline items in the selection</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>A</kbd>
-    </td>
-    <td>Select all sequence rows</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>Shift</kbd>
-    </td>
-    <td>Axis-lock canvas outline dragging</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>D</kbd>
-    </td>
-    <td>Duplicate selected sequences</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>C</kbd>
-    </td>
-    <td>Copy selected effects or effect prop values</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>X</kbd>
-    </td>
-    <td>Cut selected effects</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>V</kbd>
-    </td>
-    <td>Paste effects or effect prop values</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>Delete</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>Backspace</kbd>
-    </td>
-    <td>Delete selected keyframes, sequences or effects where supported; otherwise reset selected props or easing segments</td>
-  </tr>
-</table>
-
-### Navigation
-
-<table>
-  <tr>
-    <td>
-      <kbd>PageUp</kbd>
-    </td>
-    <td>Previous composition</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>PageDown</kbd>
-    </td>
-    <td>Next composition</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>R</kbd>
-    </td>
-    <td>Render composition, unless a sequence or prop is selected</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>T</kbd>
-    </td>
-    <td>Toggle checkerboard background, unless a sequence or prop is selected</td>
-  </tr>
-</table>
-
-### Selected sequence or prop
-
-<table>
-  <tr>
-    <td>
-      <kbd>P</kbd>
-    </td>
-    <td>Select the `style.translate` prop</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>T</kbd>
-    </td>
-    <td>Select the `style.opacity` prop</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>R</kbd>
-    </td>
-    <td>Select the `style.rotate` prop</td>
-  </tr>
-  <tr>
-    <td>
-      <kbd>S</kbd>
-    </td>
-    <td>Select the `style.scale` prop</td>
-  </tr>
-</table>
-
-### AI
-
-<table>
-  <tr>
-    <td>
-      <kbd>⌘/Ctrl</kbd>
-      <div style={{width: 2, display: 'inline-block'}} />
-      <kbd>I</kbd>
-    </td>
-    <td>Ask AI</td>
-  </tr>
-</table>
+| Shortcut                                 | Action                                                               |
+| ---------------------------------------- | -------------------------------------------------------------------- |
+| `Left Arrow` / `Right Arrow`             | Move one frame or nudge the selected canvas item                     |
+| `Shift+Left Arrow` / `Shift+Right Arrow` | Move one second or nudge the selected canvas item by a larger amount |
+| `Shift`                                  | Select a range or lock the axis while dragging                       |
+| `Cmd/Ctrl`                               | Toggle items in the selection                                        |
+| `Cmd/Ctrl+V`                             | Paste effects or property values                                     |
+| `Escape`                                 | Exit fullscreen                                                      |
 
 ## Keyboard navigation
 
-The menus are keyboard-navigation friendly. Press <kbd>Tab</kbd> to navigate between the menus and <kbd>Enter</kbd> to select an item.
+Press <kbd>Tab</kbd> to navigate between controls and <kbd>Enter</kbd> to activate the focused control.
 
-## Quick Switcher
+## Disabling keyboard shortcuts
 
-Press <kbd>⌘/Ctrl</kbd> + <kbd>K</kbd> to open the Quick Switcher. You can use it to quickly navigate to any file in your project.
-
-## Disable keyboard shortcuts
-
-Start the Studio with [`--disable-keyboard-shortcuts`](/docs/cli/studio#--disable-keyboard-shortcuts) to disable all keyboard shortcuts. Useful if you are embedding it into an iframe.
+Use [`Config.setKeyboardShortcutsEnabled(false)`](/docs/config#setkeyboardshortcutsenabled) or start the Studio with [`--disable-keyboard-shortcuts`](/docs/cli/studio#--disable-keyboard-shortcuts) to disable all shortcuts.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -4,28 +4,9 @@ title: Keyboard shortcuts
 crumb: 'Remotion Studio'
 ---
 
-Open the Shortcuts tab in the Studio settings to see the shortcuts for the current project. You can also press <kbd>?</kbd> to open this tab.
+Open the Shortcuts tab in the Studio settings to see the shortcuts for the current project.
 
-## Customizing shortcuts<AvailableFrom v="4.0.523" />
-
-Select a shortcut in the settings and press a new key combination. The Studio writes the override to `remotion.config.ts` using [`Config.setKeyboardShortcuts()`](/docs/config#setkeyboardshortcuts).
-
-You can also edit the configuration file directly:
-
-```ts twoslash title="remotion.config.ts"
-import {Config} from '@remotion/cli/config';
-// ---cut---
-Config.setKeyboardShortcuts({
-	playPause: {key: 'q'},
-	quickSwitcher: {key: 'p', commandOrControl: true},
-	toggleSnapping: {key: 's', shift: true},
-	render: null,
-});
-```
-
-Omitted actions keep their default shortcut. Set an action to `null` to disable it, or pass an array to assign multiple shortcuts.
-
-`commandOrControl` uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported.
+You can also press <kbd>?</kbd> to open this tab.
 
 ## Available actions
 
@@ -71,7 +52,7 @@ Omitted actions keep their default shortcut. Set an action to `null` to disable 
 
 ## Fixed shortcuts
 
-Some shortcuts are context-sensitive interactions or browser events and cannot yet be overridden:
+Some shortcuts are context-sensitive interactions or browser events and cannot be overridden:
 
 | Shortcut                                 | Action                                                               |
 | ---------------------------------------- | -------------------------------------------------------------------- |
@@ -89,3 +70,26 @@ Press <kbd>Tab</kbd> to navigate between controls and <kbd>Enter</kbd> to activa
 ## Disabling keyboard shortcuts
 
 Use [`Config.setKeyboardShortcutsEnabled(false)`](/docs/config#setkeyboardshortcutsenabled) or start the Studio with [`--disable-keyboard-shortcuts`](/docs/cli/studio#--disable-keyboard-shortcuts) to disable all shortcuts.
+
+## Customizing shortcuts<AvailableFrom v="4.0.523" />
+
+Select a shortcut in the settings and press a new key combination.
+
+The Studio writes the override to `remotion.config.ts` using [`Config.setKeyboardShortcuts()`](/docs/config#setkeyboardshortcuts).
+
+You can also edit the configuration file directly:
+
+```ts twoslash title="remotion.config.ts"
+import {Config} from '@remotion/cli/config';
+// ---cut---
+Config.setKeyboardShortcuts({
+	playPause: {key: 'q'},
+	quickSwitcher: {key: 'p', commandOrControl: true},
+	toggleSnapping: {key: 's', shift: true},
+	render: null,
+});
+```
+
+Omitted actions keep their default shortcut. Set an action to `null` to disable it, or pass an array to assign multiple shortcuts.
+
+`commandOrControl` uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -38,7 +38,7 @@ You can also press <kbd>?</kbd> to open this tab.
 | `zoomOut`                       | `-`                                        | Zoom out of the preview                                        |
 | `resetZoom`                     | `0`                                        | Reset the preview zoom                                         |
 | `undo`                          | `Cmd/Ctrl+Z`                               | Undo the last props edit                                       |
-| `redo`                          | `Cmd+Shift+Z` on macOS, `Ctrl+Y` otherwise | Redo the last props edit                                       |
+| `redo`                          | `Cmd/Ctrl+Shift+Z`; `Ctrl+Y` outside macOS | Redo the last props edit                                       |
 | `selectAllSequenceRows`         | `Cmd/Ctrl+A`                               | Select all sequence rows                                       |
 | `selectTranslateProp`           | `P`                                        | Select the `style.translate` property                          |
 | `selectOpacityProp`             | `T`                                        | Select the `style.opacity` property                            |

--- a/packages/docs/src/data/articles.ts
+++ b/packages/docs/src/data/articles.ts
@@ -7257,7 +7257,7 @@ export const articles = [
 	},
 	{
 		id: 'studio/shortcuts',
-		title: 'Keyboard navigation',
+		title: 'Keyboard shortcuts',
 		relativePath: 'docs/studio/shortcuts.mdx',
 		compId: 'articles-docs-studio-shortcuts',
 		crumb: 'Remotion Studio',

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1842,6 +1842,27 @@ test.describe('visual mode', () => {
 			await expect(
 				dialog.getByRole('list', {name: 'Playback', exact: true}),
 			).toBeVisible();
+			const fixedShortcutRow = dialog
+				.getByRole('listitem')
+				.filter({hasText: '1 second back'});
+			const fixedShortcutBox = await fixedShortcutRow
+				.locator('kbd')
+				.last()
+				.boundingBox();
+			const fixedLabelBox = await fixedShortcutRow
+				.getByText('Fixed', {exact: true})
+				.boundingBox();
+			if (fixedShortcutBox === null || fixedLabelBox === null) {
+				throw new Error('Expected shortcut and Fixed label to have boxes');
+			}
+
+			expect(
+				Math.abs(
+					fixedShortcutBox.y +
+						fixedShortcutBox.height / 2 -
+						(fixedLabelBox.y + fixedLabelBox.height / 2),
+				),
+			).toBeLessThan(1);
 			const playPauseShortcut = dialog.getByRole('button', {
 				name: 'Change shortcut for Play / Pause',
 			});

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1845,27 +1845,14 @@ test.describe('visual mode', () => {
 			const fixedShortcutRow = dialog
 				.getByRole('listitem')
 				.filter({hasText: '1 second back'});
-			const fixedShortcutBox = await fixedShortcutRow
-				.locator('kbd')
-				.last()
-				.boundingBox();
-			const fixedLabelBox = await fixedShortcutRow
-				.getByText('Fixed', {exact: true})
-				.boundingBox();
-			if (fixedShortcutBox === null || fixedLabelBox === null) {
-				throw new Error('Expected shortcut and Fixed label to have boxes');
-			}
-
-			expect(
-				Math.abs(
-					fixedShortcutBox.y +
-						fixedShortcutBox.height / 2 -
-						(fixedLabelBox.y + fixedLabelBox.height / 2),
-				),
-			).toBeLessThan(1);
+			await expect(fixedShortcutRow.getByRole('button')).toHaveCount(0);
 			const playPauseShortcut = dialog.getByRole('button', {
 				name: 'Change shortcut for Play / Pause',
 			});
+			const playPauseActions = dialog.getByRole('button', {
+				name: 'Actions for Play / Pause',
+			});
+			await expect(playPauseActions).toBeVisible();
 			await playPauseShortcut.click();
 			await expect(playPauseShortcut).toContainText('Press shortcut');
 			await page.keyboard.press('q');
@@ -1873,10 +1860,11 @@ test.describe('visual mode', () => {
 				.poll(() => fs.readFileSync(configFile, 'utf8'))
 				.toContain('Config.setKeyboardShortcuts({');
 			await expect(playPauseShortcut).toContainText('Q');
-			await dialog.getByTitle('Reset to default', {exact: true}).click();
+			await playPauseActions.click();
+			await page.getByText('Reset to default', {exact: true}).click();
 			await expect
 				.poll(() => fs.readFileSync(configFile, 'utf8'))
-				.not.toContain('Config.setKeyboardShortcuts');
+				.not.toContain("'playPause'");
 			await expect(playPauseShortcut).toContainText('Space');
 			await dialog.getByRole('button', {name: 'Studio', exact: true}).click();
 

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1839,6 +1839,21 @@ test.describe('visual mode', () => {
 			await expect(
 				dialog.getByText('Keyboard shortcuts', {exact: true}),
 			).toBeVisible();
+			const keyboardShortcutsEnabled = dialog.getByRole('checkbox', {
+				name: 'Keyboard shortcuts',
+			});
+			await expect(keyboardShortcutsEnabled).toBeChecked();
+			await keyboardShortcutsEnabled.uncheck();
+			await expect(
+				dialog.getByRole('list', {name: 'Playback', exact: true}),
+			).toHaveCount(0);
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.toContain('Config.setKeyboardShortcutsEnabled(false);');
+			await keyboardShortcutsEnabled.check();
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.not.toContain('Config.setKeyboardShortcutsEnabled');
 			await expect(
 				dialog.getByRole('list', {name: 'Playback', exact: true}),
 			).toBeVisible();

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1842,6 +1842,21 @@ test.describe('visual mode', () => {
 			await expect(
 				dialog.getByRole('list', {name: 'Playback', exact: true}),
 			).toBeVisible();
+			const playPauseShortcut = dialog.getByRole('button', {
+				name: 'Change shortcut for Play / Pause',
+			});
+			await playPauseShortcut.click();
+			await expect(playPauseShortcut).toContainText('Press shortcut');
+			await page.keyboard.press('q');
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.toContain('Config.setKeyboardShortcuts({');
+			await expect(playPauseShortcut).toContainText('Q');
+			await dialog.getByTitle('Reset to default', {exact: true}).click();
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.not.toContain('Config.setKeyboardShortcuts');
+			await expect(playPauseShortcut).toContainText('Space');
 			await dialog.getByRole('button', {name: 'Studio', exact: true}).click();
 
 			const askAIEnabled = dialog.getByTitle('Ask AI enabled', {exact: true});

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1853,7 +1853,8 @@ test.describe('visual mode', () => {
 				name: 'Actions for Play / Pause',
 			});
 			await expect(playPauseActions).toBeVisible();
-			await playPauseShortcut.click();
+			await playPauseActions.click();
+			await page.getByText('Remap shortcut', {exact: true}).click();
 			await expect(playPauseShortcut).toContainText('Press shortcut');
 			await page.keyboard.press('q');
 			await expect

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1862,7 +1862,12 @@ test.describe('visual mode', () => {
 				.toContain('Config.setKeyboardShortcuts({');
 			await expect(playPauseShortcut).toContainText('Q');
 			await playPauseActions.click();
-			await page.getByText('Reset to default', {exact: true}).click();
+			await expect(
+				page.getByText('Reset to default', {exact: true}),
+			).toBeVisible();
+			await page.getByText('Remap shortcut', {exact: true}).click();
+			await expect(playPauseShortcut).toContainText('Press shortcut');
+			await page.keyboard.press('Space');
 			await expect
 				.poll(() => fs.readFileSync(configFile, 'utf8'))
 				.not.toContain("'playPause'");

--- a/packages/studio-server/src/preview-server/routes/update-config.ts
+++ b/packages/studio-server/src/preview-server/routes/update-config.ts
@@ -5,6 +5,7 @@ import {
 	type ConfigUpdate,
 	type ConfigValue,
 	type StudioRuntimeConfig,
+	validateStudioKeyboardShortcuts,
 	type UpdateConfigRequest,
 	type UpdateConfigResponse,
 } from '@remotion/studio-shared';
@@ -278,6 +279,15 @@ export const updateConfigHandler = async ({
 	for (const update of input.updates) {
 		if (update.type === 'delete') {
 			continue;
+		}
+
+		if (update.setter === 'setKeyboardShortcuts') {
+			const keyboardShortcutsError = validateStudioKeyboardShortcuts(
+				update.value,
+			);
+			if (keyboardShortcutsError !== null) {
+				return {success: false, reason: keyboardShortcutsError};
+			}
 		}
 
 		if (

--- a/packages/studio-server/src/test/update-config.test.ts
+++ b/packages/studio-server/src/test/update-config.test.ts
@@ -287,7 +287,7 @@ test('uses runtime catalogs for dynamic config deduplication and skips no-op wri
 	}
 });
 
-test('persists an arbitrary valid config setter through the route', async () => {
+test('persists Studio keyboard shortcuts through the config route', async () => {
 	const directory = mkdtempSync(join(tmpdir(), 'remotion-config-update-'));
 	const configFile = join(directory, 'remotion.config.ts');
 	const fileWatcherRegistry = createFileWatcherRegistry();
@@ -304,7 +304,7 @@ test('persists an arbitrary valid config setter through the route', async () => 
 		configFile,
 		[
 			"import {Config} from '@remotion/cli/config';",
-			'Config.setOverwriteOutput(false);',
+			"Config.setKeyboardShortcuts({playPause: {key: 'Space'}});",
 			'',
 		].join('\n'),
 	);
@@ -315,25 +315,28 @@ test('persists an arbitrary valid config setter through the route', async () => 
 			configFile,
 			input: {
 				clientId: 'settings-client',
-				updates: [{setter: 'setOverwriteOutput', type: 'set', value: true}],
+				updates: [
+					{
+						setter: 'setKeyboardShortcuts',
+						type: 'set',
+						value: {
+							playPause: {key: 'p'},
+							render: null,
+						},
+					},
+				],
 			},
 			remotionRoot: directory,
 		});
 
 		expect(response).toEqual({success: true});
-		expect(readFileSync(configFile, 'utf8')).toBe(
-			[
-				"import {Config} from '@remotion/cli/config';",
-				'Config.setOverwriteOutput(true);',
-				'',
-			].join('\n'),
-		);
+		const updatedConfig = readFileSync(configFile, 'utf8');
+		expect(updatedConfig).toContain('Config.setKeyboardShortcuts({');
+		expect(updatedConfig).toContain("'playPause': {");
+		expect(updatedConfig).toContain("'key': 'p'");
+		expect(updatedConfig).toContain("'render': null");
 		expect(configChangeEvent as FileChangeEvent | null).toEqual({
-			content: [
-				"import {Config} from '@remotion/cli/config';",
-				'Config.setOverwriteOutput(true);',
-				'',
-			].join('\n'),
+			content: updatedConfig,
 			originatorClientId: 'settings-client',
 			type: 'changed',
 			skipSequencePropsUpdate: false,
@@ -353,6 +356,13 @@ test('rejects invalid updates without changing the config', async () => {
 
 	try {
 		for (const updates of [
+			[
+				{
+					setter: 'setKeyboardShortcuts',
+					type: 'set' as const,
+					value: {notAnAction: {key: 'p'}},
+				},
+			],
 			[
 				{
 					setter: 'setNotARealOption',

--- a/packages/studio-shared/src/config-method-lifecycles.ts
+++ b/packages/studio-shared/src/config-method-lifecycles.ts
@@ -63,6 +63,7 @@ export const configMethodLifecycles = {
 	setInteractivityEnabled: 'runtime',
 	setJpegQuality: 'runtime',
 	setKeyboardShortcutsEnabled: 'runtime',
+	setKeyboardShortcuts: 'runtime',
 	setLambdaInsights: 'runtime',
 	setLevel: 'restart',
 	setLogLevel: 'restart',

--- a/packages/studio-shared/src/index.ts
+++ b/packages/studio-shared/src/index.ts
@@ -197,6 +197,14 @@ export {
 	type ConfigFileChangeType,
 } from './config-file-change';
 export {configMethodLifecycles} from './config-method-lifecycles';
+export {
+	studioKeyboardShortcutActions,
+	type StudioKeyboardShortcut,
+	type StudioKeyboardShortcutAction,
+	type StudioKeyboardShortcuts,
+	type StudioKeyboardShortcutValue,
+	validateStudioKeyboardShortcuts,
+} from './keyboard-shortcuts';
 export {DEFAULT_BUFFER_STATE_DELAY_IN_MILLISECONDS} from './default-buffer-state-delay-in-milliseconds';
 export {
 	detectFileType,

--- a/packages/studio-shared/src/keyboard-shortcuts.ts
+++ b/packages/studio-shared/src/keyboard-shortcuts.ts
@@ -1,0 +1,135 @@
+export const studioKeyboardShortcutActions = [
+	'playPause',
+	'jumpToBeginning',
+	'jumpToEnd',
+	'reversePlayback',
+	'pausePlayback',
+	'playForward',
+	'goToFrame',
+	'pauseAndReturnToPlaybackStart',
+	'toggleLeftSidebar',
+	'toggleRightSidebar',
+	'toggleBothSidebars',
+	'enterFullscreen',
+	'toggleSnapping',
+	'previousComposition',
+	'nextComposition',
+	'showKeyboardShortcuts',
+	'quickSwitcher',
+	'render',
+	'toggleCheckerboard',
+	'setInPoint',
+	'setOutPoint',
+	'clearInOutPoints',
+	'zoomIn',
+	'zoomOut',
+	'resetZoom',
+	'undo',
+	'redo',
+	'selectAllSequenceRows',
+	'selectTranslateProp',
+	'selectOpacityProp',
+	'selectRotateProp',
+	'selectScaleProp',
+	'duplicateSequences',
+	'copyEffectsAndValues',
+	'cutEffects',
+	'deleteSelection',
+	'askAI',
+] as const;
+
+export type StudioKeyboardShortcutAction =
+	(typeof studioKeyboardShortcutActions)[number];
+
+export type StudioKeyboardShortcut = {
+	readonly key: string;
+	readonly commandOrControl?: boolean;
+	readonly shift?: boolean;
+	readonly alt?: boolean;
+};
+
+export type StudioKeyboardShortcutValue =
+	| StudioKeyboardShortcut
+	| readonly StudioKeyboardShortcut[]
+	| null;
+
+export type StudioKeyboardShortcuts = Partial<
+	Record<StudioKeyboardShortcutAction, StudioKeyboardShortcutValue>
+>;
+
+const actionSet = new Set<string>(studioKeyboardShortcutActions);
+
+const validateShortcut = ({
+	action,
+	shortcut,
+}: {
+	readonly action: string;
+	readonly shortcut: unknown;
+}): string | null => {
+	if (
+		typeof shortcut !== 'object' ||
+		shortcut === null ||
+		Array.isArray(shortcut)
+	) {
+		return `The keyboard shortcut for ${JSON.stringify(action)} must be an object.`;
+	}
+
+	const value = shortcut as Record<string, unknown>;
+	const allowedProperties = new Set([
+		'key',
+		'commandOrControl',
+		'shift',
+		'alt',
+	]);
+	for (const property of Object.keys(value)) {
+		if (!allowedProperties.has(property)) {
+			return `Unknown keyboard shortcut property ${JSON.stringify(property)} for ${JSON.stringify(action)}.`;
+		}
+	}
+
+	if (typeof value.key !== 'string' || value.key.length === 0) {
+		return `The keyboard shortcut for ${JSON.stringify(action)} must have a non-empty "key".`;
+	}
+
+	for (const modifier of ['commandOrControl', 'shift', 'alt'] as const) {
+		if (value[modifier] !== undefined && typeof value[modifier] !== 'boolean') {
+			return `The "${modifier}" property for ${JSON.stringify(action)} must be a boolean.`;
+		}
+	}
+
+	return null;
+};
+
+export const validateStudioKeyboardShortcuts = (
+	value: unknown,
+): string | null => {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return 'Config.setKeyboardShortcuts() expects an object.';
+	}
+
+	for (const [action, shortcutOrShortcuts] of Object.entries(value)) {
+		if (!actionSet.has(action)) {
+			return `Unknown Studio keyboard shortcut action: ${JSON.stringify(action)}.`;
+		}
+
+		if (shortcutOrShortcuts === null) {
+			continue;
+		}
+
+		const shortcuts = Array.isArray(shortcutOrShortcuts)
+			? shortcutOrShortcuts
+			: [shortcutOrShortcuts];
+		if (shortcuts.length === 0) {
+			return `The keyboard shortcut list for ${JSON.stringify(action)} must not be empty. Use null to disable it.`;
+		}
+
+		for (const shortcut of shortcuts) {
+			const error = validateShortcut({action, shortcut});
+			if (error !== null) {
+				return error;
+			}
+		}
+	}
+
+	return null;
+};

--- a/packages/studio-shared/src/studio-runtime-config.ts
+++ b/packages/studio-shared/src/studio-runtime-config.ts
@@ -3,6 +3,7 @@ import type {
 	DefaultCodingAgent,
 	LogLevel,
 } from '@remotion/renderer';
+import type {StudioKeyboardShortcuts} from './keyboard-shortcuts';
 
 export type ConfigFileStudioSettings = {
 	readonly askAIEnabled: boolean | null;
@@ -28,6 +29,7 @@ export type StudioRuntimeConfig = {
 	readonly elementLibraries?: readonly StudioElementLibrary[];
 	readonly interactivityEnabled: boolean;
 	readonly keyboardShortcutsEnabled: boolean;
+	readonly keyboardShortcuts?: StudioKeyboardShortcuts | null;
 	readonly bufferStateDelayInMilliseconds: number | null;
 	readonly defaultCodingAgent: DefaultCodingAgent | null;
 	readonly defaultEditor: BuiltInEditor | 'custom' | null;

--- a/packages/studio-shared/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio-shared/src/test/keyboard-shortcuts.test.ts
@@ -1,0 +1,28 @@
+import {expect, test} from 'bun:test';
+import {validateStudioKeyboardShortcuts} from '../keyboard-shortcuts';
+
+test('validates Studio keyboard shortcut configuration', () => {
+	expect(
+		validateStudioKeyboardShortcuts({
+			playPause: {key: 'p'},
+			quickSwitcher: {key: 'p', commandOrControl: true},
+			deleteSelection: [{key: 'Backspace'}, {key: 'Delete'}],
+			showKeyboardShortcuts: null,
+		}),
+	).toBeNull();
+
+	expect(validateStudioKeyboardShortcuts(null)).toBe(
+		'Config.setKeyboardShortcuts() expects an object.',
+	);
+	expect(validateStudioKeyboardShortcuts({unknown: {key: 'p'}})).toBe(
+		'Unknown Studio keyboard shortcut action: "unknown".',
+	);
+	expect(validateStudioKeyboardShortcuts({playPause: []})).toContain(
+		'must not be empty',
+	);
+	expect(
+		validateStudioKeyboardShortcuts({
+			playPause: {key: 'p', shift: 'yes'},
+		}),
+	).toContain('must be a boolean');
+});

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -701,8 +701,7 @@ export const Canvas: React.FC<{
 	useEffect(() => {
 		const resetBinding = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: '0',
-			commandCtrlKey: false,
+			action: 'resetZoom',
 			callback: onReset,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -711,8 +710,7 @@ export const Canvas: React.FC<{
 
 		const zoomIn = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: '+',
-			commandCtrlKey: false,
+			action: 'zoomIn',
 			callback: onZoomIn,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -721,8 +719,7 @@ export const Canvas: React.FC<{
 
 		const zoomOut = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: '-',
-			commandCtrlKey: false,
+			action: 'zoomOut',
 			callback: onZoomOut,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,

--- a/packages/studio/src/components/CheckboardToggle.tsx
+++ b/packages/studio/src/components/CheckboardToggle.tsx
@@ -2,15 +2,9 @@ import React, {useCallback, useContext} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
 import {BLUE} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {CheckerboardContext} from '../state/checkerboard';
 import {ControlButton} from './ControlButton';
-
-const accessibilityLabel = [
-	'Show transparency as checkerboard',
-	areKeyboardShortcutsDisabled() ? null : '(T)',
-]
-	.filter(NoReactInternals.truthy)
-	.join(' ');
 
 export const CheckboardToggle: React.FC = () => {
 	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
@@ -20,6 +14,13 @@ export const CheckboardToggle: React.FC = () => {
 			return !c;
 		});
 	}, [setCheckerboard]);
+	const shortcut = useKeyboardShortcutLabel('toggleCheckerboard');
+	const accessibilityLabel = [
+		'Show transparency as checkerboard',
+		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
+	]
+		.filter(NoReactInternals.truthy)
+		.join(' ');
 
 	return (
 		<ControlButton

--- a/packages/studio/src/components/FullscreenToggle.tsx
+++ b/packages/studio/src/components/FullscreenToggle.tsx
@@ -5,16 +5,10 @@ import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {FullscreenIcon} from '../icons/fullscreen';
 import {drawRef} from '../state/canvas-ref';
 import {ControlButton} from './ControlButton';
-
-const accessibilityLabel = [
-	'Enter fullscreen preview',
-	areKeyboardShortcutsDisabled() ? null : '(F)',
-]
-	.filter(NoReactInternals.truthy)
-	.join(' ');
 
 export const FullScreenToggle: React.FC<{
 	readonly hidden: boolean;
@@ -34,13 +28,19 @@ export const FullScreenToggle: React.FC<{
 				},
 			}));
 	}, [setSize]);
+	const shortcut = useKeyboardShortcutLabel('enterFullscreen');
+	const accessibilityLabel = [
+		'Enter fullscreen preview',
+		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
+	]
+		.filter(NoReactInternals.truthy)
+		.join(' ');
 
 	useEffect(() => {
 		const f = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'f',
+			action: 'enterFullscreen',
 			callback: onClick,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -1,3 +1,4 @@
+import type {StudioKeyboardShortcutAction} from '@remotion/studio-shared';
 import type React from 'react';
 import {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
@@ -17,12 +18,15 @@ import {
 	useCurrentTimelineSelectionStateAsRef,
 } from './Timeline/TimelineSelection';
 
-const sequencePropShortcuts: Record<string, string> = {
-	p: 'style.translate',
-	r: 'style.rotate',
-	s: 'style.scale',
-	t: 'style.opacity',
-};
+const sequencePropShortcuts = [
+	{action: 'selectTranslateProp', fieldKey: 'style.translate'},
+	{action: 'selectRotateProp', fieldKey: 'style.rotate'},
+	{action: 'selectScaleProp', fieldKey: 'style.scale'},
+	{action: 'selectOpacityProp', fieldKey: 'style.opacity'},
+] as const satisfies readonly {
+	readonly action: StudioKeyboardShortcutAction;
+	readonly fieldKey: string;
+}[];
 
 const hasOwnProperty = (obj: object, key: string) =>
 	Object.prototype.hasOwnProperty.call(obj, key);
@@ -118,33 +122,9 @@ export const GlobalKeybindings: React.FC = () => {
 	}, [video]);
 
 	useEffect(() => {
-		const onSequencePropKey = (event: KeyboardEvent) => {
-			const key = event.key.toLowerCase();
-			const fieldKey = sequencePropShortcuts[key];
-			if (!fieldKey) {
-				return;
-			}
-
-			if (selectSequenceProp(fieldKey)) {
-				event.preventDefault();
-				return;
-			}
-
-			if (key === 't') {
-				setCheckerboard((c) => !c);
-				event.preventDefault();
-				return;
-			}
-
-			if (key === 'r') {
-				openRenderModal();
-				event.preventDefault();
-			}
-		};
-
 		const cmdKKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'k',
+			action: 'quickSwitcher',
 			callback: () => {
 				setSelectedModal({
 					type: 'quick-switcher',
@@ -159,7 +139,6 @@ export const GlobalKeybindings: React.FC = () => {
 			},
 			triggerIfInputFieldFocused: true,
 			keepRegisteredWhenNotHighestContext: false,
-			commandCtrlKey: true,
 			preventDefault: true,
 		});
 		const cmdSKey = keybindings.registerKeybinding({
@@ -176,31 +155,57 @@ export const GlobalKeybindings: React.FC = () => {
 		const cmdIKey = getStudioAskAIEnabled()
 			? keybindings.registerKeybinding({
 					event: 'keydown',
-					key: 'i',
+					action: 'askAI',
 					callback: () => {
 						askAiModalRef.current?.toggle();
 					},
 					triggerIfInputFieldFocused: true,
 					keepRegisteredWhenNotHighestContext: true,
-					commandCtrlKey: true,
 					preventDefault: true,
 				})
 			: null;
 
-		const sequencePropKeys = Object.keys(sequencePropShortcuts).map((key) =>
+		const sequencePropKeys = sequencePropShortcuts.map(({action, fieldKey}) =>
 			keybindings.registerKeybinding({
 				event: 'keydown',
-				key,
-				callback: onSequencePropKey,
-				commandCtrlKey: false,
+				action,
+				callback: (event) => {
+					if (selectSequenceProp(fieldKey)) {
+						event.preventDefault();
+					}
+				},
 				preventDefault: false,
 				triggerIfInputFieldFocused: false,
 				keepRegisteredWhenNotHighestContext: false,
 			}),
 		);
+		const render = keybindings.registerKeybinding({
+			event: 'keydown',
+			action: 'render',
+			callback: (event) => {
+				if (event.defaultPrevented) return;
+				openRenderModal();
+				event.preventDefault();
+			},
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		const checkerboard = keybindings.registerKeybinding({
+			event: 'keydown',
+			action: 'toggleCheckerboard',
+			callback: (event) => {
+				if (event.defaultPrevented) return;
+				setCheckerboard((current) => !current);
+				event.preventDefault();
+			},
+			preventDefault: false,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
 		const questionMark = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: '?',
+			event: 'keydown',
+			action: 'showKeyboardShortcuts',
 			callback: () => {
 				setSelectedModal({
 					type: 'settings',
@@ -209,7 +214,6 @@ export const GlobalKeybindings: React.FC = () => {
 						window.remotion_renderDefaults?.publicLicenseKey ?? null,
 				});
 			},
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -217,9 +221,8 @@ export const GlobalKeybindings: React.FC = () => {
 
 		const pageDown = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'PageDown',
+			action: 'nextComposition',
 			callback: navigateToNextComposition,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -227,9 +230,8 @@ export const GlobalKeybindings: React.FC = () => {
 
 		const pageUp = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'PageUp',
+			action: 'previousComposition',
 			callback: navigateToPreviousComposition,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -237,17 +239,11 @@ export const GlobalKeybindings: React.FC = () => {
 
 		const shiftMKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'm',
-			callback: (event) => {
-				if (!event.shiftKey) {
-					return;
-				}
-
+			action: 'toggleSnapping',
+			callback: () => {
 				setEditorSnapping((current) => !current);
-				event.preventDefault();
 			},
-			commandCtrlKey: false,
-			preventDefault: false,
+			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
@@ -256,6 +252,9 @@ export const GlobalKeybindings: React.FC = () => {
 			for (const sequencePropKey of sequencePropKeys) {
 				sequencePropKey.unregister();
 			}
+
+			render.unregister();
+			checkerboard.unregister();
 
 			questionMark.unregister();
 			cmdKKey.unregister();

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -1,4 +1,10 @@
-import type {ConfigUpdate} from '@remotion/studio-shared';
+import type {
+	ConfigUpdate,
+	ConfigValue,
+	StudioKeyboardShortcut,
+	StudioKeyboardShortcutAction,
+	StudioKeyboardShortcuts,
+} from '@remotion/studio-shared';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {
@@ -13,7 +19,10 @@ import {booleanOptions, ConfigSelect} from './ConfigSelect';
 import {sectionHeader} from './InspectorPanel/styles';
 import {
 	askAIKeyboardShortcutGroup,
+	formatKeyboardShortcut,
+	getKeyboardShortcutsForAction,
 	keyboardShortcutGroups,
+	shortcutFromKeyboardEvent,
 } from './keyboard-shortcuts';
 import {Spacing} from './layout';
 import {ValidationMessage} from './NewComposition/ValidationMessage';
@@ -46,7 +55,7 @@ const shortcutRow: React.CSSProperties = {
 	gap: 16,
 	justifyContent: 'space-between',
 	margin: '0 16px',
-	minHeight: 38,
+	minHeight: 42,
 };
 
 const lastShortcutRow: React.CSSProperties = {
@@ -61,10 +70,16 @@ const actionName: React.CSSProperties = {
 	minWidth: 0,
 };
 
-const chords: React.CSSProperties = {
+const actions: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
 	flexShrink: 0,
+	gap: 6,
+};
+
+const chords: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
 	gap: 6,
 };
 
@@ -88,16 +103,81 @@ const key: React.CSSProperties = {
 	textAlign: 'center',
 };
 
+const chordButton: React.CSSProperties = {
+	alignItems: 'center',
+	background: 'transparent',
+	border: 0,
+	cursor: 'pointer',
+	display: 'flex',
+	font: 'inherit',
+	margin: 0,
+	padding: '4px 0',
+};
+
+const smallButton: React.CSSProperties = {
+	background: 'transparent',
+	border: 0,
+	color: LIGHT_TEXT,
+	cursor: 'pointer',
+	fontSize: 11,
+	padding: '4px',
+};
+
 const alternative: React.CSSProperties = {
 	color: LIGHT_TEXT,
 	fontSize: 11,
+};
+
+const emptyShortcut: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontSize: 12,
+	fontStyle: 'italic',
+};
+
+const isSameShortcut = (
+	first: StudioKeyboardShortcut,
+	second: StudioKeyboardShortcut,
+) =>
+	first.key.toLowerCase() === second.key.toLowerCase() &&
+	(first.commandOrControl ?? false) === (second.commandOrControl ?? false) &&
+	(first.shift ?? false) === (second.shift ?? false) &&
+	(first.alt ?? false) === (second.alt ?? false);
+
+const ShortcutChords: React.FC<{
+	readonly values: readonly (readonly string[])[];
+}> = ({values}) => {
+	if (values.length === 0) {
+		return <span style={emptyShortcut}>Unassigned</span>;
+	}
+
+	return (
+		<span style={chords}>
+			{values.map((keys, chordIndex) => (
+				<React.Fragment key={keys.join('-')}>
+					{chordIndex > 0 ? <span style={alternative}>or</span> : null}
+					<span style={chord}>
+						{keys.map((keyboardKey) => (
+							<kbd key={keyboardKey} style={key}>
+								{keyboardKey}
+							</kbd>
+						))}
+					</span>
+				</React.Fragment>
+			))}
+		</span>
+	);
 };
 
 export const KeyboardShortcutsSettings: React.FC = () => {
 	const {error: settingsError, revision, studioRuntimeConfig} = useSettings();
 	const isBrowserStudio = getBrowserStudioOperations() !== null;
 	const [enabled, setEnabled] = useState<boolean | null>(null);
-	const [edited, setEdited] = useState(false);
+	const [configuredShortcuts, setConfiguredShortcuts] =
+		useState<StudioKeyboardShortcuts>({});
+	const [enabledEdited, setEnabledEdited] = useState(false);
+	const [shortcutsEdited, setShortcutsEdited] = useState(false);
+	const [recording, setRecording] =
+		useState<StudioKeyboardShortcutAction | null>(null);
 	const [syncedRevision, setSyncedRevision] = useState(-1);
 	const [error, setError] = useState<string | null>(null);
 	const displayedShortcutGroups = getStudioAskAIEnabled()
@@ -113,31 +193,47 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 			studioRuntimeConfig.configFileStudioSettings?.keyboardShortcutsEnabled ??
 				null,
 		);
-		setEdited(false);
+		setConfiguredShortcuts(studioRuntimeConfig.keyboardShortcuts ?? {});
+		setEnabledEdited(false);
+		setShortcutsEdited(false);
+		setRecording(null);
 		setSyncedRevision(revision);
 		setError(null);
 	}, [revision, studioRuntimeConfig]);
 
 	const onEnabledChange = useCallback((value: boolean | null) => {
 		setEnabled(value);
-		setEdited(true);
+		setEnabledEdited(true);
 	}, []);
 
 	const updates = useMemo((): ConfigUpdate[] => {
-		if (!edited) {
-			return [];
+		const nextUpdates: ConfigUpdate[] = [];
+		if (enabledEdited) {
+			nextUpdates.push(
+				enabled === null
+					? {setter: 'setKeyboardShortcutsEnabled', type: 'delete'}
+					: {
+							setter: 'setKeyboardShortcutsEnabled',
+							type: 'set',
+							value: enabled,
+						},
+			);
 		}
 
-		return enabled === null
-			? [{setter: 'setKeyboardShortcutsEnabled', type: 'delete'}]
-			: [
-					{
-						setter: 'setKeyboardShortcutsEnabled',
-						type: 'set',
-						value: enabled,
-					},
-				];
-	}, [edited, enabled]);
+		if (shortcutsEdited) {
+			nextUpdates.push(
+				Object.keys(configuredShortcuts).length === 0
+					? {setter: 'setKeyboardShortcuts', type: 'delete'}
+					: {
+							setter: 'setKeyboardShortcuts',
+							type: 'set',
+							value: configuredShortcuts as ConfigValue,
+						},
+			);
+		}
+
+		return nextUpdates;
+	}, [configuredShortcuts, enabled, enabledEdited, shortcutsEdited]);
 
 	const ready = studioRuntimeConfig !== null && syncedRevision === revision;
 	useAutoSaveConfig({
@@ -170,36 +266,139 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 				<div key={group.name}>
 					<p style={shortcutSectionTitle}>{group.name}</p>
 					<div role="list" aria-label={group.name}>
-						{group.shortcuts.map((shortcut, shortcutIndex) => (
-							<div
-								key={shortcut.action}
-								role="listitem"
-								style={
-									groupIndex === displayedShortcutGroups.length - 1 &&
-									shortcutIndex === group.shortcuts.length - 1
-										? lastShortcutRow
-										: shortcutRow
-								}
-							>
-								<span style={actionName}>{shortcut.action}</span>
-								<span style={chords}>
-									{shortcut.chords.map((keys, chordIndex) => (
-										<React.Fragment key={keys.join('-')}>
-											{chordIndex > 0 ? (
-												<span style={alternative}>or</span>
-											) : null}
-											<span style={chord}>
-												{keys.map((keyboardKey) => (
-													<kbd key={keyboardKey} style={key}>
-														{keyboardKey}
-													</kbd>
-												))}
+						{group.shortcuts.map((shortcut, shortcutIndex) => {
+							const configured =
+								shortcut.actionId === null
+									? false
+									: Object.prototype.hasOwnProperty.call(
+											configuredShortcuts,
+											shortcut.actionId,
+										);
+							const shortcutValues =
+								shortcut.actionId === null
+									? (shortcut.fixedChords ?? [])
+									: getKeyboardShortcutsForAction(
+											shortcut.actionId,
+											configuredShortcuts,
+										).map(formatKeyboardShortcut);
+
+							return (
+								<div
+									key={shortcut.action}
+									role="listitem"
+									style={
+										groupIndex === displayedShortcutGroups.length - 1 &&
+										shortcutIndex === group.shortcuts.length - 1
+											? lastShortcutRow
+											: shortcutRow
+									}
+								>
+									<span style={actionName}>{shortcut.action}</span>
+									<span style={actions}>
+										{shortcut.actionId === null || isBrowserStudio ? (
+											<span title={shortcut.fixedReason}>
+												<ShortcutChords values={shortcutValues} />
+												{shortcut.actionId === null ? (
+													<span style={smallButton}>Fixed</span>
+												) : null}
 											</span>
-										</React.Fragment>
-									))}
-								</span>
-							</div>
-						))}
+										) : (
+											<>
+												<button
+													type="button"
+													style={chordButton}
+													title="Click, then press a new shortcut"
+													aria-label={`Change shortcut for ${shortcut.action}`}
+													onClick={() => {
+														setError(null);
+														setRecording(shortcut.actionId);
+													}}
+													onKeyDown={(event) => {
+														if (recording !== shortcut.actionId) return;
+														event.preventDefault();
+														event.stopPropagation();
+														if (event.key === 'Escape') {
+															setRecording(null);
+															return;
+														}
+
+														const value = shortcutFromKeyboardEvent(
+															event.nativeEvent,
+														);
+														if (value === null) return;
+														const conflict = displayedShortcutGroups
+															.flatMap((item) => item.shortcuts)
+															.find(
+																(item) =>
+																	item.actionId !== null &&
+																	item.actionId !== shortcut.actionId &&
+																	getKeyboardShortcutsForAction(
+																		item.actionId,
+																		configuredShortcuts,
+																	).some((candidate) =>
+																		isSameShortcut(candidate, value),
+																	),
+															);
+														if (conflict) {
+															setError(
+																`Shortcut is already used by “${conflict.action}”.`,
+															);
+															return;
+														}
+
+														setConfiguredShortcuts((current) => ({
+															...current,
+															[shortcut.actionId!]: value,
+														}));
+														setShortcutsEdited(true);
+														setRecording(null);
+													}}
+												>
+													{recording === shortcut.actionId ? (
+														<span style={emptyShortcut}>Press shortcut…</span>
+													) : (
+														<ShortcutChords values={shortcutValues} />
+													)}
+												</button>
+												{configured ? (
+													<button
+														type="button"
+														style={smallButton}
+														title="Reset to default"
+														onClick={() => {
+															setConfiguredShortcuts((current) => {
+																const next = {...current};
+																delete next[shortcut.actionId!];
+																return next;
+															});
+															setShortcutsEdited(true);
+														}}
+													>
+														Reset
+													</button>
+												) : null}
+												{configuredShortcuts[shortcut.actionId] !== null ? (
+													<button
+														type="button"
+														style={smallButton}
+														title="Disable shortcut"
+														onClick={() => {
+															setConfiguredShortcuts((current) => ({
+																...current,
+																[shortcut.actionId!]: null,
+															}));
+															setShortcutsEdited(true);
+														}}
+													>
+														Disable
+													</button>
+												) : null}
+											</>
+										)}
+									</span>
+								</div>
+							);
+						})}
 					</div>
 				</div>
 			))}

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -15,7 +15,9 @@ import {
 	WHITE,
 } from '../helpers/colors';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
+import {CaretDown} from '../icons/caret';
 import {booleanOptions, ConfigSelect} from './ConfigSelect';
+import {InlineDropdown} from './InlineDropdown';
 import {sectionHeader} from './InspectorPanel/styles';
 import {
 	askAIKeyboardShortcutGroup,
@@ -25,6 +27,7 @@ import {
 	shortcutFromKeyboardEvent,
 } from './keyboard-shortcuts';
 import {Spacing} from './layout';
+import type {ComboboxValue} from './NewComposition/ComboBox';
 import {ValidationMessage} from './NewComposition/ValidationMessage';
 import {useSettings} from './SettingsContext';
 import {useAutoSaveConfig} from './use-auto-save-config';
@@ -53,7 +56,7 @@ const shortcutRow: React.CSSProperties = {
 	borderBottom: BORDER_WHITE_ALPHA_12,
 	columnGap: 12,
 	display: 'grid',
-	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 94px',
+	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 24px',
 	margin: '0 16px',
 	minHeight: 42,
 };
@@ -121,21 +124,6 @@ const chordButton: React.CSSProperties = {
 	font: 'inherit',
 	margin: 0,
 	padding: '4px 0',
-};
-
-const smallButton: React.CSSProperties = {
-	background: 'transparent',
-	border: 0,
-	color: LIGHT_TEXT,
-	cursor: 'pointer',
-	fontSize: 11,
-	padding: '4px',
-};
-
-const fixedLabel: React.CSSProperties = {
-	color: LIGHT_TEXT,
-	fontSize: 11,
-	padding: '4px',
 };
 
 const alternative: React.CSSProperties = {
@@ -296,6 +284,54 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 											shortcut.actionId,
 											configuredShortcuts,
 										).map(formatKeyboardShortcut);
+							const shortcutMenuItems: ComboboxValue[] =
+								shortcut.actionId === null
+									? []
+									: [
+											...(configured
+												? [
+														{
+															id: 'reset-shortcut',
+															keyHint: null,
+															label: 'Reset to default',
+															leftItem: null,
+															onClick: () => {
+																setConfiguredShortcuts((current) => {
+																	const next = {...current};
+																	delete next[shortcut.actionId!];
+																	return next;
+																});
+																setShortcutsEdited(true);
+															},
+															quickSwitcherLabel: null,
+															subMenu: null,
+															type: 'item' as const,
+															value: 'reset-shortcut',
+														},
+													]
+												: []),
+											...(configuredShortcuts[shortcut.actionId] !== null
+												? [
+														{
+															id: 'disable-shortcut',
+															keyHint: null,
+															label: 'Disable shortcut',
+															leftItem: null,
+															onClick: () => {
+																setConfiguredShortcuts((current) => ({
+																	...current,
+																	[shortcut.actionId!]: null,
+																}));
+																setShortcutsEdited(true);
+															},
+															quickSwitcherLabel: null,
+															subMenu: null,
+															type: 'item' as const,
+															value: 'disable-shortcut',
+														},
+													]
+												: []),
+										];
 
 							return (
 								<div
@@ -314,13 +350,7 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 											<span style={shortcutCell}>
 												<ShortcutChords values={shortcutValues} />
 											</span>
-											<span style={actionCell}>
-												{shortcut.actionId === null ? (
-													<span style={fixedLabel} title={shortcut.fixedReason}>
-														Fixed
-													</span>
-												) : null}
-											</span>
+											<span />
 										</>
 									) : (
 										<>
@@ -382,39 +412,12 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 												</button>
 											</span>
 											<span style={actionCell}>
-												{configured ? (
-													<button
-														type="button"
-														style={smallButton}
-														title="Reset to default"
-														onClick={() => {
-															setConfiguredShortcuts((current) => {
-																const next = {...current};
-																delete next[shortcut.actionId!];
-																return next;
-															});
-															setShortcutsEdited(true);
-														}}
-													>
-														Reset
-													</button>
-												) : null}
-												{configuredShortcuts[shortcut.actionId] !== null ? (
-													<button
-														type="button"
-														style={smallButton}
-														title="Disable shortcut"
-														onClick={() => {
-															setConfiguredShortcuts((current) => ({
-																...current,
-																[shortcut.actionId!]: null,
-															}));
-															setShortcutsEdited(true);
-														}}
-													>
-														Disable
-													</button>
-												) : null}
+												<InlineDropdown
+													renderAction={(color) => <CaretDown color={color} />}
+													title={`Actions for ${shortcut.action}`}
+													values={shortcutMenuItems}
+													variant={null}
+												/>
 											</span>
 										</>
 									)}

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -283,10 +283,31 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 											shortcut.actionId,
 											configuredShortcuts,
 										).map(formatKeyboardShortcut);
+							const shortcutButtonId =
+								shortcut.actionId === null
+									? null
+									: `keyboard-shortcut-${shortcut.actionId}`;
 							const shortcutMenuItems: ComboboxValue[] =
 								shortcut.actionId === null
 									? []
 									: [
+											{
+												id: 'remap-shortcut',
+												keyHint: null,
+												label: 'Remap shortcut',
+												leftItem: null,
+												onClick: () => {
+													setError(null);
+													setRecording(shortcut.actionId);
+													requestAnimationFrame(() => {
+														document.getElementById(shortcutButtonId!)?.focus();
+													});
+												},
+												quickSwitcherLabel: null,
+												subMenu: null,
+												type: 'item',
+												value: 'remap-shortcut',
+											},
 											...(configured
 												? [
 														{
@@ -355,6 +376,7 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 										<>
 											<span style={shortcutCell}>
 												<button
+													id={shortcutButtonId!}
 													type="button"
 													style={chordButton}
 													aria-label={`Change shortcut for ${shortcut.action}`}

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -21,6 +21,7 @@ import {InlineDropdown} from './InlineDropdown';
 import {sectionHeader} from './InspectorPanel/styles';
 import {
 	askAIKeyboardShortcutGroup,
+	defaultKeyboardShortcuts,
 	formatKeyboardShortcut,
 	getKeyboardShortcutsForAction,
 	keyboardShortcutGroups,
@@ -418,10 +419,24 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 															return;
 														}
 
-														setConfiguredShortcuts((current) => ({
-															...current,
-															[shortcut.actionId!]: value,
-														}));
+														setConfiguredShortcuts((current) => {
+															if (
+																defaultKeyboardShortcuts[
+																	shortcut.actionId!
+																].some((defaultShortcut) =>
+																	isSameShortcut(defaultShortcut, value),
+																)
+															) {
+																const next = {...current};
+																delete next[shortcut.actionId!];
+																return next;
+															}
+
+															return {
+																...current,
+																[shortcut.actionId!]: value,
+															};
+														});
 														setShortcutsEdited(true);
 														setRecording(null);
 													}}

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -25,6 +25,7 @@ import {
 	formatKeyboardShortcut,
 	getKeyboardShortcutsForAction,
 	keyboardShortcutGroups,
+	keyboardShortcutsOverlap,
 	shortcutFromKeyboardEvent,
 } from './keyboard-shortcuts';
 import {Spacing} from './layout';
@@ -417,7 +418,7 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 																		item.actionId,
 																		configuredShortcuts,
 																	).some((candidate) =>
-																		isSameShortcut(candidate, value),
+																		keyboardShortcutsOverlap(candidate, value),
 																	),
 															);
 														if (conflict) {

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -54,7 +54,6 @@ const shortcutSectionTitle: React.CSSProperties = {
 const shortcutRow: React.CSSProperties = {
 	alignItems: 'center',
 	borderBottom: BORDER_WHITE_ALPHA_12,
-	columnGap: 12,
 	display: 'grid',
 	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 24px',
 	margin: '0 16px',

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -54,7 +54,7 @@ const shortcutSectionTitle: React.CSSProperties = {
 const shortcutRow: React.CSSProperties = {
 	alignItems: 'center',
 	borderBottom: BORDER_WHITE_ALPHA_12,
-	columnGap: 2,
+	columnGap: 4,
 	display: 'grid',
 	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 14px',
 	margin: '0 16px',

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -54,8 +54,9 @@ const shortcutSectionTitle: React.CSSProperties = {
 const shortcutRow: React.CSSProperties = {
 	alignItems: 'center',
 	borderBottom: BORDER_WHITE_ALPHA_12,
+	columnGap: 2,
 	display: 'grid',
-	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 24px',
+	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 14px',
 	margin: '0 16px',
 	minHeight: 42,
 };
@@ -437,7 +438,7 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 													renderAction={(color) => <CaretDown color={color} />}
 													title={`Actions for ${shortcut.action}`}
 													values={shortcutMenuItems}
-													variant={null}
+													variant="compact"
 												/>
 											</span>
 										</>

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -51,9 +51,9 @@ const shortcutSectionTitle: React.CSSProperties = {
 const shortcutRow: React.CSSProperties = {
 	alignItems: 'center',
 	borderBottom: BORDER_WHITE_ALPHA_12,
-	display: 'flex',
-	gap: 16,
-	justifyContent: 'space-between',
+	columnGap: 12,
+	display: 'grid',
+	gridTemplateColumns: 'minmax(0, 1fr) minmax(76px, max-content) 94px',
 	margin: '0 16px',
 	minHeight: 42,
 };
@@ -70,17 +70,26 @@ const actionName: React.CSSProperties = {
 	minWidth: 0,
 };
 
-const actions: React.CSSProperties = {
+const shortcutCell: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
-	flexShrink: 0,
+	justifyContent: 'flex-end',
+	minWidth: 0,
+};
+
+const actionCell: React.CSSProperties = {
+	alignItems: 'center',
+	display: 'flex',
 	gap: 6,
+	justifyContent: 'flex-start',
+	whiteSpace: 'nowrap',
 };
 
 const chords: React.CSSProperties = {
 	alignItems: 'center',
 	display: 'flex',
 	gap: 6,
+	whiteSpace: 'nowrap',
 };
 
 const chord: React.CSSProperties = {
@@ -119,6 +128,12 @@ const smallButton: React.CSSProperties = {
 	border: 0,
 	color: LIGHT_TEXT,
 	cursor: 'pointer',
+	fontSize: 11,
+	padding: '4px',
+};
+
+const fixedLabel: React.CSSProperties = {
+	color: LIGHT_TEXT,
 	fontSize: 11,
 	padding: '4px',
 };
@@ -294,20 +309,25 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 									}
 								>
 									<span style={actionName}>{shortcut.action}</span>
-									<span style={actions}>
-										{shortcut.actionId === null || isBrowserStudio ? (
-											<span title={shortcut.fixedReason}>
+									{shortcut.actionId === null || isBrowserStudio ? (
+										<>
+											<span style={shortcutCell}>
 												<ShortcutChords values={shortcutValues} />
+											</span>
+											<span style={actionCell}>
 												{shortcut.actionId === null ? (
-													<span style={smallButton}>Fixed</span>
+													<span style={fixedLabel} title={shortcut.fixedReason}>
+														Fixed
+													</span>
 												) : null}
 											</span>
-										) : (
-											<>
+										</>
+									) : (
+										<>
+											<span style={shortcutCell}>
 												<button
 													type="button"
 													style={chordButton}
-													title="Click, then press a new shortcut"
 													aria-label={`Change shortcut for ${shortcut.action}`}
 													onClick={() => {
 														setError(null);
@@ -360,6 +380,8 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 														<ShortcutChords values={shortcutValues} />
 													)}
 												</button>
+											</span>
+											<span style={actionCell}>
 												{configured ? (
 													<button
 														type="button"
@@ -393,9 +415,9 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 														Disable
 													</button>
 												) : null}
-											</>
-										)}
-									</span>
+											</span>
+										</>
+									)}
 								</div>
 							);
 						})}

--- a/packages/studio/src/components/KeyboardShortcutsSettings.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsSettings.tsx
@@ -16,7 +16,7 @@ import {
 } from '../helpers/colors';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {CaretDown} from '../icons/caret';
-import {booleanOptions, ConfigSelect} from './ConfigSelect';
+import {Checkbox} from './Checkbox';
 import {InlineDropdown} from './InlineDropdown';
 import {sectionHeader} from './InspectorPanel/styles';
 import {
@@ -30,6 +30,7 @@ import {
 import {Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 import {ValidationMessage} from './NewComposition/ValidationMessage';
+import {label, optionRow, rightRow} from './RenderModal/layout';
 import {useSettings} from './SettingsContext';
 import {useAutoSaveConfig} from './use-auto-save-config';
 
@@ -175,7 +176,7 @@ const ShortcutChords: React.FC<{
 export const KeyboardShortcutsSettings: React.FC = () => {
 	const {error: settingsError, revision, studioRuntimeConfig} = useSettings();
 	const isBrowserStudio = getBrowserStudioOperations() !== null;
-	const [enabled, setEnabled] = useState<boolean | null>(null);
+	const [enabled, setEnabled] = useState(true);
 	const [configuredShortcuts, setConfiguredShortcuts] =
 		useState<StudioKeyboardShortcuts>({});
 	const [enabledEdited, setEnabledEdited] = useState(false);
@@ -187,6 +188,7 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 	const displayedShortcutGroups = getStudioAskAIEnabled()
 		? [...keyboardShortcutGroups, askAIKeyboardShortcutGroup]
 		: keyboardShortcutGroups;
+	const visibleShortcutGroups = enabled ? displayedShortcutGroups : [];
 
 	useEffect(() => {
 		if (studioRuntimeConfig === null) {
@@ -194,8 +196,8 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 		}
 
 		setEnabled(
-			studioRuntimeConfig.configFileStudioSettings?.keyboardShortcutsEnabled ??
-				null,
+			studioRuntimeConfig.configFileStudioSettings?.keyboardShortcutsEnabled !==
+				false,
 		);
 		setConfiguredShortcuts(studioRuntimeConfig.keyboardShortcuts ?? {});
 		setEnabledEdited(false);
@@ -205,21 +207,24 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 		setError(null);
 	}, [revision, studioRuntimeConfig]);
 
-	const onEnabledChange = useCallback((value: boolean | null) => {
-		setEnabled(value);
-		setEnabledEdited(true);
-	}, []);
+	const onEnabledChange = useCallback(
+		(event: React.ChangeEvent<HTMLInputElement>) => {
+			setEnabled(event.target.checked);
+			setEnabledEdited(true);
+		},
+		[],
+	);
 
 	const updates = useMemo((): ConfigUpdate[] => {
 		const nextUpdates: ConfigUpdate[] = [];
 		if (enabledEdited) {
 			nextUpdates.push(
-				enabled === null
+				enabled
 					? {setter: 'setKeyboardShortcutsEnabled', type: 'delete'}
 					: {
 							setter: 'setKeyboardShortcutsEnabled',
 							type: 'set',
-							value: enabled,
+							value: false,
 						},
 			);
 		}
@@ -257,16 +262,19 @@ export const KeyboardShortcutsSettings: React.FC = () => {
 			{isBrowserStudio ? null : (
 				<>
 					<p style={dividerLabel}>General</p>
-					<ConfigSelect
-						defaultLabel="Enabled"
-						name="Keyboard shortcuts"
-						onChange={onEnabledChange}
-						options={booleanOptions}
-						value={enabled}
-					/>
+					<label style={optionRow}>
+						<div style={label}>Keyboard shortcuts</div>
+						<div style={rightRow}>
+							<Checkbox
+								checked={enabled}
+								name="keyboard-shortcuts"
+								onChange={onEnabledChange}
+							/>
+						</div>
+					</label>
 				</>
 			)}
-			{displayedShortcutGroups.map((group, groupIndex) => (
+			{visibleShortcutGroups.map((group, groupIndex) => (
 				<div key={group.name}>
 					<p style={shortcutSectionTitle}>{group.name}</p>
 					<div role="list" aria-label={group.name}>

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -1,12 +1,12 @@
 import type {SetStateAction} from 'react';
 import React, {useCallback, useContext, useMemo, useState} from 'react';
-import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {canShowUpdates} from '../helpers/can-show-updates';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {useMenuStructure} from '../helpers/use-menu-structure';
 import {SearchIcon} from '../icons/search';
 import {SetSelectedModalContext} from '../state/modals';
@@ -162,9 +162,11 @@ export const MenuToolbar: React.FC<{
 		return <SearchIcon color={color} width={18} height={18} />;
 	}, []);
 
-	const searchTooltip = areKeyboardShortcutsDisabled()
-		? 'Quick Switcher'
-		: `Quick Switcher (${cmdOrCtrlCharacter}+K)`;
+	const quickSwitcherShortcut = useKeyboardShortcutLabel('quickSwitcher');
+	const searchTooltip =
+		areKeyboardShortcutsDisabled() || quickSwitcherShortcut === ''
+			? 'Quick Switcher'
+			: `Quick Switcher (${quickSwitcherShortcut})`;
 
 	return (
 		<Row

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -162,36 +162,32 @@ const PlayPauseInner: React.FC<{
 		});
 		const space = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: ' ',
+			action: 'playPause',
 			callback: onSpace,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const enter = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'enter',
+			action: 'pauseAndReturnToPlaybackStart',
 			callback: onEnter,
-			commandCtrlKey: false,
 			preventDefault: false,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const a = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'a',
+			action: 'jumpToBeginning',
 			callback: jumpToStart,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const e = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'e',
+			action: 'jumpToEnd',
 			callback: jumpToEnd,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/PlaybackKeyboardShortcutsManager.tsx
+++ b/packages/studio/src/components/PlaybackKeyboardShortcutsManager.tsx
@@ -58,27 +58,24 @@ export const PlaybackKeyboardShortcutsManager: React.FC<{
 	useEffect(() => {
 		const jKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'j',
+			action: 'reversePlayback',
 			callback: onJKey,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const kKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'k',
+			action: 'pausePlayback',
 			callback: onKKey,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const lKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'l',
+			action: 'playForward',
 			callback: onLKey,
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
+++ b/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
@@ -2,6 +2,7 @@ import type {SVGProps} from 'react';
 import React, {useCallback, useContext, useMemo} from 'react';
 import {WHITE_ALPHA_80} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {Checkmark} from '../icons/Checkmark';
 import {EllipsisIcon} from '../icons/ellipsis';
 import {CheckerboardContext} from '../state/checkerboard';
@@ -41,6 +42,8 @@ export const PreviewToolbarOverflowButton: React.FC<{
 	setLoop,
 }) => {
 	const keyboardShortcutsDisabled = areKeyboardShortcutsDisabled();
+	const fullscreenShortcut = useKeyboardShortcutLabel('enterFullscreen');
+	const checkerboardShortcut = useKeyboardShortcutLabel('toggleCheckerboard');
 	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
 	const {editorShowOutlines, setEditorShowOutlines} = useContext(
 		EditorShowOutlinesContext,
@@ -138,7 +141,10 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				label: 'Transparency as checkerboard',
 				value: 'checkerboard',
 				onClick: () => setCheckerboard((current) => !current),
-				keyHint: keyboardShortcutsDisabled ? null : 'T',
+				keyHint:
+					keyboardShortcutsDisabled || checkerboardShortcut === ''
+						? null
+						: checkerboardShortcut,
 				leftItem: checkerboard ? <Checkmark /> : null,
 				subMenu: null,
 				quickSwitcherLabel: null,
@@ -194,7 +200,10 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				label: 'Fullscreen',
 				value: 'fullscreen',
 				onClick: () => clickButton('fullscreen-toggle'),
-				keyHint: keyboardShortcutsDisabled ? null : 'F',
+				keyHint:
+					keyboardShortcutsDisabled || fullscreenShortcut === ''
+						? null
+						: fullscreenShortcut,
 				leftItem: null,
 				subMenu: null,
 				quickSwitcherLabel: null,
@@ -203,6 +212,8 @@ export const PreviewToolbarOverflowButton: React.FC<{
 
 		return items;
 	}, [
+		checkerboardShortcut,
+		fullscreenShortcut,
 		previewSizeItems,
 		playbackRateItems,
 		selectedPlaybackRate,

--- a/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
+++ b/packages/studio/src/components/QuickSwitcher/ExplorerQuickSwitcherTrigger.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useContext} from 'react';
-import {cmdOrCtrlCharacter} from '../../error-overlay/remotion-overlay/ShortcutHint';
 import {
 	BLACK_HEX,
 	LIGHT_TEXT,
@@ -12,6 +11,7 @@ import {
 	hoverableStyle,
 } from '../../helpers/hoverable';
 import {areKeyboardShortcutsDisabled} from '../../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../../helpers/use-keyboard-shortcut-label';
 import {EllipsisIcon} from '../../icons/ellipsis';
 import {SetSelectedModalContext} from '../../state/modals';
 import type {RenderInlineAction} from '../InlineAction';
@@ -80,6 +80,7 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 	}, []);
 	const moreActionsTitle =
 		mode === 'assets' ? 'More asset actions' : 'More composition actions';
+	const quickSwitcherShortcut = useKeyboardShortcutLabel('quickSwitcher');
 
 	return (
 		<div style={quickSwitcherArea}>
@@ -91,8 +92,10 @@ export const ExplorerQuickSwitcherTrigger: React.FC<{
 				className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 			>
 				Search...
-				{showShortcut && !areKeyboardShortcutsDisabled() ? (
-					<span style={shortcutLabel}>{cmdOrCtrlCharacter}+K</span>
+				{showShortcut &&
+				!areKeyboardShortcutsDisabled() &&
+				quickSwitcherShortcut !== '' ? (
+					<span style={shortcutLabel}>{quickSwitcherShortcut}</span>
 				) : null}
 			</button>
 			<InlineDropdown

--- a/packages/studio/src/components/RenderButton.tsx
+++ b/packages/studio/src/components/RenderButton.tsx
@@ -16,6 +16,7 @@ import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {WHITE_ALPHA_80} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {CaretDown} from '../icons/caret';
 import {ThinRenderIcon} from '../icons/render';
 import {useTimelineInOutFramePosition} from '../state/in-out';
@@ -129,7 +130,11 @@ const RenderButtonInner: React.FC<{
 		return preferredRenderType;
 	}, [connectionStatus, isBrowserStudio, preferredRenderType, readOnlyStudio]);
 
-	const shortcut = areKeyboardShortcutsDisabled() ? '' : '(R)';
+	const renderShortcut = useKeyboardShortcutLabel('render');
+	const shortcut =
+		areKeyboardShortcutsDisabled() || renderShortcut === ''
+			? ''
+			: `(${renderShortcut})`;
 	const tooltip =
 		renderType === 'render-command'
 			? 'Copy a CLI command to render this composition ' + shortcut

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useContext, useEffect} from 'react';
-import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {
 	BORDER_CURRENT_COLOR,
 	CURRENT_COLOR,
@@ -9,6 +8,7 @@ import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {SidebarContext} from '../state/sidebar';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
@@ -118,8 +118,7 @@ export const SidebarCollapserControl: React.FC<{
 		if (side === 'left') {
 			const left = keybindings.registerKeybinding({
 				event: 'keydown',
-				key: 'b',
-				commandCtrlKey: true,
+				action: 'toggleLeftSidebar',
 				callback: toggleLeft,
 				preventDefault: true,
 				triggerIfInputFieldFocused: false,
@@ -128,8 +127,7 @@ export const SidebarCollapserControl: React.FC<{
 
 			const zen = keybindings.registerKeybinding({
 				event: 'keydown',
-				key: 'g',
-				commandCtrlKey: true,
+				action: 'toggleBothSidebars',
 				callback: toggleBoth,
 				preventDefault: true,
 				triggerIfInputFieldFocused: false,
@@ -144,8 +142,7 @@ export const SidebarCollapserControl: React.FC<{
 
 		const right = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'j',
-			commandCtrlKey: true,
+			action: 'toggleRightSidebar',
 			callback: toggleRight,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
@@ -157,13 +154,17 @@ export const SidebarCollapserControl: React.FC<{
 		};
 	}, [keybindings, side, toggleBoth, toggleLeft, toggleRight]);
 
-	const toggleLeftTooltip = areKeyboardShortcutsDisabled()
-		? 'Toggle Left Sidebar'
-		: `Toggle Left Sidebar (${cmdOrCtrlCharacter}+B)`;
+	const leftShortcut = useKeyboardShortcutLabel('toggleLeftSidebar');
+	const rightShortcut = useKeyboardShortcutLabel('toggleRightSidebar');
+	const toggleLeftTooltip =
+		areKeyboardShortcutsDisabled() || leftShortcut === ''
+			? 'Toggle Left Sidebar'
+			: `Toggle Left Sidebar (${leftShortcut})`;
 
-	const toggleRightTooltip = areKeyboardShortcutsDisabled()
-		? 'Toggle Right Sidebar'
-		: `Toggle Right Sidebar (${cmdOrCtrlCharacter}+J)`;
+	const toggleRightTooltip =
+		areKeyboardShortcutsDisabled() || rightShortcut === ''
+			? 'Toggle Right Sidebar'
+			: `Toggle Right Sidebar (${rightShortcut})`;
 
 	const colorStyle = useCallback((color: string): React.CSSProperties => {
 		return {

--- a/packages/studio/src/components/SizeSelector.tsx
+++ b/packages/studio/src/components/SizeSelector.tsx
@@ -4,6 +4,8 @@ import {Internals} from 'remotion';
 import {WHITE_ALPHA_80} from '../helpers/colors';
 import type {AssetFileType} from '../helpers/get-preview-file-type';
 import {getPreviewFileType} from '../helpers/get-preview-file-type';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {
 	CanvasFitIcon,
 	CanvasZoomIcon,
@@ -109,6 +111,10 @@ export const usePreviewSizeMenuItems = () => {
 		return false;
 	}, [canvasContent]);
 
+	const configuredResetZoomShortcut = useKeyboardShortcutLabel('resetZoom');
+	const resetZoomShortcut = areKeyboardShortcutsDisabled()
+		? ''
+		: configuredResetZoomShortcut;
 	const items: ComboboxValue[] = useMemo(() => {
 		return getUniqueSizes(size).map((newSize): ComboboxValue => {
 			return {
@@ -121,14 +127,17 @@ export const usePreviewSizeMenuItems = () => {
 				},
 				type: 'item',
 				value: newSize.size,
-				keyHint: newSize.size === 'auto' ? '0' : null,
+				keyHint:
+					newSize.size === 'auto' && resetZoomShortcut !== ''
+						? resetZoomShortcut
+						: null,
 				leftItem:
 					String(size.size) === String(newSize.size) ? <Checkmark /> : null,
 				subMenu: null,
 				quickSwitcherLabel: null,
 			};
 		});
-	}, [setSize, size]);
+	}, [resetZoomShortcut, setSize, size]);
 
 	return {
 		items,

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -2,6 +2,10 @@ import React, {useCallback, useContext} from 'react';
 import {NoReactInternals} from 'remotion/no-react';
 import {BLUE} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {MagnetIcon} from '../icons/magnet';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {ControlButton} from './ControlButton';
@@ -12,10 +16,13 @@ export const SnappingToggle: React.FC = () => {
 	const onClick = useCallback(() => {
 		setEditorSnapping((current) => !current);
 	}, [setEditorSnapping]);
+	const shortcut = useKeyboardShortcutLabel('toggleSnapping');
+	const ariaKeyShortcuts =
+		useKeyboardShortcutAriaKeyShortcuts('toggleSnapping');
 
 	const accessibilityLabel = [
 		editorSnapping ? 'Disable snapping' : 'Enable snapping',
-		areKeyboardShortcutsDisabled() ? null : '(Shift+M)',
+		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
 	]
 		.filter(NoReactInternals.truthy)
 		.join(' ');
@@ -25,7 +32,7 @@ export const SnappingToggle: React.FC = () => {
 			title={accessibilityLabel}
 			aria-label={accessibilityLabel}
 			aria-pressed={editorSnapping}
-			aria-keyshortcuts="Shift+M"
+			aria-keyshortcuts={ariaKeyShortcuts || undefined}
 			onClick={onClick}
 		>
 			{(color) => (

--- a/packages/studio/src/components/TimeValue.tsx
+++ b/packages/studio/src/components/TimeValue.tsx
@@ -129,12 +129,11 @@ export const TimeValue: React.FC = () => {
 
 	useEffect(() => {
 		const gKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 'g',
+			event: 'keydown',
+			action: 'goToFrame',
 			callback: () => {
 				ref.current?.click();
 			},
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineClipboardKeybindings.tsx
@@ -671,7 +671,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 		const copy = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'c',
+			action: 'copyEffectsAndValues',
 			callback: (e) => {
 				const {selectedItems} = currentSelection.current;
 				const propStatuses = propStatusesRef.current;
@@ -883,7 +883,6 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 						);
 					});
 			},
-			commandCtrlKey: true,
 			preventDefault: false,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -891,7 +890,7 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 
 		const cut = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'x',
+			action: 'cutEffects',
 			callback: (e) => {
 				const {selectedItems, clearSelection, selectItems} =
 					currentSelection.current;
@@ -964,7 +963,6 @@ export const TimelineClipboardKeybindings: React.FC = () => {
 						);
 					});
 			},
-			commandCtrlKey: true,
 			preventDefault: false,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
+++ b/packages/studio/src/components/Timeline/TimelineDeleteKeybindings.tsx
@@ -7,7 +7,6 @@ import {useConfirmationDialog} from '../ConfirmationDialog';
 import {duplicateSelectedTimelineItems} from './duplicate-selected-timeline-item';
 import {getCurrentFrame} from './imperative-state';
 import {
-	shouldHandleTimelineDuplicateShortcut,
 	shouldHandleTimelineSplitShortcut,
 	splitSelectedTimelineItems,
 } from './split-selected-timeline-item';
@@ -36,32 +35,18 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 			return;
 		}
 
-		const backspace = keybindings.registerKeybinding({
-			event: 'keydown',
-			key: 'Backspace',
-			callback: () => deleteTimelineItems(null),
-			commandCtrlKey: false,
-			preventDefault: true,
-			triggerIfInputFieldFocused: false,
-			keepRegisteredWhenNotHighestContext: false,
-		});
 		const deleteKey = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'Delete',
+			action: 'deleteSelection',
 			callback: () => deleteTimelineItems(null),
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const duplicate = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'd',
-			callback: (event) => {
-				if (!shouldHandleTimelineDuplicateShortcut(event)) {
-					return;
-				}
-
+			action: 'duplicateSequences',
+			callback: () => {
 				const {selectedItems} = currentSelection.current;
 				if (selectedItems.length === 0) {
 					return;
@@ -78,7 +63,6 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 
 				duplicatePromise.catch(() => undefined);
 			},
-			commandCtrlKey: true,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -117,7 +101,6 @@ export const TimelineDeleteKeybindings: React.FC = () => {
 		});
 
 		return () => {
-			backspace.unregister();
 			deleteKey.unregister();
 			duplicate.unregister();
 			split.unregister();

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -780,7 +780,7 @@ export const TimelineSelectAllKeybindings: React.FC<{
 
 		const selectAll = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'a',
+			action: 'selectAllSequenceRows',
 			callback: () => {
 				const latestSelectableSequenceSelections =
 					selectableSequenceSelectionsRef.current;
@@ -792,7 +792,6 @@ export const TimelineSelectAllKeybindings: React.FC<{
 					latestSelectableSequenceSelections,
 				);
 			},
-			commandCtrlKey: true,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,

--- a/packages/studio/src/components/TimelineInOutToggle.tsx
+++ b/packages/studio/src/components/TimelineInOutToggle.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import {Internals} from 'remotion';
 import {NoReactInternals} from 'remotion/no-react';
+import {useStudioConfigRevision} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {
 	areKeyboardShortcutsDisabled,
@@ -22,15 +23,21 @@ import {
 	useTimelineSetInOutFramePosition,
 } from '../state/in-out';
 import {ControlButton} from './ControlButton';
+import {getKeyboardShortcutLabel} from './keyboard-shortcuts';
 
-const getTooltipText = (pointType: string, key: string) =>
-	[
+const getTooltipText = (
+	pointType: string,
+	action: 'setInPoint' | 'setOutPoint',
+) => {
+	const shortcut = getKeyboardShortcutLabel(action);
+	return [
 		`Mark ${pointType}`,
-		areKeyboardShortcutsDisabled() ? null : `(${key})`,
+		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
 		'- right click to clear',
 	]
 		.filter(NoReactInternals.truthy)
 		.join(' ');
+};
 
 const style: React.CSSProperties = {
 	width: 17,
@@ -50,6 +57,7 @@ export const inOutHandles = createRef<{
 export const defaultInOutValue: InOutValue = {inFrame: null, outFrame: null};
 
 export const TimelineInOutPointToggle: React.FC = () => {
+	useStudioConfigRevision();
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();
 	const {setInAndOutFrames} = useTimelineSetInOutFramePosition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
@@ -249,34 +257,31 @@ export const TimelineInOutPointToggle: React.FC = () => {
 		}
 
 		const iKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 'i',
+			event: 'keydown',
+			action: 'setInPoint',
 			callback: (e) => {
 				onInMark(e);
 			},
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const oKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 'o',
+			event: 'keydown',
+			action: 'setOutPoint',
 			callback: (e) => {
 				onOutMark(e);
 			},
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
 		});
 		const xKey = keybindings.registerKeybinding({
-			event: 'keypress',
-			key: 'x',
+			event: 'keydown',
+			action: 'clearInOutPoints',
 			callback: () => {
 				onInOutClear(confId);
 			},
-			commandCtrlKey: false,
 			preventDefault: true,
 			triggerIfInputFieldFocused: false,
 			keepRegisteredWhenNotHighestContext: false,
@@ -305,8 +310,8 @@ export const TimelineInOutPointToggle: React.FC = () => {
 	return (
 		<>
 			<ControlButton
-				title={getTooltipText('In', 'I')}
-				aria-label={getTooltipText('In', 'I')}
+				title={getTooltipText('In', 'setInPoint')}
+				aria-label={getTooltipText('In', 'setInPoint')}
 				style={buttonStyle}
 				onClick={onInMark}
 				onContextMenu={clearInMark}
@@ -320,8 +325,8 @@ export const TimelineInOutPointToggle: React.FC = () => {
 				)}
 			</ControlButton>
 			<ControlButton
-				title={getTooltipText('Out', 'O')}
-				aria-label={getTooltipText('Out', 'O')}
+				title={getTooltipText('Out', 'setOutPoint')}
+				aria-label={getTooltipText('Out', 'setOutPoint')}
 				style={buttonStyle}
 				onClick={onOutMark}
 				onContextMenu={clearOutMark}

--- a/packages/studio/src/components/UndoRedoButtons.tsx
+++ b/packages/studio/src/components/UndoRedoButtons.tsx
@@ -6,15 +6,14 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
-import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {WHITE_ALPHA_80} from '../helpers/colors';
-import {isMac} from '../helpers/is-mac';
 import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
+import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
 import {RedoIcon} from '../icons/redo';
 import {UndoIcon} from '../icons/undo';
 import {callApi} from './call-api';
@@ -93,13 +92,8 @@ export const UndoRedoButtons: React.FC = () => {
 		// remains open. Keep undo and redo available in that higher z-index context.
 		const undo = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'z',
-			commandCtrlKey: true,
-			callback: (e) => {
-				if (e.shiftKey) {
-					return;
-				}
-
+			action: 'undo',
+			callback: () => {
 				if (undoFile) {
 					onUndo();
 				}
@@ -109,15 +103,10 @@ export const UndoRedoButtons: React.FC = () => {
 			keepRegisteredWhenNotHighestContext: true,
 		});
 
-		const redoWithShiftZ = keybindings.registerKeybinding({
+		const redo = keybindings.registerKeybinding({
 			event: 'keydown',
-			key: 'z',
-			commandCtrlKey: true,
-			callback: (e) => {
-				if (!e.shiftKey) {
-					return;
-				}
-
+			action: 'redo',
+			callback: () => {
 				if (redoFile) {
 					onRedo();
 				}
@@ -127,38 +116,23 @@ export const UndoRedoButtons: React.FC = () => {
 			keepRegisteredWhenNotHighestContext: true,
 		});
 
-		const redoWithY = isMac
-			? null
-			: keybindings.registerKeybinding({
-					event: 'keydown',
-					key: 'y',
-					commandCtrlKey: true,
-					callback: () => {
-						if (redoFile) {
-							onRedo();
-						}
-					},
-					preventDefault: true,
-					triggerIfInputFieldFocused: false,
-					keepRegisteredWhenNotHighestContext: true,
-				});
-
 		return () => {
 			undo.unregister();
-			redoWithShiftZ.unregister();
-			redoWithY?.unregister();
+			redo.unregister();
 		};
 	}, [keybindings, onRedo, onUndo, redoFile, undoFile]);
 
-	const undoTooltip = areKeyboardShortcutsDisabled()
-		? 'Undo'
-		: `Undo (${cmdOrCtrlCharacter}+Z)`;
+	const undoShortcut = useKeyboardShortcutLabel('undo');
+	const redoShortcut = useKeyboardShortcutLabel('redo');
+	const undoTooltip =
+		areKeyboardShortcutsDisabled() || undoShortcut === ''
+			? 'Undo'
+			: `Undo (${undoShortcut})`;
 
-	const redoTooltip = areKeyboardShortcutsDisabled()
-		? 'Redo'
-		: isMac
-			? `Redo (${cmdOrCtrlCharacter}+Shift+Z)`
-			: `Redo (${cmdOrCtrlCharacter}+Y)`;
+	const redoTooltip =
+		areKeyboardShortcutsDisabled() || redoShortcut === ''
+			? 'Redo'
+			: `Redo (${redoShortcut})`;
 
 	const renderUndo: RenderInlineAction = useCallback((color) => {
 		return <UndoIcon style={iconStyle} color={color} />;

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -239,10 +239,17 @@ export const keyboardEventMatchesShortcut = ({
 		event.key.toLowerCase() === normalizeKey(value.key).toLowerCase() &&
 		commandOrControl === (value.commandOrControl ?? false) &&
 		(isMac ? !event.ctrlKey : !event.metaKey) &&
-		event.shiftKey === (value.shift ?? false) &&
-		event.altKey === (value.alt ?? false)
+		(!value.shift || event.shiftKey) &&
+		(!value.alt || event.altKey)
 	);
 };
+
+export const keyboardShortcutsOverlap = (
+	first: StudioKeyboardShortcut,
+	second: StudioKeyboardShortcut,
+) =>
+	first.key.toLowerCase() === second.key.toLowerCase() &&
+	(first.commandOrControl ?? false) === (second.commandOrControl ?? false);
 
 export const keyboardEventMatchesAction = (
 	event: KeyboardEvent,

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -1,9 +1,17 @@
-import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
+import type {
+	StudioKeyboardShortcut,
+	StudioKeyboardShortcutAction,
+	StudioKeyboardShortcuts,
+	StudioKeyboardShortcutValue,
+} from '@remotion/studio-shared';
 import {isMac} from '../helpers/is-mac';
+import {getStudioKeyboardShortcuts} from '../helpers/studio-runtime-config';
 
 export type KeyboardShortcut = {
 	readonly action: string;
-	readonly chords: readonly (readonly string[])[];
+	readonly actionId: StudioKeyboardShortcutAction | null;
+	readonly fixedChords?: readonly (readonly string[])[];
+	readonly fixedReason?: string;
 };
 
 export type KeyboardShortcutGroup = {
@@ -11,134 +19,297 @@ export type KeyboardShortcutGroup = {
 	readonly shortcuts: readonly KeyboardShortcut[];
 };
 
+const shortcut = (
+	action: string,
+	actionId: StudioKeyboardShortcutAction,
+): KeyboardShortcut => ({action, actionId});
+
+const fixedShortcut = (
+	action: string,
+	fixedChords: readonly (readonly string[])[],
+	fixedReason: string,
+): KeyboardShortcut => ({action, actionId: null, fixedChords, fixedReason});
+
+export const defaultKeyboardShortcuts: Record<
+	StudioKeyboardShortcutAction,
+	readonly StudioKeyboardShortcut[]
+> = {
+	playPause: [{key: 'Space'}],
+	jumpToBeginning: [{key: 'a'}],
+	jumpToEnd: [{key: 'e'}],
+	reversePlayback: [{key: 'j'}],
+	pausePlayback: [{key: 'k'}],
+	playForward: [{key: 'l'}],
+	goToFrame: [{key: 'g'}],
+	pauseAndReturnToPlaybackStart: [{key: 'Enter'}],
+	toggleLeftSidebar: [{key: 'b', commandOrControl: true}],
+	toggleRightSidebar: [{key: 'j', commandOrControl: true}],
+	toggleBothSidebars: [{key: 'g', commandOrControl: true}],
+	enterFullscreen: [{key: 'f'}],
+	toggleSnapping: [{key: 'm', shift: true}],
+	previousComposition: [{key: 'PageUp'}],
+	nextComposition: [{key: 'PageDown'}],
+	showKeyboardShortcuts: [{key: '?', shift: true}],
+	quickSwitcher: [{key: 'k', commandOrControl: true}],
+	render: [{key: 'r'}],
+	toggleCheckerboard: [{key: 't'}],
+	setInPoint: [{key: 'i'}],
+	setOutPoint: [{key: 'o'}],
+	clearInOutPoints: [{key: 'x'}],
+	zoomIn: [{key: '+', shift: true}],
+	zoomOut: [{key: '-'}],
+	resetZoom: [{key: '0'}],
+	undo: [{key: 'z', commandOrControl: true}],
+	redo: [
+		isMac
+			? {key: 'z', commandOrControl: true, shift: true}
+			: {key: 'y', commandOrControl: true},
+	],
+	selectAllSequenceRows: [{key: 'a', commandOrControl: true}],
+	selectTranslateProp: [{key: 'p'}],
+	selectOpacityProp: [{key: 't'}],
+	selectRotateProp: [{key: 'r'}],
+	selectScaleProp: [{key: 's'}],
+	duplicateSequences: [{key: 'd', commandOrControl: true}],
+	copyEffectsAndValues: [{key: 'c', commandOrControl: true}],
+	cutEffects: [{key: 'x', commandOrControl: true}],
+	deleteSelection: [{key: 'Backspace'}, {key: 'Delete'}],
+	askAI: [{key: 'i', commandOrControl: true}],
+};
+
 export const keyboardShortcutGroups: readonly KeyboardShortcutGroup[] = [
 	{
 		name: 'Playback',
 		shortcuts: [
-			{action: '1 second back', chords: [['Shift', '←']]},
-			{action: 'Previous frame', chords: [['←']]},
-			{action: 'Play / Pause', chords: [['Space']]},
-			{action: 'Next frame', chords: [['→']]},
-			{action: '1 second forward', chords: [['Shift', '→']]},
-			{action: 'Jump to beginning', chords: [['A']]},
-			{action: 'Jump to end', chords: [['E']]},
-			{action: 'Reverse playback', chords: [['J']]},
-			{action: 'Pause', chords: [['K']]},
-			{action: 'Play / Speed up', chords: [['L']]},
-			{action: 'Go to frame', chords: [['G']]},
-			{
-				action: 'Pause & return to playback start',
-				chords: [['Enter']],
-			},
+			fixedShortcut(
+				'1 second back',
+				[['Shift', '←']],
+				'Context-sensitive timeline control',
+			),
+			fixedShortcut(
+				'Previous frame',
+				[['←']],
+				'Context-sensitive timeline control',
+			),
+			shortcut('Play / Pause', 'playPause'),
+			fixedShortcut(
+				'Next frame',
+				[['→']],
+				'Context-sensitive timeline control',
+			),
+			fixedShortcut(
+				'1 second forward',
+				[['Shift', '→']],
+				'Context-sensitive timeline control',
+			),
+			shortcut('Jump to beginning', 'jumpToBeginning'),
+			shortcut('Jump to end', 'jumpToEnd'),
+			shortcut('Reverse playback', 'reversePlayback'),
+			shortcut('Pause', 'pausePlayback'),
+			shortcut('Play / Speed up', 'playForward'),
+			shortcut('Go to frame', 'goToFrame'),
+			shortcut(
+				'Pause & return to playback start',
+				'pauseAndReturnToPlaybackStart',
+			),
 		],
 	},
 	{
 		name: 'Sidebar',
 		shortcuts: [
-			{
-				action: 'Toggle left sidebar',
-				chords: [[cmdOrCtrlCharacter, 'B']],
-			},
-			{
-				action: 'Toggle right sidebar',
-				chords: [[cmdOrCtrlCharacter, 'J']],
-			},
-			{
-				action: 'Toggle both sidebars',
-				chords: [[cmdOrCtrlCharacter, 'G']],
-			},
+			shortcut('Toggle left sidebar', 'toggleLeftSidebar'),
+			shortcut('Toggle right sidebar', 'toggleRightSidebar'),
+			shortcut('Toggle both sidebars', 'toggleBothSidebars'),
 		],
 	},
 	{
 		name: 'View',
 		shortcuts: [
-			{action: 'Enter fullscreen', chords: [['F']]},
-			{action: 'Exit fullscreen', chords: [['Esc']]},
-			{action: 'Enable snapping', chords: [['Shift', 'M']]},
+			shortcut('Enter fullscreen', 'enterFullscreen'),
+			fixedShortcut('Exit fullscreen', [['Esc']], 'Handled by the browser'),
+			shortcut('Enable snapping', 'toggleSnapping'),
 		],
 	},
 	{
 		name: 'Navigation',
 		shortcuts: [
-			{action: 'Previous composition', chords: [['PageUp']]},
-			{action: 'Next composition', chords: [['PageDown']]},
-			{
-				action: 'Render, unless a sequence or prop is selected',
-				chords: [['R']],
-			},
-			{
-				action: 'Checkerboard, unless a sequence or prop is selected',
-				chords: [['T']],
-			},
-			{action: 'Show keyboard shortcuts', chords: [['?']]},
-			{
-				action: 'Quick Switcher',
-				chords: [[cmdOrCtrlCharacter, 'K']],
-			},
+			shortcut('Previous composition', 'previousComposition'),
+			shortcut('Next composition', 'nextComposition'),
+			shortcut('Render, unless a sequence or prop is selected', 'render'),
+			shortcut(
+				'Checkerboard, unless a sequence or prop is selected',
+				'toggleCheckerboard',
+			),
+			shortcut('Show keyboard shortcuts', 'showKeyboardShortcuts'),
+			shortcut('Quick Switcher', 'quickSwitcher'),
 		],
 	},
 	{
 		name: 'Playback range',
 		shortcuts: [
-			{action: 'Set In Point', chords: [['I']]},
-			{action: 'Set Out Point', chords: [['O']]},
-			{action: 'Clear In/Out Points', chords: [['X']]},
+			shortcut('Set In Point', 'setInPoint'),
+			shortcut('Set Out Point', 'setOutPoint'),
+			shortcut('Clear In/Out Points', 'clearInOutPoints'),
 		],
 	},
 	{
 		name: 'Zoom',
 		shortcuts: [
-			{action: 'Zoom in', chords: [['+']]},
-			{action: 'Zoom out', chords: [['-']]},
-			{action: 'Reset zoom', chords: [['0']]},
+			shortcut('Zoom in', 'zoomIn'),
+			shortcut('Zoom out', 'zoomOut'),
+			shortcut('Reset zoom', 'resetZoom'),
 		],
 	},
 	{
 		name: 'Props Editor',
-		shortcuts: [
-			{action: 'Undo', chords: [[cmdOrCtrlCharacter, 'Z']]},
-			{
-				action: 'Redo',
-				chords: [
-					isMac
-						? [cmdOrCtrlCharacter, 'Shift', 'Z']
-						: [cmdOrCtrlCharacter, 'Y'],
-				],
-			},
-		],
+		shortcuts: [shortcut('Undo', 'undo'), shortcut('Redo', 'redo')],
 	},
 	{
 		name: 'Interactivity',
 		shortcuts: [
-			{action: 'Select range / axis lock drag', chords: [['Shift']]},
-			{action: 'Toggle selection', chords: [[cmdOrCtrlCharacter]]},
-			{
-				action: 'Select sequence rows',
-				chords: [[cmdOrCtrlCharacter, 'A']],
-			},
-			{action: 'Select translate prop', chords: [['P']]},
-			{action: 'Select opacity prop', chords: [['T']]},
-			{action: 'Select rotate prop', chords: [['R']]},
-			{action: 'Select scale prop', chords: [['S']]},
-			{
-				action: 'Duplicate sequences',
-				chords: [[cmdOrCtrlCharacter, 'D']],
-			},
-			{
-				action: 'Copy effects / values',
-				chords: [[cmdOrCtrlCharacter, 'C']],
-			},
-			{action: 'Cut effects', chords: [[cmdOrCtrlCharacter, 'X']]},
-			{
-				action: 'Paste effects / values',
-				chords: [[cmdOrCtrlCharacter, 'V']],
-			},
-			{action: 'Delete / reset selection', chords: [['Del'], ['⌫']]},
+			fixedShortcut(
+				'Select range / axis lock drag',
+				[['Shift']],
+				'Gesture modifier',
+			),
+			fixedShortcut(
+				'Toggle selection',
+				[[isMac ? '⌘' : 'Ctrl']],
+				'Gesture modifier',
+			),
+			shortcut('Select sequence rows', 'selectAllSequenceRows'),
+			shortcut('Select translate prop', 'selectTranslateProp'),
+			shortcut('Select opacity prop', 'selectOpacityProp'),
+			shortcut('Select rotate prop', 'selectRotateProp'),
+			shortcut('Select scale prop', 'selectScaleProp'),
+			shortcut('Duplicate sequences', 'duplicateSequences'),
+			shortcut('Copy effects / values', 'copyEffectsAndValues'),
+			shortcut('Cut effects', 'cutEffects'),
+			fixedShortcut(
+				'Paste effects / values',
+				[[isMac ? '⌘' : 'Ctrl', 'V']],
+				'Handled by the browser clipboard event',
+			),
+			shortcut('Delete / reset selection', 'deleteSelection'),
 		],
 	},
 ];
 
 export const askAIKeyboardShortcutGroup: KeyboardShortcutGroup = {
 	name: 'AI',
-	shortcuts: [{action: 'Ask AI', chords: [[cmdOrCtrlCharacter, 'I']]}],
+	shortcuts: [shortcut('Ask AI', 'askAI')],
+};
+
+export const getKeyboardShortcutsForAction = (
+	action: StudioKeyboardShortcutAction,
+	configured: StudioKeyboardShortcuts | null = getStudioKeyboardShortcuts(),
+): readonly StudioKeyboardShortcut[] => {
+	if (
+		configured !== null &&
+		Object.prototype.hasOwnProperty.call(configured, action)
+	) {
+		const value = configured[action];
+		if (value === null) {
+			return [];
+		}
+
+		return Array.isArray(value)
+			? value
+			: [
+					value as Exclude<
+						StudioKeyboardShortcutValue,
+						readonly StudioKeyboardShortcut[] | null
+					>,
+				];
+	}
+
+	return defaultKeyboardShortcuts[action];
+};
+
+const normalizeKey = (key: string) => (key === 'Space' ? ' ' : key);
+
+export const keyboardEventMatchesShortcut = ({
+	event,
+	shortcut: value,
+}: {
+	readonly event: KeyboardEvent;
+	readonly shortcut: StudioKeyboardShortcut;
+}) => {
+	const commandOrControl = isMac ? event.metaKey : event.ctrlKey;
+	return (
+		event.key.toLowerCase() === normalizeKey(value.key).toLowerCase() &&
+		commandOrControl === (value.commandOrControl ?? false) &&
+		(isMac ? !event.ctrlKey : !event.metaKey) &&
+		event.shiftKey === (value.shift ?? false) &&
+		event.altKey === (value.alt ?? false)
+	);
+};
+
+export const keyboardEventMatchesAction = (
+	event: KeyboardEvent,
+	action: StudioKeyboardShortcutAction,
+) =>
+	getKeyboardShortcutsForAction(action).some((value) =>
+		keyboardEventMatchesShortcut({event, shortcut: value}),
+	);
+
+const displayKey = (keyboardKey: string) => {
+	if (keyboardKey === 'ArrowLeft') return '←';
+	if (keyboardKey === 'ArrowRight') return '→';
+	if (keyboardKey === 'Delete') return 'Del';
+	if (keyboardKey === 'Backspace') return '⌫';
+	if (keyboardKey === 'Escape') return 'Esc';
+	return keyboardKey.length === 1 ? keyboardKey.toUpperCase() : keyboardKey;
+};
+
+export const formatKeyboardShortcut = (
+	value: StudioKeyboardShortcut,
+): readonly string[] => [
+	...(value.commandOrControl ? [isMac ? '⌘' : 'Ctrl'] : []),
+	...(value.alt ? [isMac ? 'Option' : 'Alt'] : []),
+	...(value.shift && !['+', '?'].includes(value.key) ? ['Shift'] : []),
+	displayKey(value.key),
+];
+
+export const formatKeyboardShortcutForAria = (value: StudioKeyboardShortcut) =>
+	[
+		...(value.commandOrControl ? [isMac ? 'Meta' : 'Control'] : []),
+		...(value.alt ? ['Alt'] : []),
+		...(value.shift ? ['Shift'] : []),
+		value.key,
+	].join('+');
+
+export const getKeyboardShortcutLabel = (
+	action: StudioKeyboardShortcutAction,
+) =>
+	getKeyboardShortcutsForAction(action)
+		.map((value) => formatKeyboardShortcut(value).join('+'))
+		.join(' / ');
+
+export const getKeyboardShortcutAriaKeyShortcuts = (
+	action: StudioKeyboardShortcutAction,
+) =>
+	getKeyboardShortcutsForAction(action)
+		.map(formatKeyboardShortcutForAria)
+		.join(' ');
+
+export const shortcutFromKeyboardEvent = (
+	event: KeyboardEvent,
+): StudioKeyboardShortcut | null => {
+	if (['Alt', 'Control', 'Meta', 'Shift'].includes(event.key)) {
+		return null;
+	}
+
+	if (isMac ? event.ctrlKey : event.metaKey) {
+		return null;
+	}
+
+	return {
+		key: event.key === ' ' ? 'Space' : event.key,
+		...((isMac ? event.metaKey : event.ctrlKey)
+			? {commandOrControl: true}
+			: {}),
+		...(event.shiftKey ? {shift: true} : {}),
+		...(event.altKey ? {alt: true} : {}),
+	};
 };

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -56,7 +56,7 @@ export const defaultKeyboardShortcuts: Record<
 	setInPoint: [{key: 'i'}],
 	setOutPoint: [{key: 'o'}],
 	clearInOutPoints: [{key: 'x'}],
-	zoomIn: [{key: '+', shift: true}],
+	zoomIn: [{key: '+', shift: true}, {key: '+'}],
 	zoomOut: [{key: '-'}],
 	resetZoom: [{key: '0'}],
 	undo: [{key: 'z', commandOrControl: true}],

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -61,9 +61,8 @@ export const defaultKeyboardShortcuts: Record<
 	resetZoom: [{key: '0'}],
 	undo: [{key: 'z', commandOrControl: true}],
 	redo: [
-		isMac
-			? {key: 'z', commandOrControl: true, shift: true}
-			: {key: 'y', commandOrControl: true},
+		...(isMac ? [] : [{key: 'y', commandOrControl: true}]),
+		{key: 'z', commandOrControl: true, shift: true},
 	],
 	selectAllSequenceRows: [{key: 'a', commandOrControl: true}],
 	selectTranslateProp: [{key: 'p'}],

--- a/packages/studio/src/helpers/studio-runtime-config.ts
+++ b/packages/studio/src/helpers/studio-runtime-config.ts
@@ -34,6 +34,10 @@ export const getStudioKeyboardShortcutsEnabled = () => {
 	return getStudioRuntimeConfig().keyboardShortcutsEnabled;
 };
 
+export const getStudioKeyboardShortcuts = () => {
+	return getStudioRuntimeConfig().keyboardShortcuts ?? null;
+};
+
 export const getStudioMaxTimelineTracks = () => {
 	return getStudioRuntimeConfig().maxTimelineTracks;
 };

--- a/packages/studio/src/helpers/use-keybinding.ts
+++ b/packages/studio/src/helpers/use-keybinding.ts
@@ -1,4 +1,6 @@
+import type {StudioKeyboardShortcutAction} from '@remotion/studio-shared';
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import {keyboardEventMatchesAction} from '../components/keyboard-shortcuts';
 import type {KeyEventType, RegisteredKeybinding} from '../state/keybindings';
 import {KeybindingContext} from '../state/keybindings';
 import {useZIndex} from '../state/z-index';
@@ -22,21 +24,26 @@ export const useKeybinding = () => {
 	const {isHighestContext} = useZIndex();
 
 	const registerKeybinding = useCallback(
-		(options: {
-			event: KeyEventType;
-			key: string;
-			commandCtrlKey: boolean;
-			callback: (e: KeyboardEvent) => void;
-			preventDefault: boolean;
-			triggerIfInputFieldFocused: boolean;
-			keepRegisteredWhenNotHighestContext: boolean;
-		}) => {
-			if (!getStudioKeyboardShortcutsEnabled()) {
-				return {
-					unregister: () => undefined,
-				};
-			}
-
+		(
+			options: {
+				event: KeyEventType;
+				callback: (e: KeyboardEvent) => void;
+				preventDefault: boolean;
+				triggerIfInputFieldFocused: boolean;
+				keepRegisteredWhenNotHighestContext: boolean;
+			} & (
+				| {
+						action: StudioKeyboardShortcutAction;
+						key?: never;
+						commandCtrlKey?: never;
+				  }
+				| {
+						action?: never;
+						key: string;
+						commandCtrlKey: boolean;
+				  }
+			),
+		) => {
 			if (!isHighestContext && !options.keepRegisteredWhenNotHighestContext) {
 				return {
 					unregister: () => undefined,
@@ -44,18 +51,18 @@ export const useKeybinding = () => {
 			}
 
 			const listener = (e: KeyboardEvent) => {
-				const commandKey = isMac ? e.metaKey : e.ctrlKey;
-
 				// Apparently, e.key can be undefined in Edge:
 				// https://github.com/remotion-dev/remotion/issues/5637
 				if (!e.key) {
 					return;
 				}
 
-				if (
-					e.key.toLowerCase() === options.key.toLowerCase() &&
-					options.commandCtrlKey === commandKey
-				) {
+				const matches = options.action
+					? keyboardEventMatchesAction(e, options.action)
+					: e.key.toLowerCase() === options.key.toLowerCase() &&
+						options.commandCtrlKey === (isMac ? e.metaKey : e.ctrlKey);
+
+				if (matches && getStudioKeyboardShortcutsEnabled()) {
 					if (!options.triggerIfInputFieldFocused) {
 						const {activeElement} = document;
 						if (activeElement instanceof HTMLInputElement) {
@@ -77,7 +84,7 @@ export const useKeybinding = () => {
 			const toRegister: RegisteredKeybinding = {
 				registeredFromPane: paneId,
 				event: options.event,
-				key: options.key,
+				key: options.action ?? options.key,
 				callback: listener,
 				id: String(Math.random()),
 			};

--- a/packages/studio/src/helpers/use-keyboard-shortcut-label.ts
+++ b/packages/studio/src/helpers/use-keyboard-shortcut-label.ts
@@ -1,0 +1,20 @@
+import type {StudioKeyboardShortcutAction} from '@remotion/studio-shared';
+import {
+	getKeyboardShortcutAriaKeyShortcuts,
+	getKeyboardShortcutLabel,
+} from '../components/keyboard-shortcuts';
+import {useStudioConfigRevision} from './client-id';
+
+export const useKeyboardShortcutLabel = (
+	action: StudioKeyboardShortcutAction,
+) => {
+	useStudioConfigRevision();
+	return getKeyboardShortcutLabel(action);
+};
+
+export const useKeyboardShortcutAriaKeyShortcuts = (
+	action: StudioKeyboardShortcutAction,
+) => {
+	useStudioConfigRevision();
+	return getKeyboardShortcutAriaKeyShortcuts(action);
+};

--- a/packages/studio/src/helpers/use-menu-structure.tsx
+++ b/packages/studio/src/helpers/use-menu-structure.tsx
@@ -18,7 +18,6 @@ import {getPreviewSizeLabel, getUniqueSizes} from '../components/SizeSelector';
 import {useResolvedStack} from '../components/Timeline/use-resolved-stack';
 import {inOutHandles} from '../components/TimelineInOutToggle';
 import {useEditorOpening} from '../components/use-default-editor-info';
-import {cmdOrCtrlCharacter} from '../error-overlay/remotion-overlay/ShortcutHint';
 import {Checkmark} from '../icons/Checkmark';
 import {drawRef} from '../state/canvas-ref';
 import {CheckerboardContext} from '../state/checkerboard';
@@ -45,6 +44,7 @@ import {openInEditor, preloadCompositionComponentInfo} from './open-in-editor';
 import {pickColor} from './pick-color';
 import {getStudioAskAIEnabled} from './studio-runtime-config';
 import {areKeyboardShortcutsDisabled} from './use-keybinding';
+import {useKeyboardShortcutLabel} from './use-keyboard-shortcut-label';
 
 type Structure = Menu[];
 
@@ -230,10 +230,12 @@ const getRenderMenuItems = ({
 	closeMenu,
 	previewServerState,
 	readOnlyStudio,
+	renderShortcut,
 }: {
 	closeMenu: () => void;
 	previewServerState: 'connected' | 'init' | 'disconnected';
 	readOnlyStudio: boolean;
+	renderShortcut: string;
 }): ComboboxValue[] => {
 	return [
 		readOnlyStudio
@@ -256,7 +258,9 @@ const getRenderMenuItems = ({
 						renderButton.click();
 					},
 					type: 'item' as const,
-					keyHint: 'R',
+					keyHint: areKeyboardShortcutsDisabled()
+						? null
+						: renderShortcut || null,
 					leftItem: null,
 					subMenu: null,
 					quickSwitcherLabel: 'Render...',
@@ -315,6 +319,19 @@ export const useMenuStructure = (
 		type === 'connected',
 	);
 	const keyboardShortcutsDisabled = areKeyboardShortcutsDisabled();
+	const resetZoomShortcut = useKeyboardShortcutLabel('resetZoom');
+	const toggleSnappingShortcut = useKeyboardShortcutLabel('toggleSnapping');
+	const checkerboardShortcut = useKeyboardShortcutLabel('toggleCheckerboard');
+	const quickSwitcherShortcut = useKeyboardShortcutLabel('quickSwitcher');
+	const setInPointShortcut = useKeyboardShortcutLabel('setInPoint');
+	const setOutPointShortcut = useKeyboardShortcutLabel('setOutPoint');
+	const clearInOutPointsShortcut = useKeyboardShortcutLabel('clearInOutPoints');
+	const goToFrameShortcut = useKeyboardShortcutLabel('goToFrame');
+	const renderShortcut = useKeyboardShortcutLabel('render');
+	const askAIShortcut = useKeyboardShortcutLabel('askAI');
+	const showKeyboardShortcutsShortcut = useKeyboardShortcutLabel(
+		'showKeyboardShortcuts',
+	);
 	const studioAskAIEnabled = getStudioAskAIEnabled();
 	const {
 		setSidebarCollapsedState,
@@ -501,7 +518,10 @@ export const useMenuStructure = (
 							preselectIndex: sizePreselectIndex,
 							items: sizes.map((newSize) => ({
 								id: String(newSize.size),
-								keyHint: newSize.size === 1 ? '0' : null,
+								keyHint:
+									newSize.size === 1 && !keyboardShortcutsDisabled
+										? resetZoomShortcut || null
+										: null,
 								label: getPreviewSizeLabel(newSize),
 								leftItem:
 									String(newSize.size) === String(size.size) ? (
@@ -586,7 +606,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'enable-snapping',
-						keyHint: keyboardShortcutsDisabled ? null : 'Shift+M',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: toggleSnappingShortcut || null,
 						label: 'Enable Snapping',
 						onClick: () => {
 							closeMenu();
@@ -736,7 +758,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'checkerboard',
-						keyHint: 'T',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: checkerboardShortcut || null,
 						label: 'Transparency as checkerboard',
 						onClick: () => {
 							closeMenu();
@@ -756,7 +780,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'quick-switcher',
-						keyHint: `${cmdOrCtrlCharacter}+K`,
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: quickSwitcherShortcut || null,
 						label: 'Quick Switcher',
 						onClick: () => {
 							closeMenu();
@@ -780,7 +806,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'in-mark',
-						keyHint: 'I',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: setInPointShortcut || null,
 						label: 'In Mark',
 						leftItem: null,
 						onClick: () => {
@@ -794,7 +822,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'out-mark',
-						keyHint: 'O',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: setOutPointShortcut || null,
 						label: 'Out Mark',
 						leftItem: null,
 						onClick: () => {
@@ -808,7 +838,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'x-mark',
-						keyHint: 'X',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: clearInOutPointsShortcut || null,
 						label: 'Clear In/Out Marks',
 						leftItem: null,
 						onClick: () => {
@@ -822,7 +854,9 @@ export const useMenuStructure = (
 					},
 					{
 						id: 'goto-time',
-						keyHint: 'G',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: goToFrameShortcut || null,
 						label: 'Go to frame',
 						leftItem: null,
 						onClick: () => {
@@ -865,6 +899,7 @@ export const useMenuStructure = (
 						closeMenu,
 						previewServerState: type,
 						readOnlyStudio,
+						renderShortcut,
 					}),
 					...getCompositionMenuItems({
 						closeMenu,
@@ -895,7 +930,9 @@ export const useMenuStructure = (
 									askAiModalRef.current?.toggle();
 								},
 								leftItem: null,
-								keyHint: `${cmdOrCtrlCharacter}+I`,
+								keyHint: keyboardShortcutsDisabled
+									? null
+									: askAIShortcut || null,
 								subMenu: null,
 								type: 'item' as const,
 								quickSwitcherLabel: 'Ask AI',
@@ -964,7 +1001,9 @@ export const useMenuStructure = (
 									window.remotion_renderDefaults?.publicLicenseKey ?? null,
 							});
 						},
-						keyHint: '?',
+						keyHint: keyboardShortcutsDisabled
+							? null
+							: showKeyboardShortcutsShortcut || null,
 						leftItem: null,
 						subMenu: null,
 						type: 'item' as const,
@@ -1144,6 +1183,17 @@ export const useMenuStructure = (
 		defaultEditorName,
 		keyboardShortcutsDisabled,
 		studioAskAIEnabled,
+		askAIShortcut,
+		checkerboardShortcut,
+		clearInOutPointsShortcut,
+		goToFrameShortcut,
+		quickSwitcherShortcut,
+		renderShortcut,
+		resetZoomShortcut,
+		setInPointShortcut,
+		setOutPointShortcut,
+		showKeyboardShortcutsShortcut,
+		toggleSnappingShortcut,
 		browserStudioOperations,
 		size.size,
 		setSize,

--- a/packages/studio/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio/src/test/keyboard-shortcuts.test.ts
@@ -4,6 +4,7 @@ import {
 	formatKeyboardShortcut,
 	formatKeyboardShortcutForAria,
 	keyboardEventMatchesShortcut,
+	keyboardShortcutsOverlap,
 } from '../components/keyboard-shortcuts';
 import {isMac} from '../helpers/is-mac';
 
@@ -35,7 +36,13 @@ test('includes main-row and numeric-keypad zoom-in shortcuts', () => {
 	]);
 });
 
-test('matches all shortcut modifiers exactly', () => {
+test('matches shortcut modifiers', () => {
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event({altKey: true, key: 'a', shiftKey: true}),
+			shortcut: {key: 'a'},
+		}),
+	).toBe(true);
 	expect(
 		keyboardEventMatchesShortcut({
 			event: event(isMac ? {metaKey: true} : {ctrlKey: true}),
@@ -46,10 +53,22 @@ test('matches all shortcut modifiers exactly', () => {
 		keyboardEventMatchesShortcut({
 			event: event(
 				isMac
-					? {metaKey: true, shiftKey: true}
-					: {ctrlKey: true, shiftKey: true},
+					? {altKey: true, metaKey: true, shiftKey: true}
+					: {altKey: true, ctrlKey: true, shiftKey: true},
 			),
 			shortcut: {key: 'k', commandOrControl: true},
+		}),
+	).toBe(true);
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event({key: 'k'}),
+			shortcut: {key: 'k', shift: true},
+		}),
+	).toBe(false);
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event({key: 'k'}),
+			shortcut: {alt: true, key: 'k'},
 		}),
 	).toBe(false);
 	expect(
@@ -58,6 +77,18 @@ test('matches all shortcut modifiers exactly', () => {
 			shortcut: {key: 'Space'},
 		}),
 	).toBe(true);
+});
+
+test('detects overlapping shortcuts', () => {
+	expect(keyboardShortcutsOverlap({key: 'a'}, {key: 'A', shift: true})).toBe(
+		true,
+	);
+	expect(
+		keyboardShortcutsOverlap({alt: true, key: 'a'}, {key: 'a', shift: true}),
+	).toBe(true);
+	expect(
+		keyboardShortcutsOverlap({key: 'a'}, {commandOrControl: true, key: 'a'}),
+	).toBe(false);
 });
 
 test('formats a shortcut for display', () => {

--- a/packages/studio/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio/src/test/keyboard-shortcuts.test.ts
@@ -1,0 +1,57 @@
+import {expect, test} from 'bun:test';
+import {
+	formatKeyboardShortcut,
+	formatKeyboardShortcutForAria,
+	keyboardEventMatchesShortcut,
+} from '../components/keyboard-shortcuts';
+import {isMac} from '../helpers/is-mac';
+
+const event = (overrides: Partial<KeyboardEvent>): KeyboardEvent =>
+	({
+		altKey: false,
+		ctrlKey: false,
+		key: 'k',
+		metaKey: false,
+		shiftKey: false,
+		...overrides,
+	}) as KeyboardEvent;
+
+test('matches all shortcut modifiers exactly', () => {
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event(isMac ? {metaKey: true} : {ctrlKey: true}),
+			shortcut: {key: 'k', commandOrControl: true},
+		}),
+	).toBe(true);
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event(
+				isMac
+					? {metaKey: true, shiftKey: true}
+					: {ctrlKey: true, shiftKey: true},
+			),
+			shortcut: {key: 'k', commandOrControl: true},
+		}),
+	).toBe(false);
+	expect(
+		keyboardEventMatchesShortcut({
+			event: event({key: ' ', shiftKey: false}),
+			shortcut: {key: 'Space'},
+		}),
+	).toBe(true);
+});
+
+test('formats a shortcut for display', () => {
+	expect(
+		formatKeyboardShortcut({key: 'ArrowLeft', commandOrControl: true}),
+	).toEqual([isMac ? '⌘' : 'Ctrl', '←']);
+	expect(formatKeyboardShortcut({key: '?', shift: true})).toEqual(['?']);
+	expect(formatKeyboardShortcut({key: '+', shift: true})).toEqual(['+']);
+	expect(
+		formatKeyboardShortcutForAria({
+			key: 'k',
+			commandOrControl: true,
+			shift: true,
+		}),
+	).toBe(`${isMac ? 'Meta' : 'Control'}+Shift+k`);
+});

--- a/packages/studio/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio/src/test/keyboard-shortcuts.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test';
 import {
+	defaultKeyboardShortcuts,
 	formatKeyboardShortcut,
 	formatKeyboardShortcutForAria,
 	keyboardEventMatchesShortcut,
@@ -15,6 +16,17 @@ const event = (overrides: Partial<KeyboardEvent>): KeyboardEvent =>
 		shiftKey: false,
 		...overrides,
 	}) as KeyboardEvent;
+
+test('includes the platform redo shortcuts', () => {
+	expect(defaultKeyboardShortcuts.redo).toEqual(
+		isMac
+			? [{key: 'z', commandOrControl: true, shift: true}]
+			: [
+					{key: 'y', commandOrControl: true},
+					{key: 'z', commandOrControl: true, shift: true},
+				],
+	);
+});
 
 test('matches all shortcut modifiers exactly', () => {
 	expect(

--- a/packages/studio/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio/src/test/keyboard-shortcuts.test.ts
@@ -28,6 +28,13 @@ test('includes the platform redo shortcuts', () => {
 	);
 });
 
+test('includes main-row and numeric-keypad zoom-in shortcuts', () => {
+	expect(defaultKeyboardShortcuts.zoomIn).toEqual([
+		{key: '+', shift: true},
+		{key: '+'},
+	]);
+});
+
 test('matches all shortcut modifiers exactly', () => {
 	expect(
 		keyboardEventMatchesShortcut({


### PR DESCRIPTION
## Summary

- add `Config.setKeyboardShortcuts()` as the typed source of truth for Studio command shortcuts
- make editable shortcut rows record, validate, reset, disable, and persist bindings to `remotion.config.ts`
- update command handlers and shortcut hints at runtime while leaving browser-owned and context-sensitive gesture controls fixed for a later pass
- document all overridable action IDs and defaults on the Studio keyboard shortcuts page

## Test plan

- `bun run build`
- `bun run stylecheck`
- focused keyboard shortcut unit and config integration tests
- focused Studio settings Playwright test
- documentation build, including Twoslash validation

## Preview

- [Configuration file](https://remotion-git-codex-configurable-studio-keyboard-2bf83f-remotion.vercel.app/docs/config)
- [Studio keyboard shortcuts](https://remotion-git-codex-configurable-studio-keyboard-2bf83f-remotion.vercel.app/docs/studio/shortcuts)
