### PR TITLE
`@remotion/studio`: Fix sequence selection after reordering

### DIFF
--- a/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
+++ b/packages/studio/src/components/Timeline/SequencePropsObserver.tsx
@@ -10,6 +10,7 @@ import {StudioServerConnectionCtx} from '../../helpers/client-id';
 import {takePendingSequenceNodePathMutations} from '../../helpers/sequence-node-path-mutations';
 import {ExpandedTracksSetterContext} from '../ExpandedTracksProvider';
 import {refreshSequencePropsSubscription} from './sequence-props-subscription-store';
+import {useTimelineSelection} from './TimelineSelection';
 
 export const SequencePropsObserver = () => {
 	const {subscribeToEvent} = useContext(StudioServerConnectionCtx);
@@ -31,6 +32,7 @@ export const SequencePropsObserver = () => {
 	const {migrateExpandedTracksForSubscriptionKey} = useContext(
 		ExpandedTracksSetterContext,
 	);
+	const {remapSelectionNodePaths} = useTimelineSelection();
 	useEffect(() => {
 		const handleEvent = (event: EventSourceEvent) => {
 			if (event.type !== 'sequence-props-updated') {
@@ -52,6 +54,8 @@ export const SequencePropsObserver = () => {
 		if (mutations.length === 0) {
 			return;
 		}
+
+		remapSelectionNodePaths(mutations);
 
 		const statusRemappings: SequencePropsStatusRemapping[] = [];
 		const overrideUpdates: Array<{
@@ -182,6 +186,7 @@ export const SequencePropsObserver = () => {
 		fastRefreshes,
 		migrateExpandedTracksForSubscriptionKey,
 		propStatusesRef,
+		remapSelectionNodePaths,
 		remapPropStatuses,
 		setOverrideIdToNodePath,
 	]);

--- a/packages/studio/src/components/Timeline/TimelineSelection.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSelection.tsx
@@ -12,6 +12,7 @@ import {
 import {
 	canEditEasingForInterpolationFunction,
 	stringifySequenceExpandedRowKey,
+	type SequenceNodePathMutation,
 } from '@remotion/studio-shared';
 import React, {
 	createContext,
@@ -452,6 +453,9 @@ type TimelineSelectionContextValue = {
 		readonly selectedItems: readonly TimelineSelection[];
 	};
 	readonly containsSelection: (nodePathInfo: SequenceNodePathInfo) => boolean;
+	readonly remapSelectionNodePaths: (
+		mutations: readonly SequenceNodePathMutation[],
+	) => void;
 	readonly clearSelection: () => void;
 };
 
@@ -468,6 +472,7 @@ const defaultTimelineSelectionContextValue: TimelineSelectionContextValue = {
 		selectedItems: [],
 	}),
 	containsSelection: () => false,
+	remapSelectionNodePaths: () => undefined,
 	clearSelection: () => undefined,
 };
 
@@ -1171,6 +1176,81 @@ export const TimelineSelectionProvider: React.FC<{
 		[availableSelectedItems],
 	);
 
+	const remapSelectionNodePaths = useCallback(
+		(mutations: readonly SequenceNodePathMutation[]) => {
+			const remapItem = (
+				item: TimelineSelection | null,
+			): TimelineSelection | null => {
+				if (item === null || item.type === 'guide') {
+					return item;
+				}
+
+				const {sequenceSubscriptionKey} = item.nodePathInfo;
+				let {nodePath} = sequenceSubscriptionKey;
+				let wasRemapped = false;
+
+				for (const mutation of mutations) {
+					const file = mutation.files.find(
+						(candidate) =>
+							candidate.absolutePath === sequenceSubscriptionKey.absolutePath,
+					);
+					if (!file) {
+						continue;
+					}
+
+					const nodePathString = JSON.stringify(nodePath);
+					const remapping = file.remappings.find(
+						(candidate) =>
+							candidate.oldNodePath !== null &&
+							JSON.stringify(candidate.oldNodePath) === nodePathString,
+					);
+					if (!remapping) {
+						continue;
+					}
+
+					wasRemapped = true;
+					if (remapping.newNodePath === null) {
+						return null;
+					}
+
+					nodePath = remapping.newNodePath;
+				}
+
+				if (!wasRemapped) {
+					return item;
+				}
+
+				return {
+					...item,
+					nodePathInfo: {
+						...item.nodePathInfo,
+						sequenceSubscriptionKey: {
+							...sequenceSubscriptionKey,
+							nodePath,
+						},
+					},
+				};
+			};
+
+			const snapshot = selectionController.getSnapshot();
+			const selectedItems = snapshot.selectedItems
+				.map(remapItem)
+				.filter((item): item is TimelineSelection => item !== null);
+			const anchor = remapItem(snapshot.anchor);
+
+			if (
+				selectedItems.some(
+					(item, index) => item !== snapshot.selectedItems[index],
+				) ||
+				selectedItems.length !== snapshot.selectedItems.length ||
+				anchor !== snapshot.anchor
+			) {
+				selectionController.setSnapshot({selectedItems, anchor});
+			}
+		},
+		[selectionController],
+	);
+
 	const value = useMemo(
 		(): TimelineSelectionContextValue => ({
 			canSelect,
@@ -1182,6 +1262,7 @@ export const TimelineSelectionProvider: React.FC<{
 			registerMarqueeSelectableItem,
 			getMarqueeSelection: getMarqueeSelectionForRect,
 			containsSelection,
+			remapSelectionNodePaths,
 			clearSelection,
 		}),
 		[
@@ -1194,6 +1275,7 @@ export const TimelineSelectionProvider: React.FC<{
 			registerMarqueeSelectableItem,
 			getMarqueeSelectionForRect,
 			containsSelection,
+			remapSelectionNodePaths,
 			clearSelection,
 		],
 	);

--- a/packages/studio/src/test/sequence-props-observer.test.tsx
+++ b/packages/studio/src/test/sequence-props-observer.test.tsx
@@ -242,6 +242,7 @@ test('keeps the selected sequence selected after its node path changes', () => {
 
 	queueSequenceNodePathMutation({
 		mutationId: 'reorder-selection-test',
+		timelineSelection: null,
 		files: [
 			{
 				absolutePath,

--- a/packages/studio/src/test/sequence-props-observer.test.tsx
+++ b/packages/studio/src/test/sequence-props-observer.test.tsx
@@ -1,14 +1,75 @@
 import {afterEach, expect, test} from 'bun:test';
-import {cleanup, render} from '@testing-library/react';
+import {act, cleanup, render} from '@testing-library/react';
+import type {ContextType, ReactNode} from 'react';
 import {Internals, type SequencePropsSubscriptionKey} from 'remotion';
 import {ExpandedTracksSetterContext} from '../components/ExpandedTracksProvider';
 import {subscribeToSequencePropsRefresh} from '../components/Timeline/sequence-props-subscription-store';
 import {SequencePropsObserver} from '../components/Timeline/SequencePropsObserver';
+import {
+	TimelineSelectionProvider,
+	useTimelineSelection,
+} from '../components/Timeline/TimelineSelection';
 import {FastRefreshContext} from '../fast-refresh-context';
 import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {queueSequenceNodePathMutation} from '../helpers/sequence-node-path-mutations';
+import {KeybindingContextProvider} from '../state/keybindings';
 
 afterEach(cleanup);
+
+const studioServerConnectionContext = {
+	previewServerState: {type: 'connected', clientId: 'client'},
+	configFileChangeRevision: 0,
+	subscribeToEvent: () => () => undefined,
+} as never;
+
+const ObserverTestProviders = ({
+	children,
+	values,
+}: {
+	readonly children: ReactNode;
+	readonly values: {
+		readonly expandedTracksSetter: ContextType<
+			typeof ExpandedTracksSetterContext
+		>;
+		readonly fastRefresh: ContextType<typeof FastRefreshContext>;
+		readonly overrideIdsGetter: ContextType<
+			typeof Internals.OverrideIdsToNodePathsGettersContext
+		>;
+		readonly overrideIdsSetter: ContextType<
+			typeof Internals.OverrideIdsToNodePathsSettersContext
+		>;
+		readonly propStatusesRef: ContextType<
+			typeof Internals.VisualModePropStatusesRefContext
+		>;
+		readonly visualModeSetters: ContextType<
+			typeof Internals.VisualModeSettersContext
+		>;
+	};
+}) => (
+	<StudioServerConnectionCtx.Provider value={studioServerConnectionContext}>
+		<FastRefreshContext.Provider value={values.fastRefresh}>
+			<ExpandedTracksSetterContext.Provider value={values.expandedTracksSetter}>
+				<Internals.OverrideIdsToNodePathsGettersContext.Provider
+					value={values.overrideIdsGetter}
+				>
+					<Internals.OverrideIdsToNodePathsSettersContext.Provider
+						value={values.overrideIdsSetter}
+					>
+						<Internals.VisualModePropStatusesRefContext.Provider
+							value={values.propStatusesRef}
+						>
+							<Internals.VisualModeSettersContext.Provider
+								value={values.visualModeSetters}
+							>
+								{children}
+							</Internals.VisualModeSettersContext.Provider>
+						</Internals.VisualModePropStatusesRefContext.Provider>
+					</Internals.OverrideIdsToNodePathsSettersContext.Provider>
+				</Internals.OverrideIdsToNodePathsGettersContext.Provider>
+			</ExpandedTracksSetterContext.Provider>
+		</FastRefreshContext.Provider>
+	</StudioServerConnectionCtx.Provider>
+);
 
 test('refreshes prop statuses for inserted and in-place updated nodes', () => {
 	const absolutePath = '/project/src/BarChart.tsx';
@@ -61,68 +122,41 @@ test('refreshes prop statuses for inserted and in-place updated nodes', () => {
 
 	try {
 		render(
-			<StudioServerConnectionCtx.Provider
-				value={
-					{
-						previewServerState: {type: 'connected', clientId: 'client'},
-						configFileChangeRevision: 0,
-						subscribeToEvent: () => () => undefined,
-					} as never
-				}
-			>
-				<FastRefreshContext.Provider
-					value={{
+			<ObserverTestProviders
+				values={{
+					fastRefresh: {
 						fastRefreshes: 1,
 						manualRefreshes: 0,
 						increaseManualRefreshes: () => undefined,
-					}}
-				>
-					<ExpandedTracksSetterContext.Provider
-						value={
-							{
-								expandParentTracks: () => undefined,
-								toggleTrack: () => undefined,
-								migrateExpandedTracksForSubscriptionKey: (
-									oldKey: SequencePropsSubscriptionKey,
-									newKey: SequencePropsSubscriptionKey,
-								) => migrationCalls.push([oldKey, newKey]),
-							} as never
-						}
-					>
-						<Internals.OverrideIdsToNodePathsGettersContext.Provider
-							value={{
-								overrideIdToNodePathMappings: {
-									'original-override': originalNodePath,
-									'inserted-override': insertedNodePath,
-								},
-							}}
-						>
-							<Internals.OverrideIdsToNodePathsSettersContext.Provider
-								value={{
-									setOverrideIdToNodePath: (overrideId, nodePath) =>
-										setOverrideCalls.push({overrideId, nodePath}),
-								}}
-							>
-								<Internals.VisualModePropStatusesRefContext.Provider
-									value={{current: {}}}
-								>
-									<Internals.VisualModeSettersContext.Provider
-										value={
-											{
-												remapPropStatuses: (remappings: unknown) =>
-													statusRemappingCalls.push(remappings),
-												setPropStatuses: () => undefined,
-											} as never
-										}
-									>
-										<SequencePropsObserver />
-									</Internals.VisualModeSettersContext.Provider>
-								</Internals.VisualModePropStatusesRefContext.Provider>
-							</Internals.OverrideIdsToNodePathsSettersContext.Provider>
-						</Internals.OverrideIdsToNodePathsGettersContext.Provider>
-					</ExpandedTracksSetterContext.Provider>
-				</FastRefreshContext.Provider>
-			</StudioServerConnectionCtx.Provider>,
+					},
+					expandedTracksSetter: {
+						expandParentTracks: () => undefined,
+						toggleTrack: () => undefined,
+						migrateExpandedTracksForSubscriptionKey: (
+							oldKey: SequencePropsSubscriptionKey,
+							newKey: SequencePropsSubscriptionKey,
+						) => migrationCalls.push([oldKey, newKey]),
+					} as never,
+					overrideIdsGetter: {
+						overrideIdToNodePathMappings: {
+							'original-override': originalNodePath,
+							'inserted-override': insertedNodePath,
+						},
+					},
+					overrideIdsSetter: {
+						setOverrideIdToNodePath: (overrideId, nodePath) =>
+							setOverrideCalls.push({overrideId, nodePath}),
+					},
+					propStatusesRef: {current: {}},
+					visualModeSetters: {
+						remapPropStatuses: (remappings: unknown) =>
+							statusRemappingCalls.push(remappings),
+						setPropStatuses: () => undefined,
+					} as never,
+				}}
+			>
+				<SequencePropsObserver />
+			</ObserverTestProviders>,
 		);
 
 		expect(refreshedOverrideIds).toEqual([
@@ -139,4 +173,91 @@ test('refreshes prop statuses for inserted and in-place updated nodes', () => {
 		unsubscribeOriginalRefresh();
 		unsubscribeInsertedRefresh();
 	}
+});
+
+test('keeps the selected sequence selected after its node path changes', () => {
+	const absolutePath = '/project/src/BarChart.tsx';
+	const originalNodePath: SequencePropsSubscriptionKey = {
+		absolutePath,
+		effectKeys: [],
+		nodePath: ['body', 0],
+		sequenceKeys: ['hidden', 'name'],
+		videoConfigValues: null,
+	};
+	const selectionRef: {
+		current: ReturnType<typeof useTimelineSelection> | null;
+	} = {current: null};
+	const CaptureSelection = () => {
+		selectionRef.current = useTimelineSelection();
+		return null;
+	};
+
+	const renderTree = (fastRefreshes: number) => (
+		<ObserverTestProviders
+			values={{
+				fastRefresh: {
+					fastRefreshes,
+					manualRefreshes: 0,
+					increaseManualRefreshes: () => undefined,
+				},
+				expandedTracksSetter: {
+					expandParentTracks: () => undefined,
+					toggleTrack: () => undefined,
+					migrateExpandedTracksForSubscriptionKey: () => undefined,
+				} as never,
+				overrideIdsGetter: {overrideIdToNodePathMappings: {}},
+				overrideIdsSetter: {setOverrideIdToNodePath: () => undefined},
+				propStatusesRef: {current: {}},
+				visualModeSetters: {
+					remapPropStatuses: () => undefined,
+					setPropStatuses: () => undefined,
+				} as never,
+			}}
+		>
+			<KeybindingContextProvider>
+				<TimelineSelectionProvider>
+					<CaptureSelection />
+					<SequencePropsObserver />
+				</TimelineSelectionProvider>
+			</KeybindingContextProvider>
+		</ObserverTestProviders>
+	);
+	const rendered = render(renderTree(0));
+
+	act(() => {
+		selectionRef.current?.selectItems([
+			{
+				type: 'sequence',
+				nodePathInfo: {
+					sequenceSubscriptionKey: originalNodePath,
+					auxiliaryKeys: [],
+					index: 0,
+					numberOfSequencesWithThisNodePath: 1,
+					supportsEffects: true,
+				},
+			},
+		]);
+	});
+
+	queueSequenceNodePathMutation({
+		mutationId: 'reorder-selection-test',
+		files: [
+			{
+				absolutePath,
+				remappings: [
+					{oldNodePath: ['body', 0], newNodePath: ['body', 1]},
+					{oldNodePath: ['body', 1], newNodePath: ['body', 0]},
+				],
+			},
+		],
+	});
+	rendered.rerender(renderTree(1));
+
+	expect(selectionRef.current?.selectedItems).toHaveLength(1);
+	expect(
+		selectionRef.current?.selectedItems[0]?.type === 'sequence'
+			? selectionRef.current.selectedItems[0].nodePathInfo
+					.sequenceSubscriptionKey.nodePath
+			: null,
+	).toEqual(['body', 1]);
 });


### PR DESCRIPTION
## Summary

- keep timeline selections attached to their source sequences when reorder mutations change AST node paths
- preserve the selection anchor and clear selections whose source node was deleted
- cover the refresh observer and selection provider workflow with a regression test

Closes #11117

Part of #9142
