### PR TITLE
`@remotion/studio`: Show mixed-content text as computed in inspector

### DIFF
--- a/packages/example/e2e/mixed-content-inspector.test.mts
+++ b/packages/example/e2e/mixed-content-inspector.test.mts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import {expect, test} from '@playwright/test';
+import {
+	EXPANDED_SIDEBAR_STATE,
+	STUDIO_URL,
+	visualMode3DFile,
+} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test('shows mixed text children as computed in the inspector', async ({
+	page,
+}) => {
+	const originalSource = fs.readFileSync(visualMode3DFile, 'utf-8');
+	try {
+		await startStudio();
+		fs.writeFileSync(
+			visualMode3DFile,
+			`
+import React from 'react';
+import {Interactive} from 'remotion';
+export const VisualMode3D = () => (
+	<Interactive.Div name="Headline" style={{fontSize: 72, lineHeight: 1.03, letterSpacing: -4, fontWeight: 500}}>
+		Ideas, in<br />
+		<span style={{fontFamily: 'Georgia, serif', fontStyle: 'italic', color: '#698357'}}>motion.</span>
+	</Interactive.Div>
+);
+`,
+		);
+		await page.goto(`${STUDIO_URL}/visual-mode-3d`);
+		await expect(async () => {
+			await page
+				.locator('[data-timeline-marquee-item][title="Headline"]')
+				.click();
+			await expect(
+				page.getByRole('button', {name: 'Collapse Text', exact: true}),
+			).toBeVisible({timeout: 1_000});
+		}).toPass({timeout: 30_000});
+		await expect(page.getByText('computed', {exact: true})).toBeVisible();
+	} finally {
+		await stopStudio();
+		fs.writeFileSync(visualMode3DFile, originalSource);
+	}
+});

--- a/packages/example/e2e/mixed-content-inspector.test.mts
+++ b/packages/example/e2e/mixed-content-inspector.test.mts
@@ -1,45 +1,31 @@
-import fs from 'fs';
 import {expect, test} from '@playwright/test';
-import {
-	EXPANDED_SIDEBAR_STATE,
-	STUDIO_URL,
-	visualMode3DFile,
-} from './constants.mts';
+import {EXPANDED_SIDEBAR_STATE, STUDIO_URL} from './constants.mts';
 import {startStudio, stopStudio} from './studio-server.mts';
 
 test.use({storageState: EXPANDED_SIDEBAR_STATE});
 
