### PR TITLE
`@remotion/studio`: Scroll selected timeline effects and properties into view in inspector

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -674,6 +674,75 @@ test.describe('visual mode', () => {
 		}
 	});
 
+	test('reveals selected timeline effects and props in the inspector', async ({
+		page,
+	}) => {
+		fs.writeFileSync(
+			effectKeyframeE2eFile,
+			fs
+				.readFileSync(effectKeyframeE2eFile, 'utf-8')
+				.replace(
+					'wave({})',
+					'wave({phase: interpolate(frame, [0, 30], [0, 90])})',
+				),
+		);
+		await page.setViewportSize({width: 1280, height: 720});
+		await page.goto(`${STUDIO_URL}/effect-keyframe-e2e`);
+		const addEffectButton = page.getByTitle('Add effect', {exact: true});
+		if (!(await page.getByRole('button', {name: 'Inspector'}).isVisible())) {
+			await page.locator('[data-sidebar-toggle="right"]').click();
+		}
+		await expect(async () => {
+			await page.getByTitle('Scale precision', {exact: true}).first().click();
+			await expect(addEffectButton).toBeVisible({timeout: 1000});
+		}).toPass({timeout: 15_000});
+		const inspector = page
+			.locator('.__remotion-vertical-scrollbar')
+			.filter({has: addEffectButton});
+		const inspectorWave = inspector.getByText('wave()', {exact: true});
+		await inspectorWave.click();
+		const timelineWave = page
+			.getByText('wave()', {exact: true})
+			.filter({visible: true})
+			.last();
+		await expect(page.getByText('wave()', {exact: true})).toHaveCount(2);
+		await page.getByTitle('Scale precision', {exact: true}).first().click();
+		await inspector.evaluate((element) => {
+			element.scrollTop = 0;
+		});
+		await timelineWave.click();
+		await expect(inspectorWave).toBeInViewport();
+		await expect
+			.poll(() => inspector.evaluate((element) => element.scrollTop))
+			.toBeGreaterThan(0);
+
+		await inspector
+			.getByRole('button', {name: 'Collapse wave() section', exact: true})
+			.click();
+		await page
+			.getByRole('button', {name: 'Expand wave() section', exact: true})
+			.last()
+			.click();
+		await page
+			.locator('.css-reset.__remotion-vertical-scrollbar')
+			.evaluate((element) => {
+				element.scrollTop += 200;
+			});
+		const timelinePhase = page.getByText('Phase', {exact: true});
+		await expect(timelinePhase).toHaveCount(1);
+		await inspector.evaluate((element) => {
+			element.scrollTop = 0;
+		});
+		await timelinePhase.click();
+		await expect(inspector.getByText('Phase', {exact: true})).toBeInViewport();
+		await expect(
+			inspector.getByRole('button', {
+				name: 'Collapse wave() section',
+				exact: true,
+			}),
+		).toBeVisible();
+	});
+
 	test('should keep Effects expanded and preserve the inspector scroll position when adding an effect', async ({
 		page,
 	}) => {

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -530,7 +530,7 @@ export const InspectorSequenceSection: React.FC<{
 			return;
 		}
 
-		selectedEffectRowRef.current.scrollIntoView({block: 'nearest'});
+		selectedEffectRowRef.current.scrollIntoView({block: 'center'});
 		scrolledEffectKey.current = selectedEffectKey;
 	}, [effectRows, selectedEffectKey]);
 

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -4,6 +4,7 @@ import React, {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 import {Internals, type TSequence} from 'remotion';
@@ -59,8 +60,10 @@ import {
 } from './Timeline/TimelineRowLayoutContext';
 import {
 	getTimelineSelectionFromNodePathInfo,
+	getTimelineSelectionKey,
 	getTimelineSequenceSelectionKey,
 	TimelineSelectionOrderProvider,
+	useTimelineSelection,
 	type TimelineSelection,
 } from './Timeline/TimelineSelection';
 import {propStatusHas3DTransformValue} from './Timeline/transform-3d-mode';
@@ -328,6 +331,17 @@ export const InspectorSequenceSection: React.FC<{
 		includeTextContent: true,
 		includeSourceControls: true,
 	});
