### PR TITLE
Elements: Block dependency lifecycle scripts

### DIFF
--- a/packages/docs/docs/studio-protocol/security.mdx
+++ b/packages/docs/docs/studio-protocol/security.mdx
@@ -19,7 +19,7 @@ Studio reflects only the requesting allowed origin in CORS. It does not use wild
 
 Elements delivered using [`setStudioDragData()`](/docs/studio-protocol/set-studio-drag-data) or [`installInStudio()`](/docs/studio-protocol/install-in-studio) require confirmation in Studio. A successful `installInStudio()` result only means the request reached Studio and is awaiting confirmation.
 
-Before confirming, Studio shows the requesting source, destination choice, source code, packages that will be installed, and whether an existing Element source file will be replaced. Drag-and-drop data has no reliable website provenance and is labeled as unverified. Installed source code runs with the project's file and network access. Package lifecycle scripts may also run when packages are installed.
+Before confirming, Studio shows the requesting source, destination choice, source code, packages that will be installed, and whether an existing Element source file will be replaced. Drag-and-drop data has no reliable website provenance and is labeled as unverified. Installed source code runs with the project's file and network access. Package lifecycle scripts are disabled when Studio installs dependencies.
 
 Declining the confirmation does not write source files or install packages.
 

--- a/packages/studio-server/src/preview-server/routes/install-dependency.ts
+++ b/packages/studio-server/src/preview-server/routes/install-dependency.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'node:child_process';
+import {execFileSync, spawn} from 'node:child_process';
 import {RenderInternals} from '@remotion/renderer';
 import {
 	extraPackages,
@@ -68,12 +68,25 @@ export const handleInstallPackage: ApiHandler<
 		);
 	}
 
