### PR TITLE
`@remotion/promo-pages`: Add video automation landing page

### DIFF
--- a/packages/docs/src/pages/automate.tsx
+++ b/packages/docs/src/pages/automate.tsx
@@ -1,0 +1,25 @@
+import {useColorMode} from '@docusaurus/theme-common';
+import '@remotion/promo-pages/dist/Automate.css';
+import {AutomatePage} from '@remotion/promo-pages/dist/Automate.js';
+import '@remotion/promo-pages/dist/tailwind.css';
+import Layout from '@theme/Layout';
+import React from 'react';
+
+const Inner: React.FC = () => {
+	const {colorMode, setColorMode} = useColorMode();
+
+	return <AutomatePage colorMode={colorMode} setColorMode={setColorMode} />;
+};
+
+const Automate: React.FC = () => {
+	return (
+		<Layout
+			title="Automate videos with Remotion"
+			description="Create videos programmatically with Remotion. Try the interactive demo, explore apps built with Remotion, and find the right license."
+		>
+			<Inner />
+		</Layout>
+	);
+};
+
+export default Automate;

--- a/packages/promo-pages/automate.html
+++ b/packages/promo-pages/automate.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Automate videos with Remotion</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/automate.tsx"></script>
+	</body>
+</html>

--- a/packages/promo-pages/bundle.ts
+++ b/packages/promo-pages/bundle.ts
@@ -23,9 +23,27 @@ if (nodeVersion.trim() === 'undefined') {
 
 await $`bunx tailwindcss -i src/index.css -o dist/tailwind.css`;
 
-const result = await build({
-	entrypoints: [
-		'./src/components/Automate.tsx',
+const external = [
+	'react',
+	'react/jsx-runtime',
+	'react-dom',
+	'lottie-web',
+	'hls.js',
+	'plyr',
+	'zod',
+	'@mux/upchunk',
+	'mediabunny',
+	'@mediabunny/ac3',
+	'@mediabunny/aac-encoder',
+	'@mediabunny/flac-encoder',
+	'@mediabunny/mp3-encoder',
+];
+
+// Keep Automate in a separate build. Newer Bun versions deduplicate identical
+// CSS outputs across entrypoints, which otherwise removes Homepage.css.
+const results = [
+	await build({
+		entrypoints: [
 		'./src/components/Homepage.tsx',
 		'./src/components/homepage/Pricing.tsx',
 		'./src/components/team.tsx',
@@ -38,53 +56,49 @@ const result = await build({
 		'./src/components/prompts/PromptsSubmit.tsx',
 		'./src/components/prompts/PromptsShow.tsx',
 		'./src/components/prompts/prompt-types.ts',
-	],
-	root: './src/components',
-	outdir: 'dist',
-	format: 'esm',
-	external: [
-		'react',
-		'react/jsx-runtime',
-		'react-dom',
-		'lottie-web',
-		'hls.js',
-		'plyr',
-		'zod',
-		'@mux/upchunk',
-		'mediabunny',
-		'@mediabunny/ac3',
-		'@mediabunny/aac-encoder',
-		'@mediabunny/flac-encoder',
-		'@mediabunny/mp3-encoder',
-	],
-});
-
-if (!result.success) {
-	console.log(result.logs.join('\n'));
-	process.exit(1);
-}
+		],
+		root: './src/components',
+		outdir: 'dist',
+		format: 'esm',
+		external,
+	}),
+	await build({
+		entrypoints: ['./src/components/Automate.tsx'],
+		root: './src/components',
+		outdir: 'dist',
+		format: 'esm',
+		external,
+	}),
+];
 
 const outdir = path.resolve('dist');
 
-for (const output of result.outputs) {
-	// On Windows, Bun may return absolute output paths here. Normalize them back
-	// into the local dist directory so we don't accidentally write invalid paths.
-	const relativeOutputPath = path.isAbsolute(output.path)
-		? path.relative(outdir, output.path)
-		: output.path;
-	const normalizedOutputPath = relativeOutputPath.replaceAll('\\', '/');
-	const outputPathWithoutDistPrefix = normalizedOutputPath.startsWith('dist/')
-		? normalizedOutputPath.slice('dist/'.length)
-		: normalizedOutputPath;
-
-	if (outputPathWithoutDistPrefix.startsWith('../')) {
-		throw new Error(`Unexpected build output path: ${output.path}`);
+for (const result of results) {
+	if (!result.success) {
+		console.log(result.logs.join('\n'));
+		process.exit(1);
 	}
 
-	await Bun.write(
-		path.join('dist', outputPathWithoutDistPrefix),
-		await output.text(),
-	);
+	for (const output of result.outputs) {
+		// On Windows, Bun may return absolute output paths here. Normalize them back
+		// into the local dist directory so we don't accidentally write invalid paths.
+		const relativeOutputPath = path.isAbsolute(output.path)
+			? path.relative(outdir, output.path)
+			: output.path;
+		const normalizedOutputPath = relativeOutputPath.replaceAll('\\', '/');
+		const outputPathWithoutDistPrefix = normalizedOutputPath.startsWith('dist/')
+			? normalizedOutputPath.slice('dist/'.length)
+			: normalizedOutputPath;
+
+		if (outputPathWithoutDistPrefix.startsWith('../')) {
+			throw new Error(`Unexpected build output path: ${output.path}`);
+		}
+
+		await Bun.write(
+			path.join('dist', outputPathWithoutDistPrefix),
+			await output.text(),
+		);
+	}
 }
 
 export {};

--- a/packages/promo-pages/bundle.ts
+++ b/packages/promo-pages/bundle.ts
@@ -1,5 +1,5 @@
-import {$, build} from 'bun';
 import path from 'node:path';
+import {$, build} from 'bun';
 import {NoReactInternals} from 'remotion/no-react';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -25,6 +25,7 @@ await $`bunx tailwindcss -i src/index.css -o dist/tailwind.css`;
 
 const result = await build({
 	entrypoints: [
+		'./src/components/Automate.tsx',
 		'./src/components/Homepage.tsx',
 		'./src/components/homepage/Pricing.tsx',
 		'./src/components/team.tsx',
@@ -80,7 +81,10 @@ for (const output of result.outputs) {
 		throw new Error(`Unexpected build output path: ${output.path}`);
 	}
 
-	await Bun.write(path.join('dist', outputPathWithoutDistPrefix), await output.text());
+	await Bun.write(
+		path.join('dist', outputPathWithoutDistPrefix),
+		await output.text(),
+	);
 }
 
 export {};

--- a/packages/promo-pages/server.ts
+++ b/packages/promo-pages/server.ts
@@ -1,4 +1,5 @@
 import {serve} from 'bun';
+import automate from './automate.html';
 import homepage from './homepage.html';
 import promptsShow from './prompts-show.html';
 import promptsSubmit from './prompts-submit.html';
@@ -15,6 +16,7 @@ const startServer = () => {
 				port,
 				routes: {
 					'/': homepage,
+					'/automate': automate,
 					'/about': team,
 					'/prompts': prompts,
 					'/prompts/show': promptsShow,

--- a/packages/promo-pages/src/automate.tsx
+++ b/packages/promo-pages/src/automate.tsx
@@ -1,0 +1,21 @@
+import {StrictMode, useState} from 'react';
+import {createRoot} from 'react-dom/client';
+import {AutomatePage} from './components/Automate';
+import type {ColorMode} from './components/homepage/layout/use-color-mode';
+import './index.css';
+
+const App: React.FC = () => {
+	const [colorMode, setColorMode] = useState<ColorMode>('light');
+
+	return (
+		<div data-theme={colorMode} className="bg-[var(--background)]">
+			<AutomatePage colorMode={colorMode} setColorMode={setColorMode} />
+		</div>
+	);
+};
+
+createRoot(document.getElementById('root')!).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/packages/promo-pages/src/components/Automate.tsx
+++ b/packages/promo-pages/src/components/Automate.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React from 'react';
+import {AutomateTitle} from './automate/AutomateTitle';
+import {BuiltWithRemotionShowcase} from './automate/BuiltWithRemotionShowcase';
+import {Demo} from './homepage/Demo';
+import type {ColorMode} from './homepage/layout/use-color-mode';
+import {ColorModeProvider} from './homepage/layout/use-color-mode';
+import {MakeVideosAgentically} from './homepage/MakeVideosAgentically';
+import {MakeVideosInteractively} from './homepage/MakeVideosInteractively';
+import {MakeVideosProgrammatically} from './homepage/MakeVideosProgrammatically';
+import {Pricing} from './homepage/Pricing';
+import {SectionTitle} from './homepage/VideoAppsTitle';
+
+export const AutomatePage: React.FC<{
+	readonly colorMode: ColorMode;
+	readonly setColorMode: (colorMode: ColorMode) => void;
+}> = ({colorMode, setColorMode}) => {
+	return (
+		<ColorModeProvider colorMode={colorMode} setColorMode={setColorMode}>
+			<div className="w-full relative overflow-hidden">
+				<div className="max-w-[500px] min-[900px]:max-w-[1000px] m-auto px-5 pt-24 pb-16 overflow-x-clip min-[900px]:overflow-x-visible relative">
+					<AutomateTitle />
+					<div className="mt-12 min-[900px]:mt-16 flex flex-col min-[900px]:flex-row gap-10">
+						<MakeVideosProgrammatically
+							title="Parameterization"
+							description="Organize your assets and connect your data."
+							videoSrc="/img/design-systems.webm"
+							fallbackVideoSrc="/img/design-systems.mp4"
+							links={[
+								{
+									label: 'Parameterization',
+									href: '/docs/parameterized-rendering',
+								},
+								{label: 'Motion design systems', href: '/design-systems'},
+							]}
+						/>
+						<MakeVideosAgentically
+							title="Batch rendering"
+							description="Render millions of videos on your own infrastructure."
+							links={[
+								{
+									label: 'Server-side rendering',
+									href: '/docs/compare-ssr',
+								},
+								{
+									label: 'Client-side rendering',
+									href: '/docs/client-side-rendering',
+								},
+							]}
+						/>
+						<MakeVideosInteractively
+							title="Applications"
+							description="Publish a simple tool or a complex video editor."
+							videoSrc="/img/applications.webm"
+							fallbackVideoSrc="/img/applications.mp4"
+							links={[
+								{label: 'Player', href: '/docs/player'},
+								{label: 'Editor Starter', href: '/editor-starter'},
+							]}
+						/>
+					</div>
+					<Demo
+						title="Try it out"
+						description="Remotion runs on the web. Videos are data-driven, interactive and can be exported on the client or on the server."
+					/>
+					<div className="h-16" />
+					<BuiltWithRemotionShowcase />
+					<div className="h-16" />
+					<SectionTitle>Pricing</SectionTitle>
+					<p className="mx-auto mb-8 max-w-[840px] text-center text-[15px] font-brand">
+						We want everyone to be able to build. Completely free for most, fair
+						pricing for companies.
+					</p>
+					<Pricing />
+				</div>
+			</div>
+		</ColorModeProvider>
+	);
+};

--- a/packages/promo-pages/src/components/Automate.tsx
+++ b/packages/promo-pages/src/components/Automate.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import {AutomateTitle} from './automate/AutomateTitle';
 import {BuiltWithRemotionShowcase} from './automate/BuiltWithRemotionShowcase';
 import {Demo} from './homepage/Demo';
+import EvaluateRemotionSection from './homepage/EvaluateRemotion';
 import type {ColorMode} from './homepage/layout/use-color-mode';
 import {ColorModeProvider} from './homepage/layout/use-color-mode';
 import {MakeVideosAgentically} from './homepage/MakeVideosAgentically';
 import {MakeVideosInteractively} from './homepage/MakeVideosInteractively';
 import {MakeVideosProgrammatically} from './homepage/MakeVideosProgrammatically';
 import {Pricing} from './homepage/Pricing';
+import TrustedByBanner from './homepage/TrustedByBanner';
 import {SectionTitle} from './homepage/VideoAppsTitle';
 
 export const AutomatePage: React.FC<{
@@ -73,6 +75,10 @@ export const AutomatePage: React.FC<{
 						pricing for companies.
 					</p>
 					<Pricing />
+					<div className="mt-4 min-[900px]:mt-6 flex flex-col min-[900px]:flex-row gap-10">
+						<TrustedByBanner />
+						<EvaluateRemotionSection />
+					</div>
 				</div>
 			</div>
 		</ColorModeProvider>

--- a/packages/promo-pages/src/components/Homepage.tsx
+++ b/packages/promo-pages/src/components/Homepage.tsx
@@ -93,7 +93,7 @@ export const NewLanding: React.FC<{
 							/>
 						</div>
 
-						<Demo />
+						<Demo title={null} description={null} />
 						<br />
 						<br />
 						<br />

--- a/packages/promo-pages/src/components/automate/AutomateTitle.tsx
+++ b/packages/promo-pages/src/components/automate/AutomateTitle.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const AutomateTitle: React.FC = () => {
+	return (
+		<div>
+			<h1
+				className="text-4xl sm:text-5xl lg:text-[5em] text-center fontbrand font-black leading-none text-balance"
+				style={{
+					textShadow: '0 5px 30px var(--background)',
+				}}
+			>
+				Automate video production
+			</h1>
+			<p
+				style={{
+					textShadow: '0 5px 30px var(--background)',
+				}}
+				className="font-medium text-center text-lg"
+			>
+				Build simple workflows or entire video editors. <br />
+				Scale rendering and do business.
+			</p>
+		</div>
+	);
+};

--- a/packages/promo-pages/src/components/automate/BuiltWithRemotionShowcase.tsx
+++ b/packages/promo-pages/src/components/automate/BuiltWithRemotionShowcase.tsx
@@ -1,0 +1,277 @@
+import React, {useRef, useState} from 'react';
+import {
+	IsMutedIcon,
+	NotMutedIcon,
+	PausedIcon,
+	PlayingIcon,
+} from '../homepage/Demo/icons';
+import {MuxVideo} from '../homepage/MuxVideo';
+import {SectionTitle} from '../homepage/VideoAppsTitle';
+
+const videoApps = [
+	{
+		title: 'Banger.Show',
+		description:
+			'The all-in-one 3D visual creation tool for ambitious artists. Seamlessly craft visuals that match your sound and propel your brand forward.',
+		link: 'https://banger.show?ref=remotion',
+		videoWidth: 1080,
+		videoHeight: 1080,
+		muxId: 'Kg02XHfkR6x8400BtO4Ica54XlSPimmmTRpqDHHUaeACk',
+		buttonText: 'Banger.Show website',
+	},
+	{
+		title: 'Submagic',
+		description:
+			'A video editor for creating short-form content fast. Designed for creators, teams and agencies, it accelerates video editing with AI-powered features such as descriptions, zooms, sound effects and music.',
+		additionalInfo: '',
+		link: 'https://www.submagic.co/?ref=remotion',
+		videoWidth: 540,
+		videoHeight: 1080,
+		muxId: 'pxqGEjlBBntnXrEe4v00pYUBw3FPgUPKumfhSym00Vs004',
+		buttonText: 'Submagic website',
+	},
+	{
+		title: 'Remotion Recorder',
+		description:
+			'The Remotion Recorder is a video production tool built entirely in JavaScript. Create high-quality videos that feel native on each platform while only editing them once.',
+		link: 'https://www.remotion.dev/recorder',
+		videoWidth: 1080,
+		videoHeight: 1080,
+		muxId: 'pHlwqDZFUH00Aubo9M001ty3gZ6YW8z689XTd9R479ayE',
+		buttonText: 'More infos',
+	},
+	{
+		title: 'GitHub Unwrapped',
+		description:
+			'Your coding year in review. Get a personalized video of your GitHub activity.',
+		additionalInfo:
+			'Uncover your go-to language, peak productivity hours, and track your GitHub impact – all in one video.',
+		link: 'https://githubunwrapped.com/',
+		videoWidth: 1080,
+		videoHeight: 1080,
+		muxId: 'OwQFvqomOR00q6yj5SWwaA7DBg01NaCPKcOvczoZqCty00',
+		buttonText: 'GitHub Unwrapped website',
+	},
+];
+
+const icon: React.CSSProperties = {
+	height: 16,
+	marginLeft: 10,
+};
+
+const Arrow: React.FC = () => (
+	<svg style={icon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+		<path
+			fill="currentColor"
+			d="M438.6 278.6l-160 160C272.4 444.9 264.2 448 256 448s-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L338.8 288H32C14.33 288 .0016 273.7 .0016 256S14.33 224 32 224h306.8l-105.4-105.4c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l160 160C451.1 245.9 451.1 266.1 438.6 278.6z"
+		/>
+	</svg>
+);
+
+const ShowcaseItem: React.FC<{
+	readonly videoApp: (typeof videoApps)[number];
+}> = ({videoApp}) => {
+	const [isMuted, setIsMuted] = useState(true);
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [videoLoaded, setVideoLoaded] = useState(false);
+	const videoRef = useRef<HTMLVideoElement>(null);
+
+	const handlePlayPause = () => {
+		if (!videoLoaded) {
+			setVideoLoaded(true);
+			return;
+		}
+
+		if (videoRef.current) {
+			if (videoRef.current.paused) {
+				const playPromise = videoRef.current.play();
+
+				if (playPromise !== undefined) {
+					playPromise
+						.then(() => {
+							setIsPlaying(true);
+						})
+						.catch((error) => {
+							// eslint-disable-next-line no-console
+							console.error('Playback error:', error);
+							setIsPlaying(false);
+						});
+				}
+			} else {
+				videoRef.current.pause();
+				setIsPlaying(false);
+			}
+		}
+	};
+
+	const handleMuteToggle = () => {
+		if (videoRef.current) {
+			const newMutedState = !videoRef.current.muted;
+			videoRef.current.muted = newMutedState;
+			setIsMuted(newMutedState);
+		}
+	};
+
+	return (
+		<div
+			className={'card flex p-0 overflow-hidden'}
+			// Prevent this from showing up in search engine results
+			data-nosnippet
+		>
+			<div className={'flex-1 grid grid-cols-1 min-[900px]:grid-cols-2'}>
+				<div
+					className={
+						'w-full aspect-video min-[900px]:aspect-square relative overflow-hidden bg-[#eee] cursor-pointer'
+					}
+					onClick={handlePlayPause}
+				>
+					{videoLoaded ? (
+						<MuxVideo
+							ref={videoRef}
+							muxId={videoApp.muxId}
+							className={
+								'absolute left-0 top-0 w-full h-full object-contain rounded-sm rounded-tr-none rounded-br-none'
+							}
+							loop
+							playsInline
+							muted={isMuted}
+							autoPlay
+							onPlay={() => setIsPlaying(true)}
+							onPause={() => setIsPlaying(false)}
+						/>
+					) : (
+						<img
+							src={`https://image.mux.com/${videoApp.muxId}/thumbnail.png?time=1`}
+							className={
+								'absolute left-0 top-0 w-full h-full object-contain rounded-sm rounded-tr-none rounded-br-none'
+							}
+							alt={videoApp.title}
+							loading="lazy"
+						/>
+					)}
+
+					{/* Play/Pause Button - bottom left corner */}
+					<button
+						type="button"
+						aria-label={`${isPlaying ? 'Pause' : 'Play'} ${videoApp.title}`}
+						className={
+							'absolute bottom-2.5 left-2.5 bg-white text-black rounded-full w-8 h-8 flex justify-center items-center text-base cursor-pointer transition-colors border-2 border-black border-solid'
+						}
+						onClick={(e) => {
+							e.stopPropagation();
+							handlePlayPause();
+						}}
+					>
+						{isPlaying ? (
+							<PlayingIcon
+								style={{
+									width: 12,
+									height: 20,
+									marginLeft: '2px',
+									marginTop: '1px',
+								}}
+							/>
+						) : (
+							<PausedIcon
+								style={{
+									width: 14,
+									height: 16,
+									marginLeft: '2px',
+									marginTop: '0.5px',
+								}}
+							/>
+						)}
+					</button>
+
+					{/* Mute/Unmute Button - bottom right corner */}
+					<button
+						type="button"
+						aria-label={`${isMuted ? 'Unmute' : 'Mute'} ${videoApp.title}`}
+						className={
+							'absolute bottom-2.5 right-2.5 bg-white text-black rounded-full w-8 h-8 flex justify-center items-center text-base cursor-pointer transition-colors border-2 border-black border-solid'
+						}
+						onClick={(e) => {
+							e.stopPropagation();
+							handleMuteToggle();
+						}}
+					>
+						{isMuted ? (
+							<IsMutedIcon
+								style={{
+									width: 16,
+									height: 16,
+									marginTop: '1px',
+								}}
+							/>
+						) : (
+							<NotMutedIcon
+								style={{
+									width: 16,
+									height: 16,
+									marginTop: '1px',
+								}}
+							/>
+						)}
+					</button>
+				</div>
+				<div
+					className={
+						'p-6 min-[900px]:p-10 flex min-w-0 flex-col justify-center'
+					}
+				>
+					<div className="text-3xl font-bold fontbrand mt-0">
+						{videoApp.title}
+					</div>
+					<div className="text-muted mt-3 text-base fontbrand leading-relaxed">
+						{videoApp.description}
+					</div>
+					{videoApp.additionalInfo ? (
+						<div className="text-muted mt-4 text-base fontbrand">
+							{videoApp.additionalInfo}
+						</div>
+					) : null}
+					<div className="h-5" />
+					<a
+						className="no-underline text-brand font-brand font-bold inline-flex flex-row items-center"
+						href={videoApp.link}
+					>
+						{videoApp.buttonText}
+						<Arrow />
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export const BuiltWithRemotionShowcase: React.FC = () => {
+	return (
+		<div>
+			<SectionTitle>Built with Remotion</SectionTitle>
+			<div className="mt-8 flex flex-col gap-8">
+				{videoApps.map((videoApp) => (
+					<ShowcaseItem key={videoApp.title} videoApp={videoApp} />
+				))}
+			</div>
+			<div
+				style={{
+					marginTop: '1rem',
+					justifyContent: 'center',
+					display: 'flex',
+				}}
+			>
+				<div
+					style={{
+						fontFamily: 'GTPlanar',
+					}}
+				>
+					For more examples of products and workflows, see our{' '}
+					<a href="/showcase" className="bluelink">
+						Showcase page
+					</a>
+					.
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/packages/promo-pages/src/components/homepage/Demo/index.tsx
+++ b/packages/promo-pages/src/components/homepage/Demo/index.tsx
@@ -8,7 +8,7 @@ import React, {
 	useState,
 	type CSSProperties,
 } from 'react';
-import {PALETTE} from '../layout/colors';
+import {FONTS, PALETTE} from '../layout/colors';
 import {useColorMode} from '../layout/use-color-mode';
 import {SectionTitle} from '../VideoAppsTitle';
 import {
@@ -41,7 +41,10 @@ const playerWrapper: CSSProperties = {
 	overflow: 'hidden',
 };
 
-export const Demo: React.FC = () => {
+export const Demo: React.FC<{
+	readonly title: string | null;
+	readonly description: string | null;
+}> = ({title, description}) => {
 	const {colorMode} = useColorMode();
 	const [data, setData] = useState<LocationAndTrending | null>(null);
 	const ref = useRef<PlayerRef>(null);
@@ -110,7 +113,19 @@ export const Demo: React.FC = () => {
 
 	return (
 		<div id="demo" className="pt-24">
-			<SectionTitle>Interactive demo</SectionTitle>
+			<SectionTitle>{title ?? 'Interactive demo'}</SectionTitle>
+			{description ? (
+				<p
+					className="max-w-[840px] mx-auto text-center"
+					style={{
+						fontFamily: FONTS.GTPLANAR,
+						fontSize: 15,
+						textWrap: 'balance',
+					}}
+				>
+					{description}
+				</p>
+			) : null}
 			<div className="max-w-[760px] mx-auto">
 				<div className="h-[105px] relative">
 					<DragAndDropNudge />


### PR DESCRIPTION
Adds `/automate`, a dedicated landing page for video automation with the parameterization, batch rendering, and applications feature row, the interactive Player demo, and pricing.

The page has its own title and a fork of the “Built with Remotion” showcase displayed as a vertical list, so its content and layout can evolve independently of the homepage.

Validation: `bun run build` and `bun run stylecheck` passed. Previewed the page in the local Docusaurus site.

## Preview

[/automate](https://remotion-git-codex-automate-promo-page-remotion.vercel.app/automate)
