### PR TITLE
Docs: Clarify Elements are designed for direct source editing

### DIFF
--- a/packages/docs/elements/contributing.mdx
+++ b/packages/docs/elements/contributing.mdx
@@ -97,7 +97,9 @@ Animate properties within the Element, such as translation, scale, and opacity; 
 
 ### Expose useful Studio controls
 
-Use Studio controls in the Element's `Interactive` schema, not React props on its public component, for user-facing customization. Expose only controls that meaningfully edit the treatment; they may tune details but must not switch between unrelated visual styles.
+Elements are source-code copies designed for direct editing, not managed dependencies. Expose useful Studio controls in the Element's `Interactive` schema, but there is no need to mirror every implementation detail as a public prop.
+
+Use [`Interactive.withSchema()`](/docs/interactive-with-schema) when you intentionally want an instance-level API. Controls should meaningfully edit the treatment; they may tune details but must not switch between unrelated visual styles.
 
 Give editable objects clear names, using a generic name such as `Container` for the main object and child controls only for separate editing targets.
 


### PR DESCRIPTION
## Summary

- Clarify in the Element contribution guide that Elements are editable source-code copies, not managed dependencies.
- Encourage useful Studio controls without mirroring every implementation detail as a public prop; retain `Interactive.withSchema()` for intentional instance-level APIs.

Related behavior change: #11151 introduces independent copies on reinstall by default, with Create a copy and explicit Replace existing actions. This contribution guidance can merge independently; it does not document unreleased installation behavior or change runtime code.

## Verification

- `bun run build` (80 tasks passed, cached)
- `bun run stylecheck` (265 tasks passed; existing lint warnings)
- Focused MDX compilation of `packages/docs/elements/contributing.mdx`
- `git diff --check`

Oxfmt skipped because the only changed file is MDX, which it does not support.


## Preview

- [Element contribution guide](https://remotion-git-docs-elements-source-editing-remotion.vercel.app/elements/contributing)
