### PR TITLE
`@remotion/studio`: Fix client exports after inspector edits

### DIFF
--- a/packages/bundler/src/watch-ignore-next-change-plugin.ts
+++ b/packages/bundler/src/watch-ignore-next-change-plugin.ts
@@ -128,6 +128,19 @@ export class WatchIgnoreNextChangePlugin {
 		return files;
 	}
 
+	consumeSuppressedFilesForRebuild(): string[] {
+		// Include writes whose watcher event has not arrived yet.
+		const files = [
+			...new Set([...this.suppressedFilesHistory, ...this.filesToIgnore]),
+		];
+		this.suppressedFilesHistory.clear();
+		for (const file of files) {
+			this.unignoreNextChange(file);
+		}
+
+		return files;
+	}
+
 	apply(compiler: Compiler): void {
 		compiler.hooks.afterEnvironment.tap('WatchIgnoreNextChangePlugin', () => {
 			const wfs = compiler.watchFileSystem as unknown as NodeWatchFileSystem;

--- a/packages/example/e2e/client-render-inspector-edits.test.mts
+++ b/packages/example/e2e/client-render-inspector-edits.test.mts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {expect, test} from '@playwright/test';
+import sharp from 'sharp';
+import {
+	exampleDir,
+	EXPANDED_SIDEBAR_STATE,
+	rootFile,
+	STUDIO_URL,
+} from './constants.mts';
+import {readStudioLogs, stripAnsi} from './helpers.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test('client export includes inspector edits without reloading Studio', async ({
+	page,
+}) => {
+	await startStudio();
+	const output = path.join(
+		exampleDir,
+		'out',
+		'client-render-inspector-edits.png',
+	);
+	try {
+		fs.rmSync(output, {force: true});
+		fs.writeFileSync(
+			rootFile,
+			`
+import React from 'react';
+import {Composition, Solid} from 'remotion';
+const EditableSolid = () => <Solid name="Editable color" color="#ff0000" width={32} height={32} />;
+export const E2eTestRoot = () => <Composition id="client-render-inspector" component={EditableSolid} durationInFrames={1} fps={30} width={32} height={32} />;
+`,
+		);
+		await page.goto(`${STUDIO_URL}/client-render-inspector`);
+		await expect(async () => {
+			await page.getByText('Editable color', {exact: true}).first().click();
+			await expect(
+				page.getByRole('button', {name: '#ff0000', exact: true}),
+			).toBeVisible({timeout: 1_000});
+		}).toPass();
+		const logCount = readStudioLogs().length;
+		await page.getByRole('button', {name: '#ff0000', exact: true}).click();
+		await page.getByRole('textbox', {name: 'Hex', exact: true}).fill('#0000ff');
+		await page.getByRole('textbox', {name: 'Hex', exact: true}).press('Enter');
+		await page.keyboard.press('Escape');
+		await expect
+			.poll(() =>
+				readStudioLogs()
+					.slice(logCount)
+					.map(stripAnsi)
+					.some((log) => log.includes('All changes suppressed')),
+			)
+			.toBe(true);
+
+		await page
+			.getByRole('button', {name: 'Select render type', exact: true})
+			.click();
+		await page
+			.getByRole('button', {name: 'Client-side render', exact: true})
+			.click();
+		await page.getByRole('button', {name: 'Still', exact: true}).click();
+		await page.getByRole('button', {name: 'PNG', exact: true}).click();
+		await page
+			.getByRole('textbox', {name: 'Output name', exact: true})
+			.fill('out/client-render-inspector-edits.png');
+		await page.getByRole('button', {name: /Render still/}).click();
+		await expect.poll(() => fs.existsSync(output)).toBe(true);
+		const {data, info} = await sharp(output)
+			.ensureAlpha()
+			.raw()
+			.toBuffer({resolveWithObject: true});
+		const offset = (16 * info.width + 16) * info.channels;
+		expect([...data.subarray(offset, offset + 4)]).toEqual([0, 0, 255, 255]);
+	} finally {
+		await stopStudio();
+		fs.rmSync(output, {force: true});
+	}
+});

