### PR TITLE
`@remotion/studio`: Slugify names when creating and renaming folders

### DIFF
--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -72,20 +72,26 @@ export const NewFolder: React.FC<{
 		[],
 	);
 
-	const folderNameErrMessage = validateNewFolderName({
-		folders,
-		newName,
-		parentName,
-	});
+	const folderName = Internals.isFolderNameValid(newName)
+		? newName
+		: newName
+				.toLowerCase()
+				.normalize('NFD')
+				.replace(/[\u0300-\u036f]/g, '')
+				.replace(/[^a-z0-9\u4E00-\u9FFF-]+/g, '-')
+				.replace(/^-+|-+$/g, '');
+	const folderNameErrMessage = folderName
+		? validateNewFolderName({folders, newName: folderName, parentName})
+		: 'Enter a name containing letters or numbers.';
 	const valid = folderNameErrMessage === null;
 
 	const codemod: RecastCodemod = useMemo(() => {
 		return {
 			type: 'new-folder',
-			folderName: newName,
+			folderName,
 			parentName,
 		};
-	}, [newName, parentName]);
+	}, [folderName, parentName]);
 
 	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
 		e.preventDefault();
@@ -116,6 +122,10 @@ export const NewFolder: React.FC<{
 									status="ok"
 									rightAlign
 								/>
+								<Spacing y={1} block />
+								<div aria-live="polite">
+									Folder name: {folderName || '(empty)'}
+								</div>
 								{folderNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -10,6 +10,7 @@ import React, {
 } from 'react';
 import {Internals, type _InternalTypes} from 'remotion';
 import {LIGHT_TEXT} from '../../helpers/colors';
+import {slugifyName} from '../../helpers/slugify-name';
 import {validateNewFolderName} from '../../helpers/validate-new-folder-name';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -73,13 +74,7 @@ export const NewFolder: React.FC<{
 		[],
 	);
 
-	const folderName = Internals.isFolderNameValid(newName)
-		? newName
-		: newName
-				.normalize('NFD')
-				.replace(/[\u0300-\u036f]/g, '')
-				.replace(/[^a-zA-Z0-9\u4E00-\u9FFF-]+/g, '-')
-				.replace(/^-+|-+$/g, '');
+	const folderName = slugifyName(newName);
 	const folderNameErrMessage = folderName
 		? validateNewFolderName({folders, newName: folderName, parentName})
 		: 'Enter a name containing letters or numbers.';

--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -9,6 +9,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, type _InternalTypes} from 'remotion';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {validateNewFolderName} from '../../helpers/validate-new-folder-name';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -75,10 +76,9 @@ export const NewFolder: React.FC<{
 	const folderName = Internals.isFolderNameValid(newName)
 		? newName
 		: newName
-				.toLowerCase()
 				.normalize('NFD')
 				.replace(/[\u0300-\u036f]/g, '')
-				.replace(/[^a-z0-9\u4E00-\u9FFF-]+/g, '-')
+				.replace(/[^a-zA-Z0-9\u4E00-\u9FFF-]+/g, '-')
 				.replace(/^-+|-+$/g, '');
 	const folderNameErrMessage = folderName
 		? validateNewFolderName({folders, newName: folderName, parentName})
@@ -122,10 +122,17 @@ export const NewFolder: React.FC<{
 									status="ok"
 									rightAlign
 								/>
-								<Spacing y={1} block />
-								<div aria-live="polite">
-									Folder name: {folderName || '(empty)'}
-								</div>
+								{folderName && folderName !== newName ? (
+									<>
+										<Spacing y={1} block />
+										<div
+											aria-live="polite"
+											style={{fontSize: 12, color: LIGHT_TEXT}}
+										>
+											Will be created as {folderName}
+										</div>
+									</>
+								) : null}
 								{folderNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -9,7 +9,9 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {getFolderId} from '../../helpers/get-folder-id';
+import {slugifyName} from '../../helpers/slugify-name';
 import {validateFolderRename} from '../../helpers/validate-folder-rename';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -52,23 +54,26 @@ export const RenameFolder: React.FC<{
 		[],
 	);
 
-	const folderNameErrMessage = validateFolderRename({
-		folders,
-		newName,
-		originalName: folderName,
-		parentName,
-	});
+	const slug = slugifyName(newName);
+	const folderNameErrMessage = slug
+		? validateFolderRename({
+				folders,
+				newName: slug,
+				originalName: folderName,
+				parentName,
+			})
+		: 'Enter a name containing letters or numbers.';
 
-	const valid = folderNameErrMessage === null && folderName !== newName;
+	const valid = folderNameErrMessage === null && folderName !== slug;
 
 	const codemod: RecastCodemod = useMemo(() => {
 		return {
 			type: 'rename-folder',
 			folderName,
 			parentName,
-			newName,
+			newName: slug,
 		};
-	}, [folderName, newName, parentName]);
+	}, [folderName, slug, parentName]);
 
 	const onSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
 		e.preventDefault();
@@ -95,6 +100,17 @@ export const RenameFolder: React.FC<{
 									status="ok"
 									rightAlign
 								/>
+								{slug && slug !== newName ? (
+									<>
+										<Spacing y={1} block />
+										<div
+											aria-live="polite"
+											style={{fontSize: 12, color: LIGHT_TEXT}}
+										>
+											Will be renamed to {slug}
+										</div>
+									</>
+								) : null}
 								{folderNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/helpers/slugify-name.ts
+++ b/packages/studio/src/helpers/slugify-name.ts
@@ -1,0 +1,11 @@
+import {Internals} from 'remotion';
+
+export const slugifyName = (name: string): string => {
+	return Internals.isFolderNameValid(name)
+		? name
+		: name
+				.normalize('NFD')
+				.replace(/[\u0300-\u036f]/g, '')
+				.replace(/[^a-zA-Z0-9\u4E00-\u9FFF-]+/g, '-')
+				.replace(/^-+|-+$/g, '');
+};


### PR DESCRIPTION
Closes #11149

Slugify human-readable input in the New folder and Rename folder dialogs and show the actual folder name before saving. Save that name directly as the `<Folder name>` prop, preserving already-valid names and using existing sibling collision validation. Empty slugs show an actionable error. Case is preserved (`My Videos` → `My-Videos`), and a small, muted “Will be created as …” or “Will be renamed to …” hint appears only when the input changes during normalization.

## Verification
- `bun run build`
- `bun run stylecheck`
- Focused browser workflow verified preview, empty names, collisions, and persisted source. The temporary E2E test was removed at the user's request; no new test infrastructure or dependencies are included.

Follow-up verification: Studio `bun run make`, focused ESLint, and `bunx oxfmt ... --check` passed.

Folder renaming reuses the same conversion, validates collisions against the resulting name, and disables unchanged names. Composition renaming remains unchanged.