-test('shows mixed text children as computed in the inspector', async ({
-	page,
-}) => {
-	const originalSource = fs.readFileSync(visualMode3DFile, 'utf-8');
+test('shows editable and computed text in the inspector', async ({page}) => {
 	try {
 		await startStudio();
-		fs.writeFileSync(
-			visualMode3DFile,
-			`
-import React from 'react';
-import {Interactive} from 'remotion';
-export const VisualMode3D = () => (
-	<Interactive.Div name="Headline" style={{fontSize: 72, lineHeight: 1.03, letterSpacing: -4, fontWeight: 500}}>
-		Ideas, in<br />
-		<span style={{fontFamily: 'Georgia, serif', fontStyle: 'italic', color: '#698357'}}>motion.</span>
-	</Interactive.Div>
-);
-`,
-		);
-		await page.goto(`${STUDIO_URL}/visual-mode-3d`);
+		await page.goto(`${STUDIO_URL}/interactive-html-elements`);
 		await expect(async () => {
 			await page
-				.locator('[data-timeline-marquee-item][title="Headline"]')
+				.locator('[data-timeline-marquee-item][title="Editable text"]')
 				.click();
-			await expect(
-				page.getByRole('button', {name: 'Collapse Text', exact: true}),
-			).toBeVisible({timeout: 1_000});
+			await expect(page.getByRole('textbox')).toHaveValue(
+				'Editable text schema',
+				{
+					timeout: 1_000,
+				},
+			);
 		}).toPass({timeout: 30_000});
+		await expect(page.getByRole('textbox')).toBeEditable();
+
+		await page
+			.locator('[data-timeline-marquee-item][title="Mixed text (computed)"]')
+			.click();
 		await expect(page.getByText('computed', {exact: true})).toBeVisible();
 	} finally {
 		await stopStudio();
-		fs.writeFileSync(visualMode3DFile, originalSource);
 	}
 });

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -27,6 +27,7 @@ import {VisualControls} from './VisualControls';
 import {VisualMode3D} from './VisualMode3D';
 import {AffineFrameClock} from './VisualModeTests/AffineFrameClock';
 import {FontWeightControls} from './VisualModeTests/FontWeightControls';
+import {InteractiveHtmlElements} from './VisualModeTests/InteractiveComponents';
 import {OutlineSelectionCases} from './VisualModeTests/OutlineSelectionCases';
 import {SequenceShiftRepro} from './VisualModeTests/SequenceShiftRepro';
 
@@ -259,6 +260,14 @@ export const E2eTestRoot: React.FC = () => {
 			<Composition
 				id="inspector-control-layout-e2e"
 				component={InspectorControlLayoutE2e}
+				width={1080}
+				height={1080}
+				fps={30}
+				durationInFrames={90}
+			/>
+			<Composition
+				id="interactive-html-elements"
+				component={InteractiveHtmlElements}
 				width={1080}
 				height={1080}
 				fps={30}

--- a/packages/example/src/VisualModeTests/InteractiveComponents.tsx
+++ b/packages/example/src/VisualModeTests/InteractiveComponents.tsx
@@ -78,6 +78,7 @@ export const InteractiveHtmlElements: React.FC = () => {
 				Button
 			</Interactive.Button>
 			<Interactive.P
+				name="Editable text"
 				style={{
 					position: 'absolute',
 					left: 620,
@@ -116,6 +117,31 @@ export const InteractiveHtmlElements: React.FC = () => {
 					&lt;Interactive.Section /&gt;
 				</Interactive.Code>
 			</Interactive.Section>
+			<Interactive.Div
+				name="Mixed text (computed)"
+				style={{
+					position: 'absolute',
+					left: 110,
+					top: 750,
+					color: '#f8fafc',
+					fontSize: 72,
+					lineHeight: 1.03,
+					letterSpacing: -4,
+					fontWeight: 500,
+				}}
+			>
+				&lt;br /&gt;
+				<br />
+				<span
+					style={{
+						fontFamily: 'Georgia, serif',
+						fontStyle: 'italic',
+						color: '#698357',
+					}}
+				>
+					inside
+				</span>
+			</Interactive.Div>
 		</AbsoluteFill>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -158,12 +158,16 @@ export const TimelineNonEditableStatus: React.FC<{
 	if (propStatus.status === 'computed') {
 		return (
 			<UnsupportedStatus
-				label={formatTimelineFieldValueForDisplay({
-					fieldSchema: field.fieldSchema,
-					value: runtimeValue,
-				})}
+				label={
+					runtimeValue === undefined
+						? 'computed'
+						: formatTimelineFieldValueForDisplay({
+								fieldSchema: field.fieldSchema,
+								value: runtimeValue,
+							})
+				}
 				onFix={onFix}
-				formattedValue
+				formattedValue={runtimeValue !== undefined}
 			/>
 		);
 	}


### PR DESCRIPTION
## Summary

Show **computed** instead of **unset** for computed inspector fields without a displayable runtime value, including mixed text and JSX children. Keep formatted runtime values when available.

Adds an unmocked Studio E2E regression test for #11156 using the existing `interactive-html-elements` composition. The same testbed is available in Studio for manual inspection, with named editable-text and mixed-content examples. The test verifies editable text remains editable and mixed content displays as computed. Red/green verified.

Closes #11156

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test mixed-content-inspector.test.mts`
