### PR TITLE
`@remotion/studio`: Fix asset preview timeline menu and opacity

### DIFF
--- a/packages/studio/src/components/Timeline/TimelineSequence.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequence.tsx
@@ -85,6 +85,7 @@ import {
 import {TimelineVideoInfo} from './TimelineVideoInfo';
 import {TimelineViewportContext} from './TimelineViewport';
 import {TimelineWidthContext} from './TimelineWidthProvider';
+import {useAssetTimelineContextMenu} from './use-asset-timeline-context-menu';
 import {useDeleteTimelineItems} from './use-delete-timeline-items';
 import {useOpenSequenceInApps} from './use-open-sequence-in-apps';
 import {getSequenceFreezeFrameMenuItem} from './use-sequence-freeze-frame-menu-item';
@@ -220,6 +221,8 @@ const TimelineSequenceCurrentFrame: React.FC<{
 	onPointerDownCapture,
 	onClick,
 }) => {
+	const {canvasContent} = useContext(Internals.CompositionManager);
+	const isAsset = canvasContent?.type === 'asset';
 	const ref = useRef<HTMLDivElement>(null);
 	const {onSelect, selectable, selected, selectionItem} =
 		useTimelineRowSelection(nodePathInfo);
@@ -277,9 +280,9 @@ const TimelineSequenceCurrentFrame: React.FC<{
 			...style,
 			background: negativeStart ? TRANSPARENT : style.background,
 			border: negativeStart ? 'none' : style.border,
-			opacity: selected ? 1 : 0.75,
+			opacity: selected || isAsset ? 1 : 0.75,
 		};
-	}, [negativeStart, selected, style]);
+	}, [isAsset, negativeStart, selected, style]);
 
 	const content = (
 		<>
@@ -526,6 +529,7 @@ const TimelineSequenceInner: React.FC<{
 	const {setPropStatuses} = useContext(Internals.VisualModeSettersContext);
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const selectAsset = useSelectAsset();
+	const assetContextMenu = useAssetTimelineContextMenu();
 	const selectComposition = useSelectComposition();
 	const confirm = useConfirmationDialog();
 	const deleteTimelineItems = useDeleteTimelineItems();
@@ -689,6 +693,10 @@ const TimelineSequenceInner: React.FC<{
 		validatedLocation?.source,
 	]);
 	const getContextMenuItems = useCallback(() => {
+		if (assetContextMenu !== null) {
+			return assetContextMenu;
+		}
+
 		if (selectable && !selected) {
 			onSelect({shiftKey: false, toggleKey: false});
 		}
@@ -761,6 +769,7 @@ const TimelineSequenceInner: React.FC<{
 				: [],
 		});
 	}, [
+		assetContextMenu,
 		canOpenInEditor,
 		canConfigureApps,
 		codingAgentInfo,

--- a/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSequenceItem.tsx
@@ -105,6 +105,7 @@ import {
 } from './TimelineSelection';
 import {TimelineSequenceName} from './TimelineSequenceName';
 import {TIMELINE_TIME_INDICATOR_HEIGHT} from './TimelineTimeIndicators';
+import {useAssetTimelineContextMenu} from './use-asset-timeline-context-menu';
 import {useDeleteTimelineItems} from './use-delete-timeline-items';
 import {useOpenSequenceInApps} from './use-open-sequence-in-apps';
 import {useRenameSequence} from './use-rename-sequence';
@@ -316,6 +317,7 @@ const TimelineSequenceItemInner: React.FC<{
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const {isHighestContext} = useKeybinding();
 	const selectAsset = useSelectAsset();
+	const assetContextMenu = useAssetTimelineContextMenu();
 	const selectComposition = useSelectComposition();
 	const deleteTimelineItems = useDeleteTimelineItems();
 	const {onSelect, selectable, selected} =
@@ -1127,6 +1129,10 @@ const TimelineSequenceItemInner: React.FC<{
 	}, [canRotate, nodePathInfo, selectItem, setManuallyEnabled]);
 
 	const getContextMenuItems = useCallback(() => {
+		if (assetContextMenu !== null) {
+			return assetContextMenu;
+		}
+
 		if (selectable && !selected) {
 			onSelect({shiftKey: false, toggleKey: false});
 		}
@@ -1271,6 +1277,7 @@ const TimelineSequenceItemInner: React.FC<{
 				: [],
 		});
 	}, [
+		assetContextMenu,
 		canAddEffect,
 		canCrop,
 		canRotate,

--- a/packages/studio/src/components/Timeline/use-asset-timeline-context-menu.ts
+++ b/packages/studio/src/components/Timeline/use-asset-timeline-context-menu.ts
@@ -1,0 +1,48 @@
+import {useContext, useMemo} from 'react';
+import {Internals} from 'remotion';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {getFileManagerName} from '../../helpers/get-file-manager-name';
+import type {ComboboxValue} from '../NewComposition/ComboBox';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {openInFileExplorer} from '../RenderQueue/actions';
+
+export const useAssetTimelineContextMenu = (): ComboboxValue[] | null => {
+	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+
+	return useMemo(() => {
+		if (canvasContent?.type !== 'asset') {
+			return null;
+		}
+
+		if (getBrowserStudioOperations() !== null) {
+			return [];
+		}
+
+		return [
+			{
+				type: 'item',
+				id: 'open-asset-in-explorer',
+				label: `Show in ${getFileManagerName(window.remotion_fileSystemPlatform)}`,
+				keyHint: null,
+				leftItem: null,
+				quickSwitcherLabel: null,
+				subMenu: null,
+				value: 'open-asset-in-explorer',
+				disabled:
+					Boolean(window.remotion_isReadOnlyStudio) ||
+					!window.remotion_publicFolderExists ||
+					previewServerState.type !== 'connected',
+				onClick: () => {
+					openInFileExplorer({
+						directory:
+							window.remotion_publicFolderExists + '/' + canvasContent.asset,
+					}).catch((err) => {
+						showNotification(`Could not open file: ${err.message}`, 2000);
+					});
+				},
+			},
+		];
+	}, [canvasContent, previewServerState.type]);
+};

--- a/packages/studio/src/components/Timeline/use-asset-timeline-context-menu.ts
+++ b/packages/studio/src/components/Timeline/use-asset-timeline-context-menu.ts
@@ -6,6 +6,7 @@ import {getFileManagerName} from '../../helpers/get-file-manager-name';
 import type {ComboboxValue} from '../NewComposition/ComboBox';
 import {showNotification} from '../Notifications/NotificationCenter';
 import {openInFileExplorer} from '../RenderQueue/actions';
+import {getCopyContextForAgentsMenuItem} from './get-copy-context-for-agents-menu-item';
 
 export const useAssetTimelineContextMenu = (): ComboboxValue[] | null => {
 	const {canvasContent} = useContext(Internals.CompositionManager);
@@ -16,8 +17,14 @@ export const useAssetTimelineContextMenu = (): ComboboxValue[] | null => {
 			return null;
 		}
 
+		const copyContextItem = getCopyContextForAgentsMenuItem({
+			contextForAgents: window.remotion_publicFolderExists
+				? `Asset: ${window.remotion_publicFolderExists}/${canvasContent.asset}`
+				: `Asset: staticFile(${JSON.stringify(canvasContent.asset)})`,
+		});
+
 		if (getBrowserStudioOperations() !== null) {
-			return [];
+			return [copyContextItem];
 		}
 
 		return [
@@ -43,6 +50,7 @@ export const useAssetTimelineContextMenu = (): ComboboxValue[] | null => {
 					});
 				},
 			},
+			copyContextItem,
 		];
 	}, [canvasContent, previewServerState.type]);
 };


### PR DESCRIPTION
When an asset is opened as the Studio canvas content, its timeline now shows the filmstrip at full opacity. Both timeline context menus offer “Show in Finder/Explorer,” targeting the asset file, and retain “Copy context for agents” with the asset path. This removes the self-linking “Show asset” action and project-oriented app actions.

Validation: `bun run build`, `bun run stylecheck`, Studio typecheck, and all 11 existing sequence context-menu tests passed.