+	const additionalArgs = ['--ignore-scripts'];
+	if (manager.manager === 'yarn') {
+		const version = execFileSync('yarn', ['--version'], {
+			...getPackageManagerSpawnOptions(),
+			cwd: remotionRoot,
+			encoding: 'utf8',
+			timeout: 10_000,
+		}).trim();
+		if (!/^1\./.test(version)) {
+			additionalArgs[0] = '--mode=skip-build';
+		}
+	}
+
 	const packagesWithVersions = dependencies.map(getPackageInstallSpec);
 	const command = getInstallCommand({
 		manager: manager.manager,
 		packages: packagesWithVersions,
 		version: '',
-		additionalArgs: manager.manager === 'yarn' ? [] : ['--ignore-scripts'],
+		additionalArgs,
 	});
 	RenderInternals.Log.info(
 		{indent: false, logLevel},
@@ -84,6 +97,7 @@ export const handleInstallPackage: ApiHandler<
 		await new Promise<void>((resolve, reject) => {
 			const cmd = spawn(manager.manager, command, {
 				...getPackageManagerSpawnOptions(),
+				cwd: remotionRoot,
 				env: {
 					...process.env,
 					YARN_ENABLE_SCRIPTS: 'false',

--- a/packages/studio-server/src/test/install-dependency.test.ts
+++ b/packages/studio-server/src/test/install-dependency.test.ts
@@ -1,6 +1,6 @@
 import {expect, spyOn, test} from 'bun:test';
-import * as childProcess from 'node:child_process';
 import type {SpawnOptions} from 'node:child_process';
+import * as childProcess from 'node:child_process';
 import {EventEmitter} from 'node:events';
 import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import type {IncomingMessage, ServerResponse} from 'node:http';
@@ -90,6 +90,7 @@ test('always aligns Remotion package versions', () => {
 
 test('installs without running dependency lifecycle scripts', async () => {
 	const {calls: spawnCalls, spawnSpy} = mockPackageManagerSpawn();
+	const versionSpy = spyOn(childProcess, 'execFileSync').mockReturnValue('');
 	const lockfiles: Record<PackageManager, string> = {
 		npm: 'package-lock.json',
 		pnpm: 'pnpm-lock.yaml',
@@ -100,7 +101,14 @@ test('installs without running dependency lifecycle scripts', async () => {
 	const temporaryDirectories: string[] = [];
 
 	try {
-		for (const manager of Object.keys(lockfiles) as PackageManager[]) {
+		for (const {manager, version} of (
+			Object.keys(lockfiles) as PackageManager[]
+		).flatMap((packageManager) =>
+			(packageManager === 'yarn' ? ['1.22.22', '3.8.7', '4.9.2'] : ['']).map(
+				(yarnVersion) => ({manager: packageManager, version: yarnVersion}),
+			),
+		)) {
+			versionSpy.mockReturnValue(version);
 			const remotionRoot = await mkdtemp(
 				path.join(tmpdir(), `remotion-install-${manager}-`),
 			);
@@ -137,7 +145,9 @@ test('installs without running dependency lifecycle scripts', async () => {
 				expect(call.args[0]).toBe('add');
 			}
 
-			if (manager === 'yarn') {
+			expect(call.options.cwd).toBe(remotionRoot);
+			if (manager === 'yarn' && !version.startsWith('1.')) {
+				expect(call.args).toContain('--mode=skip-build');
 				expect(call.args).not.toContain('--ignore-scripts');
 				expect(call.options.env?.YARN_ENABLE_SCRIPTS).toBe('false');
 			} else {
@@ -146,6 +156,7 @@ test('installs without running dependency lifecycle scripts', async () => {
 		}
 	} finally {
 		spawnSpy.mockRestore();
+		versionSpy.mockRestore();
 		await Promise.all(
 			temporaryDirectories.map((directory) =>
 				rm(directory, {force: true, recursive: true}),

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -189,9 +189,9 @@ const warningStyle: React.CSSProperties = {
 };
 
 const warningIconStyle: React.CSSProperties = {
-	width: 16,
-	height: 16,
-	marginTop: 1,
+	width: 14,
+	height: 14,
+	marginTop: 2,
 	flexShrink: 0,
 	fill: WARNING_COLOR,
 };

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -10,7 +10,6 @@ import React, {
 import {createPortal} from 'react-dom';
 import {Internals} from 'remotion';
 import {ShortcutHint} from '../error-overlay/remotion-overlay/ShortcutHint';
-import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {
 	INPUT_BACKGROUND,
 	LIGHT_TEXT,
@@ -380,7 +379,6 @@ export const ElementInstallConfirmation: React.FC<{
 					height: config.height,
 					width: config.width,
 				};
-	const usesBrowserDependencyResolution = getBrowserStudioOperations() !== null;
 	const {currentZIndex} = useZIndex();
 	const [mode, setMode] = useState<'current-composition' | 'new-composition'>(
 		currentPlan === null || request.source.type === 'browser-studio-link'
@@ -1005,11 +1003,7 @@ export const ElementInstallConfirmation: React.FC<{
 					<div style={warningStyle}>
 						<WarningTriangle style={warningIconStyle} />
 						<p style={warningDescriptionStyle}>
-							This adds executable source code to your project, with access to
-							your files and the network.
-							{usesBrowserDependencyResolution || missingPackages.length === 0
-								? null
-								: ' Package lifecycle scripts may also run during installation.'}
+							Installed code can access your files and network.
 						</p>
 					</div>
 


### PR DESCRIPTION
## Summary

Stacked on #11165. This layer contains only dependency-installation hardening and the shorter warning.

- Disable lifecycle scripts with `--ignore-scripts` for Yarn Classic and `--mode=skip-build` for modern Yarn, including builds explicitly enabled by project configuration. Other supported package managers already use `--ignore-scripts`.
- Run package installation and Yarn version detection from the project root.
- Shorten the warning to “Installed code can access your files and network.” and update the security documentation.

Follow-up to #11124 (closed by the base PR).

## Verification

- `bun run build`
- `bun run stylecheck`
- `bunx turbo run make lint test --filter='@remotion/studio-server' --filter='@remotion/studio'`
- Oxfmt and `git diff --check`
- Extended the existing handler-level integration test across Yarn 1, 3, and 4, mocking only the package-manager process boundary. Red/green verified by restoring the old Yarn arguments and observing failure.

Existing lint warnings only. Warning layout still needs visual confirmation.
