### PR TITLE
`@remotion/studio`: Fix early truncation of composition and asset names

### DIFF
--- a/packages/studio/src/components/CompositionContextButton.tsx
+++ b/packages/studio/src/components/CompositionContextButton.tsx
@@ -9,6 +9,7 @@ import {
 import {EllipsisIcon} from '../icons/ellipsis';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineDropdown} from './InlineDropdown';
+import {Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
 
 const revealStyle: React.CSSProperties = {
@@ -44,6 +45,7 @@ export const CompositionContextButton: React.FC<{
 
 	return (
 		<div className={HOVER_GROUP_REVEAL_CLASS_NAME} style={revealStyle}>
+			<Spacing x={0.5} />
 			<InlineDropdown
 				renderAction={renderAction}
 				getItems={getItems}

--- a/packages/studio/src/components/CompositionSelectorItem.tsx
+++ b/packages/studio/src/components/CompositionSelectorItem.tsx
@@ -798,7 +798,6 @@ export const CompositionSelectorItem: React.FC<{
 								)}
 								<Spacing x={1} />
 								<div style={labelStyle}>{item.folderName}</div>
-								<Spacing x={0.5} />
 								<CompositionContextButton
 									getItems={getContextMenuItems}
 									visible
@@ -873,7 +872,6 @@ export const CompositionSelectorItem: React.FC<{
 						/>
 						<Spacing x={1} />
 						<div style={labelStyle}>{item.composition.id}</div>
-						<Spacing x={0.5} />
 						<CompositionContextButton
 							getItems={getContextMenuItems}
 							visible={!isDragging}

--- a/packages/studio/src/helpers/hoverable.ts
+++ b/packages/studio/src/helpers/hoverable.ts
@@ -63,6 +63,10 @@ export const makeHoverableCSS = () => `
     color: var(${COLOR_VARIABLE}, inherit);
   }
 
+  ${hoverGroup} ${reveal} {
+    flex-shrink: 0;
+  }
+
   @media (hover: hover) {
     ${hoverable}:hover {
       background-color: var(${HOVER_BG_VARIABLE}, var(${BG_VARIABLE}, ${TRANSPARENT}));
@@ -83,10 +87,14 @@ export const makeHoverableCSS = () => `
 
     ${hoverGroup} ${reveal} {
       opacity: 0;
+      width: 0;
+      overflow: hidden;
     }
 
     ${hoverGroup}:hover ${reveal} {
       opacity: 1;
+      width: auto;
+      overflow: visible;
     }
   }
 `;


### PR DESCRIPTION
Composition and asset names now use the full available row width while inline actions are hidden. Hovering restores the actions and their spacing, truncating labels only when that space is needed.

Validation: `bun run build`, `bun run stylecheck`, and targeted ESLint and formatting checks passed.
