### PR TITLE
`@remotion/studio`: Add shared inspector controls for multiple sequences

### DIFF
--- a/packages/example/e2e/multi-sequence-inspector.test.mts
+++ b/packages/example/e2e/multi-sequence-inspector.test.mts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import {expect, test} from '@playwright/test';
+import {
+	EXPANDED_SIDEBAR_STATE,
+	STUDIO_URL,
+	visualMode3DFile,
+} from './constants.mts';
+import {startStudio, stopStudio} from './studio-server.mts';
+
+test.use({storageState: EXPANDED_SIDEBAR_STATE});
+
+test('edits shared controls and preserves relative translations in a single undoable save', async ({
+	page,
+}) => {
+	try {
+		await startStudio();
+		await page.goto(`${STUDIO_URL}/visual-mode-3d`);
+		const first = page.locator(
+			'[data-timeline-marquee-item][title="2D transform"]',
+		);
+		const second = page.locator(
+			'[data-timeline-marquee-item][title="3D transform"]',
+		);
+		await expect(async () => {
+			await first.click();
+			await second.click({modifiers: ['ControlOrMeta']});
+			await expect(
+				page.getByRole('button', {name: 'Offset X', exact: true}),
+			).toHaveText('Mixed', {timeout: 1000});
+		}).toPass({timeout: 30_000});
+		await expect(
+			page.getByText('2 sequences selected', {exact: true}),
+		).toBeVisible();
+		await page.screenshot({
+			path: test.info().outputPath('mixed-inspector.png'),
+		});
+		const sourceBefore = fs.readFileSync(visualMode3DFile, 'utf-8');
+		const x = page.getByRole('button', {name: 'Offset X', exact: true});
+		await x.click();
+		const input = page.getByRole('textbox', {name: 'Offset X', exact: true});
+		await input.fill('99');
+		await input.press('Escape');
+		await expect(x).toHaveText('Mixed');
+		await x.click();
+		await input.fill('120');
+		await input.press('Enter');
+		await expect
+			.poll(() => fs.readFileSync(visualMode3DFile, 'utf-8'))
+			.toContain('120px 0px');
+		await expect
+			.poll(() => fs.readFileSync(visualMode3DFile, 'utf-8'))
+			.toContain('120px 500px');
+		await expect(x).toHaveText('120px');
+		await expect(
+			page.getByRole('button', {name: 'Offset Y', exact: true}),
+		).toHaveText('Mixed');
+
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect
+			.poll(() => fs.readFileSync(visualMode3DFile, 'utf-8'))
+			.toBe(sourceBefore);
+		await expect(x).toHaveText('Mixed');
+		const box = await x.boundingBox();
+		if (!box) {
+			throw new Error('Translation control is not visible');
+		}
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.down();
+		await page.mouse.move(box.x + box.width / 2 + 24, box.y + box.height / 2, {
+			steps: 4,
+		});
+		await page.mouse.up();
+		await expect
+			.poll(() => {
+				const source = fs.readFileSync(visualMode3DFile, 'utf-8');
+				return [
+					...source.matchAll(/translate:\s*['"](-?[\d.]+)px (-?[\d.]+)px['"]/g),
+				].map((match) => [Number(match[1]), Number(match[2])]);
+			})
+			.toEqual([
+				[60, 0],
+				[560, 500],
+				[450, 450],
+			]);
+		await expect(
+			page.getByText('2 sequences selected', {exact: true}),
+		).toBeVisible();
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect
+			.poll(() => fs.readFileSync(visualMode3DFile, 'utf-8'))
+			.toBe(sourceBefore);
+		// AbsoluteFill and Sequence share transform fields, but only Sequence has layout.
+		await expect(
+			page.getByText('Layout', {exact: true}).first(),
+		).toBeAttached();
+		await page
+			.locator('[data-timeline-marquee-item][title="<AbsoluteFill>"]')
+			.first()
+			.click();
+		await first.click({modifiers: ['ControlOrMeta']});
+		await expect(
+			page.getByText('2 sequences selected', {exact: true}),
+		).toBeVisible();
+		await expect(page.getByText('Layout', {exact: true})).toHaveCount(0);
+		await page.getByRole('button', {name: 'Opacity', exact: true}).click();
+		const opacity = page.getByRole('textbox', {name: 'Opacity', exact: true});
+		await opacity.fill('0.5');
+		await opacity.press('Enter');
+		await expect
+			.poll(
+				() =>
+					(
+						fs
+							.readFileSync(visualMode3DFile, 'utf-8')
+							.match(/opacity: 0\.5/g) ?? []
+					).length,
+			)
+			.toBe(2);
+		const opacityButton = page.getByRole('button', {
+			name: 'Opacity',
+			exact: true,
+		});
+		const opacityBox = await opacityButton.boundingBox();
+		if (!opacityBox) {
+			throw new Error('Opacity control is not visible');
+		}
+		await page.mouse.move(
+			opacityBox.x + opacityBox.width / 2,
+			opacityBox.y + opacityBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			opacityBox.x + opacityBox.width / 2 + 14,
+			opacityBox.y + opacityBox.height / 2,
+			{steps: 3},
+		);
+		await page.mouse.up();
+		await expect
+			.poll(
+				() =>
+					(
+						fs
+							.readFileSync(visualMode3DFile, 'utf-8')
+							.match(/opacity: 0\.6[,\s}]/g) ?? []
+					).length,
+			)
+			.toBe(2);
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect(opacityButton).toHaveText('0.50');
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect
+			.poll(() => fs.readFileSync(visualMode3DFile, 'utf-8'))
+			.toBe(sourceBefore);
+	} finally {
+		await stopStudio();
+	}
+});

--- a/packages/studio/src/components/InspectorPanel.tsx
+++ b/packages/studio/src/components/InspectorPanel.tsx
@@ -5,6 +5,7 @@ import {AssetInspector} from './InspectorPanel/AssetInspector';
 import {InspectorMessage} from './InspectorPanel/common';
 import {CompositionInspector} from './InspectorPanel/CompositionInspector';
 import {getSameSequenceInspectorSelection} from './InspectorPanel/inspector-selection';
+import {MultiSequenceInspector} from './InspectorPanel/MultiSequenceInspector';
 import {SelectedInspector} from './InspectorPanel/SelectedInspector';
 import {container} from './InspectorPanel/styles';
 import type {UpdaterFunction} from './RenderModal/SchemaEditor/ZodSwitch';
@@ -51,6 +52,15 @@ export const InspectorPanel: React.FC<{
 						readOnlyStudio={readOnlyStudio}
 					/>
 				</div>
+			);
+		}
+
+		if (selectedItems.every((item) => item.type === 'sequence')) {
+			return (
+				<MultiSequenceInspector
+					selections={selectedItems}
+					readOnlyStudio={readOnlyStudio}
+				/>
 			);
 		}
 

