### PR TITLE
Docs: Rewrite Mediabunny overview

### DIFF
--- a/packages/docs/docs/mediabunny/index.mdx
+++ b/packages/docs/docs/mediabunny/index.mdx
@@ -5,7 +5,7 @@ crumb: 'Mediabunny'
 sidebar_label: Overview
 ---
 
-[Mediabunny](https://mediabunny.dev) is a multimedia library by [Vanilagy](https://github.com/Vanilagy).  
+[Mediabunny](https://mediabunny.dev) is an awesome multimedia library by [Vanilagy](https://github.com/Vanilagy).  
 It allows for general purpose media tasks like extracting metadata and format conversions such as trimming and cropping in the browser.
 
 ## Remotion and Mediabunny

--- a/packages/docs/docs/mediabunny/index.mdx
+++ b/packages/docs/docs/mediabunny/index.mdx
@@ -1,64 +1,58 @@
 ---
 image: /generated/articles-docs-mediabunny-index.png
-title: Remotion and Mediabunny
-crumb: 'Migration'
-sidebar_label: Remotion and Mediabunny
+title: Mediabunny
+crumb: 'Mediabunny'
+sidebar_label: Overview
 ---
 
-[On September 1st 2025, we announced](/blog/mediabunny) that we are combining our efforts and are helping Mediabunny become the definitive multimedia library for the web!
+[Mediabunny](https://mediabunny.dev) is a multimedia library by [Vanilagy](https://github.com/Vanilagy).  
+It allows for general purpose media tasks like extracting metadata and format conversions such as trimming and cropping in the browser.
 
-As a result, we will be slowing phasing out [`@remotion/media-parser`](/docs/media-parser) and [`@remotion/webcodecs`](/docs/webcodecs) and deprecate it when Mediabunny has reached the same capabilities.
+## Remotion and Mediabunny
 
-## Should I use Mediabunny or Media Parser?
+Mediabunny is internally used in packages such as [`@remotion/media`](/docs/media) and [`@remotion/media-utils`](/docs/media-utils) as well as in [Remotion Studio](/docs/studio) and [remotion.dev/convert](https://www.remotion.dev/convert).
 
-As of February 2026, we recommend that you now [migrate to Mediabunny](https://mediabunny.dev/guide/quick-start).  
-Media Parser is now deprecated.
+Mediabunny is a completely independent project.  
+Remotion is a Gold Sponsor of Mediabunny ($1000/month).
 
-See the snippets in this documentation section to help you migrate.
+## Installation
 
-## Differences in features
+Install Mediabunny with the version that matches your Remotion installation:
 
-Some features are available in Media Parser but not (yet) in Mediabunny, and vice versa.  
-Here are some notable ones:
+<Installation pkg="mediabunny" />
 
-**Features exclusive to Media Parser**:
+To upgrade Remotion and Mediabunny together, run [`npx remotion upgrade`](/docs/cli/upgrade):
 
-- `.avi` container support
-- Foreign file probing
+```bash
+npx remotion upgrade
+```
 
-**Features exclusive to Mediabunny**:
+See [Mediabunny version used by Remotion](/docs/mediabunny/version) for more details.
 
-- `.ogg`, `.adts` container support
-- Compression
-- Media Player
-- Video creation
-- Live recording and streaming
-- Tree shaking
+## `@remotion/media-parser`
 
-Mediabunny is generally faster.  
-Media Parser has higher-level APIs ("`extractFrames()`") while Mediabunny's API is lower-level.  
-Mediabunny has a more permissive license (see below).
+Before Mediabunny, Remotion had its own multimedia libraries [`@remotion/media-parser`](/docs/media-parser) and [`@remotion/webcodecs`](/docs/webcodecs).
 
-If one of these characteristics is important for you, let this influence your choice.
-
-## How are Remotion and Mediabunny related?
-
-Mediabunny is an independent project by [Vanilagy](https://github.com/vanilagy).  
-Remotion is a Gold Sponsor of Mediabunny.
+Those packages are now deprecated. Use [Mediabunny](https://mediabunny.dev) instead.
 
 ## Reporting bugs
 
-If you can pin down an issue to the Mediabunny library directly, then report an issue under [Mediabunny's repo](https://github.com/vanilagy/mediabunny/issues).  
+If you can pin down an issue to the Mediabunny library directly, then report an issue under [Mediabunny's repo](https://github.com/Vanilagy/mediabunny/issues).  
 If an issue also concerns Remotion usage described in our docs, you can file it within the [Remotion repo](https://github.com/remotion-dev/remotion/issues).
 
 ## License
 
-Remotion (the framework), `@remotion/media-parser` and `@remotion/webcodecs` continue to use the [Remotion License](/docs/license).
+Remotion continues to use the [Remotion License](/docs/license).  
 If you are using Remotion and are not eligible for the Free License, you continue to require a Company License.
 
 [Mediabunny](https://mediabunny.dev) has a more permissive MPL 2.0 license.  
-If you are a company and you are only interested in the multimedia library, you don't need a Company License to use Mediabunny - it is truly open source!
+If you are only using Mediabunny and not Remotion, you don't need a Company License.
 
-## What happens with remotion.dev/convert?
+## See also
 
-As of October 20th 2025, [remotion.dev/convert](https://remotion.dev/convert) is now updated to use Mediabunny!
+- [`<Video>` and `<Audio>` tags](/docs/mediabunny/new-video)
+- [Getting metadata](/docs/mediabunny/metadata)
+- [Extracting frames](/docs/mediabunny/extract-frames)
+- [Supported formats](/docs/mediabunny/formats)
+- [Mediabunny version](/docs/mediabunny/version)
+- [Mediabunny documentation](https://mediabunny.dev)

--- a/packages/docs/src/data/articles.ts
+++ b/packages/docs/src/data/articles.ts
@@ -4690,10 +4690,10 @@ export const articles = [
 	},
 	{
 		id: 'mediabunny/index',
-		title: 'Remotion and Mediabunny',
+		title: 'Mediabunny',
 		relativePath: 'docs/mediabunny/index.mdx',
 		compId: 'articles-docs-mediabunny-index',
-		crumb: 'Migration',
+		crumb: 'Mediabunny',
 		noAi: false,
 		slug: 'mediabunny/index',
 	},

--- a/packages/docs/vercel.ts
+++ b/packages/docs/vercel.ts
@@ -131,6 +131,7 @@ export const config: VercelConfig = {
 		routes.redirect('/gif', '/docs/gif', {permanent: false}),
 		routes.redirect('/gsap', '/docs/gsap', {permanent: false}),
 		routes.redirect('/lottie', '/docs/lottie', {permanent: false}),
+		routes.redirect('/mediabunny', '/docs/mediabunny', {permanent: false}),
 		routes.redirect('/paths', '/docs/paths', {permanent: false}),
 		routes.redirect('/shapes', '/docs/shapes', {permanent: false}),
 		routes.redirect('/api', '/docs/api', {permanent: false}),

--- a/packages/studio-shared/src/package-info.ts
+++ b/packages/studio-shared/src/package-info.ts
@@ -140,7 +140,7 @@ export const extraPackages: ExtraPackage[] = [
 		name: 'mediabunny',
 		version: '1.55.5',
 		description: 'Multimedia library used by Remotion',
-		docsUrl: 'https://www.remotion.dev/docs/mediabunny/version',
+		docsUrl: 'https://www.remotion.dev/docs/mediabunny',
 		versionDocsUrl: 'https://www.remotion.dev/docs/mediabunny/version',
 	},
 	{


### PR DESCRIPTION
## Summary

- Rewrite the Mediabunny docs overview around current Remotion usage, `npx remotion add mediabunny`, and `npx remotion upgrade`
- Add a `remotion.dev/mediabunny` redirect to `/docs/mediabunny`

Closes #9128

## Test plan

- [ ] Open `/docs/mediabunny` and confirm the install and upgrade commands
- [ ] Confirm `remotion.dev/mediabunny` redirects to `/docs/mediabunny`

## Preview

- https://remotion-git-docs-rewrite-mediabunny-remotion.vercel.app/docs/mediabunny