--- a/packages/studio-server/src/preview-server/api-routes.ts
+++ b/packages/studio-server/src/preview-server/api-routes.ts
@@ -35,6 +35,7 @@ import {handleOpenInFileExplorer} from './routes/open-in-file-explorer';
 import {openInGitClientHandler} from './routes/open-in-git-client';
 import {openInTerminalHandler} from './routes/open-in-terminal';
 import {pasteEffectsHandler} from './routes/paste-effects';
+import {prepareClientRenderHandler} from './routes/prepare-client-render';
 import {prepareElementInstallHandler} from './routes/prepare-element-install';
 import {projectInfoHandler} from './routes/project-info';
 import {redoHandler} from './routes/redo';
@@ -75,6 +76,7 @@ export const allApiRoutes: {
 		ApiRoutes[key]['Response']
 	>;
 } = {
+	'/api/prepare-client-render': prepareClientRenderHandler,
 	'/api/composition-component-info': compositionComponentInfoHandler,
 	'/api/copy-render-output-to-asset': copyRenderOutputToAssetHandler,
 	'/api/convert-figma-clipboard-to-svg': convertFigmaClipboardToSvgHandler,

--- a/packages/studio-server/src/preview-server/routes/prepare-client-render.ts
+++ b/packages/studio-server/src/preview-server/routes/prepare-client-render.ts
@@ -1,0 +1,9 @@
+import type {ApiRoutes} from '@remotion/studio-shared';
+import type {ApiHandler} from '../api-types';
+import {prepareClientRender} from '../watch-ignore-next-change';
+import {withSourceFileWriteQueue} from './source-file-write-queue';
+
+export const prepareClientRenderHandler: ApiHandler<
+	ApiRoutes['/api/prepare-client-render']['Request'],
+	ApiRoutes['/api/prepare-client-render']['Response']
+> = () => withSourceFileWriteQueue(prepareClientRender);

--- a/packages/studio-server/src/preview-server/start-server.ts
+++ b/packages/studio-server/src/preview-server/start-server.ts
@@ -240,7 +240,7 @@ export const startServer = async (options: {
 			compiler = webpack(webpackConf);
 		}
 
-		setWatchIgnoreNextChangePlugin(watchIgnorePlugin);
+		setWatchIgnoreNextChangePlugin(watchIgnorePlugin, compiler);
 
 		const wdmMiddleware = wdm(compiler, options.logLevel);
 		const liveEventsServer = makeLiveEventsRouter(options.logLevel, () => {

--- a/packages/studio-server/src/preview-server/watch-ignore-next-change.ts
+++ b/packages/studio-server/src/preview-server/watch-ignore-next-change.ts
@@ -1,12 +1,70 @@
 import {promises as fs} from 'node:fs';
-import type {WatchIgnoreNextChangePlugin} from '@remotion/bundler';
+import type {WatchIgnoreNextChangePlugin, webpack} from '@remotion/bundler';
 
 let currentPlugin: WatchIgnoreNextChangePlugin | null = null;
+let currentCompiler: webpack.Compiler | null = null;
+let latestStats: webpack.Stats | null = null;
+let filesToRebuild: string[] = [];
 
 export const setWatchIgnoreNextChangePlugin = (
 	plugin: WatchIgnoreNextChangePlugin,
+	compiler: webpack.Compiler,
 ): void => {
 	currentPlugin = plugin;
+	currentCompiler = compiler;
+	latestStats = null;
+	filesToRebuild = [];
+	compiler.hooks.invalid.tap('remotion-prepare-client-render', () => {
+		latestStats = null;
+	});
+	compiler.hooks.watchRun.tap('remotion-prepare-client-render', () => {
+		if (filesToRebuild.length === 0) {
+			return;
+		}
+
+		compiler.modifiedFiles = new Set([
+			...(compiler.modifiedFiles ?? []),
+			...filesToRebuild,
+		]);
+		for (const file of filesToRebuild) {
+			compiler.inputFileSystem?.purge?.(file);
+			compiler.fileTimestamps?.delete(file);
+		}
+
+		filesToRebuild = [];
+	});
+	compiler.hooks.done.tap('remotion-prepare-client-render', (stats) => {
+		latestStats = stats;
+	});
+};
+
+export const prepareClientRender = async (): Promise<{hash: string}> => {
+	if (!currentCompiler?.watching || !currentPlugin) {
+		throw new Error('Studio bundler is not running');
+	}
+
+	filesToRebuild = currentPlugin.consumeSuppressedFilesForRebuild();
+	if (filesToRebuild.length > 0) {
+		await new Promise<void>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				reject(new Error('Timed out preparing the composition for export'));
+			}, 60_000);
+			currentCompiler!.watching!.invalidate((error) => {
+				clearTimeout(timeout);
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	if (!latestStats || latestStats.hasErrors() || !latestStats.hash) {
+		throw new Error('Fix the compilation errors before exporting');
+	}
+
+	return {hash: latestStats.hash};
 };
 
 export const suppressBundlerUpdateForFile = (absolutePath: string): void => {

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -1254,6 +1254,10 @@ export type LogStudioErrorResponse = {};
 // When adding a route, also update the Browser Studio parity checklist:
 // https://github.com/remotion-dev/remotion/issues/9807
 export type ApiRoutes = {
+	'/api/prepare-client-render': ReqAndRes<
+		Record<string, never>,
+		{hash: string}
+	>;
 	'/api/composition-component-info': ReqAndRes<
 		CompositionComponentInfoRequest,
 		CompositionComponentInfoResponse

--- a/packages/studio/src/components/RenderModal/PrepareClientRender.tsx
+++ b/packages/studio/src/components/RenderModal/PrepareClientRender.tsx
@@ -1,0 +1,52 @@
+import {useEffect, useState} from 'react';
+import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
+import {waitForHotUpdate} from '../../hot-middleware-client/wait-for-hot-update';
+import {callApi} from '../call-api';
+import {ModalHeader} from '../ModalHeader';
+import {loaderLabel} from '../RunningCalculateMetadata';
+
+export const PrepareClientRender: React.FC<{
+	readonly children: React.ReactNode;
+}> = ({children}) => {
+	const [state, setState] = useState<'loading' | 'ready' | Error>(() =>
+		window.remotion_isReadOnlyStudio || getBrowserStudioOperations() !== null
+			? 'ready'
+			: 'loading',
+	);
+
+	useEffect(() => {
+		if (
+			window.remotion_isReadOnlyStudio ||
+			getBrowserStudioOperations() !== null
+		) {
+			return;
+		}
+
+		const controller = new AbortController();
+		callApi('/api/prepare-client-render', {}, controller.signal)
+			.then(({hash}) => waitForHotUpdate(hash, controller.signal))
+			.then(() => setState('ready'))
+			.catch((error) => {
+				if (!controller.signal.aborted) {
+					setState(error);
+				}
+			});
+		return () => controller.abort();
+	}, []);
+
+	if (state === 'ready') {
+		return children;
+	}
+
+	return (
+		<div>
+			<ModalHeader title="Preparing export" />
+			<div
+				style={{...loaderLabel, padding: 20}}
+				role={state === 'loading' ? 'status' : 'alert'}
+			>
+				{state === 'loading' ? 'Loading the latest changes…' : state.message}
+			</div>
+		</div>
+	);
+};

--- a/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
+++ b/packages/studio/src/components/RenderModal/RenderModalOutputName.tsx
@@ -80,6 +80,7 @@ export const RenderModalOutputName = ({
 			<div style={rightRow}>
 				<div style={outputNameInputContainer}>
 					<RemotionInput
+						aria-label={labelText}
 						status={validationMessage ? 'error' : existence ? 'warning' : 'ok'}
 						style={inputStyle}
 						type="text"

--- a/packages/studio/src/components/RenderModal/WebRenderModal.tsx
+++ b/packages/studio/src/components/RenderModal/WebRenderModal.tsx
@@ -39,6 +39,7 @@ import {SegmentedControl} from '../SegmentedControl';
 import {VerticalTab} from '../Tabs/vertical';
 import {DataEditor} from './DataEditor';
 import {getStringBeforeSuffix} from './get-string-before-suffix';
+import {PrepareClientRender} from './PrepareClientRender';
 import {
 	buttonStyle,
 	container as containerStyle,
@@ -825,9 +826,11 @@ export const WebRenderModalWithLoader: React.FC<WebRenderModalState> = (
 ) => {
 	return (
 		<DismissableModal>
-			<ResolveCompositionBeforeModal compositionId={props.compositionId}>
-				<WebRenderModal {...props} />
-			</ResolveCompositionBeforeModal>
+			<PrepareClientRender>
+				<ResolveCompositionBeforeModal compositionId={props.compositionId}>
+					<WebRenderModal {...props} />
+				</ResolveCompositionBeforeModal>
+			</PrepareClientRender>
 		</DismissableModal>
 	);
 };

--- a/packages/studio/src/hot-middleware-client/wait-for-hot-update.ts
+++ b/packages/studio/src/hot-middleware-client/wait-for-hot-update.ts
@@ -1,0 +1,65 @@
+declare const __webpack_module__: {
+	hot:
+		| {
+				status: () => string;
+				addStatusHandler: (callback: () => void) => void;
+				removeStatusHandler: (callback: () => void) => void;
+		  }
+		| undefined;
+};
+
+export const waitForHotUpdate = (hash: string, signal: AbortSignal) => {
+	return new Promise<void>((resolve, reject) => {
+		const {hot} = __webpack_module__;
+		if (!hot) {
+			reject(
+				new Error(
+					'Hot refresh is unavailable. Refresh Studio before exporting.',
+				),
+			);
+			return;
+		}
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			hot.removeStatusHandler(onStatusChange);
+			signal.removeEventListener('abort', onAbort);
+		};
+
+		const onAbort = () => {
+			cleanup();
+			reject(new Error('Preparing the export was cancelled'));
+		};
+
+		const check = () => {
+			if (hot.status() === 'idle' && __webpack_hash__ === hash) {
+				cleanup();
+				resolve();
+			} else if (hot.status() === 'abort' || hot.status() === 'fail') {
+				cleanup();
+				reject(
+					new Error('Hot refresh failed. Refresh Studio before exporting.'),
+				);
+			}
+		};
+
+		// Let all idle handlers finish, including React Fast Refresh, before
+		// resolving or removing our handler from the runtime's listener array.
+		const onStatusChange = () => queueMicrotask(check);
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(
+				new Error(
+					'Timed out updating the composition. Refresh Studio before exporting.',
+				),
+			);
+		}, 60_000);
+		hot.addStatusHandler(onStatusChange);
+		signal.addEventListener('abort', onAbort, {once: true});
+		if (signal.aborted) {
+			onAbort();
+		} else {
+			check();
+		}
+	});
+};


### PR DESCRIPTION
Inspector edits are saved to source without recompiling, so browser exports can use the old component even though the Studio preview shows the new values. Prepare the latest saved code and wait for hot refresh before opening the client-side export dialog.

Wait for queued source writes, include pending watcher events, and report compilation or refresh failures before rendering. Inspector edits continue to avoid rebuilding during normal preview use.

## Validation

- `bun run build`
- `bun run stylecheck`
- Studio E2E test edits a solid from red to blue in the inspector, confirms rebuild suppression, exports a PNG without reloading, and verifies its pixels. No internal dependencies mocked.
- Red/green verified: disconnecting preparation produces a red export; restoring it produces blue. Tested with Rspack and Webpack.
- Existing rebuild-suppression E2E workflow passes.