--- a/packages/studio/src/components/InspectorPanel/MultiSequenceField.tsx
+++ b/packages/studio/src/components/InspectorPanel/MultiSequenceField.tsx
@@ -1,0 +1,231 @@
+import React, {useCallback, useContext, useEffect, useState} from 'react';
+import type {SequencePropsSubscriptionKey, TSequence} from 'remotion';
+import {Internals} from 'remotion';
+import {StudioServerConnectionCtx} from '../../helpers/client-id';
+import {BLUE} from '../../helpers/colors';
+import {isStudioInteractivityEnabled} from '../../helpers/interactivity-enabled';
+import {noop} from '../../helpers/noop';
+import type {
+	SchemaFieldInfo,
+	TimelineFieldOnSave,
+} from '../../helpers/timeline-layout';
+import {showNotification} from '../Notifications/NotificationCenter';
+import {saveSequenceProps} from '../Timeline/save-sequence-prop';
+import {TimelineExpandArrowSpacer} from '../Timeline/TimelineExpandArrowButton';
+import {TimelineFieldRowContent} from '../Timeline/TimelineFieldRowContent';
+import {TimelineLayerEyeSpacer} from '../Timeline/TimelineLayerEye';
+import {TimelineRowChrome} from '../Timeline/TimelineRowChrome';
+import {
+	TimelineFieldValue,
+	UnsupportedStatus,
+} from '../Timeline/TimelineSchemaField';
+import {MultiSequenceNumberField} from './MultiSequenceNumberField';
+
+export type MultiSequenceTarget = {
+	readonly nodePath: SequencePropsSubscriptionKey;
+	readonly controls: NonNullable<TSequence['controls']>;
+};
+
+export const MultiSequenceField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly targets: MultiSequenceTarget[];
+	readonly readOnlyStudio: boolean;
+}> = ({field, targets, readOnlyStudio}) => {
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {setPropStatuses, setDragOverrides, clearDragOverrides} = useContext(
+		Internals.VisualModeSettersContext,
+	);
+	const {previewServerState} = useContext(StudioServerConnectionCtx);
+	const [editingMixed, setEditingMixed] = useState(false);
+	const statuses = targets.map(
+		(target) =>
+			Internals.getPropStatusesCtx(propStatuses, target.nodePath)?.[field.key],
+	);
+	const values = statuses.map((status) =>
+		status?.status === 'static'
+			? Internals.getEffectiveVisualModeValue({
+					propStatus: status,
+					dragOverrideValue: undefined,
+					defaultValue: field.fieldSchema.default,
+					shouldResortToDefaultValueIfUndefined: true,
+				})
+			: undefined,
+	);
+	const mixed = values.some(
+		(value) => JSON.stringify(value) !== JSON.stringify(values[0]),
+	);
+	const staticValues = statuses.every((status) => status?.status === 'static');
+	const editable =
+		!readOnlyStudio &&
+		isStudioInteractivityEnabled() &&
+		previewServerState.type === 'connected' &&
+		staticValues;
+	const clear = useCallback(() => {
+		for (const target of targets) {
+			clearDragOverrides(target.nodePath);
+		}
+	}, [clearDragOverrides, targets]);
+	useEffect(() => clear, [clear]);
+	const preview = useCallback(
+		(nextValues: unknown[]) => {
+			if (!editable) {
+				return;
+			}
+
+			for (const [index, target] of targets.entries()) {
+				setDragOverrides(
+					target.nodePath,
+					field.key,
+					Internals.makeStaticDragOverride(nextValues[index]),
+				);
+			}
+		},
+		[editable, field.key, setDragOverrides, targets],
+	);
+	const save = useCallback(
+		async (
+			nextValues: unknown[],
+			options: Parameters<TimelineFieldOnSave>[1],
+		) => {
+			if (!editable || previewServerState.type !== 'connected') {
+				return;
+			}
+
+			try {
+				await saveSequenceProps({
+					changes: targets.map((target, index) => ({
+						fileName: target.nodePath.absolutePath,
+						nodePath: target.nodePath,
+						fieldKey: field.key,
+						value: nextValues[index],
+						defaultValue:
+							field.typeName === 'text-content' ||
+							field.fieldSchema.default === undefined
+								? null
+								: JSON.stringify(field.fieldSchema.default),
+						schema: target.controls.schema,
+						sourceEdit: options?.sourceEdit,
+					})),
+					addedKeyframes: null,
+					movedKeyframes: null,
+					setPropStatuses,
+					clientId: previewServerState.clientId,
+					undoLabel: `Update ${field.description ?? field.key} on selected sequences`,
+					redoLabel: `Update ${field.description ?? field.key} on selected sequences again`,
+				});
+				setEditingMixed(false);
+			} catch (err) {
+				showNotification(
+					`Could not save shared control: ${(err as Error).message}`,
+					3000,
+				);
+			} finally {
+				clear();
+			}
+		},
+		[clear, editable, field, previewServerState, setPropStatuses, targets],
+	);
+	let content: React.ReactNode;
+	if (!editable) {
+		content = (
+			<UnsupportedStatus
+				formattedValue={staticValues}
+				label={
+					!staticValues
+						? statuses.some((status) => !status)
+							? 'Loading…'
+							: statuses.some((status) => status?.status === 'computed')
+								? 'Computed'
+								: 'Keyframed'
+						: mixed
+							? 'Mixed'
+							: String(values[0] ?? '')
+				}
+			/>
+		);
+	} else if (
+		(field.typeName === 'number' &&
+			values.every(
+				(value) => typeof value === 'number' && Number.isFinite(value),
+			)) ||
+		(field.typeName === 'translate' &&
+			values.every(
+				(value) =>
+					typeof value === 'string' &&
+					/^-?\d+(?:\.\d+)?px(?:\s+-?\d+(?:\.\d+)?px){0,2}$/.test(value),
+			))
+	) {
+		content = (
+			<MultiSequenceNumberField
+				field={field}
+				values={values}
+				onPreview={preview}
+				onSave={(next) => save(next, undefined)}
+				onClear={clear}
+			/>
+		);
+	} else if (mixed && !editingMixed) {
+		content = (
+			<button
+				type="button"
+				style={{
+					appearance: 'none',
+					border: 'none',
+					background: 'none',
+					color: BLUE,
+					fontSize: 12,
+					padding: 0,
+				}}
+				title="Set a value for all selected sequences"
+				onClick={() => setEditingMixed(true)}
+			>
+				Mixed
+			</button>
+		);
+	} else {
+		content = (
+			<>
+				{mixed ? <span style={{fontSize: 12}}>Mixed · </span> : null}
+				<TimelineFieldValue
+					field={field}
+					effectiveValue={values[0]}
+					propStatus={{
+						status: 'static',
+						keyframeDisplayOffsetAdjustment: null,
+						codeValue: mixed ? undefined : values[0],
+					}}
+					scaleLockNodePath={
+						field.typeName === 'text-content' ? null : targets[0].nodePath
+					}
+					onSave={(value, options) =>
+						save(
+							targets.map(() => value),
+							options,
+						)
+					}
+					onDragValueChange={(value) => preview(targets.map(() => value))}
+					onDragEnd={clear}
+				/>
+			</>
+		);
+	}
+
+	return (
+		<TimelineRowChrome
+			depth={0}
+			eye={<TimelineLayerEyeSpacer />}
+			arrow={<TimelineExpandArrowSpacer />}
+			style={{minHeight: field.rowHeight}}
+			selected={false}
+			selectable={false}
+			onSelect={noop}
+			showSelectedBackground={false}
+			containsSelection={false}
+			outerHeight={null}
+		>
+			<TimelineFieldRowContent field={field} rowDepth={0} selected={false}>
+				{content}
+			</TimelineFieldRowContent>
+		</TimelineRowChrome>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/MultiSequenceInspector.tsx
+++ b/packages/studio/src/components/InspectorPanel/MultiSequenceInspector.tsx
@@ -1,0 +1,177 @@
+import {stringifySequenceExpandedRowKey} from '@remotion/studio-shared';
+import React, {useContext, useMemo, useSyncExternalStore} from 'react';
+import {Internals} from 'remotion';
+import {calculateTimeline} from '../../helpers/calculate-timeline';
+import {LIGHT_TEXT} from '../../helpers/colors';
+import {
+	getFieldsToShow,
+	SCHEMA_FIELD_GROUPS,
+} from '../../helpers/timeline-layout';
+import {InspectorInfoHeader} from '../InspectorInfoHeader';
+import {INSPECTOR_PANEL_HORIZONTAL_PADDING} from '../InspectorPanelLayout';
+import {COMPACT_CONTROL_ROW_HEIGHT} from '../layout';
+import {VERTICAL_SCROLLBAR_CLASSNAME} from '../Menu/is-menu-item';
+import {
+	TimelineRowLayoutContext,
+	INSPECTOR_TIMELINE_ROW_LAYOUT,
+} from '../Timeline/TimelineRowLayoutContext';
+import type {TimelineSelection} from '../Timeline/TimelineSelection';
+import {InspectorMessage, InspectorSection} from './common';
+import {
+	MultiSequenceField,
+	type MultiSequenceTarget,
+} from './MultiSequenceField';
+import {scrollableContainer, sequenceHeaderDivider} from './styles';
+
+const selectionCountStyle: React.CSSProperties = {
+	color: LIGHT_TEXT,
+	fontFamily: 'sans-serif',
+	fontSize: 13,
+	height: COMPACT_CONTROL_ROW_HEIGHT,
+	lineHeight: `${COMPACT_CONTROL_ROW_HEIGHT}px`,
+	overflow: 'hidden',
+	padding: `0 ${INSPECTOR_PANEL_HORIZONTAL_PADDING}px`,
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+};
+
+export const MultiSequenceInspector: React.FC<{
+	readonly selections: readonly Extract<
+		TimelineSelection,
+		{type: 'sequence'}
+	>[];
+	readonly readOnlyStudio: boolean;
+}> = ({selections, readOnlyStudio}) => {
+	const {sequences} = useContext(Internals.SequenceManager);
+	const {overrideIdToNodePathMappings} = useContext(
+		Internals.OverrideIdsToNodePathsGettersContext,
+	);
+	const {propStatuses} = useContext(Internals.VisualModePropStatusesContext);
+	const {getDragOverrides} = useContext(
+		Internals.VisualModeDragOverridesContext,
+	);
+	const targets = useMemo(() => {
+		const tracks = calculateTimeline({
+			sequences,
+			overrideIdsToNodePaths: overrideIdToNodePathMappings,
+		});
+		const result: MultiSequenceTarget[] = [];
+		const seen = new Set<string>();
+		for (const selection of selections) {
+			const key = stringifySequenceExpandedRowKey(
+				selection.nodePathInfo.sequenceSubscriptionKey,
+			);
+			const track = tracks.find(
+				(candidate) =>
+					candidate.nodePathInfo !== null &&
+					stringifySequenceExpandedRowKey(
+						candidate.nodePathInfo.sequenceSubscriptionKey,
+					) === key &&
+					candidate.nodePathInfo.index === selection.nodePathInfo.index,
+			);
+			if (!track?.sequence.controls || !track.nodePathInfo) {
+				return null;
+			}
+
+			// Multiple rendered instances can share the same editable source.
+			if (seen.has(key)) {
+				continue;
+			}
+
+			seen.add(key);
+			result.push({
+				nodePath: track.nodePathInfo.sequenceSubscriptionKey,
+				controls: track.sequence.controls,
+			});
+		}
+
+		return result;
+	}, [overrideIdToNodePathMappings, selections, sequences]);
+	const store = useMemo(() => {
+		const stores = (targets ?? []).map(
+			(target) => target.controls.runtimeValues,
+		);
+		let snapshots = stores.map((value) => value.getSnapshot());
+		return {
+			subscribe: (listener: () => void) => {
+				const unsubscribes = stores.map((value) => value.subscribe(listener));
+				return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+			},
+			getSnapshot: () => {
+				const next = stores.map((value) => value.getSnapshot());
+				if (next.some((value, index) => value !== snapshots[index])) {
+					snapshots = next;
+				}
+
+				return snapshots;
+			},
+		};
+	}, [targets]);
+	const runtimeValues = useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getSnapshot,
+	);
+	const fields = useMemo(() => {
+		const allFields = (targets ?? []).map(
+			(target, index) =>
+				getFieldsToShow({
+					schema: target.controls.schema,
+					currentRuntimeValueDotNotation: runtimeValues[index],
+					getDragOverrides,
+					propStatuses,
+					nodePath: target.nodePath,
+					includeTextContent: true,
+				}) ?? [],
+		);
+		return (allFields[0] ?? []).filter((field) =>
+			allFields.every((candidate) =>
+				candidate.some(
+					(other) =>
+						other.key === field.key && other.fieldSchema === field.fieldSchema,
+				),
+			),
+		);
+	}, [getDragOverrides, propStatuses, runtimeValues, targets]);
+
+	return (
+		<div style={scrollableContainer} className={VERTICAL_SCROLLBAR_CLASSNAME}>
+			<InspectorInfoHeader padding="4px 0">
+				<div style={selectionCountStyle}>
+					{selections.length} sequences selected
+				</div>
+			</InspectorInfoHeader>
+			<div role="separator" style={sequenceHeaderDivider} />
+			{targets === null ? (
+				<InspectorMessage>Sequence controls unavailable</InspectorMessage>
+			) : fields.length === 0 ? (
+				<InspectorMessage>No shared controls</InspectorMessage>
+			) : (
+				<TimelineRowLayoutContext.Provider
+					value={INSPECTOR_TIMELINE_ROW_LAYOUT}
+				>
+					{SCHEMA_FIELD_GROUPS.map((group) => {
+						const groupedFields = fields.filter(
+							(field) => field.group === group.id,
+						);
+						return groupedFields.length === 0 ? null : (
+							<InspectorSection key={group.id} header={group.label}>
+								{groupedFields.map((field) => (
+									<MultiSequenceField
+										key={
+											JSON.stringify(targets.map((target) => target.nodePath)) +
+											field.key
+										}
+										field={field}
+										targets={targets}
+										readOnlyStudio={readOnlyStudio}
+									/>
+								))}
+							</InspectorSection>
+						);
+					})}
+				</TimelineRowLayoutContext.Provider>
+			)}
+		</div>
+	);
+};

--- a/packages/studio/src/components/InspectorPanel/MultiSequenceNumberField.tsx
+++ b/packages/studio/src/components/InspectorPanel/MultiSequenceNumberField.tsx
@@ -1,0 +1,165 @@
+import React, {useRef, useState} from 'react';
+import {noop} from '../../helpers/noop';
+import type {SchemaFieldInfo} from '../../helpers/timeline-layout';
+import {InputDragger} from '../NewComposition/InputDragger';
+import {formatTimelineFieldValueForDisplay} from '../Timeline/timeline-field-display-utils';
+import {
+	getDecimalPlaces,
+	getTimelineDisplayDecimalPlaces,
+	roundToDecimalPlaces,
+} from '../Timeline/timeline-field-utils';
+import {
+	parseTranslate,
+	serializeTranslate,
+} from '../Timeline/timeline-translate-utils';
+
+const NumericAxis: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly values: unknown[];
+	readonly axis: 0 | 1 | 2 | null;
+	readonly onPreview: (values: unknown[]) => void;
+	readonly onSave: (values: unknown[]) => Promise<void>;
+	readonly onClear: () => void;
+}> = ({field, values, axis, onPreview, onSave, onClear}) => {
+	const [dragValue, setDragValue] = useState<number | null>(null);
+	const initialValues = useRef<unknown[] | null>(null);
+	const coordinates = values.map((value) =>
+		axis === null ? Number(value) : (parseTranslate(String(value))[axis] ?? 0),
+	);
+	const mixed = coordinates.some((value) => value !== coordinates[0]);
+	const schema = field.fieldSchema;
+	const step = 'step' in schema ? (schema.step ?? 1) : 1;
+	const decimalPlaces = getTimelineDisplayDecimalPlaces({
+		defaultDecimalPlaces: 1,
+		step,
+	});
+	const min = schema.type === 'number' ? (schema.min ?? -Infinity) : -Infinity;
+	const max = schema.type === 'number' ? (schema.max ?? Infinity) : Infinity;
+	const nextValues = (value: number, source: 'input' | 'drag') => {
+		const baseline = initialValues.current ?? values;
+		const first =
+			axis === null
+				? Number(baseline[0])
+				: (parseTranslate(String(baseline[0]))[axis] ?? 0);
+		return baseline.map((original) => {
+			const coordinatesForValue =
+				axis === null ? null : parseTranslate(String(original));
+			const current =
+				coordinatesForValue === null || axis === null
+					? Number(original)
+					: (coordinatesForValue[axis] ?? 0);
+			const next = Math.min(
+				max,
+				Math.max(
+					min,
+					source === 'drag'
+						? roundToDecimalPlaces(
+								current + value - first,
+								Math.max(
+									getDecimalPlaces(current),
+									getDecimalPlaces(value),
+									getDecimalPlaces(first),
+								),
+							)
+						: value,
+				),
+			);
+			if (coordinatesForValue === null || axis === null) {
+				return next;
+			}
+
+			const [x, y, z] = coordinatesForValue;
+			return serializeTranslate(
+				[axis === 0 ? next : x, axis === 1 ? next : y, axis === 2 ? next : z],
+				decimalPlaces,
+			);
+		});
+	};
+
+	const clear = () => {
+		initialValues.current = null;
+		setDragValue(null);
+		onClear();
+	};
+
+	return (
+		<span
+			onKeyDownCapture={(event) => {
+				if (event.key === 'Escape') {
+					clear();
+				}
+			}}
+			onPointerCancelCapture={clear}
+			onBlurCapture={(event) => {
+				if (
+					event.target instanceof HTMLInputElement &&
+					event.target.value.trim() === ''
+				) {
+					clear();
+				}
+			}}
+		>
+			<InputDragger
+				type="number"
+				value={dragValue ?? coordinates[0]}
+				aria-label={
+					axis === null
+						? (field.description ?? field.key)
+						: `Offset ${['X', 'Y', 'Z'][axis]}`
+				}
+				title="Type to set all values; drag to adjust each value"
+				status="ok"
+				small
+				rightAlign={false}
+				min={min}
+				max={max}
+				step={step}
+				snapToStep={axis === null}
+				dragDecimalPlaces={decimalPlaces}
+				dragSensitivity={axis === null ? 1 : 3}
+				buttonStyle={{paddingLeft: 0}}
+				style={{width: 70}}
+				formatter={(value) =>
+					mixed && dragValue === null
+						? 'Mixed'
+						: formatTimelineFieldValueForDisplay({fieldSchema: schema, value})
+				}
+				onTextChange={noop}
+				onValueChange={(value, source) => {
+					initialValues.current ??= values;
+					setDragValue(value);
+					onPreview(nextValues(value, source));
+				}}
+				onValueChangeEnd={(value, source) => {
+					if (initialValues.current === null) {
+						return;
+					}
+
+					onSave(nextValues(value, source)).finally(clear);
+				}}
+			/>
+		</span>
+	);
+};
+
+export const MultiSequenceNumberField: React.FC<{
+	readonly field: SchemaFieldInfo;
+	readonly values: unknown[];
+	readonly onPreview: (values: unknown[]) => void;
+	readonly onSave: (values: unknown[]) => Promise<void>;
+	readonly onClear: () => void;
+}> = (props) => {
+	const axes: (0 | 1 | 2 | null)[] =
+		props.field.typeName === 'translate'
+			? props.values.some((value) => parseTranslate(String(value))[2] !== null)
+				? [0, 1, 2]
+				: [0, 1]
+			: [null];
+	return (
+		<span style={{display: 'flex', gap: 4}}>
+			{axes.map((axis) => (
+				<NumericAxis key={axis ?? 'value'} {...props} axis={axis} />
+			))}
+		</span>
+	);
+};

