### PR TITLE
`@remotion/media`: Fix audio gaps after pausing playback

### DIFF
--- a/packages/media/src/media-player.ts
+++ b/packages/media/src/media-player.ts
@@ -871,11 +871,14 @@ export class MediaPlayer {
 		}
 	};
 
-	public audioSyncAnchorChanged = () => {
+	public audioSyncAnchorChanged = async (unloopedTimeInSeconds: number) => {
 		if (!this.audioIteratorManager) {
 			return;
 		}
 
 		this.audioIteratorManager.destroyIterator();
+		// An anchor can change while paused, when no frame update will restart
+		// scheduling. Refill the queue against the new anchor immediately.
+		await this.seekTo(unloopedTimeInSeconds);
 	};
 }

--- a/packages/media/src/test/audio-anchor-reschedule.test.tsx
+++ b/packages/media/src/test/audio-anchor-reschedule.test.tsx
@@ -1,0 +1,87 @@
+import {Player, type PlayerRef} from '@remotion/player';
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import {Internals} from 'remotion';
+import {expect, test, vi} from 'vitest';
+import {Audio} from '../audio/audio';
+
+test('replaces queued audio after a suspension re-anchors a stationary Player', async () => {
+	const createdNodes: {
+		node: AudioBufferSourceNode;
+		start: ReturnType<typeof vi.spyOn>;
+		stop: ReturnType<typeof vi.spyOn>;
+	}[] = [];
+	const originalCreateBufferSource = AudioContext.prototype.createBufferSource;
+	const createBufferSourceSpy = vi
+		.spyOn(AudioContext.prototype, 'createBufferSource')
+		.mockImplementation(function (this: AudioContext) {
+			const node = originalCreateBufferSource.call(this);
+			createdNodes.push({
+				node,
+				start: vi.spyOn(node, 'start'),
+				stop: vi.spyOn(node, 'stop'),
+			});
+			return node;
+		});
+	let audioContext: AudioContext | null = null;
+	const Composition: React.FC = () => {
+		audioContext =
+			React.useContext(Internals.SharedAudioContext)?.audioContext ?? null;
+		return <Audio src="/voice-note.m4a" disallowFallbackToHtml5Audio />;
+	};
+
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = createRoot(container);
+	const playerRef = React.createRef<PlayerRef>();
+	root.render(
+		<Player
+			ref={playerRef}
+			acknowledgeRemotionLicense
+			component={Composition}
+			compositionWidth={100}
+			compositionHeight={100}
+			durationInFrames={300}
+			fps={30}
+			inputProps={{}}
+		/>,
+	);
+	try {
+		await vi.waitFor(() => {
+			expect(
+				createdNodes.filter(({node}) => node.buffer !== null).length,
+			).toBeGreaterThan(5);
+		});
+		if (!audioContext) throw new Error('Audio context did not initialize');
+		const context: AudioContext = audioContext;
+		const oldNodes = createdNodes.filter(({node}) => node.buffer !== null);
+		const oldNodeCount = createdNodes.length;
+		// Control only the browser clock/state: reproduce suspension after the
+		// audio clock advanced beyond the frozen composition frame.
+		vi.spyOn(context, 'currentTime', 'get').mockReturnValue(0.25);
+		vi.spyOn(context, 'state', 'get').mockReturnValue('suspended');
+		context.dispatchEvent(new Event('statechange'));
+		await vi.waitFor(() => {
+			expect(oldNodes.every(({stop}) => stop.mock.calls.length > 0)).toBe(true);
+			const replacements = createdNodes
+				.slice(oldNodeCount)
+				.filter(({node}) => node.buffer !== null);
+			expect(replacements.length).toBeGreaterThan(5);
+		});
+		expect(playerRef.current?.getCurrentFrame()).toBe(0);
+		expect(playerRef.current?.isPlaying()).toBe(false);
+		// Suspended contexts retain the replacement start commands until play.
+		playerRef.current?.play();
+		await vi.waitFor(() => {
+			const replacements = createdNodes
+				.slice(oldNodeCount)
+				.filter(({node}) => node.buffer !== null);
+			expect(replacements[0].start.mock.calls[0]?.[0]).toBeCloseTo(0.25, 4);
+		});
+	} finally {
+		root.unmount();
+		container.remove();
+		createBufferSourceSpy.mockRestore();
+		vi.restoreAllMocks();
+	}
+});

--- a/packages/media/src/use-common-effects.ts
+++ b/packages/media/src/use-common-effects.ts
@@ -77,7 +77,11 @@ export const useCommonEffects = ({
 		const {remove} = sharedAudioContext.audioSyncAnchorEmitter.subscribe(
 			(event) => {
 				if (event === 'changed') {
-					mediaPlayerRef.current?.audioSyncAnchorChanged();
+					mediaPlayerRef.current
+						?.audioSyncAnchorChanged(currentTimeRef.current)
+						.catch(() => {
+							// Might be disposed
+						});
 				}
 			},
 		);
@@ -85,7 +89,7 @@ export const useCommonEffects = ({
 		return () => {
 			remove();
 		};
-	}, [sharedAudioContext, mediaPlayerRef]);
+	}, [sharedAudioContext, mediaPlayerRef, currentTimeRef]);
 
 	useLayoutEffect(() => {
 		const mediaPlayer = mediaPlayerRef.current;

--- a/packages/player/src/use-playback.ts
+++ b/packages/player/src/use-playback.ts
@@ -124,7 +124,7 @@ export const usePlayback = ({
 		const callback = () => {
 			const newState = sharedAudioContext?.getAudioContextState();
 			if (newState && shouldForceAnchorChange(newState)) {
-				setGlobalTimeAnchor({
+				const changed = setGlobalTimeAnchor({
 					audioContext,
 					audioSyncAnchor: sharedAudioContext.audioSyncAnchor,
 					absoluteTimeInSeconds: getCurrentFrame() / config.fps,
@@ -132,6 +132,9 @@ export const usePlayback = ({
 					logLevel,
 					force: true,
 				});
+				if (changed) {
+					sharedAudioContext.audioSyncAnchorEmitter.dispatch('changed');
+				}
 			}
 		};
 


### PR DESCRIPTION
Fix audio gaps after pausing or buffering changes the audio synchronization anchor. Forced updates on suspension now notify media players, which cancel stale audio nodes and refill the queue at the current position even when the composition frame is stationary.

Adds a browser regression test mounting a real Player and Audio with a media fixture. It verifies cancellation, replacement scheduling before the next frame, and corrected start times on resume. Only browser clock/state is controlled; Remotion collaborators remain real. Red/green verified.

Validation: repository build and stylecheck; focused browser regression, media-player and loop frame-accuracy tests; Player resume and keep-audio-context-alive tests; Studio pause/resume with scheduling logs.

Closes #9747. This addresses the pause/resume discontinuity found while investigating that report; uninterrupted playback and the reported mirroring behavior were not established as fixed.
