### PR TITLE
`@remotion/studio`: Clamp right-edge media resizing to asset duration

### DIFF
--- a/packages/studio/src/components/Timeline/Timeline.tsx
+++ b/packages/studio/src/components/Timeline/Timeline.tsx
@@ -58,6 +58,7 @@ import {
 	TimelineSelectAllKeybindings,
 	useTimelineSelection,
 } from './TimelineSelection';
+import {TimelineSequenceMediaDurationDragLimitsProvider} from './TimelineSequenceRightEdgeDragHandle';
 import {TimelineSlider} from './TimelineSlider';
 import {TimelineTickFormatProvider} from './TimelineTickFormatProvider';
 import {
@@ -533,7 +534,9 @@ const MemoizedTimelineInner = React.memo(TimelineInner);
 export const Timeline: React.FC = () => {
 	return (
 		<TimelineTickFormatProvider>
-			<MemoizedTimelineInner />
+			<TimelineSequenceMediaDurationDragLimitsProvider>
+				<MemoizedTimelineInner />
+			</TimelineSequenceMediaDurationDragLimitsProvider>
 		</TimelineTickFormatProvider>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -2,7 +2,13 @@ import {
 	getTimelineVisibleDuration,
 	getTimelineVisibleStart,
 } from '@remotion/canvas';
-import React, {useCallback, useContext, useMemo, useRef} from 'react';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from 'react';
 import type {_InternalTypes, TSequence} from 'remotion';
 import {Internals, useCurrentFrame} from 'remotion';
 import {StudioServerConnectionCtx} from '../../helpers/client-id';
@@ -56,6 +62,7 @@ import {LoopedTimelineIndicator} from './LoopedTimelineIndicators';
 import {getTimelineAssetLinkInfo} from './timeline-asset-link';
 import {TimelineImageInfo} from './TimelineImageInfo';
 import {
+	getTimelineSequenceSelectionKey,
 	isTimelineSelectionModifierEvent,
 	shouldSelectTimelineRowOnPointerDown,
 	TIMELINE_MARQUEE_ITEM_ATTR,
@@ -71,6 +78,7 @@ import {
 	isTimelineSequenceDurationDraggable,
 	isTimelineSequenceLeftEdgeDraggable,
 	TimelineSequenceLeftEdgeDragHandle,
+	TimelineSequenceMediaDurationDragLimitsContext,
 	TimelineSequenceRightEdgeDragHandle,
 	useTimelineSequenceFromDrag,
 } from './TimelineSequenceRightEdgeDragHandle';
@@ -428,6 +436,9 @@ const TimelineSequenceInner: React.FC<{
 	const video = Internals.useVideo();
 	const {sequences} = useContext(Internals.SequenceManager);
 	const renderWindow = useContext(TimelineViewportContext);
+	const mediaDurationDragLimitsRegistry = useContext(
+		TimelineSequenceMediaDurationDragLimitsContext,
+	);
 	const dragAwareDoubleClick = useMemo(
 		() => createDragAwareDoubleClickTracker(),
 		[],
@@ -924,6 +935,29 @@ const TimelineSequenceInner: React.FC<{
 				timelineDurationInFrames: video.durationInFrames,
 			})
 		: null;
+	const mediaDurationDragSelectionKey = nodePathInfo
+		? getTimelineSequenceSelectionKey(nodePathInfo)
+		: null;
+	useEffect(() => {
+		if (
+			mediaDurationDragLimitsRegistry === null ||
+			mediaDurationDragSelectionKey === null ||
+			!isMedia
+		) {
+			return;
+		}
+
+		const registry = mediaDurationDragLimitsRegistry.current;
+		registry.set(mediaDurationDragSelectionKey, mediaDurationDragLimits);
+		return () => {
+			registry.delete(mediaDurationDragSelectionKey);
+		};
+	}, [
+		isMedia,
+		mediaDurationDragLimits,
+		mediaDurationDragLimitsRegistry,
+		mediaDurationDragSelectionKey,
+	]);
 
 	const showRightBorderRadius =
 		visibleLayout?.rightEdgeVisible === true &&

--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -66,6 +66,7 @@ import {
 import {TimelineSequenceFrame} from './TimelineSequenceFrame';
 import {
 	canResizeTimelineSequenceDuration,
+	getTimelineSequenceMediaDurationDragLimits,
 	isCascadingSequence,
 	isTimelineSequenceDurationDraggable,
 	isTimelineSequenceLeftEdgeDraggable,
@@ -497,7 +498,6 @@ const TimelineSequenceInner: React.FC<{
 	const durationCanResize = Boolean(
 		isStudioInteractivityEnabled() &&
 		canResizeTimelineSequenceDuration({
-			sequence: s,
 			status: propStatusesForOverride?.durationInFrames,
 		}),
 	);
@@ -898,6 +898,32 @@ const TimelineSequenceInner: React.FC<{
 	const endsAtContainerBoundary =
 		Math.ceil(s.from + displayDurationInFrames) >=
 		Math.ceil(Math.min(parentEnd, video.durationInFrames));
+	const hasImplicitMediaDuration =
+		(s.type === 'audio' || s.type === 'video') &&
+		propStatusesForOverride?.durationInFrames?.status === 'static' &&
+		propStatusesForOverride.durationInFrames.codeValue === undefined;
+	const durationInFramesCodeValue =
+		propStatusesForOverride?.durationInFrames?.status === 'static'
+			? propStatusesForOverride.durationInFrames.codeValue
+			: null;
+	const explicitDurationInFrames =
+		typeof durationInFramesCodeValue === 'number' &&
+		Number.isFinite(durationInFramesCodeValue)
+			? durationInFramesCodeValue
+			: null;
+	const isMedia = s.type === 'audio' || s.type === 'video';
+	const mediaDurationDragLimits = isMedia
+		? getTimelineSequenceMediaDurationDragLimits({
+				cascadedStart,
+				displayDurationInFrames: s.duration,
+				displayStart: s.from,
+				effectiveMaxMediaDuration,
+				explicitDurationInFrames,
+				hasImplicitDuration: hasImplicitMediaDuration,
+				naturalMediaDuration,
+				timelineDurationInFrames: video.durationInFrames,
+			})
+		: null;
 
 	const showRightBorderRadius =
 		visibleLayout?.rightEdgeVisible === true &&
@@ -943,7 +969,8 @@ const TimelineSequenceInner: React.FC<{
 		isTimelineSequenceDurationDraggable(s) &&
 		nodePath !== null &&
 		validatedLocation !== null &&
-		durationCanResize;
+		durationCanResize &&
+		(!isMedia || mediaDurationDragLimits !== null);
 	const showLeftEdgeDragHandle =
 		isTimelineSequenceLeftEdgeDraggable(s) &&
 		nodePath !== null &&
@@ -1004,6 +1031,7 @@ const TimelineSequenceInner: React.FC<{
 					validatedLocation ? (
 						<TimelineSequenceRightEdgeDragHandle
 							nodePathInfo={nodePathInfo}
+							mediaDurationDragLimits={mediaDurationDragLimits}
 							windowWidth={windowWidth}
 							timelineDurationInFrames={video.durationInFrames ?? 1}
 							onDragEnd={dragAwareDoubleClick.endPointerGesture}

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -173,7 +173,6 @@ export type TimelineSequenceDurationDragTarget = {
 	readonly maximumDuration: number;
 	readonly minimumDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
-	readonly onlyCommitDurationWithinMaximum: boolean;
 	readonly schema: InteractivitySchema;
 };
 
@@ -492,32 +491,6 @@ export const getTimelineSequenceDurationDragValue = ({
 		Math.max(minimumDuration, initialDuration + deltaFrames),
 	);
 
-const getTimelineSequenceDurationDragValueForTarget = ({
-	target,
-	deltaFrames,
-}: {
-	readonly target: TimelineSequenceDurationDragTarget;
-	readonly deltaFrames: number;
-}) => {
-	const unclampedValue = Math.max(
-		target.minimumDuration,
-		target.initialDuration + deltaFrames,
-	);
-	if (
-		target.onlyCommitDurationWithinMaximum &&
-		unclampedValue > target.maximumDuration
-	) {
-		return null;
-	}
-
-	return getTimelineSequenceDurationDragValue({
-		initialDuration: target.initialDuration,
-		deltaFrames,
-		maximumDuration: target.maximumDuration,
-		minimumDuration: target.minimumDuration,
-	});
-};
-
 export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
 	initialTrimBefore,
@@ -633,13 +606,12 @@ export const getTimelineSequenceDurationDragChanges = ({
 	readonly deltaFrames: number;
 }): SaveSequencePropChange[] => {
 	return targets.flatMap((target) => {
-		const nextValue = getTimelineSequenceDurationDragValueForTarget({
-			target,
+		const nextValue = getTimelineSequenceDurationDragValue({
+			initialDuration: target.initialDuration,
 			deltaFrames,
+			maximumDuration: target.maximumDuration,
+			minimumDuration: target.minimumDuration,
 		});
-		if (nextValue === null) {
-			return [];
-		}
 
 		if (nextValue === target.initialDuration) {
 			return [];
@@ -911,10 +883,6 @@ export const getTimelineSequenceDurationDragTargets = ({
 			const selectionKey = getTimelineSequenceSelectionKey(nodePathInfo);
 			const isMedia =
 				originalSequence.type === 'audio' || originalSequence.type === 'video';
-			const hasImplicitMediaDuration =
-				isMedia &&
-				durationStatus?.status === 'static' &&
-				durationStatus.codeValue === undefined;
 			const isDraggedSequence = selectionKey === draggedSelectionKey;
 			const mediaDurationDragLimits = isMedia
 				? isDraggedSequence
@@ -935,12 +903,8 @@ export const getTimelineSequenceDurationDragTargets = ({
 				mediaDurationDragLimits?.maximumDuration ?? Infinity,
 				timelineDurationInFrames - track.cascadedStart,
 			);
-			if (isMedia && constrainedMaximumDuration < minimumDuration) {
-				return null;
-			}
-
 			const maximumDuration = isMedia
-				? constrainedMaximumDuration
+				? Math.max(minimumDuration, initialDuration, constrainedMaximumDuration)
 				: Math.max(minimumDuration, constrainedMaximumDuration);
 
 			targets.set(key, {
@@ -950,8 +914,6 @@ export const getTimelineSequenceDurationDragTargets = ({
 				// A negative start needs enough duration to retain one visible frame.
 				minimumDuration,
 				nodePath,
-				onlyCommitDurationWithinMaximum:
-					hasImplicitMediaDuration || initialDuration > maximumDuration,
 				schema: controls.schema,
 			});
 		}
@@ -2088,19 +2050,12 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 				}
 
 				for (const target of dragState.targets) {
-					const committableValue =
-						getTimelineSequenceDurationDragValueForTarget({
-							target,
-							deltaFrames,
-						});
-					const previewValue =
-						committableValue ??
-						getTimelineSequenceDurationDragValue({
-							initialDuration: target.initialDuration,
-							deltaFrames,
-							maximumDuration: target.initialDuration,
-							minimumDuration: target.minimumDuration,
-						});
+					const previewValue = getTimelineSequenceDurationDragValue({
+						initialDuration: target.initialDuration,
+						deltaFrames,
+						maximumDuration: target.maximumDuration,
+						minimumDuration: target.minimumDuration,
+					});
 
 					latestRef.current.setDragOverrides(
 						target.nodePath,

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -82,27 +82,31 @@ export const getTimelineSequenceMediaDurationDragLimits = ({
 		return null;
 	}
 
-	return {
-		initialDuration:
-			explicitDurationInFrames ??
-			Math.ceil(
-				displayStart +
-					Math.max(
-						0,
-						Math.min(
-							displayDurationInFrames,
-							timelineDurationInFrames - displayStart,
-							effectiveMaxMediaDuration ?? Infinity,
-						),
-					) -
-					cascadedStart,
-			),
-		maximumDuration:
-			// Keeping duration omitted represents the media's natural end. An
-			// explicit duration is only useful once its edge is before that end.
-			Math.ceil(displayStart + naturalMediaDuration - cascadedStart) -
-			(hasImplicitDuration ? 1 : 0),
-	};
+	const initialDuration =
+		explicitDurationInFrames ??
+		Math.ceil(
+			displayStart +
+				Math.max(
+					0,
+					Math.min(
+						displayDurationInFrames,
+						timelineDurationInFrames - displayStart,
+						effectiveMaxMediaDuration ?? Infinity,
+					),
+				) -
+				cascadedStart,
+		);
+	const maximumDuration =
+		// Keeping duration omitted represents the media's natural end. An
+		// explicit duration is only useful once its edge is before that end.
+		Math.ceil(displayStart + naturalMediaDuration - cascadedStart) -
+		(hasImplicitDuration ? 1 : 0);
+
+	if (hasImplicitDuration && initialDuration > maximumDuration) {
+		return null;
+	}
+
+	return {initialDuration, maximumDuration};
 };
 
 const getTimelineSequenceEdgeSelectionInteraction = ({

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -55,6 +55,25 @@ export type TimelineSequenceMediaDurationDragLimits = {
 	readonly maximumDuration: number;
 };
 
+export const TimelineSequenceMediaDurationDragLimitsContext =
+	React.createContext<React.RefObject<
+		Map<string, TimelineSequenceMediaDurationDragLimits | null>
+	> | null>(null);
+
+export const TimelineSequenceMediaDurationDragLimitsProvider: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const limits = useRef(
+		new Map<string, TimelineSequenceMediaDurationDragLimits | null>(),
+	);
+
+	return (
+		<TimelineSequenceMediaDurationDragLimitsContext.Provider value={limits}>
+			{children}
+		</TimelineSequenceMediaDurationDragLimitsContext.Provider>
+	);
+};
+
 export const getTimelineSequenceMediaDurationDragLimits = ({
 	cascadedStart,
 	displayDurationInFrames,
@@ -810,6 +829,7 @@ const findSequenceTrack = ({
 export const getTimelineSequenceDurationDragTargets = ({
 	draggedNodePathInfo,
 	draggedSequenceMediaDurationDragLimits,
+	selectedSequenceMediaDurationDragLimits,
 	selectedItems,
 	sequences,
 	overrideIdsToNodePaths,
@@ -818,6 +838,10 @@ export const getTimelineSequenceDurationDragTargets = ({
 }: {
 	readonly draggedNodePathInfo: SequenceNodePathInfo;
 	readonly draggedSequenceMediaDurationDragLimits: TimelineSequenceMediaDurationDragLimits | null;
+	readonly selectedSequenceMediaDurationDragLimits: ReadonlyMap<
+		string,
+		TimelineSequenceMediaDurationDragLimits | null
+	> | null;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
@@ -884,23 +908,18 @@ export const getTimelineSequenceDurationDragTargets = ({
 
 		const key = stringifySequenceSubscriptionKey(nodePath);
 		if (!targets.has(key)) {
+			const selectionKey = getTimelineSequenceSelectionKey(nodePathInfo);
 			const isMedia =
 				originalSequence.type === 'audio' || originalSequence.type === 'video';
 			const hasImplicitMediaDuration =
 				isMedia &&
 				durationStatus?.status === 'static' &&
 				durationStatus.codeValue === undefined;
-			const isDraggedSequence =
-				getTimelineSequenceSelectionKey(nodePathInfo) === draggedSelectionKey;
+			const isDraggedSequence = selectionKey === draggedSelectionKey;
 			const mediaDurationDragLimits = isMedia
 				? isDraggedSequence
 					? draggedSequenceMediaDurationDragLimits
-					: hasImplicitMediaDuration
-						? null
-						: {
-								initialDuration: originalSequence.duration,
-								maximumDuration: originalSequence.duration,
-							}
+					: (selectedSequenceMediaDurationDragLimits?.get(selectionKey) ?? null)
 				: null;
 			if (isMedia && mediaDurationDragLimits === null) {
 				return null;
@@ -1881,6 +1900,9 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	);
 	const {previewServerState} = useContext(StudioServerConnectionCtx);
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
+	const mediaDurationDragLimitsRegistry = useContext(
+		TimelineSequenceMediaDurationDragLimitsContext,
+	);
 
 	const stopPointerSessionRef = useRef<(() => void) | null>(null);
 	const dragStateRef = useRef<{
@@ -2022,6 +2044,8 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 						draggedNodePathInfo: latestNodePathInfo,
 						draggedSequenceMediaDurationDragLimits:
 							latestMediaDurationDragLimits,
+						selectedSequenceMediaDurationDragLimits:
+							mediaDurationDragLimitsRegistry?.current ?? null,
 						selectedItems: latestSelectedItems,
 						sequences: sequencesRef.current,
 						overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
@@ -2130,6 +2154,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 		[
 			currentSelection,
 			finishDrag,
+			mediaDurationDragLimitsRegistry,
 			propStatusesRef,
 			selected,
 			sequencesRef,

--- a/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceRightEdgeDragHandle.tsx
@@ -50,6 +50,61 @@ const HANDLE_OUTSET = 8;
 const timelineSequenceEdgeDragThresholdPx = 4;
 export const timelineSequenceFromDragSnapThresholdPx = 10;
 
+export type TimelineSequenceMediaDurationDragLimits = {
+	readonly initialDuration: number;
+	readonly maximumDuration: number;
+};
+
+export const getTimelineSequenceMediaDurationDragLimits = ({
+	cascadedStart,
+	displayDurationInFrames,
+	displayStart,
+	effectiveMaxMediaDuration,
+	explicitDurationInFrames,
+	hasImplicitDuration,
+	naturalMediaDuration,
+	timelineDurationInFrames,
+}: {
+	readonly cascadedStart: number;
+	readonly displayDurationInFrames: number;
+	readonly displayStart: number;
+	readonly effectiveMaxMediaDuration: number | null;
+	readonly explicitDurationInFrames: number | null;
+	readonly hasImplicitDuration: boolean;
+	readonly naturalMediaDuration: number | null;
+	readonly timelineDurationInFrames: number;
+}): TimelineSequenceMediaDurationDragLimits | null => {
+	if (
+		naturalMediaDuration === null ||
+		!Number.isFinite(naturalMediaDuration) ||
+		naturalMediaDuration <= 0
+	) {
+		return null;
+	}
+
+	return {
+		initialDuration:
+			explicitDurationInFrames ??
+			Math.ceil(
+				displayStart +
+					Math.max(
+						0,
+						Math.min(
+							displayDurationInFrames,
+							timelineDurationInFrames - displayStart,
+							effectiveMaxMediaDuration ?? Infinity,
+						),
+					) -
+					cascadedStart,
+			),
+		maximumDuration:
+			// Keeping duration omitted represents the media's natural end. An
+			// explicit duration is only useful once its edge is before that end.
+			Math.ceil(displayStart + naturalMediaDuration - cascadedStart) -
+			(hasImplicitDuration ? 1 : 0),
+	};
+};
+
 const getTimelineSequenceEdgeSelectionInteraction = ({
 	button,
 	selected,
@@ -95,6 +150,7 @@ export type TimelineSequenceDurationDragTarget = {
 	readonly maximumDuration: number;
 	readonly minimumDuration: number;
 	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly onlyCommitDurationWithinMaximum: boolean;
 	readonly schema: InteractivitySchema;
 };
 
@@ -349,21 +405,11 @@ export const isTimelineSequenceDurationDraggable = (sequence: TSequence) => {
 };
 
 export const canResizeTimelineSequenceDuration = ({
-	sequence,
 	status,
 }: {
-	readonly sequence: TSequence;
 	readonly status: CanUpdateSequencePropStatus | undefined;
 }) => {
-	if (status?.status !== 'static') {
-		return false;
-	}
-
-	if (sequence.type === 'audio' || sequence.type === 'video') {
-		return status.codeValue !== undefined;
-	}
-
-	return true;
+	return status?.status === 'static';
 };
 
 export const isTimelineSequenceLeftEdgeDraggable = (sequence: TSequence) => {
@@ -422,6 +468,32 @@ export const getTimelineSequenceDurationDragValue = ({
 		maximumDuration,
 		Math.max(minimumDuration, initialDuration + deltaFrames),
 	);
+
+const getTimelineSequenceDurationDragValueForTarget = ({
+	target,
+	deltaFrames,
+}: {
+	readonly target: TimelineSequenceDurationDragTarget;
+	readonly deltaFrames: number;
+}) => {
+	const unclampedValue = Math.max(
+		target.minimumDuration,
+		target.initialDuration + deltaFrames,
+	);
+	if (
+		target.onlyCommitDurationWithinMaximum &&
+		unclampedValue > target.maximumDuration
+	) {
+		return null;
+	}
+
+	return getTimelineSequenceDurationDragValue({
+		initialDuration: target.initialDuration,
+		deltaFrames,
+		maximumDuration: target.maximumDuration,
+		minimumDuration: target.minimumDuration,
+	});
+};
 
 export const getTimelineSequenceLeftEdgeDragDelta = ({
 	initialDuration,
@@ -538,12 +610,13 @@ export const getTimelineSequenceDurationDragChanges = ({
 	readonly deltaFrames: number;
 }): SaveSequencePropChange[] => {
 	return targets.flatMap((target) => {
-		const nextValue = getTimelineSequenceDurationDragValue({
-			initialDuration: target.initialDuration,
+		const nextValue = getTimelineSequenceDurationDragValueForTarget({
+			target,
 			deltaFrames,
-			maximumDuration: target.maximumDuration,
-			minimumDuration: target.minimumDuration,
 		});
+		if (nextValue === null) {
+			return [];
+		}
 
 		if (nextValue === target.initialDuration) {
 			return [];
@@ -732,6 +805,7 @@ const findSequenceTrack = ({
 
 export const getTimelineSequenceDurationDragTargets = ({
 	draggedNodePathInfo,
+	draggedSequenceMediaDurationDragLimits,
 	selectedItems,
 	sequences,
 	overrideIdsToNodePaths,
@@ -739,6 +813,7 @@ export const getTimelineSequenceDurationDragTargets = ({
 	timelineDurationInFrames,
 }: {
 	readonly draggedNodePathInfo: SequenceNodePathInfo;
+	readonly draggedSequenceMediaDurationDragLimits: TimelineSequenceMediaDurationDragLimits | null;
 	readonly selectedItems: readonly TimelineSelection[];
 	readonly sequences: TSequence[];
 	readonly overrideIdsToNodePaths: OverrideIdToNodePaths;
@@ -792,7 +867,6 @@ export const getTimelineSequenceDurationDragTargets = ({
 		)?.durationInFrames;
 		if (
 			!canResizeTimelineSequenceDuration({
-				sequence: originalSequence,
 				status: durationStatus,
 			})
 		) {
@@ -806,20 +880,55 @@ export const getTimelineSequenceDurationDragTargets = ({
 
 		const key = stringifySequenceSubscriptionKey(nodePath);
 		if (!targets.has(key)) {
+			const isMedia =
+				originalSequence.type === 'audio' || originalSequence.type === 'video';
+			const hasImplicitMediaDuration =
+				isMedia &&
+				durationStatus?.status === 'static' &&
+				durationStatus.codeValue === undefined;
+			const isDraggedSequence =
+				getTimelineSequenceSelectionKey(nodePathInfo) === draggedSelectionKey;
+			const mediaDurationDragLimits = isMedia
+				? isDraggedSequence
+					? draggedSequenceMediaDurationDragLimits
+					: hasImplicitMediaDuration
+						? null
+						: {
+								initialDuration: originalSequence.duration,
+								maximumDuration: originalSequence.duration,
+							}
+				: null;
+			if (isMedia && mediaDurationDragLimits === null) {
+				return null;
+			}
+
 			const minimumDuration = Math.max(
 				1 - originalSequence.from,
 				getMinimumSequenceDuration({sequence: originalSequence, sequences}),
 			);
+			const initialDuration =
+				mediaDurationDragLimits?.initialDuration ?? originalSequence.duration;
+			const constrainedMaximumDuration = Math.min(
+				mediaDurationDragLimits?.maximumDuration ?? Infinity,
+				timelineDurationInFrames - track.cascadedStart,
+			);
+			if (isMedia && constrainedMaximumDuration < minimumDuration) {
+				return null;
+			}
+
+			const maximumDuration = isMedia
+				? constrainedMaximumDuration
+				: Math.max(minimumDuration, constrainedMaximumDuration);
+
 			targets.set(key, {
 				fileName: nodePath.absolutePath,
-				initialDuration: originalSequence.duration,
-				maximumDuration: Math.max(
-					minimumDuration,
-					timelineDurationInFrames - track.cascadedStart,
-				),
+				initialDuration,
+				maximumDuration,
 				// A negative start needs enough duration to retain one visible frame.
 				minimumDuration,
 				nodePath,
+				onlyCommitDurationWithinMaximum:
+					hasImplicitMediaDuration || initialDuration > maximumDuration,
 				schema: controls.schema,
 			});
 		}
@@ -1741,6 +1850,7 @@ export const useTimelineSequenceFromDrag = ({
 
 const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	readonly nodePathInfo: SequenceNodePathInfo;
+	readonly mediaDurationDragLimits: TimelineSequenceMediaDurationDragLimits | null;
 	readonly windowWidth: number;
 	readonly timelineDurationInFrames: number;
 	readonly onDragEnd: (wasDragged: boolean) => void;
@@ -1748,6 +1858,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	readonly selected: boolean;
 }> = ({
 	nodePathInfo,
+	mediaDurationDragLimits,
 	windowWidth,
 	timelineDurationInFrames,
 	onDragEnd,
@@ -1781,6 +1892,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	// Keep latest props/setters available to window listeners installed once at pointerdown.
 	const latestRef = useRef({
 		nodePathInfo,
+		mediaDurationDragLimits,
 		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
@@ -1791,6 +1903,7 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 	});
 	latestRef.current = {
 		nodePathInfo,
+		mediaDurationDragLimits,
 		setPropStatuses,
 		setDragOverrides,
 		clearDragOverrides,
@@ -1896,12 +2009,15 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 
 			const {
 				nodePathInfo: latestNodePathInfo,
+				mediaDurationDragLimits: latestMediaDurationDragLimits,
 				overrideIdToNodePathMappings: latestOverrideIdsToNodePaths,
 			} = latestRef.current;
 			const {selectedItems: latestSelectedItems} = currentSelection.current;
 			const targets = canCalculateDelta
 				? (getTimelineSequenceDurationDragTargets({
 						draggedNodePathInfo: latestNodePathInfo,
+						draggedSequenceMediaDurationDragLimits:
+							latestMediaDurationDragLimits,
 						selectedItems: latestSelectedItems,
 						sequences: sequencesRef.current,
 						overrideIdsToNodePaths: latestOverrideIdsToNodePaths,
@@ -1944,17 +2060,24 @@ const TimelineSequenceRightEdgeDragHandleInner: React.FC<{
 				}
 
 				for (const target of dragState.targets) {
+					const committableValue =
+						getTimelineSequenceDurationDragValueForTarget({
+							target,
+							deltaFrames,
+						});
+					const previewValue =
+						committableValue ??
+						getTimelineSequenceDurationDragValue({
+							initialDuration: target.initialDuration,
+							deltaFrames,
+							maximumDuration: target.initialDuration,
+							minimumDuration: target.minimumDuration,
+						});
+
 					latestRef.current.setDragOverrides(
 						target.nodePath,
 						'durationInFrames',
-						Internals.makeStaticDragOverride(
-							getTimelineSequenceDurationDragValue({
-								initialDuration: target.initialDuration,
-								deltaFrames,
-								maximumDuration: target.maximumDuration,
-								minimumDuration: target.minimumDuration,
-							}),
-						),
+						Internals.makeStaticDragOverride(previewValue),
 					);
 				}
 			};

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1793,6 +1793,7 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: firstNodePathInfo,
 		draggedSequenceMediaDurationDragLimits: null,
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [
 			{type: 'sequence', nodePathInfo: firstNodePathInfo},
 			{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -1825,12 +1826,85 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 	).toEqual([schema, schema]);
 });
 
+test('Timeline duration drag clamps each selected media item to its asset end', () => {
+	const schema = {} satisfies InteractivitySchema;
+	const firstNodePathInfo = makeNodePathInfo(['body', 0], []);
+	const secondNodePathInfo = makeNodePathInfo(['body', 1], []);
+	const sequences = [
+		makeTimelineSequence({
+			schema,
+			id: 'first',
+			overrideId: 'first',
+			duration: 40,
+			type: 'video',
+		}),
+		makeTimelineSequence({
+			schema,
+			id: 'second',
+			overrideId: 'second',
+			duration: 15,
+			type: 'audio',
+		}),
+	];
+	const common = {
+		draggedNodePathInfo: firstNodePathInfo,
+		draggedSequenceMediaDurationDragLimits: {
+			initialDuration: 40,
+			maximumDuration: 45,
+		},
+		selectedItems: [
+			{type: 'sequence' as const, nodePathInfo: firstNodePathInfo},
+			{type: 'sequence' as const, nodePathInfo: secondNodePathInfo},
+		],
+		sequences,
+		overrideIdsToNodePaths: {
+			first: firstNodePathInfo.sequenceSubscriptionKey,
+			second: secondNodePathInfo.sequenceSubscriptionKey,
+		},
+		propStatuses: makeDurationPropStatuses([
+			firstNodePathInfo.sequenceSubscriptionKey,
+			secondNodePathInfo.sequenceSubscriptionKey,
+		]),
+		timelineDurationInFrames: 1000,
+	};
+
+	expect(
+		getTimelineSequenceDurationDragTargets({
+			...common,
+			selectedSequenceMediaDurationDragLimits: null,
+		}),
+	).toBe(null);
+
+	const targets = getTimelineSequenceDurationDragTargets({
+		...common,
+		selectedSequenceMediaDurationDragLimits: new Map([
+			[
+				getTimelineSequenceSelectionKey(secondNodePathInfo),
+				{initialDuration: 15, maximumDuration: 18},
+			],
+		]),
+	});
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: 10,
+		}).map((change) => change.value),
+	).toEqual([45, 18]);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -10,
+		}).map((change) => change.value),
+	).toEqual([30, 5]);
+});
+
 test('Timeline duration drag uses the declared duration for negative from values', () => {
 	const schema = {} satisfies InteractivitySchema;
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
 		draggedSequenceMediaDurationDragLimits: null,
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -1863,6 +1937,7 @@ test('Timeline duration drag clamps to the composition end', () => {
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
 		draggedSequenceMediaDurationDragLimits: null,
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -1905,6 +1980,7 @@ test('Timeline duration drag supports interactive video clips', () => {
 				initialDuration: 78,
 				maximumDuration: 1000,
 			},
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [{type: 'sequence', nodePathInfo}],
 			sequences: [video],
 			overrideIdsToNodePaths: {
@@ -1992,6 +2068,7 @@ test('Timeline duration drag clamps explicit audio and video to the asset end', 
 				initialDuration: 200,
 				maximumDuration: 225,
 			},
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [{type: 'sequence', nodePathInfo}],
 			sequences: [
 				makeTimelineSequence({
@@ -2025,6 +2102,7 @@ test('An overlong explicit Video is only saved once it reaches the asset end', (
 			initialDuration: 300,
 			maximumDuration: 225,
 		},
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -2068,6 +2146,7 @@ test('Timeline duration drag trims audio and video without an explicit duration'
 				initialDuration: 78,
 				maximumDuration: 77,
 			},
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [{type: 'sequence', nodePathInfo}],
 			sequences: [media],
 			overrideIdsToNodePaths: {
@@ -2123,6 +2202,7 @@ test('Timeline duration drag waits for an effective implicit media duration', ()
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: nodePathInfo,
 			draggedSequenceMediaDurationDragLimits: null,
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [{type: 'sequence', nodePathInfo}],
 			sequences: [
 				makeTimelineSequence({
@@ -2160,6 +2240,7 @@ test('Implicit Video duration is only inserted below the media end', () => {
 			initialDuration: 300,
 			maximumDuration: 99,
 		},
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -2297,6 +2378,7 @@ test('TransitionSeries.Sequence resize clamps to adjacent transition durations',
 	const durationTargets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
 		draggedSequenceMediaDurationDragLimits: null,
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems,
 		sequences,
 		overrideIdsToNodePaths,
@@ -2354,6 +2436,7 @@ test('Timeline duration drag is blocked if one selected sequence cannot update d
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: firstNodePathInfo,
 			draggedSequenceMediaDurationDragLimits: null,
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [
 				{type: 'sequence', nodePathInfo: firstNodePathInfo},
 				{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -2417,6 +2500,7 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: firstNodePathInfo,
 			draggedSequenceMediaDurationDragLimits: null,
+			selectedSequenceMediaDurationDragLimits: null,
 			selectedItems: [
 				{type: 'sequence', nodePathInfo: firstNodePathInfo},
 				{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -2454,6 +2538,7 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: firstNodePathInfo,
 		draggedSequenceMediaDurationDragLimits: null,
+		selectedSequenceMediaDurationDragLimits: null,
 		selectedItems: [
 			{type: 'sequence', nodePathInfo: secondNodePathInfo},
 			{type: 'sequence', nodePathInfo: thirdNodePathInfo},

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1998,7 +1998,6 @@ test('Timeline duration drag supports interactive video clips', () => {
 			maximumDuration: 1000,
 			minimumDuration: 1,
 			nodePath: nodePathInfo.sequenceSubscriptionKey,
-			onlyCommitDurationWithinMaximum: false,
 			schema: Internals.baseSchema,
 		},
 	]);
@@ -2093,7 +2092,7 @@ test('Timeline duration drag clamps explicit audio and video to the asset end', 
 	}
 });
 
-test('An overlong explicit Video is only saved once it reaches the asset end', () => {
+test('An overlong explicit Video can be shortened without snapping', () => {
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
 	const nodePath = nodePathInfo.sequenceSubscriptionKey;
 	const targets = getTimelineSequenceDurationDragTargets({
@@ -2117,18 +2116,19 @@ test('An overlong explicit Video is only saved once it reaches the asset end', (
 		timelineDurationInFrames: 1000,
 	});
 
+	expect(targets?.[0].maximumDuration).toBe(300);
 	expect(
 		getTimelineSequenceDurationDragChanges({
 			targets: targets ?? [],
-			deltaFrames: -74,
+			deltaFrames: 1,
 		}),
 	).toEqual([]);
 	expect(
 		getTimelineSequenceDurationDragChanges({
 			targets: targets ?? [],
-			deltaFrames: -75,
+			deltaFrames: -1,
 		})[0].value,
-	).toBe(225);
+	).toBe(299);
 });
 
 test('Timeline duration drag trims audio and video without an explicit duration', () => {
@@ -2143,7 +2143,7 @@ test('Timeline duration drag trims audio and video without an explicit duration'
 		const targets = getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: nodePathInfo,
 			draggedSequenceMediaDurationDragLimits: {
-				initialDuration: 78,
+				initialDuration: 70,
 				maximumDuration: 77,
 			},
 			selectedSequenceMediaDurationDragLimits: null,
@@ -2169,14 +2169,14 @@ test('Timeline duration drag trims audio and video without an explicit duration'
 		});
 
 		expect(isTimelineSequenceDurationDraggable(media)).toBe(true);
-		expect(targets?.[0].initialDuration).toBe(78);
+		expect(targets?.[0].initialDuration).toBe(70);
 		expect(targets?.[0].maximumDuration).toBe(77);
 		expect(
 			getTimelineSequenceDurationDragChanges({
 				targets: targets ?? [],
 				deltaFrames: 10,
-			}),
-		).toEqual([]);
+			})[0].value,
+		).toBe(77);
 		expect(
 			getTimelineSequenceDurationDragChanges({
 				targets: targets ?? [],
@@ -2187,7 +2187,7 @@ test('Timeline duration drag trims audio and video without an explicit duration'
 				fileName: nodePath.absolutePath,
 				nodePath,
 				fieldKey: 'durationInFrames',
-				value: 68,
+				value: 60,
 				defaultValue: null,
 				schema: Internals.baseSchema,
 			},
@@ -2228,56 +2228,6 @@ test('Timeline duration drag waits for an effective implicit media duration', ()
 			timelineDurationInFrames: 1000,
 		}),
 	).toBe(null);
-});
-
-test('Implicit Video duration is only inserted below the media end', () => {
-	const nodePathInfo = makeNodePathInfo(['body', 0], []);
-	const nodePath = nodePathInfo.sequenceSubscriptionKey;
-	const targets = getTimelineSequenceDurationDragTargets({
-		draggedNodePathInfo: nodePathInfo,
-		draggedSequenceMediaDurationDragLimits: {
-			// <Video> holds its last frame and can therefore reach the composition end.
-			initialDuration: 300,
-			maximumDuration: 99,
-		},
-		selectedSequenceMediaDurationDragLimits: null,
-		selectedItems: [{type: 'sequence', nodePathInfo}],
-		sequences: [
-			makeTimelineSequence({
-				schema: Internals.baseSchema,
-				type: 'video',
-				duration: Infinity,
-			}),
-		],
-		overrideIdsToNodePaths: {override: nodePath},
-		propStatuses: {
-			[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
-				canUpdate: true,
-				props: {
-					durationInFrames: {
-						status: 'static',
-						keyframeDisplayOffsetAdjustment: null,
-						codeValue: undefined,
-					},
-				},
-				effects: [],
-			},
-		},
-		timelineDurationInFrames: 300,
-	});
-
-	expect(
-		getTimelineSequenceDurationDragChanges({
-			targets: targets ?? [],
-			deltaFrames: -200,
-		}),
-	).toEqual([]);
-	expect(
-		getTimelineSequenceDurationDragChanges({
-			targets: targets ?? [],
-			deltaFrames: -201,
-		})[0].value,
-	).toBe(99);
 });
 
 test('Timeline duration drag supports interactive cascading sequence rows', () => {

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -1955,6 +1955,33 @@ test('Media duration drag limits account for a negative from', () => {
 	).toEqual({initialDuration: 300, maximumDuration: 225});
 });
 
+test('Implicit media cannot be resized once its edge reaches the asset end', () => {
+	const common = {
+		cascadedStart: -34,
+		displayDurationInFrames: 266,
+		displayStart: 0,
+		effectiveMaxMediaDuration: null,
+		explicitDurationInFrames: null,
+		hasImplicitDuration: true,
+		timelineDurationInFrames: 300,
+	};
+
+	expect(
+		getTimelineSequenceMediaDurationDragLimits({
+			...common,
+			// The video holds its last frame until the composition ends.
+			naturalMediaDuration: 220,
+		}),
+	).toBe(null);
+	expect(
+		getTimelineSequenceMediaDurationDragLimits({
+			...common,
+			// The composition ends before the source video does.
+			naturalMediaDuration: 400,
+		}),
+	).toEqual({initialDuration: 300, maximumDuration: 433});
+});
+
 test('Timeline duration drag clamps explicit audio and video to the asset end', () => {
 	for (const type of ['audio', 'video'] as const) {
 		const nodePathInfo = makeNodePathInfo(['body', type], []);

--- a/packages/studio/src/test/timeline-selection.test.ts
+++ b/packages/studio/src/test/timeline-selection.test.ts
@@ -133,6 +133,7 @@ import {
 	getTimelineSequenceDurationDragChanges,
 	getTimelineSequenceDurationDragTargets,
 	getTimelineSequenceDurationDragValue,
+	getTimelineSequenceMediaDurationDragLimits,
 	getTimelineSequenceFromDragChanges,
 	getTimelineSequenceFromDragDelta,
 	getTimelineSequenceFromDragKeyframeMoves,
@@ -1791,6 +1792,7 @@ test('Timeline duration drag applies the same delta to selected sequences', () =
 	];
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: firstNodePathInfo,
+		draggedSequenceMediaDurationDragLimits: null,
 		selectedItems: [
 			{type: 'sequence', nodePathInfo: firstNodePathInfo},
 			{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -1828,6 +1830,7 @@ test('Timeline duration drag uses the declared duration for negative from values
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
+		draggedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -1859,6 +1862,7 @@ test('Timeline duration drag clamps to the composition end', () => {
 	const nodePathInfo = makeNodePathInfo(['body', 0], []);
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
+		draggedSequenceMediaDurationDragLimits: null,
 		selectedItems: [{type: 'sequence', nodePathInfo}],
 		sequences: [
 			makeTimelineSequence({
@@ -1897,6 +1901,10 @@ test('Timeline duration drag supports interactive video clips', () => {
 	expect(
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: nodePathInfo,
+			draggedSequenceMediaDurationDragLimits: {
+				initialDuration: 78,
+				maximumDuration: 1000,
+			},
 			selectedItems: [{type: 'sequence', nodePathInfo}],
 			sequences: [video],
 			overrideIdsToNodePaths: {
@@ -1914,26 +1922,127 @@ test('Timeline duration drag supports interactive video clips', () => {
 			maximumDuration: 1000,
 			minimumDuration: 1,
 			nodePath: nodePathInfo.sequenceSubscriptionKey,
+			onlyCommitDurationWithinMaximum: false,
 			schema: Internals.baseSchema,
 		},
 	]);
 });
 
-test('Timeline duration drag rejects media without an explicit duration', () => {
-	const nodePathInfo = makeNodePathInfo(['body', 0], []);
-	const audio = makeTimelineSequence({
-		schema: Internals.baseSchema,
-		type: 'audio',
-		duration: 78,
-	});
-	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+test('Media duration drag limits account for a negative from', () => {
+	const common = {
+		cascadedStart: -192,
+		displayDurationInFrames: 108,
+		displayStart: 0,
+		explicitDurationInFrames: 300,
+		hasImplicitDuration: false,
+		naturalMediaDuration: 33,
+		timelineDurationInFrames: 1000,
+	};
 
-	expect(isTimelineSequenceDurationDraggable(audio)).toBe(true);
 	expect(
-		getTimelineSequenceDurationDragTargets({
+		getTimelineSequenceMediaDurationDragLimits({
+			...common,
+			// <Video> keeps displaying its last frame.
+			effectiveMaxMediaDuration: null,
+		}),
+	).toEqual({initialDuration: 300, maximumDuration: 225});
+	expect(
+		getTimelineSequenceMediaDurationDragLimits({
+			...common,
+			// Audio and OffthreadVideo stop at the asset end.
+			effectiveMaxMediaDuration: 33,
+		}),
+	).toEqual({initialDuration: 300, maximumDuration: 225});
+});
+
+test('Timeline duration drag clamps explicit audio and video to the asset end', () => {
+	for (const type of ['audio', 'video'] as const) {
+		const nodePathInfo = makeNodePathInfo(['body', type], []);
+		const nodePath = nodePathInfo.sequenceSubscriptionKey;
+		const targets = getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: nodePathInfo,
+			draggedSequenceMediaDurationDragLimits: {
+				initialDuration: 200,
+				maximumDuration: 225,
+			},
 			selectedItems: [{type: 'sequence', nodePathInfo}],
-			sequences: [audio],
+			sequences: [
+				makeTimelineSequence({
+					schema: Internals.baseSchema,
+					type,
+					duration: 200,
+					from: -192,
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+			propStatuses: makeDurationPropStatuses([nodePath]),
+			timelineDurationInFrames: 1000,
+		});
+
+		expect(targets?.[0].maximumDuration).toBe(225);
+		expect(
+			getTimelineSequenceDurationDragChanges({
+				targets: targets ?? [],
+				deltaFrames: 100,
+			})[0].value,
+		).toBe(225);
+	}
+});
+
+test('An overlong explicit Video is only saved once it reaches the asset end', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const targets = getTimelineSequenceDurationDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		draggedSequenceMediaDurationDragLimits: {
+			initialDuration: 300,
+			maximumDuration: 225,
+		},
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema: Internals.baseSchema,
+				type: 'video',
+				duration: 300,
+				from: -192,
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses: makeDurationPropStatuses([nodePath]),
+		timelineDurationInFrames: 1000,
+	});
+
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -74,
+		}),
+	).toEqual([]);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -75,
+		})[0].value,
+	).toBe(225);
+});
+
+test('Timeline duration drag trims audio and video without an explicit duration', () => {
+	for (const type of ['audio', 'video'] as const) {
+		const nodePathInfo = makeNodePathInfo(['body', type], []);
+		const media = makeTimelineSequence({
+			schema: Internals.baseSchema,
+			type,
+			duration: Infinity,
+		});
+		const nodePath = nodePathInfo.sequenceSubscriptionKey;
+		const targets = getTimelineSequenceDurationDragTargets({
+			draggedNodePathInfo: nodePathInfo,
+			draggedSequenceMediaDurationDragLimits: {
+				initialDuration: 78,
+				maximumDuration: 77,
+			},
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			sequences: [media],
 			overrideIdsToNodePaths: {
 				override: nodePath,
 			},
@@ -1951,8 +2060,116 @@ test('Timeline duration drag rejects media without an explicit duration', () => 
 				},
 			},
 			timelineDurationInFrames: 1000,
+		});
+
+		expect(isTimelineSequenceDurationDraggable(media)).toBe(true);
+		expect(targets?.[0].initialDuration).toBe(78);
+		expect(targets?.[0].maximumDuration).toBe(77);
+		expect(
+			getTimelineSequenceDurationDragChanges({
+				targets: targets ?? [],
+				deltaFrames: 10,
+			}),
+		).toEqual([]);
+		expect(
+			getTimelineSequenceDurationDragChanges({
+				targets: targets ?? [],
+				deltaFrames: -10,
+			}),
+		).toEqual([
+			{
+				fileName: nodePath.absolutePath,
+				nodePath,
+				fieldKey: 'durationInFrames',
+				value: 68,
+				defaultValue: null,
+				schema: Internals.baseSchema,
+			},
+		]);
+	}
+});
+
+test('Timeline duration drag waits for an effective implicit media duration', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	expect(
+		getTimelineSequenceDurationDragTargets({
+			draggedNodePathInfo: nodePathInfo,
+			draggedSequenceMediaDurationDragLimits: null,
+			selectedItems: [{type: 'sequence', nodePathInfo}],
+			sequences: [
+				makeTimelineSequence({
+					schema: Internals.baseSchema,
+					type: 'video',
+					duration: Infinity,
+				}),
+			],
+			overrideIdsToNodePaths: {override: nodePath},
+			propStatuses: {
+				[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+					canUpdate: true,
+					props: {
+						durationInFrames: {
+							status: 'static',
+							keyframeDisplayOffsetAdjustment: null,
+							codeValue: undefined,
+						},
+					},
+					effects: [],
+				},
+			},
+			timelineDurationInFrames: 1000,
 		}),
 	).toBe(null);
+});
+
+test('Implicit Video duration is only inserted below the media end', () => {
+	const nodePathInfo = makeNodePathInfo(['body', 0], []);
+	const nodePath = nodePathInfo.sequenceSubscriptionKey;
+	const targets = getTimelineSequenceDurationDragTargets({
+		draggedNodePathInfo: nodePathInfo,
+		draggedSequenceMediaDurationDragLimits: {
+			// <Video> holds its last frame and can therefore reach the composition end.
+			initialDuration: 300,
+			maximumDuration: 99,
+		},
+		selectedItems: [{type: 'sequence', nodePathInfo}],
+		sequences: [
+			makeTimelineSequence({
+				schema: Internals.baseSchema,
+				type: 'video',
+				duration: Infinity,
+			}),
+		],
+		overrideIdsToNodePaths: {override: nodePath},
+		propStatuses: {
+			[Internals.makeSequencePropsSubscriptionKey(nodePath)]: {
+				canUpdate: true,
+				props: {
+					durationInFrames: {
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: undefined,
+					},
+				},
+				effects: [],
+			},
+		},
+		timelineDurationInFrames: 300,
+	});
+
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -200,
+		}),
+	).toEqual([]);
+	expect(
+		getTimelineSequenceDurationDragChanges({
+			targets: targets ?? [],
+			deltaFrames: -201,
+		})[0].value,
+	).toBe(99);
 });
 
 test('Timeline duration drag supports interactive cascading sequence rows', () => {
@@ -2052,6 +2269,7 @@ test('TransitionSeries.Sequence resize clamps to adjacent transition durations',
 	const selectedItems = [{type: 'sequence' as const, nodePathInfo}];
 	const durationTargets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: nodePathInfo,
+		draggedSequenceMediaDurationDragLimits: null,
 		selectedItems,
 		sequences,
 		overrideIdsToNodePaths,
@@ -2108,6 +2326,7 @@ test('Timeline duration drag is blocked if one selected sequence cannot update d
 	expect(
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: firstNodePathInfo,
+			draggedSequenceMediaDurationDragLimits: null,
 			selectedItems: [
 				{type: 'sequence', nodePathInfo: firstNodePathInfo},
 				{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -2170,6 +2389,7 @@ test('Timeline duration drag is blocked if one selected sequence duration is key
 	expect(
 		getTimelineSequenceDurationDragTargets({
 			draggedNodePathInfo: firstNodePathInfo,
+			draggedSequenceMediaDurationDragLimits: null,
 			selectedItems: [
 				{type: 'sequence', nodePathInfo: firstNodePathInfo},
 				{type: 'sequence', nodePathInfo: secondNodePathInfo},
@@ -2206,6 +2426,7 @@ test('Timeline duration drag ignores selection if dragged sequence is not select
 	const thirdNodePathInfo = makeNodePathInfo(['body', 2], []);
 	const targets = getTimelineSequenceDurationDragTargets({
 		draggedNodePathInfo: firstNodePathInfo,
+		draggedSequenceMediaDurationDragLimits: null,
 		selectedItems: [
 			{type: 'sequence', nodePathInfo: secondNodePathInfo},
 			{type: 'sequence', nodePathInfo: thirdNodePathInfo},


### PR DESCRIPTION
## Summary

- enable right-edge resizing for implicit-duration media only while its current edge is before the natural asset end
- clamp explicit audio and video growth to the natural asset end while keeping existing overlong durations continuously shrinkable
- account for negative `from` values and avoid inserting a redundant duration at the natural media end

## Testing

- `bun test packages/studio/src/test/timeline-selection.test.ts`
- `bun run build`
- `bun run stylecheck`

Closes #11079