--- a/packages/studio/src/components/NewComposition/InputDragger.tsx
+++ b/packages/studio/src/components/NewComposition/InputDragger.tsx
@@ -18,8 +18,11 @@ import type {RemInputStatus} from './RemInput';
 import {RemotionInput, inputBaseStyle} from './RemInput';
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
-	readonly onValueChange: (newVal: number) => void;
-	readonly onValueChangeEnd?: (newVal: number) => void;
+	readonly onValueChange: (newVal: number, source: 'input' | 'drag') => void;
+	readonly onValueChangeEnd?: (
+		newVal: number,
+		source: 'input' | 'drag',
+	) => void;
 	readonly onTextChange: (newVal: string) => void;
 	readonly status: RemInputStatus;
 	readonly formatter?: (str: number | string) => string;
@@ -589,7 +592,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 					value: parsed,
 				})
 			) {
-				onValueChange(parsed);
+				onValueChange(parsed, 'input');
 			}
 		},
 		[_max, _min, onValueChange],
@@ -615,7 +618,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 
 		if (validation.valid) {
 			fallbackRef.current.setCustomValidity('');
-			onValueChangeEnd?.(validation.value);
+			onValueChangeEnd?.(validation.value, 'input');
 
 			setInputFallback(false);
 		} else {
@@ -659,7 +662,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 
 				e.currentTarget.value = String(nextValue);
 				e.currentTarget.setCustomValidity('');
-				onValueChange(nextValue);
+				onValueChange(nextValue, 'input');
 			},
 			[_max, _min, deriveStep, onValueChange, value],
 		);
