### PR TITLE
`remotion`: Make `componentIdentity` optional in `Interactive.withSchema()`

### DIFF
--- a/packages/brand/src/3DContext/Div3D.tsx
+++ b/packages/brand/src/3DContext/Div3D.tsx
@@ -553,7 +553,6 @@ ExtrudeDivInner.displayName = '<ExtrudeDiv>';
 export const ExtrudeDiv = Interactive.withSchema({
 	Component: ExtrudeDivInner,
 	componentName: '<ExtrudeDiv>',
-	componentIdentity: null,
 	schema: extrudeDivSchema,
 	supportsEffects: false,
 });

--- a/packages/brand/src/3DContext/transformation-context.tsx
+++ b/packages/brand/src/3DContext/transformation-context.tsx
@@ -168,7 +168,6 @@ const make3DTransform = <ValueKey extends string>({
 	const Wrapped = Interactive.withSchema({
 		Component: Inner,
 		componentName,
-		componentIdentity: null,
 		schema,
 		supportsEffects: false,
 	}) as unknown as React.FC<Props>;

--- a/packages/brand/src/Compose/WhatIsRemotion.tsx
+++ b/packages/brand/src/Compose/WhatIsRemotion.tsx
@@ -134,7 +134,6 @@ LabelInner.displayName = '<Label>';
 const Label = Interactive.withSchema({
 	Component: LabelInner,
 	componentName: '<Label>',
-	componentIdentity: null,
 	schema: labelSchema,
 	supportsEffects: false,
 });

--- a/packages/core/src/with-interactivity-schema.ts
+++ b/packages/core/src/with-interactivity-schema.ts
@@ -165,7 +165,8 @@ export type WithInteractivitySchemaOptions<
 		Props & {readonly controls: SequenceControls | undefined}
 	>;
 	componentName: string;
-	componentIdentity: JsxComponentIdentity | null;
+	/** @internal */
+	componentIdentity?: JsxComponentIdentity | null;
 	schema: S;
 	supportsEffects: boolean;
 };
@@ -188,7 +189,7 @@ export const withInteractivitySchema = <
 >({
 	Component,
 	componentName,
-	componentIdentity,
+	componentIdentity = null,
 	schema,
 	supportsEffects,
 }: WithInteractivitySchemaOptions<S, Props>): React.ComponentType<Props> => {

--- a/packages/docs/docs/interactive-with-schema.mdx
+++ b/packages/docs/docs/interactive-with-schema.mdx
@@ -95,7 +95,6 @@ const CircleInner = forwardRef<
 export const Circle = Interactive.withSchema({
   Component: CircleInner,
   componentName: '<Circle>',
-  componentIdentity: 'com.example.Circle',
   schema: circleSchema,
   supportsEffects: false,
 });
@@ -131,12 +130,6 @@ An [`InteractivitySchema`](/docs/interactivity-schema) that describes which prop
 
 Use [`Interactive.baseSchema`](/docs/interactive#interactivebaseschema) for Sequence-like timeline props. Use [`Interactive.transformSchema`](/docs/interactive#interactivetransformschema) if the component accepts a `style` prop and should expose transform controls. Use [`Interactive.cropSchema`](/docs/interactive#interactivecropschema) with `InteractiveCropProps` to opt the component into crop controls.
 For reliable source updates, follow [Interactivity best practices](/docs/studio/interactivity-best-practices): Keep editable values inline, use hardcoded `interpolate()` keyframe arrays, use `translate`, `scale`, `rotate` and `opacity` directly, and avoid animated layout props or `transform` strings.
-
-### `componentIdentity`
-
-A stable string that identifies the component type.
-
-Use reverse-DNS style names such as `"com.example.Circle"`. Pass `null` if the component should not be identified for source updates.
 
 ### `supportsEffects`
 

--- a/packages/docs/docs/studio/make-component-interactive.mdx
+++ b/packages/docs/docs/studio/make-component-interactive.mdx
@@ -169,8 +169,6 @@ Pass [`outlineRef`](/docs/sequence#outlineref) when using `<Sequence layout="non
 
 ## Wrap the component
 
-Set `componentIdentity` to `null` for a component defined in your project.
-
 ```tsx twoslash title="Badge.tsx"
 import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import {
@@ -259,7 +257,6 @@ const BadgeInner = forwardRef<
 export const Badge = Interactive.withSchema({
   Component: BadgeInner,
   componentName: '<Badge>',
-  componentIdentity: null,
   schema: badgeSchema,
   supportsEffects: false,
 });

--- a/packages/docs/elements/audio/mirrored-spectrum/mirrored-spectrum.tsx
+++ b/packages/docs/elements/audio/mirrored-spectrum/mirrored-spectrum.tsx
@@ -171,7 +171,6 @@ const MirroredAudioSpectrumInner = forwardRef<
 export const MirroredAudioSpectrum = Interactive.withSchema({
 	Component: MirroredAudioSpectrumInner,
 	componentName: '<MirroredAudioSpectrum>',
-	componentIdentity: null,
 	schema: mirroredAudioSpectrumSchema,
 	supportsEffects: false,
 }) as React.FC<MirroredAudioSpectrumProps>;

--- a/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
+++ b/packages/docs/elements/audio/oscilloscope/audio-oscilloscope.tsx
@@ -198,7 +198,6 @@ const AudioOscilloscopeInner = forwardRef<
 export const AudioOscilloscope = Interactive.withSchema({
 	Component: AudioOscilloscopeInner,
 	componentName: '<AudioOscilloscope>',
-	componentIdentity: null,
 	schema: audioOscilloscopeSchema,
 	supportsEffects: false,
 }) as React.FC<AudioOscilloscopeProps>;

--- a/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
+++ b/packages/docs/elements/audio/waveform-progress/audio-waveform-progress.tsx
@@ -236,7 +236,6 @@ const AudioWaveformProgressInner = forwardRef<
 export const AudioWaveformProgress = Interactive.withSchema({
 	Component: AudioWaveformProgressInner,
 	componentName: '<AudioWaveformProgress>',
-	componentIdentity: null,
 	schema: audioWaveformProgressSchema,
 	supportsEffects: false,
 }) as React.FC<AudioWaveformProgressProps>;

--- a/packages/docs/elements/captions/basic-captions/basic-captions.tsx
+++ b/packages/docs/elements/captions/basic-captions/basic-captions.tsx
@@ -157,7 +157,6 @@ const BasicCaptionsInner = forwardRef<
 const BasicCaptionsLayer = Interactive.withSchema({
 	Component: BasicCaptionsInner,
 	componentName: '<BasicCaptions>',
-	componentIdentity: null,
 	schema: basicCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<BasicCaptionsProps>;

--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -436,7 +436,6 @@ const MovingPillCaptionsInner = forwardRef<
 const MovingPillCaptionsLayer = Interactive.withSchema({
 	Component: MovingPillCaptionsInner,
 	componentName: '<MovingPillCaptions>',
-	componentIdentity: null,
 	schema: movingPillCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<MovingPillCaptionsProps>;

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -347,7 +347,6 @@ const PoppingWordCaptionsInner = forwardRef<
 const PoppingWordCaptionsLayer = Interactive.withSchema({
 	Component: PoppingWordCaptionsInner,
 	componentName: '<PoppingWordCaptions>',
-	componentIdentity: null,
 	schema: poppingWordCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<PoppingWordCaptionsProps>;

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -305,7 +305,6 @@ const WordHighlightCaptionsInner = forwardRef<
 const WordHighlightCaptionsLayer = Interactive.withSchema({
 	Component: WordHighlightCaptionsInner,
 	componentName: '<WordHighlightCaptions>',
-	componentIdentity: null,
 	schema: wordHighlightCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<WordHighlightCaptionsProps>;

--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -341,7 +341,6 @@ const ProductCardInner = forwardRef<
 const ProductCard = Interactive.withSchema({
 	Component: ProductCardInner,
 	componentName: '<ProductCard>',
-	componentIdentity: null,
 	schema: productCardSchema,
 	supportsEffects: false,
 }) as React.FC<ProductCardProps>;

--- a/packages/docs/elements/maps/map-flyover/a-to-b-map-flyover.tsx
+++ b/packages/docs/elements/maps/map-flyover/a-to-b-map-flyover.tsx
@@ -638,7 +638,6 @@ const MapFlyoverLayerInner = forwardRef<
 const InteractiveMapFlyoverLayer = Interactive.withSchema({
 	Component: MapFlyoverLayerInner,
 	componentName: '<MapFlyover>',
-	componentIdentity: null,
 	schema: mapFlyoverSchema,
 	supportsEffects: false,
 }) as React.FC<MapFlyoverLayerProps>;

--- a/packages/docs/elements/maps/watercolor-map/watercolor-map.tsx
+++ b/packages/docs/elements/maps/watercolor-map/watercolor-map.tsx
@@ -453,7 +453,6 @@ const WatercolorMapInner = forwardRef<
 const InteractiveWatercolorMap = Interactive.withSchema({
 	Component: WatercolorMapInner,
 	componentName: '<WatercolorMap>',
-	componentIdentity: null,
 	schema: watercolorMapSchema,
 	supportsEffects: false,
 }) as React.FC<WatercolorMapProps>;

--- a/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
+++ b/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
@@ -176,7 +176,6 @@ const SocialSafeZonesInner = forwardRef<
 export const SocialSafeZones = Interactive.withSchema({
 	Component: SocialSafeZonesInner,
 	componentName: '<SocialSafeZones>',
-	componentIdentity: null,
 	schema: socialSafeZonesSchema,
 	supportsEffects: false,
 }) as React.FC<SocialSafeZonesProps>;

--- a/packages/docs/elements/text/spinning-text-wheel/spinning-text-wheel.tsx
+++ b/packages/docs/elements/text/spinning-text-wheel/spinning-text-wheel.tsx
@@ -175,7 +175,6 @@ const SpinningTextWheelInner = forwardRef<
 const InteractiveSpinningTextWheel = Interactive.withSchema({
 	Component: SpinningTextWheelInner,
 	componentName: '<SpinningTextWheel>',
-	componentIdentity: null,
 	schema: spinningTextWheelSchema,
 	supportsEffects: false,
 }) as React.FC<InteractiveSpinningTextWheelProps>;

--- a/packages/example/src/CaptionsTester/AnimatedCaptions.tsx
+++ b/packages/example/src/CaptionsTester/AnimatedCaptions.tsx
@@ -176,7 +176,6 @@ const AnimatedCaptionsInner = forwardRef<
 export const AnimatedCaptions = Interactive.withSchema({
 	Component: AnimatedCaptionsInner,
 	componentName: '<AnimatedCaptions>',
-	componentIdentity: null,
 	schema: animatedCaptionsSchema,
 	supportsEffects: false,
 });

--- a/packages/example/src/InspectorControlLayoutE2e.tsx
+++ b/packages/example/src/InspectorControlLayoutE2e.tsx
@@ -78,7 +78,6 @@ const InspectorControlLayoutInner: React.FC<
 const InteractiveInspectorControlLayout = Interactive.withSchema({
 	Component: InspectorControlLayoutInner,
 	componentName: '<InspectorControlLayout>',
-	componentIdentity: null,
 	schema: inspectorControlLayoutSchema,
 	supportsEffects: false,
 }) as React.FC<InspectorControlLayoutProps>;

--- a/packages/example/src/mirrored-spectrum.element.tsx
+++ b/packages/example/src/mirrored-spectrum.element.tsx
@@ -171,7 +171,6 @@ const MirroredAudioSpectrumInner = forwardRef<
 export const MirroredAudioSpectrum = Interactive.withSchema({
 	Component: MirroredAudioSpectrumInner,
 	componentName: '<MirroredAudioSpectrum>',
-	componentIdentity: null,
 	schema: mirroredAudioSpectrumSchema,
 	supportsEffects: false,
 }) as React.FC<MirroredAudioSpectrumProps>;

--- a/packages/example/src/moving-pill-captions.element.tsx
+++ b/packages/example/src/moving-pill-captions.element.tsx
@@ -479,7 +479,6 @@ const MovingPillCaptionsInner = forwardRef<
 const MovingPillCaptionsLayer = Interactive.withSchema({
 	Component: MovingPillCaptionsInner,
 	componentName: '<MovingPillCaptions>',
-	componentIdentity: null,
 	schema: movingPillCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<MovingPillCaptionsLayerProps>;

--- a/packages/example/src/oscilloscope.element.tsx
+++ b/packages/example/src/oscilloscope.element.tsx
@@ -198,7 +198,6 @@ const AudioOscilloscopeInner = forwardRef<
 export const AudioOscilloscope = Interactive.withSchema({
 	Component: AudioOscilloscopeInner,
 	componentName: '<AudioOscilloscope>',
-	componentIdentity: null,
 	schema: audioOscilloscopeSchema,
 	supportsEffects: false,
 }) as React.FC<AudioOscilloscopeProps>;

--- a/packages/jonnys-videos/src/components/AnimatedCaptions.tsx
+++ b/packages/jonnys-videos/src/components/AnimatedCaptions.tsx
@@ -482,7 +482,6 @@ const AnimatedCaptionsInner = forwardRef<
 export const AnimatedCaptions = Interactive.withSchema({
 	Component: AnimatedCaptionsInner,
 	componentName: '<AnimatedCaptions>',
-	componentIdentity: null,
 	schema: animatedCaptionsSchema,
 	supportsEffects: false,
 }) as React.FC<AnimatedCaptionsProps>;

--- a/packages/maptiler/src/MapOverlay.tsx
+++ b/packages/maptiler/src/MapOverlay.tsx
@@ -184,7 +184,6 @@ const MapOverlayInner = forwardRef(MapOverlayRefForwardingFunction);
 export const MapOverlay = Interactive.withSchema({
 	Component: MapOverlayInner,
 	componentName: '<MapOverlay>',
-	componentIdentity: null,
 	schema: mapOverlaySchema,
 	supportsEffects: false,
 });

--- a/packages/maptiler/src/MapRegion.tsx
+++ b/packages/maptiler/src/MapRegion.tsx
@@ -391,7 +391,6 @@ const MapRegionInner = forwardRef(MapRegionRefForwardingFunction);
 export const MapRegion = Interactive.withSchema({
 	Component: MapRegionInner,
 	componentName: '<MapRegion>',
-	componentIdentity: null,
 	schema: mapRegionSchema,
 	supportsEffects: false,
 });

--- a/packages/maptiler/src/MapRoute.tsx
+++ b/packages/maptiler/src/MapRoute.tsx
@@ -319,7 +319,6 @@ const MapRouteInner = forwardRef(MapRouteRefForwardingFunction);
 export const MapRoute = Interactive.withSchema({
 	Component: MapRouteInner,
 	componentName: '<MapRoute>',
-	componentIdentity: null,
 	schema: mapRouteSchema,
 	supportsEffects: false,
 });

--- a/packages/maptiler/src/MapViewport.tsx
+++ b/packages/maptiler/src/MapViewport.tsx
@@ -555,7 +555,6 @@ export const MapViewport: ComponentType<MapViewportProps> =
 	Interactive.withSchema({
 		Component: MapViewportInner,
 		componentName: '<MapViewport>',
-		componentIdentity: null,
 		schema: mapViewportSchema,
 		supportsEffects: false,
 	});


### PR DESCRIPTION
Custom components using `Interactive.withSchema()` no longer need to specify `componentIdentity`. Make the internal option optional with a `null` default and remove it from public documentation, examples, and Elements. Built-in component identities remain unchanged.

Closes #11172

Validation: full build, stylecheck, core typecheck, and 71 interactivity/sequence tests.

## Preview

- [Interactive.withSchema()](https://remotion-git-codex-optional-component-identity-remotion.vercel.app/docs/interactive-with-schema)
- [Make a component interactive](https://remotion-git-codex-optional-component-identity-remotion.vercel.app/docs/studio/make-component-interactive)
