### PR TITLE
Elements: Add local installation playground in docs Studio

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -5,6 +5,7 @@
 /build
 
 # Generated files
+/src/remotion/element-playground/*.element.tsx
 .docusaurus
 .cache-loader
 .element-previews

--- a/packages/docs/remotion.config.ts
+++ b/packages/docs/remotion.config.ts
@@ -2,3 +2,25 @@ import path from 'path';
 import {Config} from '@remotion/cli/config';
 
 Config.setPublicDir(path.join(process.cwd(), 'static'));
+
+// Run: cd packages/docs && bun run remotion (default Webpack, no Docusaurus).
+// Open http://127.0.0.1:<port>/elements-install-playground, then choose an Element and confirm.
+// Public protocol discovery probes localhost:3000–3009; using 127.0.0.1 ensures
+// the browser sends the cross-origin Origin header required by discovery.
+// Docs already has dependencies, so this does not verify dependency installation
+// into a fresh project. Installation edits the composition and copies source beside it.
+Config.overrideWebpackConfig((config) => ({
+	...config,
+	module: {
+		...config.module,
+		rules: [
+			...(config.module?.rules ?? []),
+			{
+				test: /element-sources\.ts$/,
+				use: path.resolve(
+					'src/remotion/element-playground/element-sources-loader.mjs',
+				),
+			},
+		],
+	},
+}));

--- a/packages/docs/src/remotion/Root.tsx
+++ b/packages/docs/src/remotion/Root.tsx
@@ -116,6 +116,7 @@ import {
 import {articles} from '../data/articles';
 import {AllTemplates} from './AllTemplates';
 import {Article} from './Article';
+import {ElementPlayground} from './element-playground/ElementPlayground';
 import {Expert} from './Expert';
 import {TemplateComp} from './Template';
 
@@ -135,6 +136,14 @@ export const RemotionRoot: React.FC = () => {
 	return (
 		<>
 			<Folder name="elements">
+				<Composition
+					id="elements-install-playground"
+					component={ElementPlayground}
+					durationInFrames={300}
+					fps={30}
+					width={1920}
+					height={1080}
+				/>
 				{elementDefinitions.map((definition) => {
 					const dimensions = getElementPreviewDimensions(definition);
 

--- a/packages/docs/src/remotion/element-playground/ElementPlayground.tsx
+++ b/packages/docs/src/remotion/element-playground/ElementPlayground.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import {PlaygroundControls} from './PlaygroundControls';
+
+export const ElementPlayground: React.FC = () => {
+	return <PlaygroundControls />;
+};

--- a/packages/docs/src/remotion/element-playground/PlaygroundControls.tsx
+++ b/packages/docs/src/remotion/element-playground/PlaygroundControls.tsx
@@ -1,0 +1,87 @@
+import {installInStudio} from '@remotion/studio-protocol';
+import React, {useState} from 'react';
+import {createPortal} from 'react-dom';
+import {getRemotionEnvironment} from 'remotion';
+import {elementDefinitions} from '../../components/Elements/element-definitions';
+import {createElementPayloadFromDefinition} from '../../components/Elements/element-drag-data';
+import sources from './element-sources';
+
+export const PlaygroundControls: React.FC = () => {
+	const [installing, setInstalling] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	if (!getRemotionEnvironment().isStudio) return null;
+
+	return createPortal(
+		<section
+			aria-label="Add element"
+			style={{
+				position: 'fixed',
+				bottom: 40,
+				right: 16,
+				zIndex: 10,
+				background: '#202020',
+				color: 'white',
+				padding: 12,
+				font: '13px system-ui',
+			}}
+		>
+			<div style={{marginBottom: 8}}>Add element</div>
+			<form
+				style={{display: 'flex', gap: 8, height: 32}}
+				onSubmit={async (event) => {
+					event.preventDefault();
+					const input = event.currentTarget.elements.namedItem(
+						'element',
+					) as HTMLSelectElement;
+					const definition = elementDefinitions.find(
+						({slug}) => slug === input.value,
+					);
+					const sourceCode = sources[input.value];
+					if (!definition || typeof sourceCode !== 'string') {
+						input.setCustomValidity('Choose a local Element from the list.');
+						input.reportValidity();
+						return;
+					}
+
+					setInstalling(true);
+					setError(null);
+					try {
+						const result = await installInStudio({
+							payload: createElementPayloadFromDefinition({
+								definition,
+								sourceCode,
+							}),
+						});
+						if (!result.success) setError(result.message);
+					} catch (err) {
+						setError(String(err));
+					} finally {
+						setInstalling(false);
+					}
+				}}
+			>
+				<select
+					name="element"
+					aria-label="Local element"
+					defaultValue=""
+					required
+					onChange={(event) => event.currentTarget.setCustomValidity('')}
+				>
+					<option value="" disabled>
+						Choose an element
+					</option>
+					{elementDefinitions.map(({slug, displayName}) => (
+						<option key={slug} value={slug}>
+							{displayName}
+						</option>
+					))}
+				</select>
+				<button type="submit" disabled={installing} style={{cursor: 'default'}}>
+					Install element
+				</button>
+			</form>
+			{error ? <p role="alert">{error}</p> : null}
+		</section>,
+		document.body,
+	);
+};

--- a/packages/docs/src/remotion/element-playground/element-sources-loader.mjs
+++ b/packages/docs/src/remotion/element-playground/element-sources-loader.mjs
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import {getRemotionElementSourceMap} from '../../../plugins/element-source-utils.js';
+
+export default function elementSourcesLoader() {
+	const elementsRoot = path.resolve(
+		path.dirname(this.resourcePath),
+		'../../../elements',
+	);
+	this.addContextDependency(elementsRoot);
+	return `export default ${JSON.stringify(getRemotionElementSourceMap({elementsRoot}))};`;
+}

--- a/packages/docs/src/remotion/element-playground/element-sources.ts
+++ b/packages/docs/src/remotion/element-playground/element-sources.ts
@@ -1,0 +1,4 @@
+// Replaced by element-sources-loader.mjs in docs Studio. The loader watches
+// local Element files and reuses the same source lookup as the docs site.
+const sources: Record<string, string> = {};
+export default sources;


### PR DESCRIPTION
## Summary

Add an `elements-install-playground` composition under the docs Studio's `elements` folder, with an always-visible native Element selector outside the canvas.

- Load current local Element source through the existing docs source lookup and Webpack watching.
- Use public `installInStudio()` for the real confirmation, source copying, import insertion, and hot reload flow.
- Edit an ordinary composition file and copy Elements beside it. Ignore playground `*.element.tsx` files to avoid committing accidental installations; composition edits remain Git-visible.
- Keep the implementation entirely in docs: no Studio package changes, extra server, reset mechanism, or added dependencies.

## Try it

```sh
cd packages/docs
bun run remotion
```

Use a port from **3000–3009**, open `http://127.0.0.1:<port>/elements-install-playground`, select a local Element, and click **Install element**. Confirm **Current composition** to insert into the playground. Docusaurus is not needed.

## Verification

- Oxfmt on changed source/config files
- `bun run build` — passed (80 tasks)
- `bun run stylecheck` — passed (265 tasks and skill validation)
- Manually verified source copying, composition imports/insertion, and hot reload during development; verified the final public protocol route opens Studio confirmation with the ordinary playground destination.
- No automated tests added, as requested.

## Limitations

- Public protocol discovery currently probes `localhost:3000–3009`. Open Studio through `127.0.0.1` so discovery is cross-origin and sends the required Origin header; same-origin `localhost` discovery is rejected.
- Docs already has Element dependencies installed, so this does not fully exercise dependency installation into a fresh project.
- The source loader uses the default Webpack bundler, not Rspack.
- Review composition edits before committing: an installed component can reference ignored copied source files.
