### PR TITLE
Adding MapAnimate and Captioner into Resources page.

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -192,6 +192,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [LaunchCut - Create a launch video](https://www.launchcut.io)
 - [VibeKnow - Free AI Explainer Video Generator](https://vibeknow.ai)
 - [CutSnap — AI video editor with auto-captions](https://cutsnap.ai)
+- [MapAnimate - Travel Map Animation Generator](https://mapanimate.app)
 
 ## See also
 

--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -193,6 +193,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [VibeKnow - Free AI Explainer Video Generator](https://vibeknow.ai)
 - [CutSnap — AI video editor with auto-captions](https://cutsnap.ai)
 - [MapAnimate - Travel Map Animation Generator](https://mapanimate.app)
+- [Captioner - AI Video Translator](https://captioner.io)
 
 ## See also
 


### PR DESCRIPTION
I would like to add the products I built into the list of products in the resources page.

[Captioner](https://captioner.io) has been running for 2.5 years now, and since day 1 it is using Remotion for rendering the subtitles and captions onto videos.

I recently built [MapAnimate](https://mapanimate.app) to render 3d flight animations. It is built with Three.js and Remotion and thanks to the great library, I am able to build out smooth animations for international travels around the world!