@@ -713,7 +716,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 						? newValue
 						: roundToDecimalPlaces(newValue, dragDecimalPlaces);
 				lastDragValue = nextValue;
-				onValueChange(nextValue);
+				onValueChange(nextValue, 'drag');
 			};
 
 			startCapturedPointerSession({
@@ -727,7 +730,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 					const commit =
 						reason === 'pointerup' || reason === 'buttons-released';
 					if (commit && lastDragValue !== null && onValueChangeEnd) {
-						onValueChangeEnd(lastDragValue);
+						onValueChangeEnd(lastDragValue, 'drag');
 					}
 
 					setTimeout(() => {
@@ -792,6 +795,7 @@ const InputDraggerForwardRefFn: React.ForwardRefRenderFunction<
 			ref={ref}
 			type="button"
 			aria-label={props['aria-label']}
+			title={props.title}
 			className={'__remotion_input_dragger'}
 			style={
 				buttonStyle

--- a/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
+++ b/packages/studio/src/components/Timeline/TimelineSchemaField.tsx
@@ -40,8 +40,10 @@ const unsupportedStatusWrapper: React.CSSProperties = {
 
 const unsupportedLabel: React.CSSProperties = {
 	color: WHITE_ALPHA_40,
+	fontFamily: 'Arial, Helvetica, sans-serif',
 	fontSize: 12,
 	fontStyle: 'italic',
+	lineHeight: '18px',
 };
 
 const computedValue: React.CSSProperties = {


### PR DESCRIPTION
Selecting multiple sequences now keeps the Inspector controls shared by their schemas, with differing values displayed as “Mixed”. The selection count uses the usual info-header layout and divider, and both the count and Computed label have explicit styling that survives the Studio CSS reset.

Typing a numeric value applies it to every selected sequence; dragging adjusts each original value by the same delta. Translation axes preserve the other coordinates. Each batch edit is one undoable change. Other mixed controls can be opened to replace the shared property, while computed and keyframed properties remain read-only. Shared fields require matching keys and schema object references.

Validation:
- `bun run build`
- `bun run stylecheck`
- Studio lint and tests
- Playwright coverage for schema intersection, mixed values, absolute edits, relative dragging, cancellation, and undo; existing input-dragger coverage also passes
- Browser verification of header layout and label colors through idle, hover, and click states
