### PR TITLE
Elements: Refine install dialog styling

### DIFF
--- a/packages/browser-studio/e2e/browser-studio.test.ts
+++ b/packages/browser-studio/e2e/browser-studio.test.ts
@@ -1175,8 +1175,8 @@ export const LinkedElement = () => <Rect width={320} height={180} fill="red" />;
 		).__browserStudioInstallPreservedIframe = true;
 	});
 	await expect(
-		studio.getByRole('radio', {name: 'New composition'}),
-	).toBeChecked();
+		studio.getByRole('button', {name: 'New composition'}),
+	).toHaveAttribute('aria-pressed', 'true');
 	await studio.getByRole('button', {name: /^Install/}).click();
 	await expect
 		.poll(() =>

--- a/packages/bundler/src/setup-environment.ts
+++ b/packages/bundler/src/setup-environment.ts
@@ -85,6 +85,11 @@ injectCSS(`
     color: #0584f2
   }
 
+  .__remotion-vertical-scrollbar::-webkit-scrollbar-corner,
+  .__remotion-horizontal-scrollbar::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   .__remotion-vertical-scrollbar {
     scrollbar-gutter: stable;
   }

--- a/packages/example/e2e/studio-protocol.test.mts
+++ b/packages/example/e2e/studio-protocol.test.mts
@@ -359,17 +359,17 @@ const CloseupPlaceholder = () => {
 			name: 'Install Protocol Element',
 		});
 		await expect(dialog).toBeVisible();
-		const currentDestination = dialog.getByRole('radio', {
+		const currentDestination = dialog.getByRole('button', {
 			name: 'Current composition',
 		});
-		const newDestination = dialog.getByRole('radio', {
+		const newDestination = dialog.getByRole('button', {
 			name: 'New composition',
 		});
-		await expect(currentDestination).toBeChecked();
+		await expect(currentDestination).toHaveAttribute('aria-pressed', 'true');
 		await currentDestination.press('ArrowRight');
-		await expect(newDestination).toBeChecked();
+		await expect(newDestination).toHaveAttribute('aria-pressed', 'true');
 		await newDestination.press('ArrowLeft');
-		await expect(currentDestination).toBeChecked();
+		await expect(currentDestination).toHaveAttribute('aria-pressed', 'true');
 		await expect(dialog.getByText(senderUrl, {exact: true})).toBeVisible();
 		await expect(dialog.getByLabel('Installation name')).toBeHidden();
 		await expect(
@@ -443,11 +443,11 @@ const CloseupPlaceholder = () => {
 			.getByRole('radio', {name: 'Replace existing'})
 			.check();
 		await newCompositionDialog
-			.getByRole('radio', {name: 'New composition', exact: true})
-			.check();
+			.getByRole('button', {name: 'New composition', exact: true})
+			.click();
 		await newCompositionDialog
-			.getByRole('radio', {name: 'Current composition', exact: true})
-			.check();
+			.getByRole('button', {name: 'Current composition', exact: true})
+			.click();
 		await expect(
 			newCompositionDialog.getByRole('radio', {name: 'Create a copy'}),
 		).toBeChecked();
@@ -528,7 +528,7 @@ const CloseupPlaceholder = () => {
 
 		await senderPage.getByRole('button', {name: 'Install in Studio'}).click();
 		await newCompositionDialog
-			.getByRole('radio', {name: 'New composition'})
+			.getByRole('button', {name: 'New composition'})
 			.click();
 		await expect(
 			newCompositionDialog.getByPlaceholder('Composition ID'),

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -56,6 +56,7 @@ import {
 } from './NewComposition/ValidationMessage';
 import {showNotification} from './Notifications/NotificationCenter';
 import {RadioButton} from './RadioButton';
+import {SegmentedControl} from './SegmentedControl';
 import {
 	hasResolvedStack,
 	useResolvedStack,
@@ -191,7 +192,7 @@ const warningStyle: React.CSSProperties = {
 const warningIconStyle: React.CSSProperties = {
 	width: 16,
 	height: 16,
-	marginTop: 3,
+	marginTop: 1,
 	flexShrink: 0,
 	fill: WARNING_COLOR,
 };
@@ -235,15 +236,19 @@ const sourceSummaryStyle: React.CSSProperties = {
 	lineHeight: 1.5,
 };
 
-const sourceCodeBlockStyle: React.CSSProperties = {
+const sourceCodeContainerStyle: React.CSSProperties = {
 	marginTop: 10,
-	marginBottom: 0,
-	maxHeight: 240,
-	overflow: 'auto',
-	padding: 12,
+	overflow: 'hidden',
 	border: `1px solid ${WHITE_ALPHA_12}`,
 	borderRadius: 6,
 	backgroundColor: INPUT_BACKGROUND,
+};
+
+const sourceCodeBlockStyle: React.CSSProperties = {
+	margin: 0,
+	maxHeight: 240,
+	overflow: 'auto',
+	padding: 12,
 	color: LIGHT_TEXT,
 	fontFamily: 'monospace',
 	fontSize: 12,
@@ -266,45 +271,6 @@ const destinationControlStyle: React.CSSProperties = {
 	rowGap: 10,
 	flexWrap: 'wrap',
 };
-
-const destinationOptionsStyle: React.CSSProperties = {
-	display: 'flex',
-	overflow: 'hidden',
-	maxWidth: '100%',
-	marginLeft: 'auto',
-	border: `1px solid ${WHITE_ALPHA_12}`,
-	borderRadius: 4,
-};
-
-const destinationOptionStyle: React.CSSProperties = {
-	appearance: 'none',
-	minHeight: 26,
-	border: 0,
-	cursor: 'default',
-	fontFamily: 'sans-serif',
-	fontSize: 12,
-	fontWeight: 400,
-	lineHeight: '18px',
-	padding: '4px 8px',
-	whiteSpace: 'nowrap',
-};
-
-const getDestinationOptionStyle = ({
-	disabled,
-	selected,
-}: {
-	readonly disabled: boolean;
-	readonly selected: boolean;
-}): React.CSSProperties => ({
-	...destinationOptionStyle,
-	opacity: disabled ? 0.5 : 1,
-	...hoverableStyle({
-		idleBackground: selected ? INPUT_BACKGROUND : TRANSPARENT,
-		hoverBackground: selected ? INPUT_BACKGROUND : TRANSPARENT,
-		idleColor: selected ? WHITE : LIGHT_TEXT,
-		hoverColor: disabled ? LIGHT_TEXT : WHITE,
-	}),
-});
 
 const footerStyle: React.CSSProperties = {
 	minWidth: 0,
@@ -423,8 +389,6 @@ export const ElementInstallConfirmation: React.FC<{
 	);
 	const [submitting, setSubmitting] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
-	const currentDestinationRef = useRef<HTMLButtonElement>(null);
-	const newDestinationRef = useRef<HTMLButtonElement>(null);
 	const [newCompositionValues, setNewCompositionValues] =
 		useState<NewCompositionFormValues>(() => {
 			const elementComponentName =
@@ -820,32 +784,25 @@ export const ElementInstallConfirmation: React.FC<{
 		}
 	}, [onClose, submitting]);
 
-	const onDestinationKeyDown = useCallback(
-		(event: React.KeyboardEvent<HTMLDivElement>) => {
-			if (
-				!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)
-			) {
-				return;
-			}
-
-			event.preventDefault();
-			if (currentPlan === null) {
-				return;
-			}
-
-			const nextMode =
-				mode === 'current-composition'
-					? 'new-composition'
-					: 'current-composition';
-			setMode(nextMode);
-			requestAnimationFrame(() => {
-				if (nextMode === 'current-composition') {
-					currentDestinationRef.current?.focus();
-				} else {
-					newDestinationRef.current?.focus();
-				}
-			});
-		},
+	const destinationOptions = useMemo(
+		() => [
+			{
+				key: 'current-composition',
+				label: 'Current composition',
+				selected: mode === 'current-composition',
+				onClick:
+					currentPlan === null ? null : () => setMode('current-composition'),
+			},
+			{
+				key: 'new-composition',
+				label: 'New composition',
+				selected: mode === 'new-composition',
+				onClick: () => {
+					setMode('new-composition');
+					requestAnimationFrame(() => inputRef.current?.select());
+				},
+			},
+		],
 		[currentPlan, mode],
 	);
 
@@ -885,47 +842,14 @@ export const ElementInstallConfirmation: React.FC<{
 						<div style={sectionTitleStyle}>Destination</div>
 						<div
 							aria-label="Installation destination"
-							onKeyDown={onDestinationKeyDown}
-							role="radiogroup"
-							style={destinationOptionsStyle}
+							role="group"
+							style={{marginLeft: 'auto'}}
 						>
-							<button
-								ref={currentDestinationRef}
-								aria-checked={mode === 'current-composition'}
-								className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
-								disabled={currentPlan === null}
-								onClick={() => setMode('current-composition')}
-								role="radio"
-								style={getDestinationOptionStyle({
-									disabled: currentPlan === null,
-									selected: mode === 'current-composition',
-								})}
-								tabIndex={mode === 'current-composition' ? 0 : -1}
-								type="button"
-							>
-								Current composition
-							</button>
-							<button
-								ref={newDestinationRef}
-								aria-checked={mode === 'new-composition'}
-								className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
-								onClick={() => {
-									setMode('new-composition');
-									requestAnimationFrame(() => inputRef.current?.select());
-								}}
-								role="radio"
-								style={{
-									...getDestinationOptionStyle({
-										disabled: false,
-										selected: mode === 'new-composition',
-									}),
-									borderLeft: `1px solid ${WHITE_ALPHA_12}`,
-								}}
-								tabIndex={mode === 'new-composition' ? 0 : -1}
-								type="button"
-							>
-								New composition
-							</button>
+							<SegmentedControl
+								items={destinationOptions}
+								needsWrapping={false}
+								size="compact"
+							/>
 						</div>
 					</div>
 
@@ -1093,14 +1017,16 @@ export const ElementInstallConfirmation: React.FC<{
 						>
 							Source code
 						</summary>
-						<pre
-							className={`${HORIZONTAL_SCROLLBAR_CLASSNAME} ${VERTICAL_SCROLLBAR_CLASSNAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
-							style={sourceCodeBlockStyle}
-						>
-							<code style={sourceCodeStyle}>
-								{makeSourceControlsVisible(request.element.sourceCode)}
-							</code>
-						</pre>
+						<div style={sourceCodeContainerStyle}>
+							<pre
+								className={`${HORIZONTAL_SCROLLBAR_CLASSNAME} ${VERTICAL_SCROLLBAR_CLASSNAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+								style={sourceCodeBlockStyle}
+							>
+								<code style={sourceCodeStyle}>
+									{makeSourceControlsVisible(request.element.sourceCode)}
+								</code>
+							</pre>
+						</div>
 					</details>
 				</div>
 				<ModalFooterContainer style={footerStyle}>

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -853,7 +853,7 @@ export const ElementInstallConfirmation: React.FC<{
 							<SegmentedControl
 								items={destinationOptions}
 								needsWrapping={false}
-								size="compact"
+								size="medium"
 							/>
 						</div>
 					</div>

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -36,6 +36,10 @@ import {Button} from './Button';
 import {prepareElementInstall} from './element-install-api';
 import {insertElement} from './import-assets';
 import {Flex, Row, Spacing} from './layout';
+import {
+	HORIZONTAL_SCROLLBAR_CLASSNAME,
+	VERTICAL_SCROLLBAR_CLASSNAME,
+} from './Menu/is-menu-item';
 import {getPortal} from './Menu/portals';
 import {ModalButton} from './ModalButton';
 import {ModalContainer} from './ModalContainer';
@@ -59,7 +63,7 @@ const container: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'column',
 	gap: 20,
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	lineHeight: 1.5,
@@ -81,7 +85,7 @@ const sectionStyle: React.CSSProperties = {
 
 const sectionTitleStyle: React.CSSProperties = {
 	margin: 0,
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 600,
@@ -113,7 +117,7 @@ const metadataTermStyle: React.CSSProperties = {
 const metadataDescriptionStyle: React.CSSProperties = {
 	margin: 0,
 	minWidth: 0,
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 400,
@@ -162,11 +166,13 @@ const dependencyListStyle: React.CSSProperties = {
 	margin: 0,
 	padding: 0,
 	listStyleType: 'none',
+	textAlign: 'right',
+	minWidth: 0,
 };
 
 const dependencyNameStyle: React.CSSProperties = {
 	minWidth: 0,
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	lineHeight: 1.5,
@@ -183,7 +189,7 @@ const warningStyle: React.CSSProperties = {
 const warningIconStyle: React.CSSProperties = {
 	width: 16,
 	height: 16,
-	marginTop: 1,
+	marginTop: 3,
 	flexShrink: 0,
 	fill: WARNING_COLOR,
 };
@@ -196,11 +202,6 @@ const warningDescriptionStyle: React.CSSProperties = {
 	fontSize: 13,
 	fontWeight: 400,
 	lineHeight: 1.5,
-};
-
-const installWarningDescriptionStyle: React.CSSProperties = {
-	...warningDescriptionStyle,
-	color: WHITE,
 };
 
 const browseElementsStyle: React.CSSProperties = {
@@ -220,7 +221,12 @@ const sourceDetailsStyle: React.CSSProperties = {
 
 const sourceSummaryStyle: React.CSSProperties = {
 	cursor: 'default',
-	color: WHITE,
+	...hoverableStyle({
+		idleBackground: TRANSPARENT,
+		hoverBackground: TRANSPARENT,
+		idleColor: LIGHT_TEXT,
+		hoverColor: WHITE,
+	}),
 	fontFamily: 'sans-serif',
 	fontSize: 13,
 	fontWeight: 500,
@@ -236,7 +242,7 @@ const sourceCodeBlockStyle: React.CSSProperties = {
 	border: `1px solid ${WHITE_ALPHA_12}`,
 	borderRadius: 6,
 	backgroundColor: INPUT_BACKGROUND,
-	color: WHITE,
+	color: LIGHT_TEXT,
 	fontFamily: 'monospace',
 	fontSize: 12,
 	lineHeight: 1.5,
@@ -691,7 +697,7 @@ export const ElementInstallConfirmation: React.FC<{
 				<ModalHeader title={title} onClose={cancel} />
 			</div>
 			<form onSubmit={onSubmit}>
-				<div style={dialogContent}>
+				<div style={dialogContent} className={VERTICAL_SCROLLBAR_CLASSNAME}>
 					<dl style={requestSourceStyle} aria-label="Request source">
 						<dt style={sectionTitleStyle}>From</dt>
 						<dd
@@ -756,7 +762,7 @@ export const ElementInstallConfirmation: React.FC<{
 					{currentPlan === null ? (
 						<div style={warningStyle} role="status">
 							<WarningTriangle style={warningIconStyle} />
-							<p style={installWarningDescriptionStyle}>
+							<p style={warningDescriptionStyle}>
 								Studio could not find a safe place in “{request.compositionId}”
 								to insert the Element. Install it into a new composition
 								instead.
@@ -765,7 +771,10 @@ export const ElementInstallConfirmation: React.FC<{
 					) : null}
 
 					{mode === 'new-composition' ? (
-						<section style={sectionStyle} aria-label="New composition settings">
+						<section
+							style={{...sectionStyle, marginInline: -16}}
+							aria-label="New composition settings"
+						>
 							<NewCompositionFields
 								heightValidationMessage={heightValidationMessage}
 								inputRef={inputRef}
@@ -792,7 +801,7 @@ export const ElementInstallConfirmation: React.FC<{
 
 					{missingPackages.length > 0 ? (
 						<section
-							style={sectionStyle}
+							style={requestSourceStyle}
 							aria-labelledby="element-install-dependencies"
 						>
 							<h3 id="element-install-dependencies" style={sectionTitleStyle}>
@@ -810,7 +819,7 @@ export const ElementInstallConfirmation: React.FC<{
 
 					<div style={warningStyle}>
 						<WarningTriangle style={warningIconStyle} />
-						<p style={installWarningDescriptionStyle}>
+						<p style={warningDescriptionStyle}>
 							This adds executable source code to your project, with access to
 							your files and the network.
 							{usesBrowserDependencyResolution || missingPackages.length === 0
@@ -820,8 +829,16 @@ export const ElementInstallConfirmation: React.FC<{
 					</div>
 
 					<details style={sourceDetailsStyle}>
-						<summary style={sourceSummaryStyle}>Source code</summary>
-						<pre style={sourceCodeBlockStyle}>
+						<summary
+							className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+							style={sourceSummaryStyle}
+						>
+							Source code
+						</summary>
+						<pre
+							className={`${HORIZONTAL_SCROLLBAR_CLASSNAME} ${VERTICAL_SCROLLBAR_CLASSNAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
+							style={sourceCodeBlockStyle}
+						>
 							<code style={sourceCodeStyle}>
 								{makeSourceControlsVisible(request.element.sourceCode)}
 							</code>

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -838,13 +838,18 @@ export const ElementInstallConfirmation: React.FC<{
 						</dd>
 					</dl>
 
+					{activePlan ? (
+						<dl style={requestSourceStyle}>
+							<dt style={sectionTitleStyle}>Destination</dt>
+							<dd style={requestSourceDescriptionStyle}>
+								{activePlan.filePath}
+							</dd>
+						</dl>
+					) : null}
+
 					<div style={destinationControlStyle}>
-						<div style={sectionTitleStyle}>Destination</div>
-						<div
-							aria-label="Installation destination"
-							role="group"
-							style={{marginLeft: 'auto'}}
-						>
+						<div style={sectionTitleStyle}>Add to</div>
+						<div aria-label="Add to" role="group" style={{marginLeft: 'auto'}}>
 							<SegmentedControl
 								items={destinationOptions}
 								needsWrapping={false}
@@ -970,9 +975,7 @@ export const ElementInstallConfirmation: React.FC<{
 									) : null}
 								</div>
 							</div>
-						) : activePlan ? (
-							<p style={metadataDescriptionStyle}>{activePlan.filePath}</p>
-						) : planError ? (
+						) : !activePlan && planError ? (
 							<ValidationMessage
 								align="flex-start"
 								message={planError}

--- a/packages/studio/src/components/SegmentedControl.tsx
+++ b/packages/studio/src/components/SegmentedControl.tsx
@@ -1,5 +1,5 @@
 import type {PropsWithChildren} from 'react';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {
 	BLACK_ALPHA_60,
 	INPUT_BACKGROUND,
@@ -7,6 +7,11 @@ import {
 	TRANSPARENT,
 	WHITE,
 } from '../helpers/colors';
+import {
+	FOCUS_VISIBLE_ONLY_CLASS_NAME,
+	HOVERABLE_CLASS_NAME,
+	hoverableStyle,
+} from '../helpers/hoverable';
 import {useZIndex} from '../state/z-index';
 
 const container: React.CSSProperties = {
@@ -24,6 +29,7 @@ const item: React.CSSProperties = {
 	fontSize: 15,
 	padding: '4px 12px',
 	appearance: 'none',
+	cursor: 'default',
 	border: 'none',
 	flex: 1,
 	justifyContent: 'center',
@@ -39,7 +45,7 @@ const compactItem: React.CSSProperties = {
 
 export type SegmentedControlItem = {
 	label: React.ReactNode;
-	onClick: () => void;
+	onClick: (() => void) | null;
 	key: string;
 	selected: boolean;
 };
@@ -67,8 +73,37 @@ export const SegmentedControl: React.FC<{
 		};
 	}, [needsWrapping]);
 
+	const onKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLDivElement>) => {
+			if (
+				!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)
+			) {
+				return;
+			}
+
+			const buttons = Array.from(
+				event.currentTarget.querySelectorAll<HTMLButtonElement>(
+					'button:not(:disabled)',
+				),
+			);
+			const index = buttons.indexOf(event.target as HTMLButtonElement);
+			if (index === -1) {
+				return;
+			}
+
+			event.preventDefault();
+			const direction =
+				event.key === 'ArrowLeft' || event.key === 'ArrowUp' ? -1 : 1;
+			const next =
+				buttons[(index + direction + buttons.length) % buttons.length];
+			next.click();
+			requestAnimationFrame(() => next.focus());
+		},
+		[],
+	);
+
 	return (
-		<div style={controlStyle}>
+		<div style={controlStyle} onKeyDown={onKeyDown}>
 			{items.map((i) => {
 				return (
 					<Item
@@ -88,38 +123,34 @@ export const SegmentedControl: React.FC<{
 const Item: React.FC<
 	PropsWithChildren<{
 		readonly selected: boolean;
-		readonly onClick: () => void;
+		readonly onClick: (() => void) | null;
 		readonly size: SegmentedControlSize;
 	}>
 > = ({selected, onClick, children, size}) => {
-	const [hovered, setHovered] = useState(false);
-
 	const {tabIndex} = useZIndex();
-
-	const onPointerEnter = useCallback(() => {
-		setHovered(true);
-	}, []);
-
-	const onPointerLeave = useCallback(() => {
-		setHovered(false);
-	}, []);
 
 	const itemStyle: React.CSSProperties = useMemo(() => {
 		return {
 			...(size === 'compact' ? compactItem : item),
-			backgroundColor: selected ? INPUT_BACKGROUND : TRANSPARENT,
-			color: selected ? WHITE : hovered ? WHITE : LIGHT_TEXT,
+			opacity: onClick === null ? 0.5 : 1,
+			...hoverableStyle({
+				idleBackground: selected ? INPUT_BACKGROUND : TRANSPARENT,
+				hoverBackground: selected ? INPUT_BACKGROUND : TRANSPARENT,
+				idleColor: selected ? WHITE : LIGHT_TEXT,
+				hoverColor: onClick === null ? LIGHT_TEXT : WHITE,
+			}),
 		};
-	}, [hovered, selected, size]);
+	}, [onClick, selected, size]);
 
 	return (
 		<button
 			type="button"
-			onPointerEnter={onPointerEnter}
-			onPointerLeave={onPointerLeave}
+			aria-pressed={selected}
+			disabled={onClick === null}
+			className={`${HOVERABLE_CLASS_NAME} ${FOCUS_VISIBLE_ONLY_CLASS_NAME}`}
 			style={itemStyle}
 			tabIndex={tabIndex}
-			onClick={onClick}
+			onClick={onClick ?? undefined}
 		>
 			{children}
 		</button>

--- a/packages/studio/src/components/SegmentedControl.tsx
+++ b/packages/studio/src/components/SegmentedControl.tsx
@@ -43,6 +43,13 @@ const compactItem: React.CSSProperties = {
 	padding: '2px 7px',
 };
 
+const mediumItem: React.CSSProperties = {
+	...item,
+	fontSize: 13,
+	fontWeight: 400,
+	padding: '3px 10px',
+};
+
 export type SegmentedControlItem = {
 	label: React.ReactNode;
 	onClick: (() => void) | null;
@@ -50,7 +57,7 @@ export type SegmentedControlItem = {
 	selected: boolean;
 };
 
-type SegmentedControlSize = 'default' | 'compact';
+type SegmentedControlSize = 'default' | 'medium' | 'compact';
 
 export const SegmentedControl: React.FC<{
 	readonly items: SegmentedControlItem[];
@@ -131,7 +138,11 @@ const Item: React.FC<
 
 	const itemStyle: React.CSSProperties = useMemo(() => {
 		return {
-			...(size === 'compact' ? compactItem : item),
+			...(size === 'compact'
+				? compactItem
+				: size === 'medium'
+					? mediumItem
+					: item),
 			opacity: onClick === null ? 0.5 : 1,
 			...hoverableStyle({
 				idleBackground: selected ? INPUT_BACKGROUND : TRANSPARENT,


### PR DESCRIPTION
## Summary
- Match the Element install dialog to Studio's muted text, shared scrollbars, and keyboard-only focus styles.
- Right-align packages and align new composition fields with the dialog content. Keep the warning triangle's original size and alignment.
- Reuse the shared segmented control with a medium size (13px text, 3px 10px padding) for the installation destination, with shared disabled-option support, arrow-key navigation, and hover/focus styling.
- Make the shared scrollbar corner transparent to avoid a white square where both scrollbars meet, and clip the source scroller inside its rounded border.

- Show the file path in a right-aligned Destination row and label the composition selector Add to, preserving source provenance and overwrite warnings.

Closes #11124

## Verification
- `bun run build`
- `bun run stylecheck` (passes with existing lint warnings)
- `bunx turbo run make lint test --filter='@remotion/studio'` (passes with existing lint warnings)
- Formatting and Git diff checks pass.
- User confirmed scrollbars appear on hover; render-modal arrow-key switching verified in the browser.
- Final rounded-corner clipping and medium-sized destination control still need visual confirmation.
