### PR TITLE
`@remotion/studio-server`: Fix same-origin Studio Protocol requests

### DIFF
--- a/packages/docs/remotion.config.ts
+++ b/packages/docs/remotion.config.ts
@@ -4,9 +4,8 @@ import {Config} from '@remotion/cli/config';
 Config.setPublicDir(path.join(process.cwd(), 'static'));
 
 // Run: cd packages/docs && bun run remotion (default Webpack, no Docusaurus).
-// Open http://127.0.0.1:<port>/elements-install-playground, then choose an Element and confirm.
-// Public protocol discovery probes localhost:3000–3009; using 127.0.0.1 ensures
-// the browser sends the cross-origin Origin header required by discovery.
+// Open http://localhost:<port>/elements-install-playground, then choose an Element and confirm.
+// Public protocol discovery probes localhost:3000–3009.
 // Docs already has dependencies, so this does not verify dependency installation
 // into a fresh project. Installation edits the composition and copies source beside it.
 Config.overrideWebpackConfig((config) => ({

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-discovery.ts
@@ -87,7 +87,7 @@ export const handleStudioProtocolDiscovery = ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const requestOrigin = getAllowedStudioProtocolOrigin(request);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-element-library.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-element-library.ts
@@ -27,7 +27,7 @@ export const handleStudioProtocolElementLibrary = async ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const requestOrigin = getAllowedStudioProtocolOrigin(request);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -79,7 +79,7 @@ export const handleStudioProtocolInstall = async ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const requestOrigin = getAllowedStudioProtocolOrigin(request);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-license-key.ts
@@ -27,7 +27,7 @@ export const handleStudioProtocolLicenseKey = async ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const requestOrigin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const requestOrigin = getAllowedStudioProtocolOrigin(request);
 	if (requestOrigin === null) {
 		writeStudioProtocolError({
 			code: 'unsupported-origin',

--- a/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/origin-policy.ts
@@ -5,13 +5,20 @@ const isLoopbackHttp = (url: URL) =>
 	(url.hostname === 'localhost' || url.hostname === '127.0.0.1');
 
 export const getAllowedStudioProtocolOrigin = (
-	origin: string | undefined,
+	request: IncomingMessage,
 ): string | null => {
-	if (!origin) {
-		return null;
-	}
-
 	try {
+		const {origin, referer, host} = request.headers;
+		if (origin === undefined) {
+			// Browsers omit Origin on same-origin GET requests. Only trust a
+			// Referer matching this local HTTP Studio, never an arbitrary site.
+			const refererUrl = new URL(referer ?? '');
+			return isLoopbackHttp(refererUrl) &&
+				refererUrl.origin === `http://${host}`
+				? refererUrl.origin
+				: null;
+		}
+
 		const url = new URL(origin);
 		if (url.protocol !== 'https:' && !isLoopbackHttp(url)) {
 			return null;
@@ -30,7 +37,7 @@ export const setStudioProtocolCorsHeaders = ({
 	readonly request: IncomingMessage;
 	readonly response: ServerResponse;
 }): void => {
-	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const origin = getAllowedStudioProtocolOrigin(request);
 	if (origin === null) {
 		return;
 	}
@@ -54,7 +61,7 @@ export const handleStudioProtocolOptions = ({
 	readonly response: ServerResponse;
 }): Promise<void> => {
 	setStudioProtocolCorsHeaders({request, response});
-	const origin = getAllowedStudioProtocolOrigin(request.headers.origin);
+	const origin = getAllowedStudioProtocolOrigin(request);
 	response.writeHead(origin === null ? 403 : 204);
 	response.end();
 	return Promise.resolve();


### PR DESCRIPTION
## Summary

Stacked on #11192. Fixes local Studio Protocol discovery rejecting same-origin browser requests because GET requests omit the `Origin` header.

- When `Origin` is absent, accept only a valid loopback HTTP `Referer` whose origin exactly matches the request host.
- Explicit invalid origins still fail; missing, malformed, cross-origin, and different-port referrers remain rejected.
- Reuse the shared validation across discovery, installation, Element libraries, license keys, and CORS handling. No public API or wire-protocol changes.
- Remove the playground's `127.0.0.1` workaround instructions.

## Verification

- `bun run build` and `bun run stylecheck` passed.
- Studio Server build, lint, formatting, and existing Studio Protocol route tests passed.
- Temporary HTTP integration check: same-origin discovery followed by installation delivery; rejected-origin cases also verified. Red/green verified; no new test files retained.
- Browser: confirmed the installation dialog opens in the correct playground at `http://localhost:3004/elements-install-playground`.

Existing Studio processes must restart to load the server fix. Automatic most-recently-focused Studio selection is unchanged.
