### PR TITLE
Skills: Create projects in existing empty folders

### DIFF
--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -13,26 +13,31 @@ If a project already exists, skip this.
 Ensure Node.js and Git is installed, and the current folder is appropriate for starting a new project.
 
 Inspect the current folder, including hidden files, before choosing where to scaffold.
+
+### Empty folder
+
 If it is empty, or contains only disposable operating-system metadata such as `.DS_Store`, create the project directly in the current folder.
 Remove only those disposable metadata files first, since `create-video` rejects non-empty folders.
 Do not treat all hidden files as disposable: files such as `.env` and directories such as `.git` are meaningful contents.
 
-Use `.` as the directory argument to scaffold in the current folder, without creating or changing into a subfolder:
+Scaffold in existing folder:
 
 ```bash
 npx create-video@latest --yes --blank --no-tailwind .
 npm i
 ```
 
-If the current folder contains meaningful contents and no project already exists, scaffold into a new subfolder:
+### Non-empty folder
+
+If the current folder contains meaningful contents and no project already exists, scaffold into a new subfolder.
+Replace `my-video` with a suitable project name.
+
 
 ```bash
 npx create-video@latest --yes --blank --no-tailwind my-video
 cd my-video
 npm i
 ```
-
-Replace `my-video` with a suitable project name.
 
 ## Designing a video
 

--- a/packages/skills/skills/remotion-create/SKILL.md
+++ b/packages/skills/skills/remotion-create/SKILL.md
@@ -12,7 +12,19 @@ If this is not the next task, see [Remotion Best Practices](../remotion-best-pra
 If a project already exists, skip this.
 Ensure Node.js and Git is installed, and the current folder is appropriate for starting a new project.
 
-Scaffold one using:
+Inspect the current folder, including hidden files, before choosing where to scaffold.
+If it is empty, or contains only disposable operating-system metadata such as `.DS_Store`, create the project directly in the current folder.
+Remove only those disposable metadata files first, since `create-video` rejects non-empty folders.
+Do not treat all hidden files as disposable: files such as `.env` and directories such as `.git` are meaningful contents.
+
+Use `.` as the directory argument to scaffold in the current folder, without creating or changing into a subfolder:
+
+```bash
+npx create-video@latest --yes --blank --no-tailwind .
+npm i
+```
+
+If the current folder contains meaningful contents and no project already exists, scaffold into a new subfolder:
 
 ```bash
 npx create-video@latest --yes --blank --no-tailwind my-video


### PR DESCRIPTION
Teach `remotion-create` to scaffold directly in the current folder using `.` when it is empty, instead of always creating a nested project folder. Inspect hidden files and remove only disposable OS metadata such as `.DS_Store` before scaffolding; use a new subfolder when meaningful contents are present.

Closes #11135

Validation: Oxfmt, `bun run build`, `bun run stylecheck`, and `git diff --check` passed.