+	const {selectedItems} = useTimelineSelection();
+	const selectedEffect =
+		selectedItems.length === 1 &&
+		(selectedItems[0].type === 'sequence-effect' ||
+			selectedItems[0].type === 'sequence-effect-prop')
+			? selectedItems[0]
+			: null;
+	const selectedEffectKey =
+		selectedEffect === null ? null : getTimelineSelectionKey(selectedEffect);
+	const selectedEffectRowRef = useRef<HTMLDivElement>(null);
+	const scrolledEffectKey = useRef<string | null>(null);
 	const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(
 		loadInspectorCollapsedKeys,
 	);
@@ -455,6 +469,70 @@ export const InspectorSequenceSection: React.FC<{
 						}),
 		};
 	}, [getIsExpanded, tree]);
+
+	useEffect(() => {
+		if (
+			selectedEffectKey === null ||
+			scrolledEffectKey.current === selectedEffectKey
+		) {
+			return;
+		}
+
+		const rows = flattenVisibleTreeNodes({
+			nodes: tree,
+			getIsExpanded: () => true,
+		});
+		const targetIndex = rows.findIndex(({node}) => {
+			const selection = getTimelineSelectionFromNodePathInfo(node.nodePathInfo);
+			return (
+				selection !== null &&
+				getTimelineSelectionKey(selection) === selectedEffectKey
+			);
+		});
+		if (targetIndex === -1) {
+			return;
+		}
+
+		const parentKeys: string[] = [];
+		let {depth} = rows[targetIndex];
+		for (let i = targetIndex - 1; i >= 0 && depth > 0; i--) {
+			if (rows[i].depth < depth) {
+				parentKeys.push(getInspectorExpansionKey(rows[i].node.nodePathInfo));
+				depth = rows[i].depth;
+			}
+		}
+
+		setCollapsedKeys((previous) => {
+			if (!parentKeys.some((key) => previous.has(key))) {
+				return previous;
+			}
+
+			const next = new Set(previous);
+			for (const key of parentKeys) {
+				next.delete(key);
+			}
+
+			persistInspectorCollapsedKeys(next);
+			return next;
+		});
+	}, [selectedEffectKey, tree]);
+
+	useEffect(() => {
+		if (selectedEffectKey === null) {
+			scrolledEffectKey.current = null;
+			return;
+		}
+
+		if (
+			scrolledEffectKey.current === selectedEffectKey ||
+			selectedEffectRowRef.current === null
+		) {
+			return;
+		}
+
+		selectedEffectRowRef.current.scrollIntoView({block: 'nearest'});
+		scrolledEffectKey.current = selectedEffectKey;
+	}, [effectRows, selectedEffectKey]);
 
 	const effectSelectableItems = useMemo(
 		() => getInspectorSelectableItems(effectRows),
@@ -857,7 +935,22 @@ export const InspectorSequenceSection: React.FC<{
 					<InspectorSection header={effectsHeader}>
 						{effectRows.length > 0 ? (
 							<TimelineSelectionOrderProvider items={effectSelectableItems}>
-								{effectRows.map(renderRow)}
+								{effectRows.map((row) => {
+									const selection = getTimelineSelectionFromNodePathInfo(
+										row.node.nodePathInfo,
+									);
+									const selected =
+										selection !== null &&
+										getTimelineSelectionKey(selection) === selectedEffectKey;
+									return (
+										<div
+											key={getInspectorExpansionKey(row.node.nodePathInfo)}
+											ref={selected ? selectedEffectRowRef : null}
+										>
+											{renderRow(row)}
+										</div>
+									);
+								})}
 							</TimelineSelectionOrderProvider>
 						) : null}
 					</InspectorSection>


### PR DESCRIPTION
Selecting an effect or effect property in the timeline now scrolls its matching inspector row into view. Collapsed parent rows expand to reveal a selected property, and ordinary rerenders preserve the inspector scroll position.

Closes #11140

Validation: `bun run build`, `bun run stylecheck`, and a Studio Playwright workflow covering effect selection and a property inside a collapsed effect. Red/green verified: disabling the scroll call makes the viewport assertion fail.
