### PR TITLE
`@remotion/studio`: Show keyboard shortcuts in toolbar button tooltips

### DIFF
--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -54,8 +54,6 @@ You can also press <kbd>?</kbd> to open this tab.
 | `deleteSelection`               | `Backspace` or `Delete`                    | Delete or reset the selection                                  |
 | `askAI`                         | `Cmd/Ctrl+I`                               | Open Ask AI when it is enabled                                 |
 
-## Mute and loop<AvailableFrom v="4.0.523" />
-
 Press <kbd>M</kbd> to mute or unmute preview audio, and <kbd>Shift</kbd> + <kbd>L</kbd> to toggle looping.
 These shortcuts also work when the controls are in the toolbar's overflow menu.
 
@@ -63,8 +61,6 @@ These shortcuts also work when the controls are in the toolbar's overflow menu.
 
 To change these shortcuts, open Settings → Shortcuts → Playback and select the shortcut next to "Mute / Unmute" or "Loop".
 Use the action menu beside a shortcut to disable it or reset it to its default. The toolbar tooltips reflect your configured shortcuts.
-
-## Outlines, rulers and guides<AvailableFrom v="4.0.523" />
 
 Press <kbd>Shift</kbd> + <kbd>O</kbd> to toggle outlines, and <kbd>Shift</kbd> + <kbd>R</kbd> to toggle rulers and guides together.
 These shortcuts also work when the controls are in the toolbar's overflow menu. When previewing a video asset, the rulers shortcut toggles only rulers.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -54,21 +54,6 @@ You can also press <kbd>?</kbd> to open this tab.
 | `deleteSelection`               | `Backspace` or `Delete`                    | Delete or reset the selection                                  |
 | `askAI`                         | `Cmd/Ctrl+I`                               | Open Ask AI when it is enabled                                 |
 
-Press <kbd>M</kbd> to mute or unmute preview audio, and <kbd>Shift</kbd> + <kbd>L</kbd> to toggle looping.
-These shortcuts also work when the controls are in the toolbar's overflow menu.
-
-<kbd>L</kbd> still plays forward or increases playback speed, and <kbd>Shift</kbd> + <kbd>M</kbd> toggles snapping.
-
-To change these shortcuts, open Settings → Shortcuts → Playback and select the shortcut next to "Mute / Unmute" or "Loop".
-Use the action menu beside a shortcut to disable it or reset it to its default. The toolbar tooltips reflect your configured shortcuts.
-
-Press <kbd>Shift</kbd> + <kbd>O</kbd> to toggle outlines, and <kbd>Shift</kbd> + <kbd>R</kbd> to toggle rulers and guides together.
-These shortcuts also work when the controls are in the toolbar's overflow menu. When previewing a video asset, the rulers shortcut toggles only rulers.
-
-Remap, disable, or reset either shortcut in Settings → Shortcuts → View. Their toolbar tooltips show the configured shortcuts.
-
-<kbd>O</kbd> still sets the Out Point, and <kbd>R</kbd> opens Render or selects the rotation property, depending on the current selection.
-
 ## Fixed shortcuts
 
 Some shortcuts are context-sensitive interactions or browser events and cannot be overridden:
@@ -114,5 +99,3 @@ Config.setKeyboardShortcuts({
 Omitted actions keep their default shortcut. Set an action to `null` to disable it, or pass an array to assign multiple shortcuts.
 
 `commandOrControl` uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported.
-
-Set `shift` or `alt` to `true` to require that modifier, or `false` to require it to be released. Omitting either modifier allows either state. Shortcuts recorded in Studio save both modifier states.

--- a/packages/docs/docs/studio/shortcuts.mdx
+++ b/packages/docs/docs/studio/shortcuts.mdx
@@ -13,6 +13,8 @@ You can also press <kbd>?</kbd> to open this tab.
 | Action ID                       | Default                                    | Action                                                         |
 | ------------------------------- | ------------------------------------------ | -------------------------------------------------------------- |
 | `playPause`                     | `Space`                                    | Play or pause                                                  |
+| `toggleMute`                    | `M`                                        | Mute or unmute preview audio                                   |
+| `toggleLoop`                    | `Shift+L`                                  | Enable or disable looping                                      |
 | `jumpToBeginning`               | `A`                                        | Jump to the beginning                                          |
 | `jumpToEnd`                     | `E`                                        | Jump to the end                                                |
 | `reversePlayback`               | `J`                                        | Play in reverse                                                |
@@ -24,6 +26,8 @@ You can also press <kbd>?</kbd> to open this tab.
 | `toggleRightSidebar`            | `Cmd/Ctrl+J`                               | Toggle the right sidebar                                       |
 | `toggleBothSidebars`            | `Cmd/Ctrl+G`                               | Toggle both sidebars                                           |
 | `enterFullscreen`               | `F`                                        | Enter fullscreen                                               |
+| `toggleOutlines`                | `Shift+O`                                  | Show or hide outlines                                          |
+| `toggleRulersAndGuides`         | `Shift+R`                                  | Show or hide rulers and guides                                 |
 | `toggleSnapping`                | `Shift+M`                                  | Enable or disable snapping                                     |
 | `previousComposition`           | `PageUp`                                   | Select the previous composition                                |
 | `nextComposition`               | `PageDown`                                 | Select the next composition                                    |
@@ -49,6 +53,25 @@ You can also press <kbd>?</kbd> to open this tab.
 | `cutEffects`                    | `Cmd/Ctrl+X`                               | Cut selected effects                                           |
 | `deleteSelection`               | `Backspace` or `Delete`                    | Delete or reset the selection                                  |
 | `askAI`                         | `Cmd/Ctrl+I`                               | Open Ask AI when it is enabled                                 |
+
+## Mute and loop<AvailableFrom v="4.0.523" />
+
+Press <kbd>M</kbd> to mute or unmute preview audio, and <kbd>Shift</kbd> + <kbd>L</kbd> to toggle looping.
+These shortcuts also work when the controls are in the toolbar's overflow menu.
+
+<kbd>L</kbd> still plays forward or increases playback speed, and <kbd>Shift</kbd> + <kbd>M</kbd> toggles snapping.
+
+To change these shortcuts, open Settings → Shortcuts → Playback and select the shortcut next to "Mute / Unmute" or "Loop".
+Use the action menu beside a shortcut to disable it or reset it to its default. The toolbar tooltips reflect your configured shortcuts.
+
+## Outlines, rulers and guides<AvailableFrom v="4.0.523" />
+
+Press <kbd>Shift</kbd> + <kbd>O</kbd> to toggle outlines, and <kbd>Shift</kbd> + <kbd>R</kbd> to toggle rulers and guides together.
+These shortcuts also work when the controls are in the toolbar's overflow menu. When previewing a video asset, the rulers shortcut toggles only rulers.
+
+Remap, disable, or reset either shortcut in Settings → Shortcuts → View. Their toolbar tooltips show the configured shortcuts.
+
+<kbd>O</kbd> still sets the Out Point, and <kbd>R</kbd> opens Render or selects the rotation property, depending on the current selection.
 
 ## Fixed shortcuts
 
@@ -83,13 +106,17 @@ You can also edit the configuration file directly:
 import {Config} from '@remotion/cli/config';
 // ---cut---
 Config.setKeyboardShortcuts({
-	playPause: {key: 'q'},
-	quickSwitcher: {key: 'p', commandOrControl: true},
-	toggleSnapping: {key: 's', shift: true},
-	render: null,
+  playPause: {key: 'q'},
+  toggleMute: {key: 'u'},
+  toggleLoop: {key: 'y'},
+  quickSwitcher: {key: 'p', commandOrControl: true},
+  toggleSnapping: {key: 's', shift: true},
+  render: null,
 });
 ```
 
 Omitted actions keep their default shortcut. Set an action to `null` to disable it, or pass an array to assign multiple shortcuts.
 
 `commandOrControl` uses Command on macOS and Control on other platforms. The `shift` and `alt` modifiers are also supported.
+
+Set `shift` or `alt` to `true` to require that modifier, or `false` to require it to be released. Omitting either modifier allows either state. Shortcuts recorded in Studio save both modifier states.

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -428,6 +428,7 @@ test.describe('visual mode', () => {
 				.poll(() => fs.readFileSync(configFile, 'utf8'))
 				.not.toContain('toggleLoop');
 			await page.keyboard.press('Escape');
+			await expect(dialog).toHaveCount(0);
 			await page.keyboard.press('m');
 			await expect(muteButton).toBeVisible();
 			await page.keyboard.press('Shift+L');
@@ -3547,7 +3548,7 @@ export const SequenceShiftRepro = () => {
 			});
 			expect(canvasHtml).toContain('Performance overview');
 			expect(canvasHtml).toContain('Regional growth');
-			expect(canvasHtml).not.toContain('Change the playback rate');
+			expect(canvasHtml).not.toContain('Playback rate');
 			const webMcpOutlines = await page.evaluate(async () => {
 				const tools = (
 					window as typeof window & {
@@ -3971,7 +3972,7 @@ export const SequenceShiftRepro = () => {
 			});
 			await expect(
 				page.getByRole('button', {
-					name: 'Change the playback rate',
+					name: 'Playback rate',
 					exact: true,
 				}),
 			).toContainText('1.5x');

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -3305,10 +3305,10 @@ export const SequenceShiftRepro = () => {
 			await expect
 				.poll(() => page.evaluate(() => navigator.clipboard.readText()))
 				.toBe(contextForAgents);
-			await page.getByRole('button', {name: 'Jump to beginning'}).click();
+			await page.getByRole('button', {name: 'Go to beginning'}).click();
 			for (let i = 0; i < 3; i++) {
 				await page
-					.getByRole('button', {name: 'Step forward one frame'})
+					.getByRole('button', {name: 'Go forward 1 frame'})
 					.click();
 			}
 			await expect

--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -291,6 +291,261 @@ test.describe('visual mode', () => {
 		await stopStudio();
 	});
 
+	test('customizes playback and view shortcuts and keeps modifiers distinct', async ({
+		page,
+	}) => {
+		const configFile = path.join(exampleDir, 'remotion.config.ts');
+		const originalConfig = fs.readFileSync(configFile, 'utf8');
+		try {
+			await page.goto(`${STUDIO_URL}/schema-test`);
+			const muteButton = page.getByRole('button', {
+				name: 'Mute video',
+				exact: true,
+			});
+			const unmuteButton = page.getByRole('button', {
+				name: 'Unmute video',
+				exact: true,
+			});
+			await expect(muteButton).toBeVisible();
+			await page.keyboard.press('m');
+			await expect(unmuteButton).toBeVisible();
+			await page.keyboard.press('Shift+M');
+			await expect(unmuteButton).toBeVisible();
+			await page.keyboard.press('m');
+			await expect(muteButton).toBeVisible();
+
+			const loopButton = page.getByRole('button', {name: 'Loop', exact: true});
+			if (
+				await page
+					.getByRole('button', {name: 'Loop', exact: true, pressed: true})
+					.count()
+			) {
+				await loopButton.click();
+			}
+			await page.keyboard.press('Shift+L');
+			await expect(
+				page.getByRole('button', {name: 'Loop', exact: true, pressed: true}),
+			).toBeVisible();
+			await expect(
+				page.getByRole('button', {name: 'Play', exact: true}),
+			).toBeVisible();
+			await page.keyboard.press('l');
+			await expect(
+				page.getByRole('button', {name: 'Pause', exact: true}),
+			).toBeVisible();
+			await page.keyboard.press('k');
+			await expect(
+				page.getByRole('button', {name: 'Play', exact: true}),
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'Settings', exact: true}).click();
+			const dialog = page.getByRole('dialog');
+			await dialog
+				.getByRole('button', {name: 'Shortcuts', exact: true})
+				.click();
+			for (const [name, key, action] of [
+				['Mute / Unmute', 'u', 'toggleMute'],
+				['Loop', 'y', 'toggleLoop'],
+			]) {
+				const control = dialog.getByRole('button', {
+					name: `Change shortcut for ${name}`,
+					exact: true,
+				});
+				await control.click();
+				await page.keyboard.press(key);
+				await expect(control).toContainText(key.toUpperCase());
+				await expect
+					.poll(() => fs.readFileSync(configFile, 'utf8'))
+					.toContain(action);
+				await expect(
+					page.getByRole('button', {
+						name: action === 'toggleMute' ? 'Mute video' : 'Loop',
+						exact: true,
+						includeHidden: true,
+					}),
+				).toHaveAttribute('aria-keyshortcuts', key);
+			}
+			await page.keyboard.press('Escape');
+			await expect(dialog).toHaveCount(0);
+			await page.reload();
+			await expect(muteButton).toBeVisible();
+			await page.keyboard.press('u');
+			await expect(unmuteButton).toBeVisible();
+			await page.keyboard.press('m');
+			await expect(unmuteButton).toBeVisible();
+			await unmuteButton.hover();
+			await expect(page.getByRole('tooltip')).toContainText('U');
+
+			await page.setViewportSize({width: 600, height: 800});
+			await page.keyboard.press('y');
+			await page.setViewportSize({width: 1280, height: 800});
+			await expect(
+				page.getByRole('button', {name: 'Loop', exact: true, pressed: false}),
+			).toBeVisible();
+			await page.keyboard.press('Shift+L');
+			await expect(
+				page.getByRole('button', {name: 'Loop', exact: true, pressed: false}),
+			).toBeVisible();
+			await page.keyboard.press('y');
+			await expect(
+				page.getByRole('button', {name: 'Loop', exact: true, pressed: true}),
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'Settings', exact: true}).click();
+			await dialog
+				.getByRole('button', {name: 'Shortcuts', exact: true})
+				.click();
+			await dialog
+				.getByRole('button', {name: 'Actions for Mute / Unmute', exact: true})
+				.click();
+			await page.getByText('Disable shortcut', {exact: true}).click();
+			await expect(
+				dialog.getByRole('button', {
+					name: 'Change shortcut for Mute / Unmute',
+					exact: true,
+				}),
+			).toHaveText('Unassigned');
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.toMatch(/toggleMute['"]?: null/);
+			await page.keyboard.press('Escape');
+			await page.keyboard.press('u');
+			await expect(unmuteButton).toBeVisible();
+			await page.getByRole('button', {name: 'Settings', exact: true}).click();
+			await dialog
+				.getByRole('button', {name: 'Shortcuts', exact: true})
+				.click();
+			for (const name of ['Mute / Unmute', 'Loop']) {
+				await dialog
+					.getByRole('button', {name: `Actions for ${name}`, exact: true})
+					.click();
+				await page.getByText('Reset to default', {exact: true}).click();
+			}
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.not.toContain('toggleMute');
+			await expect
+				.poll(() => fs.readFileSync(configFile, 'utf8'))
+				.not.toContain('toggleLoop');
+			await page.keyboard.press('Escape');
+			await page.keyboard.press('m');
+			await expect(muteButton).toBeVisible();
+			await page.keyboard.press('Shift+L');
+			await expect(
+				page.getByRole('button', {name: 'Loop', exact: true, pressed: false}),
+			).toBeVisible();
+
+			for (const [name, pattern, defaultKey, remappedKey, action] of [
+				[
+					'Outlines',
+					/^(Show|Hide) outlines$/,
+					'Shift+O',
+					'Shift+U',
+					'toggleOutlines',
+				],
+				[
+					'Rulers and guides',
+					/^(Show|Hide) rulers and guides$/,
+					'Shift+R',
+					'Shift+Y',
+					'toggleRulersAndGuides',
+				],
+			] as const) {
+				const button = page.getByRole('button', {name: pattern});
+				if (
+					await page.getByRole('button', {name: pattern, pressed: true}).count()
+				) {
+					await button.click();
+				}
+				await page.keyboard.press(defaultKey);
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: true}),
+				).toBeVisible();
+				await expect(dialog).toHaveCount(0);
+				await button.hover();
+				await expect(page.getByRole('tooltip')).toContainText(
+					defaultKey.slice(-1),
+				);
+
+				await page.getByRole('button', {name: 'Settings', exact: true}).click();
+				await dialog
+					.getByRole('button', {name: 'Shortcuts', exact: true})
+					.click();
+				const control = dialog.getByRole('button', {
+					name: `Change shortcut for ${name}`,
+					exact: true,
+				});
+				await control.click();
+				await page.keyboard.press(remappedKey);
+				await expect(control).toContainText(remappedKey.slice(-1));
+				await expect
+					.poll(() => fs.readFileSync(configFile, 'utf8'))
+					.toContain(action);
+				await page.keyboard.press('Escape');
+				await expect(dialog).toHaveCount(0);
+				await page.reload();
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: true}),
+				).toBeVisible();
+				await page.keyboard.press(defaultKey);
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: true}),
+				).toBeVisible();
+				await page.setViewportSize({width: 600, height: 800});
+				await page.keyboard.press(remappedKey);
+				await page.setViewportSize({width: 1280, height: 800});
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: false}),
+				).toBeVisible();
+				await button.hover();
+				await expect(page.getByRole('tooltip')).toContainText(
+					remappedKey.slice(-1),
+				);
+
+				await page.getByRole('button', {name: 'Settings', exact: true}).click();
+				await dialog
+					.getByRole('button', {name: 'Shortcuts', exact: true})
+					.click();
+				await dialog
+					.getByRole('button', {name: `Actions for ${name}`, exact: true})
+					.click();
+				await page.getByText('Disable shortcut', {exact: true}).click();
+				await expect(control).toHaveText('Unassigned');
+				await page.keyboard.press('Escape');
+				await expect(dialog).toHaveCount(0);
+				await expect(button).not.toHaveAttribute('aria-keyshortcuts');
+				await page.keyboard.press(remappedKey);
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: false}),
+				).toBeVisible();
+				await page.getByRole('button', {name: 'Settings', exact: true}).click();
+				await dialog
+					.getByRole('button', {name: 'Shortcuts', exact: true})
+					.click();
+				await dialog
+					.getByRole('button', {name: `Actions for ${name}`, exact: true})
+					.click();
+				await page.getByText('Reset to default', {exact: true}).click();
+				await expect
+					.poll(() => fs.readFileSync(configFile, 'utf8'))
+					.not.toContain(action);
+				await expect(control).toContainText(defaultKey.slice(-1));
+				await page.keyboard.press('Escape');
+				await expect(dialog).toHaveCount(0);
+				await expect(button).toHaveAttribute(
+					'aria-keyshortcuts',
+					`Shift+${defaultKey.slice(-1).toLowerCase()}`,
+				);
+				await page.keyboard.press(defaultKey);
+				await expect(
+					page.getByRole('button', {name: pattern, pressed: true}),
+				).toBeVisible();
+			}
+		} finally {
+			fs.writeFileSync(configFile, originalConfig);
+		}
+	});
+
 	test('should load the studio without flashing a composition error', async ({
 		page,
 	}) => {

--- a/packages/studio-shared/src/keyboard-shortcuts.ts
+++ b/packages/studio-shared/src/keyboard-shortcuts.ts
@@ -1,5 +1,7 @@
 export const studioKeyboardShortcutActions = [
 	'playPause',
+	'toggleMute',
+	'toggleLoop',
 	'jumpToBeginning',
 	'jumpToEnd',
 	'reversePlayback',
@@ -12,6 +14,8 @@ export const studioKeyboardShortcutActions = [
 	'toggleBothSidebars',
 	'enterFullscreen',
 	'toggleSnapping',
+	'toggleOutlines',
+	'toggleRulersAndGuides',
 	'previousComposition',
 	'nextComposition',
 	'showKeyboardShortcuts',

--- a/packages/studio-shared/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio-shared/src/test/keyboard-shortcuts.test.ts
@@ -5,6 +5,8 @@ test('validates Studio keyboard shortcut configuration', () => {
 	expect(
 		validateStudioKeyboardShortcuts({
 			playPause: {key: 'p'},
+			toggleMute: {key: 'm', shift: false},
+			toggleLoop: [{key: 'l', shift: true}, {key: 'y'}],
 			quickSwitcher: {key: 'p', commandOrControl: true},
 			deleteSelection: [{key: 'Backspace'}, {key: 'Delete'}],
 			showKeyboardShortcuts: null,

--- a/packages/studio/src/components/ActionTooltip.tsx
+++ b/packages/studio/src/components/ActionTooltip.tsx
@@ -1,0 +1,224 @@
+import React, {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react';
+import {createPortal} from 'react-dom';
+import {
+	TIMELINE_BACKGROUND_COLOR,
+	WHITE_ALPHA_10,
+	WHITE_ALPHA_90,
+} from '../helpers/colors';
+import {useZIndex} from '../state/z-index';
+import {getPortal} from './Menu/portals';
+import {SHADOW_TOWARDS_TOP} from './Menu/styles';
+
+const triggerStyle: React.CSSProperties = {display: 'inline-flex'};
+
+const tooltipStyle: React.CSSProperties = {
+	position: 'fixed',
+	display: 'flex',
+	alignItems: 'center',
+	gap: 6,
+	backgroundColor: TIMELINE_BACKGROUND_COLOR,
+	color: WHITE_ALPHA_90,
+	borderRadius: 6,
+	padding: '6px 8px',
+	fontSize: 12,
+	lineHeight: '16px',
+	whiteSpace: 'pre-wrap',
+	overflowWrap: 'anywhere',
+	maxWidth: 'calc(100vw - 16px)',
+	boxShadow: SHADOW_TOWARDS_TOP,
+	pointerEvents: 'none',
+};
+
+const labelStyle: React.CSSProperties = {
+	font: 'inherit',
+	color: 'inherit',
+	minWidth: 0,
+};
+
+const shortcutStyle: React.CSSProperties = {
+	...labelStyle,
+	backgroundColor: WHITE_ALPHA_10,
+	borderRadius: 3,
+	padding: '0 4px',
+	minWidth: 16,
+	textAlign: 'center',
+	whiteSpace: 'nowrap',
+	flexShrink: 0,
+};
+
+let nextTooltipId = 0;
+let visibleTooltipCount = 0;
+let lastTooltipHiddenAt: number | null = null;
+const TOOLTIP_SKIP_DELAY_WINDOW = 300;
+
+export const ActionTooltip: React.FC<{
+	readonly label: string;
+	readonly shortcut: string | null;
+	/** Hover delay in milliseconds. Pass null to show immediately. */
+	readonly delay: number | null;
+	readonly dismissOnClick: boolean;
+	readonly children: (describedBy: string | undefined) => React.ReactNode;
+}> = ({label, shortcut, delay, dismissOnClick, children}) => {
+	const [id] = useState(() => `action-tooltip-${nextTooltipId++}`);
+	const triggerRef = useRef<HTMLSpanElement>(null);
+	const tooltipRef = useRef<HTMLDivElement>(null);
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [visible, setVisible] = useState(false);
+	const [position, setPosition] = useState<{left: number; top: number} | null>(
+		null,
+	);
+	const {currentZIndex} = useZIndex();
+
+	useLayoutEffect(() => {
+		if (!visible) {
+			return;
+		}
+
+		visibleTooltipCount++;
+		return () => {
+			visibleTooltipCount--;
+			lastTooltipHiddenAt = Date.now();
+		};
+	}, [visible]);
+
+	const hide = useCallback(() => {
+		if (timer.current !== null) {
+			clearTimeout(timer.current);
+			timer.current = null;
+		}
+
+		setVisible(false);
+		setPosition(null);
+	}, []);
+
+	const show = useCallback(() => {
+		if (timer.current !== null) {
+			clearTimeout(timer.current);
+			timer.current = null;
+		}
+
+		setVisible(true);
+	}, []);
+
+	const onPointerEnter = useCallback(
+		(event: React.PointerEvent<HTMLSpanElement>) => {
+			if (
+				event.pointerType === 'touch' ||
+				timer.current !== null ||
+				!event.currentTarget.contains(event.target as Node)
+			) {
+				return;
+			}
+
+			// Keep adjacent controls instant, including crossing the gap between them.
+			if (
+				!delay ||
+				visibleTooltipCount > 0 ||
+				(lastTooltipHiddenAt !== null &&
+					Date.now() - lastTooltipHiddenAt < TOOLTIP_SKIP_DELAY_WINDOW)
+			) {
+				show();
+				return;
+			}
+
+			timer.current = setTimeout(show, delay);
+		},
+		[delay, show],
+	);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				hide();
+			}
+		};
+
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('blur', hide);
+		window.addEventListener('resize', hide);
+		window.addEventListener('scroll', hide, true);
+		return () => {
+			if (timer.current !== null) {
+				clearTimeout(timer.current);
+			}
+
+			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('blur', hide);
+			window.removeEventListener('resize', hide);
+			window.removeEventListener('scroll', hide, true);
+		};
+	}, [hide]);
+
+	useLayoutEffect(() => {
+		if (!visible || !triggerRef.current || !tooltipRef.current) {
+			return;
+		}
+
+		const trigger = triggerRef.current.getBoundingClientRect();
+		const tooltip = tooltipRef.current.getBoundingClientRect();
+		const above = trigger.top - tooltip.height - 4;
+		setPosition({
+			left: Math.max(
+				8,
+				Math.min(
+					trigger.left + (trigger.width - tooltip.width) / 2,
+					window.innerWidth - tooltip.width - 8,
+				),
+			),
+			top: Math.max(
+				8,
+				Math.min(
+					above >= 8 ? above : trigger.bottom + 4,
+					window.innerHeight - tooltip.height - 8,
+				),
+			),
+		});
+	}, [label, shortcut, visible]);
+
+	return (
+		<>
+			<span
+				ref={triggerRef}
+				style={triggerStyle}
+				onPointerEnter={onPointerEnter}
+				onPointerLeave={hide}
+				onPointerDownCapture={dismissOnClick ? hide : undefined}
+				onClickCapture={dismissOnClick ? hide : undefined}
+				onFocus={(event) => {
+					if (event.currentTarget.contains(event.target)) {
+						show();
+					}
+				}}
+				onBlur={hide}
+			>
+				{children(visible ? id : undefined)}
+			</span>
+			{visible
+				? createPortal(
+						<div
+							ref={tooltipRef}
+							id={id}
+							role="tooltip"
+							className="css-reset"
+							style={{
+								...tooltipStyle,
+								left: position?.left ?? 0,
+								top: position?.top ?? 0,
+								visibility: position ? 'visible' : 'hidden',
+							}}
+						>
+							<span style={labelStyle}>{label}</span>
+							{shortcut ? <kbd style={shortcutStyle}>{shortcut}</kbd> : null}
+						</div>,
+						getPortal(currentZIndex),
+					)
+				: null}
+		</>
+	);
+};

--- a/packages/studio/src/components/ActionTooltip.tsx
+++ b/packages/studio/src/components/ActionTooltip.tsx
@@ -52,7 +52,6 @@ const shortcutStyle: React.CSSProperties = {
 	flexShrink: 0,
 };
 
-let nextTooltipId = 0;
 let visibleTooltipCount = 0;
 let lastTooltipHiddenAt: number | null = null;
 const TOOLTIP_SKIP_DELAY_WINDOW = 300;
@@ -63,9 +62,8 @@ export const ActionTooltip: React.FC<{
 	/** Hover delay in milliseconds. Pass null to show immediately. */
 	readonly delay: number | null;
 	readonly dismissOnClick: boolean;
-	readonly children: (describedBy: string | undefined) => React.ReactNode;
+	readonly children: React.ReactNode;
 }> = ({label, shortcut, delay, dismissOnClick, children}) => {
-	const [id] = useState(() => `action-tooltip-${nextTooltipId++}`);
 	const triggerRef = useRef<HTMLSpanElement>(null);
 	const tooltipRef = useRef<HTMLDivElement>(null);
 	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -197,13 +195,12 @@ export const ActionTooltip: React.FC<{
 				}}
 				onBlur={hide}
 			>
-				{children(visible ? id : undefined)}
+				{children}
 			</span>
 			{visible
 				? createPortal(
 						<div
 							ref={tooltipRef}
-							id={id}
 							role="tooltip"
 							className="css-reset"
 							style={{

--- a/packages/studio/src/components/CheckboardToggle.tsx
+++ b/packages/studio/src/components/CheckboardToggle.tsx
@@ -1,9 +1,12 @@
 import React, {useCallback, useContext} from 'react';
-import {NoReactInternals} from 'remotion/no-react';
 import {BLUE} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
-import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {CheckerboardContext} from '../state/checkerboard';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
 export const CheckboardToggle: React.FC = () => {
@@ -15,49 +18,60 @@ export const CheckboardToggle: React.FC = () => {
 		});
 	}, [setCheckerboard]);
 	const shortcut = useKeyboardShortcutLabel('toggleCheckerboard');
-	const accessibilityLabel = [
-		'Show transparency as checkerboard',
-		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
-	]
-		.filter(NoReactInternals.truthy)
-		.join(' ');
+	const ariaKeyShortcuts =
+		useKeyboardShortcutAriaKeyShortcuts('toggleCheckerboard');
+	const accessibilityLabel = 'Show transparency as checkerboard';
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			aria-pressed={checkerboard}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) => (
-				<svg
-					aria-hidden="true"
-					focusable="false"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 512 512"
-					style={{width: 18, height: 18}}
-					fill="none"
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-pressed={checkerboard}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+					}
+					onClick={onClick}
 				>
-					<path
-						fill={checkerboard ? BLUE : color}
-						d="M256 48h184c13.3 0 24 10.7 24 24v184H256V48zM48 256h208v208H72c-13.3 0-24-10.7-24-24V256z"
-					/>
-					<rect
-						x="48"
-						y="48"
-						width="416"
-						height="416"
-						rx="24"
-						stroke={checkerboard ? BLUE : color}
-						strokeWidth="32"
-					/>
-					<path
-						d="M256 48v416M48 256h416"
-						stroke={checkerboard ? BLUE : color}
-						strokeWidth="32"
-					/>
-				</svg>
+					{(color) => (
+						<svg
+							aria-hidden="true"
+							focusable="false"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 512 512"
+							style={{width: 18, height: 18}}
+							fill="none"
+						>
+							<path
+								fill={checkerboard ? BLUE : color}
+								d="M256 48h184c13.3 0 24 10.7 24 24v184H256V48zM48 256h208v208H72c-13.3 0-24-10.7-24-24V256z"
+							/>
+							<rect
+								x="48"
+								y="48"
+								width="416"
+								height="416"
+								rx="24"
+								stroke={checkerboard ? BLUE : color}
+								strokeWidth="32"
+							/>
+							<path
+								d="M256 48v416M48 256h416"
+								stroke={checkerboard ? BLUE : color}
+								strokeWidth="32"
+							/>
+						</svg>
+					)}
+				</ControlButton>
 			)}
-		</ControlButton>
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/CheckboardToggle.tsx
+++ b/packages/studio/src/components/CheckboardToggle.tsx
@@ -30,48 +30,45 @@ export const CheckboardToggle: React.FC = () => {
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-pressed={checkerboard}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
-					}
-					onClick={onClick}
-				>
-					{(color) => (
-						<svg
-							aria-hidden="true"
-							focusable="false"
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 512 512"
-							style={{width: 18, height: 18}}
-							fill="none"
-						>
-							<path
-								fill={checkerboard ? BLUE : color}
-								d="M256 48h184c13.3 0 24 10.7 24 24v184H256V48zM48 256h208v208H72c-13.3 0-24-10.7-24-24V256z"
-							/>
-							<rect
-								x="48"
-								y="48"
-								width="416"
-								height="416"
-								rx="24"
-								stroke={checkerboard ? BLUE : color}
-								strokeWidth="32"
-							/>
-							<path
-								d="M256 48v416M48 256h416"
-								stroke={checkerboard ? BLUE : color}
-								strokeWidth="32"
-							/>
-						</svg>
-					)}
-				</ControlButton>
-			)}
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-pressed={checkerboard}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+				}
+				onClick={onClick}
+			>
+				{(color) => (
+					<svg
+						aria-hidden="true"
+						focusable="false"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 512 512"
+						style={{width: 18, height: 18}}
+						fill="none"
+					>
+						<path
+							fill={checkerboard ? BLUE : color}
+							d="M256 48h184c13.3 0 24 10.7 24 24v184H256V48zM48 256h208v208H72c-13.3 0-24-10.7-24-24V256z"
+						/>
+						<rect
+							x="48"
+							y="48"
+							width="416"
+							height="416"
+							rx="24"
+							stroke={checkerboard ? BLUE : color}
+							strokeWidth="32"
+						/>
+						<path
+							d="M256 48v416M48 256h416"
+							stroke={checkerboard ? BLUE : color}
+							strokeWidth="32"
+						/>
+					</svg>
+				)}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/FullscreenToggle.tsx
+++ b/packages/studio/src/components/FullscreenToggle.tsx
@@ -65,22 +65,19 @@ export const FullScreenToggle: React.FC<{
 			delay={800}
 			dismissOnClick
 		>
-			{(describedBy) => (
-				<ControlButton
-					id="fullscreen-toggle"
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
-					}
-					onClick={onClick}
-				>
-					{(color) => (
-						<FullscreenIcon color={color} style={{width: 18, height: 18}} />
-					)}
-				</ControlButton>
-			)}
+			<ControlButton
+				id="fullscreen-toggle"
+				title=""
+				aria-label={accessibilityLabel}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+				}
+				onClick={onClick}
+			>
+				{(color) => (
+					<FullscreenIcon color={color} style={{width: 18, height: 18}} />
+				)}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/FullscreenToggle.tsx
+++ b/packages/studio/src/components/FullscreenToggle.tsx
@@ -1,13 +1,16 @@
 import {useCallback, useContext, useEffect} from 'react';
 import {Internals} from 'remotion';
-import {NoReactInternals} from 'remotion/no-react';
 import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
-import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {FullscreenIcon} from '../icons/fullscreen';
 import {drawRef} from '../state/canvas-ref';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
 export const FullScreenToggle: React.FC<{
@@ -29,12 +32,10 @@ export const FullScreenToggle: React.FC<{
 			}));
 	}, [setSize]);
 	const shortcut = useKeyboardShortcutLabel('enterFullscreen');
-	const accessibilityLabel = [
-		'Enter fullscreen preview',
-		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
-	]
-		.filter(NoReactInternals.truthy)
-		.join(' ');
+	const ariaKeyShortcuts =
+		useKeyboardShortcutAriaKeyShortcuts('enterFullscreen');
+	const accessibilityLabel = 'Enter fullscreen preview';
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 
 	useEffect(() => {
 		const f = keybindings.registerKeybinding({
@@ -58,15 +59,28 @@ export const FullScreenToggle: React.FC<{
 			onClick={onClick}
 		/>
 	) : (
-		<ControlButton
-			id="fullscreen-toggle"
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick
 		>
-			{(color) => (
-				<FullscreenIcon color={color} style={{width: 18, height: 18}} />
+			{(describedBy) => (
+				<ControlButton
+					id="fullscreen-toggle"
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+					}
+					onClick={onClick}
+				>
+					{(color) => (
+						<FullscreenIcon color={color} style={{width: 18, height: 18}} />
+					)}
+				</ControlButton>
 			)}
-		</ControlButton>
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/GlobalKeybindings.tsx
+++ b/packages/studio/src/components/GlobalKeybindings.tsx
@@ -3,10 +3,14 @@ import type React from 'react';
 import {useCallback, useContext, useEffect, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {calculateTimeline} from '../helpers/calculate-timeline';
+import {getPreviewFileType} from '../helpers/get-preview-file-type';
 import {getStudioAskAIEnabled} from '../helpers/studio-runtime-config';
 import {timelineNodePathInfoToKey} from '../helpers/timeline-node-path-key';
 import {useKeybinding} from '../helpers/use-keybinding';
 import {CheckerboardContext} from '../state/checkerboard';
+import {EditorShowGuidesContext} from '../state/editor-guides';
+import {EditorShowOutlinesContext} from '../state/editor-outlines';
+import {EditorShowRulersContext} from '../state/editor-rulers';
 import {EditorSnappingContext} from '../state/editor-snapping';
 import {SetSelectedModalContext} from '../state/modals';
 import {askAiModalRef} from './AskAiModal';
@@ -36,6 +40,62 @@ export const GlobalKeybindings: React.FC = () => {
 	const {setSelectedModal} = useContext(SetSelectedModalContext);
 	const {setCheckerboard} = useContext(CheckerboardContext);
 	const {setEditorSnapping} = useContext(EditorSnappingContext);
+	const {canvasContent} = useContext(Internals.CompositionManager);
+	const {setEditorShowOutlines} = useContext(EditorShowOutlinesContext);
+	const {editorShowRulers, setEditorShowRulers} = useContext(
+		EditorShowRulersContext,
+	);
+	const {editorShowGuides, setEditorShowGuides} = useContext(
+		EditorShowGuidesContext,
+	);
+	const showGuides = canvasContent?.type === 'composition';
+	const showCanvasViewControls =
+		showGuides ||
+		(canvasContent?.type === 'asset' &&
+			getPreviewFileType(canvasContent.asset) === 'video');
+
+	useEffect(() => {
+		if (!showCanvasViewControls) return;
+		const outlines = showGuides
+			? keybindings.registerKeybinding({
+					event: 'keydown',
+					action: 'toggleOutlines',
+					callback: (event) => {
+						if (!event.repeat) setEditorShowOutlines((current) => !current);
+					},
+					preventDefault: true,
+					triggerIfInputFieldFocused: false,
+					keepRegisteredWhenNotHighestContext: false,
+				})
+			: null;
+		const rulers = keybindings.registerKeybinding({
+			event: 'keydown',
+			action: 'toggleRulersAndGuides',
+			callback: (event) => {
+				if (event.repeat) return;
+				const visible = editorShowRulers || (showGuides && editorShowGuides);
+				setEditorShowRulers(() => !visible);
+				if (showGuides) setEditorShowGuides(() => !visible);
+			},
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		return () => {
+			outlines?.unregister();
+			rulers.unregister();
+		};
+	}, [
+		keybindings,
+		showCanvasViewControls,
+		showGuides,
+		editorShowRulers,
+		editorShowGuides,
+		setEditorShowOutlines,
+		setEditorShowRulers,
+		setEditorShowGuides,
+	]);
+
 	const currentSelection = useCurrentTimelineSelectionStateAsRef();
 	const {sequences} = useContext(Internals.SequenceManager);
 	const videoConfig = Internals.useUnsafeVideoConfig();

--- a/packages/studio/src/components/LoopToggle.tsx
+++ b/packages/studio/src/components/LoopToggle.tsx
@@ -1,9 +1,15 @@
 import React, {useCallback} from 'react';
 import {BLUE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {persistLoopOption} from '../state/loop';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
-const accessibilityLabel = 'Loop video';
+const accessibilityLabel = 'Loop';
 
 export const toggleLoop = (
 	setLoop: React.Dispatch<React.SetStateAction<boolean>>,
@@ -18,24 +24,41 @@ export const LoopToggle: React.FC<{
 	readonly loop: boolean;
 	readonly setLoop: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({loop, setLoop}) => {
+	const shortcut = useKeyboardShortcutLabel('toggleLoop');
+	const ariaShortcut = useKeyboardShortcutAriaKeyShortcuts('toggleLoop');
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 	const onClick = useCallback(() => {
 		toggleLoop(setLoop);
 	}, [setLoop]);
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) => (
-				<svg viewBox="0 0 512 512" style={{width: 18, height: 18}}>
-					<path
-						fill={loop ? BLUE : color}
-						d="M384 150.3V41.6l64 53.3v2l-64 53.3zM352 23.5V80H192C86 80 0 166 0 272c0 8.8 7.2 16 16 16s16-7.2 16-16c0-88.4 71.6-160 160-160h160v56.5c0 13 10.5 23.5 23.5 23.5 5.5 0 10.8-1.9 15-5.4l78-65c7.3-6.1 11.5-15.1 11.5-24.6v-2c0-9.5-4.2-18.5-11.5-24.6l-78-65c-4.2-3.5-9.5-5.4-15-5.4-13 0-23.5 10.5-23.5 23.5zM128 415.9v54.5l-64-53.3v-2l64-53.3v54.1zM160 400v-56.5c0-13-10.5-23.5-23.5-23.5-5.5 0-10.8 1.9-15 5.4l-78 65C36.2 396.5 32 405.5 32 415v2c0 9.5 4.2 18.5 11.5 24.6l78 65c4.2 3.5 9.5 5.4 15 5.4 13 0 23.5-10.5 23.5-23.5V432h160c106 0 192-86 192-192 0-8.8-7.2-16-16-16s-16 7.2-16 16c0 88.4-71.6 160-160 160H160z"
-					/>
-				</svg>
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaShortcut || undefined
+					}
+					aria-pressed={loop}
+					onClick={onClick}
+				>
+					{(color) => (
+						<svg viewBox="0 0 512 512" style={{width: 18, height: 18}}>
+							<path
+								fill={loop ? BLUE : color}
+								d="M384 150.3V41.6l64 53.3v2l-64 53.3zM352 23.5V80H192C86 80 0 166 0 272c0 8.8 7.2 16 16 16s16-7.2 16-16c0-88.4 71.6-160 160-160h160v56.5c0 13 10.5 23.5 23.5 23.5 5.5 0 10.8-1.9 15-5.4l78-65c7.3-6.1 11.5-15.1 11.5-24.6v-2c0-9.5-4.2-18.5-11.5-24.6l-78-65c-4.2-3.5-9.5-5.4-15-5.4-13 0-23.5 10.5-23.5 23.5zM128 415.9v54.5l-64-53.3v-2l64-53.3v54.1zM160 400v-56.5c0-13-10.5-23.5-23.5-23.5-5.5 0-10.8 1.9-15 5.4l-78 65C36.2 396.5 32 405.5 32 415v2c0 9.5 4.2 18.5 11.5 24.6l78 65c4.2 3.5 9.5 5.4 15 5.4 13 0 23.5-10.5 23.5-23.5V432h160c106 0 192-86 192-192 0-8.8-7.2-16-16-16s-16 7.2-16 16c0 88.4-71.6 160-160 160H160z"
+							/>
+						</svg>
+					)}
+				</ControlButton>
 			)}
-		</ControlButton>
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/LoopToggle.tsx
+++ b/packages/studio/src/components/LoopToggle.tsx
@@ -38,27 +38,24 @@ export const LoopToggle: React.FC<{
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaShortcut || undefined
-					}
-					aria-pressed={loop}
-					onClick={onClick}
-				>
-					{(color) => (
-						<svg viewBox="0 0 512 512" style={{width: 18, height: 18}}>
-							<path
-								fill={loop ? BLUE : color}
-								d="M384 150.3V41.6l64 53.3v2l-64 53.3zM352 23.5V80H192C86 80 0 166 0 272c0 8.8 7.2 16 16 16s16-7.2 16-16c0-88.4 71.6-160 160-160h160v56.5c0 13 10.5 23.5 23.5 23.5 5.5 0 10.8-1.9 15-5.4l78-65c7.3-6.1 11.5-15.1 11.5-24.6v-2c0-9.5-4.2-18.5-11.5-24.6l-78-65c-4.2-3.5-9.5-5.4-15-5.4-13 0-23.5 10.5-23.5 23.5zM128 415.9v54.5l-64-53.3v-2l64-53.3v54.1zM160 400v-56.5c0-13-10.5-23.5-23.5-23.5-5.5 0-10.8 1.9-15 5.4l-78 65C36.2 396.5 32 405.5 32 415v2c0 9.5 4.2 18.5 11.5 24.6l78 65c4.2 3.5 9.5 5.4 15 5.4 13 0 23.5-10.5 23.5-23.5V432h160c106 0 192-86 192-192 0-8.8-7.2-16-16-16s-16 7.2-16 16c0 88.4-71.6 160-160 160H160z"
-							/>
-						</svg>
-					)}
-				</ControlButton>
-			)}
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaShortcut || undefined
+				}
+				aria-pressed={loop}
+				onClick={onClick}
+			>
+				{(color) => (
+					<svg viewBox="0 0 512 512" style={{width: 18, height: 18}}>
+						<path
+							fill={loop ? BLUE : color}
+							d="M384 150.3V41.6l64 53.3v2l-64 53.3zM352 23.5V80H192C86 80 0 166 0 272c0 8.8 7.2 16 16 16s16-7.2 16-16c0-88.4 71.6-160 160-160h160v56.5c0 13 10.5 23.5 23.5 23.5 5.5 0 10.8-1.9 15-5.4l78-65c7.3-6.1 11.5-15.1 11.5-24.6v-2c0-9.5-4.2-18.5-11.5-24.6l-78-65c-4.2-3.5-9.5-5.4-15-5.4-13 0-23.5 10.5-23.5 23.5zM128 415.9v54.5l-64-53.3v-2l64-53.3v54.1zM160 400v-56.5c0-13-10.5-23.5-23.5-23.5-5.5 0-10.8 1.9-15 5.4l-78 65C36.2 396.5 32 405.5 32 415v2c0 9.5 4.2 18.5 11.5 24.6l78 65c4.2 3.5 9.5 5.4 15 5.4 13 0 23.5-10.5 23.5-23.5V432h160c106 0 192-86 192-192 0-8.8-7.2-16-16-16s-16 7.2-16 16c0 88.4-71.6 160-160 160H160z"
+						/>
+					</svg>
+				)}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -6,10 +6,14 @@ import {StudioServerConnectionCtx} from '../helpers/client-id';
 import {BACKGROUND, BORDER_BLACK, WHITE} from '../helpers/colors';
 import {useMobileLayout} from '../helpers/mobile-layout';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
-import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {useMenuStructure} from '../helpers/use-menu-structure';
 import {SearchIcon} from '../icons/search';
 import {SetSelectedModalContext} from '../state/modals';
+import {ActionTooltip} from './ActionTooltip';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {Row} from './layout';
@@ -163,10 +167,9 @@ export const MenuToolbar: React.FC<{
 	}, []);
 
 	const quickSwitcherShortcut = useKeyboardShortcutLabel('quickSwitcher');
-	const searchTooltip =
-		areKeyboardShortcutsDisabled() || quickSwitcherShortcut === ''
-			? 'Quick Switcher'
-			: `Quick Switcher (${quickSwitcherShortcut})`;
+	const quickSwitcherAriaShortcut =
+		useKeyboardShortcutAriaKeyShortcuts('quickSwitcher');
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 
 	return (
 		<Row
@@ -177,12 +180,27 @@ export const MenuToolbar: React.FC<{
 		>
 			<div style={fixedWidthLeft}>
 				{mobileLayout ? (
-					<InlineAction
-						variant={null}
-						onClick={openQuickSwitcher}
-						renderAction={renderSearchIcon}
-						title={searchTooltip}
-					/>
+					<ActionTooltip
+						label="Quick switcher"
+						shortcut={shortcutsDisabled ? null : quickSwitcherShortcut}
+						delay={800}
+						dismissOnClick
+					>
+						{(describedBy) => (
+							<InlineAction
+								variant={null}
+								onClick={openQuickSwitcher}
+								renderAction={renderSearchIcon}
+								aria-label="Quick switcher"
+								aria-describedby={describedBy}
+								aria-keyshortcuts={
+									shortcutsDisabled
+										? undefined
+										: quickSwitcherAriaShortcut || undefined
+								}
+							/>
+						)}
+					</ActionTooltip>
 				) : (
 					<SidebarCollapserControl side="left" />
 				)}

--- a/packages/studio/src/components/MenuToolbar.tsx
+++ b/packages/studio/src/components/MenuToolbar.tsx
@@ -186,20 +186,17 @@ export const MenuToolbar: React.FC<{
 						delay={800}
 						dismissOnClick
 					>
-						{(describedBy) => (
-							<InlineAction
-								variant={null}
-								onClick={openQuickSwitcher}
-								renderAction={renderSearchIcon}
-								aria-label="Quick switcher"
-								aria-describedby={describedBy}
-								aria-keyshortcuts={
-									shortcutsDisabled
-										? undefined
-										: quickSwitcherAriaShortcut || undefined
-								}
-							/>
-						)}
+						<InlineAction
+							variant={null}
+							onClick={openQuickSwitcher}
+							renderAction={renderSearchIcon}
+							aria-label="Quick switcher"
+							aria-keyshortcuts={
+								shortcutsDisabled
+									? undefined
+									: quickSwitcherAriaShortcut || undefined
+							}
+						/>
 					</ActionTooltip>
 				) : (
 					<SidebarCollapserControl side="left" />

--- a/packages/studio/src/components/MuteToggle.tsx
+++ b/packages/studio/src/components/MuteToggle.tsx
@@ -1,30 +1,62 @@
 import {useCallback} from 'react';
 import {BLUE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {VolumeOffIcon, VolumeOnIcon} from '../icons/media-volume';
 import {persistMuteOption} from '../state/mute';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
+
+export const toggleMute = (
+	setMuted: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+	setMuted((muted) => {
+		persistMuteOption(!muted);
+		return !muted;
+	});
+};
 
 export const MuteToggle: React.FC<{
 	muted: boolean;
 	setMuted: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({muted, setMuted}) => {
+	const shortcut = useKeyboardShortcutLabel('toggleMute');
+	const ariaShortcut = useKeyboardShortcutAriaKeyShortcuts('toggleMute');
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 	const onClick = useCallback(() => {
-		setMuted((m) => {
-			persistMuteOption(!m);
-			return !m;
-		});
+		toggleMute(setMuted);
 	}, [setMuted]);
 	const accessibilityLabel = muted ? 'Unmute video' : 'Mute video';
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) =>
-				muted ? <VolumeOffIcon color={BLUE} /> : <VolumeOnIcon color={color} />
-			}
-		</ControlButton>
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaShortcut || undefined
+					}
+					onClick={onClick}
+				>
+					{(color) =>
+						muted ? (
+							<VolumeOffIcon color={BLUE} />
+						) : (
+							<VolumeOnIcon color={color} />
+						)
+					}
+				</ControlButton>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/MuteToggle.tsx
+++ b/packages/studio/src/components/MuteToggle.tsx
@@ -38,25 +38,22 @@ export const MuteToggle: React.FC<{
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaShortcut || undefined
-					}
-					onClick={onClick}
-				>
-					{(color) =>
-						muted ? (
-							<VolumeOffIcon color={BLUE} />
-						) : (
-							<VolumeOnIcon color={color} />
-						)
-					}
-				</ControlButton>
-			)}
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaShortcut || undefined
+				}
+				onClick={onClick}
+			>
+				{(color) =>
+					muted ? (
+						<VolumeOffIcon color={BLUE} />
+					) : (
+						<VolumeOnIcon color={color} />
+					)
+				}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/OutlineToggle.tsx
+++ b/packages/studio/src/components/OutlineToggle.tsx
@@ -33,55 +33,52 @@ export const OutlineToggle: React.FC = () => {
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaShortcut || undefined
-					}
-					aria-pressed={editorShowOutlines}
-					onClick={onClick}
-				>
-					{(color) => {
-						const iconColor = editorShowOutlines ? BLUE : color;
-						return (
-							<svg
-								style={{width: 17, height: 17}}
-								viewBox="0 0 512 512"
-								fill="none"
-								aria-hidden="true"
-								focusable="false"
-							>
-								<path
-									d="M64 64H448V448H64V64Z"
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaShortcut || undefined
+				}
+				aria-pressed={editorShowOutlines}
+				onClick={onClick}
+			>
+				{(color) => {
+					const iconColor = editorShowOutlines ? BLUE : color;
+					return (
+						<svg
+							style={{width: 17, height: 17}}
+							viewBox="0 0 512 512"
+							fill="none"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path
+								d="M64 64H448V448H64V64Z"
+								stroke={iconColor}
+								strokeWidth="36"
+							/>
+							{[
+								[16, 16],
+								[400, 16],
+								[16, 400],
+								[400, 400],
+							].map(([x, y]) => (
+								<rect
+									key={`${x}-${y}`}
+									x={x}
+									y={y}
+									width="96"
+									height="96"
+									rx="24"
+									fill={BACKGROUND_HEX}
 									stroke={iconColor}
-									strokeWidth="36"
+									strokeWidth="32"
 								/>
-								{[
-									[16, 16],
-									[400, 16],
-									[16, 400],
-									[400, 400],
-								].map(([x, y]) => (
-									<rect
-										key={`${x}-${y}`}
-										x={x}
-										y={y}
-										width="96"
-										height="96"
-										rx="24"
-										fill={BACKGROUND_HEX}
-										stroke={iconColor}
-										strokeWidth="32"
-									/>
-								))}
-							</svg>
-						);
-					}}
-				</ControlButton>
-			)}
+							))}
+						</svg>
+					);
+				}}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/OutlineToggle.tsx
+++ b/packages/studio/src/components/OutlineToggle.tsx
@@ -1,6 +1,12 @@
 import React, {useCallback, useContext} from 'react';
 import {BACKGROUND_HEX, BLUE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutLabel,
+	useKeyboardShortcutAriaKeyShortcuts,
+} from '../helpers/use-keyboard-shortcut-label';
 import {EditorShowOutlinesContext} from '../state/editor-outlines';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
 export const OutlineToggle: React.FC = () => {
@@ -12,52 +18,70 @@ export const OutlineToggle: React.FC = () => {
 		setEditorShowOutlines((current) => !current);
 	}, [setEditorShowOutlines]);
 
+	const shortcut = useKeyboardShortcutLabel('toggleOutlines');
+	const ariaShortcut = useKeyboardShortcutAriaKeyShortcuts('toggleOutlines');
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
+
 	const accessibilityLabel = editorShowOutlines
 		? 'Hide outlines'
 		: 'Show outlines';
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) => {
-				const iconColor = editorShowOutlines ? BLUE : color;
-				return (
-					<svg
-						style={{width: 17, height: 17}}
-						viewBox="0 0 512 512"
-						fill="none"
-						aria-hidden="true"
-						focusable="false"
-					>
-						<path
-							d="M64 64H448V448H64V64Z"
-							stroke={iconColor}
-							strokeWidth="36"
-						/>
-						{[
-							[16, 16],
-							[400, 16],
-							[16, 400],
-							[400, 400],
-						].map(([x, y]) => (
-							<rect
-								key={`${x}-${y}`}
-								x={x}
-								y={y}
-								width="96"
-								height="96"
-								rx="24"
-								fill={BACKGROUND_HEX}
-								stroke={iconColor}
-								strokeWidth="32"
-							/>
-						))}
-					</svg>
-				);
-			}}
-		</ControlButton>
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaShortcut || undefined
+					}
+					aria-pressed={editorShowOutlines}
+					onClick={onClick}
+				>
+					{(color) => {
+						const iconColor = editorShowOutlines ? BLUE : color;
+						return (
+							<svg
+								style={{width: 17, height: 17}}
+								viewBox="0 0 512 512"
+								fill="none"
+								aria-hidden="true"
+								focusable="false"
+							>
+								<path
+									d="M64 64H448V448H64V64Z"
+									stroke={iconColor}
+									strokeWidth="36"
+								/>
+								{[
+									[16, 16],
+									[400, 16],
+									[16, 400],
+									[400, 400],
+								].map(([x, y]) => (
+									<rect
+										key={`${x}-${y}`}
+										x={x}
+										y={y}
+										width="96"
+										height="96"
+										rx="24"
+										fill={BACKGROUND_HEX}
+										stroke={iconColor}
+										strokeWidth="32"
+									/>
+								))}
+							</svg>
+						);
+					}}
+				</ControlButton>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -281,18 +281,15 @@ const PlayPauseInner: React.FC<{
 					delay={800}
 					dismissOnClick
 				>
-					{(describedBy) => (
-						<ControlButton
-							aria-label="Go to beginning"
-							aria-describedby={describedBy}
-							aria-keyshortcuts={jumpToBeginningAriaShortcut || undefined}
-							title=""
-							disabled={!videoConfig}
-							onClick={jumpToStart}
-						>
-							{(color) => <JumpToStart style={backStyle} color={color} />}
-						</ControlButton>
-					)}
+					<ControlButton
+						aria-label="Go to beginning"
+						aria-keyshortcuts={jumpToBeginningAriaShortcut || undefined}
+						title=""
+						disabled={!videoConfig}
+						onClick={jumpToStart}
+					>
+						{(color) => <JumpToStart style={backStyle} color={color} />}
+					</ControlButton>
 				</ActionTooltip>
 			)}
 			{hideNavigationControls ? null : (
@@ -302,18 +299,15 @@ const PlayPauseInner: React.FC<{
 					delay={800}
 					dismissOnClick
 				>
-					{(describedBy) => (
-						<ControlButton
-							aria-label="Go back 1 frame"
-							aria-describedby={describedBy}
-							aria-keyshortcuts="ArrowLeft"
-							title=""
-							disabled={!videoConfig}
-							onClick={oneFrameBack}
-						>
-							{(color) => <StepBack style={forwardBackStyle} color={color} />}
-						</ControlButton>
-					)}
+					<ControlButton
+						aria-label="Go back 1 frame"
+						aria-keyshortcuts="ArrowLeft"
+						title=""
+						disabled={!videoConfig}
+						onClick={oneFrameBack}
+					>
+						{(color) => <StepBack style={forwardBackStyle} color={color} />}
+					</ControlButton>
 				</ActionTooltip>
 			)}
 
@@ -323,31 +317,28 @@ const PlayPauseInner: React.FC<{
 				delay={800}
 				dismissOnClick={false}
 			>
-				{(describedBy) => (
-					<ControlButton
-						aria-label={playing ? 'Pause' : 'Play'}
-						aria-describedby={describedBy}
-						aria-keyshortcuts={playPauseAriaShortcut || undefined}
-						title=""
-						onClick={playing ? pause : play}
-						disabled={!videoConfig}
-					>
-						{(color) =>
-							playing ? (
-								showBufferIndicator ? (
-									<PlayerInternals.BufferingIndicator
-										type="studio"
-										color={color}
-									/>
-								) : (
-									<Pause style={iconButton} color={color} />
-								)
+				<ControlButton
+					aria-label={playing ? 'Pause' : 'Play'}
+					aria-keyshortcuts={playPauseAriaShortcut || undefined}
+					title=""
+					onClick={playing ? pause : play}
+					disabled={!videoConfig}
+				>
+					{(color) =>
+						playing ? (
+							showBufferIndicator ? (
+								<PlayerInternals.BufferingIndicator
+									type="studio"
+									color={color}
+								/>
 							) : (
-								<Play style={iconButton} color={color} />
+								<Pause style={iconButton} color={color} />
 							)
-						}
-					</ControlButton>
-				)}
+						) : (
+							<Play style={iconButton} color={color} />
+						)
+					}
+				</ControlButton>
 			</ActionTooltip>
 
 			{hideNavigationControls ? null : (
@@ -357,20 +348,15 @@ const PlayPauseInner: React.FC<{
 					delay={800}
 					dismissOnClick
 				>
-					{(describedBy) => (
-						<ControlButton
-							aria-label="Go forward 1 frame"
-							aria-describedby={describedBy}
-							aria-keyshortcuts="ArrowRight"
-							title=""
-							disabled={!videoConfig}
-							onClick={oneFrameForward}
-						>
-							{(color) => (
-								<StepForward style={forwardBackStyle} color={color} />
-							)}
-						</ControlButton>
-					)}
+					<ControlButton
+						aria-label="Go forward 1 frame"
+						aria-keyshortcuts="ArrowRight"
+						title=""
+						disabled={!videoConfig}
+						onClick={oneFrameForward}
+					>
+						{(color) => <StepForward style={forwardBackStyle} color={color} />}
+					</ControlButton>
 				</ActionTooltip>
 			)}
 		</>

--- a/packages/studio/src/components/PlayPause.tsx
+++ b/packages/studio/src/components/PlayPause.tsx
@@ -3,12 +3,17 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {Internals} from 'remotion';
 import {useIsStill} from '../helpers/is-current-selected-still';
 import {useKeybinding} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {JumpToStart} from '../icons/jump-to-start';
 import {Pause} from '../icons/pause';
 import {Play} from '../icons/play';
 import {StepBack} from '../icons/step-back';
 import {StepForward} from '../icons/step-forward';
 import {useTimelineInOutFramePosition} from '../state/in-out';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 import {getCurrentDuration} from './Timeline/imperative-state';
 import {ensureFrameIsInViewport} from './Timeline/timeline-scroll-logic';
@@ -82,6 +87,12 @@ const PlayPauseInner: React.FC<{
 	const playing = Internals.usePlaying();
 
 	const isStill = useIsStill();
+	const jumpToBeginningShortcut = useKeyboardShortcutLabel('jumpToBeginning');
+	const jumpToBeginningAriaShortcut =
+		useKeyboardShortcutAriaKeyShortcuts('jumpToBeginning');
+	const playPauseShortcut = useKeyboardShortcutLabel('playPause');
+	const playPauseAriaShortcut =
+		useKeyboardShortcutAriaKeyShortcuts('playPause');
 
 	useEffect(() => {
 		if (isStill) {
@@ -264,54 +275,103 @@ const PlayPauseInner: React.FC<{
 				getCurrentFrame={getCurrentFrame}
 			/>
 			{hideNavigationControls ? null : (
-				<ControlButton
-					aria-label="Jump to beginning"
-					title="Jump to beginning"
-					disabled={!videoConfig}
-					onClick={jumpToStart}
+				<ActionTooltip
+					label="Go to beginning"
+					shortcut={jumpToBeginningShortcut}
+					delay={800}
+					dismissOnClick
 				>
-					{(color) => <JumpToStart style={backStyle} color={color} />}
-				</ControlButton>
+					{(describedBy) => (
+						<ControlButton
+							aria-label="Go to beginning"
+							aria-describedby={describedBy}
+							aria-keyshortcuts={jumpToBeginningAriaShortcut || undefined}
+							title=""
+							disabled={!videoConfig}
+							onClick={jumpToStart}
+						>
+							{(color) => <JumpToStart style={backStyle} color={color} />}
+						</ControlButton>
+					)}
+				</ActionTooltip>
 			)}
 			{hideNavigationControls ? null : (
-				<ControlButton
-					aria-label="Step back one frame"
-					title="Step back one frame"
-					disabled={!videoConfig}
-					onClick={oneFrameBack}
+				<ActionTooltip
+					label="Go back 1 frame"
+					shortcut="←"
+					delay={800}
+					dismissOnClick
 				>
-					{(color) => <StepBack style={forwardBackStyle} color={color} />}
-				</ControlButton>
+					{(describedBy) => (
+						<ControlButton
+							aria-label="Go back 1 frame"
+							aria-describedby={describedBy}
+							aria-keyshortcuts="ArrowLeft"
+							title=""
+							disabled={!videoConfig}
+							onClick={oneFrameBack}
+						>
+							{(color) => <StepBack style={forwardBackStyle} color={color} />}
+						</ControlButton>
+					)}
+				</ActionTooltip>
 			)}
 
-			<ControlButton
-				aria-label={playing ? 'Pause' : 'Play'}
-				title={playing ? 'Pause' : 'Play'}
-				onClick={playing ? pause : play}
-				disabled={!videoConfig}
+			<ActionTooltip
+				label={playing ? 'Pause' : 'Play'}
+				shortcut={playPauseShortcut}
+				delay={800}
+				dismissOnClick={false}
 			>
-				{(color) =>
-					playing ? (
-						showBufferIndicator ? (
-							<PlayerInternals.BufferingIndicator type="studio" color={color} />
-						) : (
-							<Pause style={iconButton} color={color} />
-						)
-					) : (
-						<Play style={iconButton} color={color} />
-					)
-				}
-			</ControlButton>
+				{(describedBy) => (
+					<ControlButton
+						aria-label={playing ? 'Pause' : 'Play'}
+						aria-describedby={describedBy}
+						aria-keyshortcuts={playPauseAriaShortcut || undefined}
+						title=""
+						onClick={playing ? pause : play}
+						disabled={!videoConfig}
+					>
+						{(color) =>
+							playing ? (
+								showBufferIndicator ? (
+									<PlayerInternals.BufferingIndicator
+										type="studio"
+										color={color}
+									/>
+								) : (
+									<Pause style={iconButton} color={color} />
+								)
+							) : (
+								<Play style={iconButton} color={color} />
+							)
+						}
+					</ControlButton>
+				)}
+			</ActionTooltip>
 
 			{hideNavigationControls ? null : (
-				<ControlButton
-					aria-label="Step forward one frame"
-					title="Step forward one frame"
-					disabled={!videoConfig}
-					onClick={oneFrameForward}
+				<ActionTooltip
+					label="Go forward 1 frame"
+					shortcut="→"
+					delay={800}
+					dismissOnClick
 				>
-					{(color) => <StepForward style={forwardBackStyle} color={color} />}
-				</ControlButton>
+					{(describedBy) => (
+						<ControlButton
+							aria-label="Go forward 1 frame"
+							aria-describedby={describedBy}
+							aria-keyshortcuts="ArrowRight"
+							title=""
+							disabled={!videoConfig}
+							onClick={oneFrameForward}
+						>
+							{(color) => (
+								<StepForward style={forwardBackStyle} color={color} />
+							)}
+						</ControlButton>
+					)}
+				</ActionTooltip>
 			)}
 		</>
 	);

--- a/packages/studio/src/components/PlaybackKeyboardShortcutsManager.tsx
+++ b/packages/studio/src/components/PlaybackKeyboardShortcutsManager.tsx
@@ -1,12 +1,49 @@
 import {PlayerInternals} from '@remotion/player';
 import type React from 'react';
 import {useCallback, useEffect} from 'react';
+import {useIsVideoComposition} from '../helpers/is-current-selected-still';
 import {useKeybinding} from '../helpers/use-keybinding';
+import {toggleLoop} from './LoopToggle';
+import {toggleMute} from './MuteToggle';
 
 export const PlaybackKeyboardShortcutsManager: React.FC<{
 	readonly setPlaybackRate: React.Dispatch<React.SetStateAction<number>>;
-}> = ({setPlaybackRate}) => {
+	readonly setMuted: React.Dispatch<React.SetStateAction<boolean>>;
+	readonly setLoop: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({setPlaybackRate, setMuted, setLoop}) => {
 	const keybindings = useKeybinding();
+	const isVideoComposition = useIsVideoComposition();
+
+	useEffect(() => {
+		if (!isVideoComposition) {
+			return;
+		}
+
+		const mute = keybindings.registerKeybinding({
+			event: 'keydown',
+			action: 'toggleMute',
+			callback: (event) => {
+				if (!event.repeat) toggleMute(setMuted);
+			},
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		const loop = keybindings.registerKeybinding({
+			event: 'keydown',
+			action: 'toggleLoop',
+			callback: (event) => {
+				if (!event.repeat) toggleLoop(setLoop);
+			},
+			preventDefault: true,
+			triggerIfInputFieldFocused: false,
+			keepRegisteredWhenNotHighestContext: false,
+		});
+		return () => {
+			mute.unregister();
+			loop.unregister();
+		};
+	}, [isVideoComposition, keybindings, setLoop, setMuted]);
 
 	const {play, pause, isPlaying} = PlayerInternals.usePlayerMethods();
 

--- a/packages/studio/src/components/PlaybackRateSelector.tsx
+++ b/packages/studio/src/components/PlaybackRateSelector.tsx
@@ -12,7 +12,7 @@ const getPlaybackRateLabel = (playbackRate: number) => {
 	return `${playbackRate}x`;
 };
 
-const accessibilityLabel = 'Change the playback rate';
+const accessibilityLabel = 'Playback rate';
 
 type PlaybackRateMenuItemsProps = {
 	readonly playbackRate: number;
@@ -77,6 +77,7 @@ export const PlaybackRateSelector: React.FC<PlaybackRateMenuItemsProps> = ({
 	return (
 		<TimelineCombobox
 			title={accessibilityLabel}
+			tooltipDelay={800}
 			labelWidth={30}
 			selectedId={selectedId}
 			values={items}

--- a/packages/studio/src/components/PreviewToolbar.tsx
+++ b/packages/studio/src/components/PreviewToolbar.tsx
@@ -238,7 +238,11 @@ export const PreviewToolbar: React.FC<{
 				</PreviewToolbarControl>
 				<Spacing x={1.5} />
 			</div>
-			<PlaybackKeyboardShortcutsManager setPlaybackRate={setPlaybackRate} />
+			<PlaybackKeyboardShortcutsManager
+				setPlaybackRate={setPlaybackRate}
+				setMuted={setPlayerMuted}
+				setLoop={setLoop}
+			/>
 			<PlaybackRatePersistor />
 		</div>
 	);

--- a/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
+++ b/packages/studio/src/components/PreviewToolbarOverflowButton.tsx
@@ -43,6 +43,8 @@ export const PreviewToolbarOverflowButton: React.FC<{
 }) => {
 	const keyboardShortcutsDisabled = areKeyboardShortcutsDisabled();
 	const fullscreenShortcut = useKeyboardShortcutLabel('enterFullscreen');
+	const loopShortcut = useKeyboardShortcutLabel('toggleLoop');
+	const outlinesShortcut = useKeyboardShortcutLabel('toggleOutlines');
 	const checkerboardShortcut = useKeyboardShortcutLabel('toggleCheckerboard');
 	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
 	const {editorShowOutlines, setEditorShowOutlines} = useContext(
@@ -127,7 +129,10 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				label: 'Loop',
 				value: 'loop',
 				onClick: () => toggleLoop(setLoop),
-				keyHint: null,
+				keyHint:
+					keyboardShortcutsDisabled || loopShortcut === ''
+						? null
+						: loopShortcut,
 				leftItem: loop ? <Checkmark /> : null,
 				subMenu: null,
 				quickSwitcherLabel: null,
@@ -158,7 +163,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 				label: 'Outlines',
 				value: 'outlines',
 				onClick: () => setEditorShowOutlines((current) => !current),
-				keyHint: null,
+				keyHint: keyboardShortcutsDisabled ? null : outlinesShortcut || null,
 				leftItem: editorShowOutlines ? <Checkmark /> : null,
 				subMenu: null,
 				quickSwitcherLabel: null,
@@ -214,6 +219,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 	}, [
 		checkerboardShortcut,
 		fullscreenShortcut,
+		loopShortcut,
 		previewSizeItems,
 		playbackRateItems,
 		selectedPlaybackRate,
@@ -227,6 +233,7 @@ export const PreviewToolbarOverflowButton: React.FC<{
 		checkerboard,
 		editorShowGuides,
 		editorShowOutlines,
+		outlinesShortcut,
 		editorShowRulers,
 		setCheckerboard,
 		setEditorShowGuides,

--- a/packages/studio/src/components/RenderQueue/CaptionQueueItem.tsx
+++ b/packages/studio/src/components/RenderQueue/CaptionQueueItem.tsx
@@ -225,15 +225,12 @@ export const CaptionQueueItem: React.FC<{
 			<Spacing x={1} />
 			{job.status === 'running' ? null : (
 				<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
-					{(describedBy) => (
-						<InlineAction
-							renderAction={renderRemoveAction}
-							onClick={onRemove}
-							aria-label="Clear"
-							aria-describedby={describedBy}
-							variant={null}
-						/>
-					)}
+					<InlineAction
+						renderAction={renderRemoveAction}
+						onClick={onRemove}
+						aria-label="Clear"
+						variant={null}
+					/>
 				</ActionTooltip>
 			)}
 		</Row>

--- a/packages/studio/src/components/RenderQueue/CaptionQueueItem.tsx
+++ b/packages/studio/src/components/RenderQueue/CaptionQueueItem.tsx
@@ -12,6 +12,7 @@ import {
 	LIGHT_TEXT,
 } from '../../helpers/colors';
 import {pushUrl} from '../../helpers/url-state';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {Row, Spacing} from '../layout';
@@ -223,12 +224,17 @@ export const CaptionQueueItem: React.FC<{
 			</div>
 			<Spacing x={1} />
 			{job.status === 'running' ? null : (
-				<InlineAction
-					renderAction={renderRemoveAction}
-					onClick={onRemove}
-					title="Remove"
-					variant={null}
-				/>
+				<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
+					{(describedBy) => (
+						<InlineAction
+							renderAction={renderRemoveAction}
+							onClick={onRemove}
+							aria-label="Clear"
+							aria-describedby={describedBy}
+							variant={null}
+						/>
+					)}
+				</ActionTooltip>
 			)}
 		</Row>
 	);

--- a/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
@@ -4,6 +4,7 @@ import {CURRENT_COLOR} from '../../helpers/colors';
 import {remotion_outputsBase} from '../../helpers/get-asset-metadata';
 import {useCopyFeedback} from '../../helpers/use-copy-feedback';
 import {CopyIcon} from '../../icons/copy';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -76,11 +77,21 @@ export const RenderQueueCopyToClipboard: React.FC<{
 	);
 
 	return (
-		<InlineAction
-			variant={null}
-			title="Copy to clipboard"
-			renderAction={renderCopyAction}
-			onClick={onClick}
-		/>
+		<ActionTooltip
+			label="Copy to clipboard"
+			shortcut={null}
+			delay={800}
+			dismissOnClick
+		>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Copy to clipboard"
+					aria-describedby={describedBy}
+					variant={null}
+					renderAction={renderCopyAction}
+					onClick={onClick}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueCopyToClipboard.tsx
@@ -83,15 +83,12 @@ export const RenderQueueCopyToClipboard: React.FC<{
 			delay={800}
 			dismissOnClick
 		>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Copy to clipboard"
-					aria-describedby={describedBy}
-					variant={null}
-					renderAction={renderCopyAction}
-					onClick={onClick}
-				/>
-			)}
+			<InlineAction
+				aria-label="Copy to clipboard"
+				variant={null}
+				renderAction={renderCopyAction}
+				onClick={onClick}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
@@ -56,15 +56,12 @@ export const RenderQueueDownloadItem: React.FC<{
 
 	return (
 		<ActionTooltip label="Download" shortcut={null} delay={800} dismissOnClick>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Download"
-					aria-describedby={describedBy}
-					variant={null}
-					renderAction={renderAction}
-					onClick={onClick}
-				/>
-			)}
+			<InlineAction
+				aria-label="Download"
+				variant={null}
+				renderAction={renderAction}
+				onClick={onClick}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueDownloadItem.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo} from 'react';
 import {CURRENT_COLOR} from '../../helpers/colors';
 import {downloadBlob} from '../../helpers/download-blob';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -54,11 +55,16 @@ export const RenderQueueDownloadItem: React.FC<{
 	);
 
 	return (
-		<InlineAction
-			variant={null}
-			renderAction={renderAction}
-			onClick={onClick}
-			title="Download"
-		/>
+		<ActionTooltip label="Download" shortcut={null} delay={800} dismissOnClick>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Download"
+					aria-describedby={describedBy}
+					variant={null}
+					renderAction={renderAction}
+					onClick={onClick}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueItemCancelButton.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueItemCancelButton.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useContext, useMemo} from 'react';
 import {CURRENT_COLOR} from '../../helpers/colors';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -55,10 +56,21 @@ export const RenderQueueCancelButton: React.FC<{
 	);
 
 	return (
-		<InlineAction
-			renderAction={renderAction}
-			onClick={onClick}
-			variant={null}
-		/>
+		<ActionTooltip
+			label="Cancel render"
+			shortcut={null}
+			delay={800}
+			dismissOnClick
+		>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Cancel render"
+					aria-describedby={describedBy}
+					renderAction={renderAction}
+					onClick={onClick}
+					variant={null}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueItemCancelButton.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueItemCancelButton.tsx
@@ -62,15 +62,12 @@ export const RenderQueueCancelButton: React.FC<{
 			delay={800}
 			dismissOnClick
 		>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Cancel render"
-					aria-describedby={describedBy}
-					renderAction={renderAction}
-					onClick={onClick}
-					variant={null}
-				/>
-			)}
+			<InlineAction
+				aria-label="Cancel render"
+				renderAction={renderAction}
+				onClick={onClick}
+				variant={null}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useMemo} from 'react';
 import {getBrowserStudioOperations} from '../../helpers/browser-studio-operations';
 import {CURRENT_COLOR} from '../../helpers/colors';
 import {ExpandedFolderIconSolid} from '../../icons/folder';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -37,10 +38,21 @@ export const RenderQueueOpenInFinderItem: React.FC<{
 	);
 
 	return isBrowserStudio ? null : (
-		<InlineAction
-			renderAction={renderAction}
-			onClick={onClick}
-			variant={null}
-		/>
+		<ActionTooltip
+			label="Open in Folder"
+			shortcut={null}
+			delay={800}
+			dismissOnClick
+		>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Open in Folder"
+					aria-describedby={describedBy}
+					renderAction={renderAction}
+					onClick={onClick}
+					variant={null}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueOpenInFolder.tsx
@@ -44,15 +44,12 @@ export const RenderQueueOpenInFinderItem: React.FC<{
 			delay={800}
 			dismissOnClick
 		>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Open in Folder"
-					aria-describedby={describedBy}
-					renderAction={renderAction}
-					onClick={onClick}
-					variant={null}
-				/>
-			)}
+			<InlineAction
+				aria-label="Open in Folder"
+				renderAction={renderAction}
+				onClick={onClick}
+				variant={null}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
@@ -71,15 +71,12 @@ export const RenderQueueRemoveItem: React.FC<{
 
 	return (
 		<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Clear"
-					aria-describedby={describedBy}
-					renderAction={renderAction}
-					onClick={onClick}
-					variant={null}
-				/>
-			)}
+			<InlineAction
+				aria-label="Clear"
+				renderAction={renderAction}
+				onClick={onClick}
+				variant={null}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRemoveItem.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useContext, useMemo} from 'react';
 import {Internals} from 'remotion';
 import {unregisterClientRender} from '../../api/save-render-output';
 import {CURRENT_COLOR} from '../../helpers/colors';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {showNotification} from '../Notifications/NotificationCenter';
@@ -69,11 +70,16 @@ export const RenderQueueRemoveItem: React.FC<{
 	);
 
 	return (
-		<InlineAction
-			renderAction={renderAction}
-			onClick={onClick}
-			title="Remove"
-			variant={null}
-		/>
+		<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Clear"
+					aria-describedby={describedBy}
+					renderAction={renderAction}
+					onClick={onClick}
+					variant={null}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
@@ -6,6 +6,7 @@ import {
 	makeRetryPayload,
 } from '../../helpers/retry-payload';
 import {SetSelectedModalContext} from '../../state/modals';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import type {
@@ -61,10 +62,16 @@ export const RenderQueueRepeatItem: React.FC<{
 	);
 
 	return (
-		<InlineAction
-			onClick={onClick}
-			renderAction={renderAction}
-			variant={null}
-		/>
+		<ActionTooltip label="Retry" shortcut={null} delay={800} dismissOnClick>
+			{(describedBy) => (
+				<InlineAction
+					aria-label="Retry"
+					aria-describedby={describedBy}
+					onClick={onClick}
+					renderAction={renderAction}
+					variant={null}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
+++ b/packages/studio/src/components/RenderQueue/RenderQueueRepeat.tsx
@@ -63,15 +63,12 @@ export const RenderQueueRepeatItem: React.FC<{
 
 	return (
 		<ActionTooltip label="Retry" shortcut={null} delay={800} dismissOnClick>
-			{(describedBy) => (
-				<InlineAction
-					aria-label="Retry"
-					aria-describedby={describedBy}
-					onClick={onClick}
-					renderAction={renderAction}
-					variant={null}
-				/>
-			)}
+			<InlineAction
+				aria-label="Retry"
+				onClick={onClick}
+				renderAction={renderAction}
+				variant={null}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RenderQueue/VideoMattingQueueItem.tsx
+++ b/packages/studio/src/components/RenderQueue/VideoMattingQueueItem.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../helpers/colors';
 import {pushUrl} from '../../helpers/url-state';
 import {EllipsisIcon} from '../../icons/ellipsis';
+import {ActionTooltip} from '../ActionTooltip';
 import type {RenderInlineAction} from '../InlineAction';
 import {InlineAction} from '../InlineAction';
 import {InlineDropdown} from '../InlineDropdown';
@@ -204,22 +205,37 @@ export const VideoMattingQueueItem: React.FC<{
 			</div>
 			<Spacing x={1} />
 			{done ? (
-				<InlineDropdown
-					renderAction={(color) => (
-						<EllipsisIcon fill={color} svgProps={ellipsisIconStyle} />
+				<ActionTooltip
+					label="Reveal video layer"
+					shortcut={null}
+					delay={800}
+					dismissOnClick
+				>
+					{(describedBy) => (
+						<InlineDropdown
+							renderAction={(color) => (
+								<EllipsisIcon fill={color} svgProps={ellipsisIconStyle} />
+							)}
+							aria-label="Reveal video layer"
+							aria-describedby={describedBy}
+							values={revealItems}
+							variant={null}
+						/>
 					)}
-					title="Reveal video layer"
-					values={revealItems}
-					variant={null}
-				/>
+				</ActionTooltip>
 			) : null}
 			{job.status === 'running' ? null : (
-				<InlineAction
-					renderAction={renderRemove}
-					onClick={onRemove}
-					title="Remove"
-					variant={null}
-				/>
+				<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
+					{(describedBy) => (
+						<InlineAction
+							renderAction={renderRemove}
+							onClick={onRemove}
+							aria-label="Clear"
+							aria-describedby={describedBy}
+							variant={null}
+						/>
+					)}
+				</ActionTooltip>
 			)}
 		</Row>
 	);

--- a/packages/studio/src/components/RenderQueue/VideoMattingQueueItem.tsx
+++ b/packages/studio/src/components/RenderQueue/VideoMattingQueueItem.tsx
@@ -211,30 +211,24 @@ export const VideoMattingQueueItem: React.FC<{
 					delay={800}
 					dismissOnClick
 				>
-					{(describedBy) => (
-						<InlineDropdown
-							renderAction={(color) => (
-								<EllipsisIcon fill={color} svgProps={ellipsisIconStyle} />
-							)}
-							aria-label="Reveal video layer"
-							aria-describedby={describedBy}
-							values={revealItems}
-							variant={null}
-						/>
-					)}
+					<InlineDropdown
+						renderAction={(color) => (
+							<EllipsisIcon fill={color} svgProps={ellipsisIconStyle} />
+						)}
+						aria-label="Reveal video layer"
+						values={revealItems}
+						variant={null}
+					/>
 				</ActionTooltip>
 			) : null}
 			{job.status === 'running' ? null : (
 				<ActionTooltip label="Clear" shortcut={null} delay={800} dismissOnClick>
-					{(describedBy) => (
-						<InlineAction
-							renderAction={renderRemove}
-							onClick={onRemove}
-							aria-label="Clear"
-							aria-describedby={describedBy}
-							variant={null}
-						/>
-					)}
+					<InlineAction
+						renderAction={renderRemove}
+						onClick={onRemove}
+						aria-label="Clear"
+						variant={null}
+					/>
 				</ActionTooltip>
 			)}
 		</Row>

--- a/packages/studio/src/components/RulersAndGuidesToggle.tsx
+++ b/packages/studio/src/components/RulersAndGuidesToggle.tsx
@@ -1,7 +1,13 @@
 import React, {useCallback, useContext} from 'react';
 import {BLUE} from '../helpers/colors';
+import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutLabel,
+	useKeyboardShortcutAriaKeyShortcuts,
+} from '../helpers/use-keyboard-shortcut-label';
 import {EditorShowGuidesContext} from '../state/editor-guides';
 import {EditorShowRulersContext} from '../state/editor-rulers';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
 export const RulersAndGuidesToggle: React.FC<{
@@ -28,6 +34,12 @@ export const RulersAndGuidesToggle: React.FC<{
 		showGuides,
 	]);
 
+	const shortcut = useKeyboardShortcutLabel('toggleRulersAndGuides');
+	const ariaShortcut = useKeyboardShortcutAriaKeyShortcuts(
+		'toggleRulersAndGuides',
+	);
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
+
 	const accessibilityLabel = showGuides
 		? rulersOrGuidesAreVisible
 			? 'Hide rulers and guides'
@@ -37,26 +49,39 @@ export const RulersAndGuidesToggle: React.FC<{
 			: 'Show rulers';
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			aria-pressed={rulersOrGuidesAreVisible}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) => (
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 576 512"
-					style={{width: 18, height: 18}}
-					aria-hidden="true"
-					focusable="false"
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaShortcut || undefined
+					}
+					aria-pressed={rulersOrGuidesAreVisible}
+					onClick={onClick}
 				>
-					<path
-						fill={rulersOrGuidesAreVisible ? BLUE : color}
-						d="M525.9 154.2L186.5 493.6c-6.2 6.2-16.4 6.2-22.6 0L50.7 380.5c-6.2-6.2-6.2-16.4 0-22.6l33.9-33.9 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 33.9-33.9c6.2-6.2 16.4-6.2 22.6 0L525.9 131.5c6.2 6.2 6.2 16.4 0 22.6zM73.3 289.9L28.1 335.2c-18.7 18.7-18.7 49.1 0 67.9L141.2 516.2c18.7 18.7 49.1 18.7 67.9 0L548.5 176.8c18.7-18.7 18.7-49.1 0-67.9L435.4-4.2C416.6-23 386.2-23 367.5-4.2 77.1 286.2 140.3 223 73.3 289.9z"
-					/>
-				</svg>
+					{(color) => (
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 576 512"
+							style={{width: 18, height: 18}}
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path
+								fill={rulersOrGuidesAreVisible ? BLUE : color}
+								d="M525.9 154.2L186.5 493.6c-6.2 6.2-16.4 6.2-22.6 0L50.7 380.5c-6.2-6.2-6.2-16.4 0-22.6l33.9-33.9 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 33.9-33.9c6.2-6.2 16.4-6.2 22.6 0L525.9 131.5c6.2 6.2 6.2 16.4 0 22.6zM73.3 289.9L28.1 335.2c-18.7 18.7-18.7 49.1 0 67.9L141.2 516.2c18.7 18.7 49.1 18.7 67.9 0L548.5 176.8c18.7-18.7 18.7-49.1 0-67.9L435.4-4.2C416.6-23 386.2-23 367.5-4.2 77.1 286.2 140.3 223 73.3 289.9z"
+							/>
+						</svg>
+					)}
+				</ControlButton>
 			)}
-		</ControlButton>
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/RulersAndGuidesToggle.tsx
+++ b/packages/studio/src/components/RulersAndGuidesToggle.tsx
@@ -55,33 +55,30 @@ export const RulersAndGuidesToggle: React.FC<{
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaShortcut || undefined
-					}
-					aria-pressed={rulersOrGuidesAreVisible}
-					onClick={onClick}
-				>
-					{(color) => (
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 576 512"
-							style={{width: 18, height: 18}}
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path
-								fill={rulersOrGuidesAreVisible ? BLUE : color}
-								d="M525.9 154.2L186.5 493.6c-6.2 6.2-16.4 6.2-22.6 0L50.7 380.5c-6.2-6.2-6.2-16.4 0-22.6l33.9-33.9 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 33.9-33.9c6.2-6.2 16.4-6.2 22.6 0L525.9 131.5c6.2 6.2 6.2 16.4 0 22.6zM73.3 289.9L28.1 335.2c-18.7 18.7-18.7 49.1 0 67.9L141.2 516.2c18.7 18.7 49.1 18.7 67.9 0L548.5 176.8c18.7-18.7 18.7-49.1 0-67.9L435.4-4.2C416.6-23 386.2-23 367.5-4.2 77.1 286.2 140.3 223 73.3 289.9z"
-							/>
-						</svg>
-					)}
-				</ControlButton>
-			)}
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaShortcut || undefined
+				}
+				aria-pressed={rulersOrGuidesAreVisible}
+				onClick={onClick}
+			>
+				{(color) => (
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 576 512"
+						style={{width: 18, height: 18}}
+						aria-hidden="true"
+						focusable="false"
+					>
+						<path
+							fill={rulersOrGuidesAreVisible ? BLUE : color}
+							d="M525.9 154.2L186.5 493.6c-6.2 6.2-16.4 6.2-22.6 0L50.7 380.5c-6.2-6.2-6.2-16.4 0-22.6l33.9-33.9 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 39.6-39.6 33.9 33.9c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-33.9-33.9 39.6-39.6 56.6 56.6c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-56.6-56.6 33.9-33.9c6.2-6.2 16.4-6.2 22.6 0L525.9 131.5c6.2 6.2 6.2 16.4 0 22.6zM73.3 289.9L28.1 335.2c-18.7 18.7-18.7 49.1 0 67.9L141.2 516.2c18.7 18.7 49.1 18.7 67.9 0L548.5 176.8c18.7-18.7 18.7-49.1 0-67.9L435.4-4.2C416.6-23 386.2-23 367.5-4.2 77.1 286.2 140.3 223 73.3 289.9z"
+						/>
+					</svg>
+				)}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SettingsButton.tsx
+++ b/packages/studio/src/components/SettingsButton.tsx
@@ -65,17 +65,14 @@ export const SettingsButton: React.FC<{
 
 	return (
 		<ActionTooltip label={label} shortcut={null} delay={800} dismissOnClick>
-			{(describedBy) => (
-				<InlineAction
-					variant={null}
-					onClick={openModal}
-					renderAction={updateAvailable ? renderUpdateIcon : renderGearIcon}
-					unhoveredColor={hasBugfixesAvailable ? WARNING_COLOR : WHITE_ALPHA_80}
-					title=""
-					aria-label={label}
-					aria-describedby={describedBy}
-				/>
-			)}
+			<InlineAction
+				variant={null}
+				onClick={openModal}
+				renderAction={updateAvailable ? renderUpdateIcon : renderGearIcon}
+				unhoveredColor={hasBugfixesAvailable ? WARNING_COLOR : WHITE_ALPHA_80}
+				title=""
+				aria-label={label}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SettingsButton.tsx
+++ b/packages/studio/src/components/SettingsButton.tsx
@@ -3,6 +3,7 @@ import {getBrowserStudioOperations} from '../helpers/browser-studio-operations';
 import {WARNING_COLOR, WHITE_ALPHA_80} from '../helpers/colors';
 import {GearIcon} from '../icons/gear';
 import {SetSelectedModalContext} from '../state/modals';
+import {ActionTooltip} from './ActionTooltip';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {useUpdateStatus} from './UpdateStatusContext';
@@ -56,19 +57,25 @@ export const SettingsButton: React.FC<{
 		);
 	}, []);
 
+	const label = hasBugfixesAvailable
+		? 'Bugfixes available'
+		: updateAvailable
+			? 'Update available'
+			: 'Settings';
+
 	return (
-		<InlineAction
-			variant={null}
-			onClick={openModal}
-			renderAction={updateAvailable ? renderUpdateIcon : renderGearIcon}
-			unhoveredColor={hasBugfixesAvailable ? WARNING_COLOR : WHITE_ALPHA_80}
-			title={
-				hasBugfixesAvailable
-					? 'Bugfixes available'
-					: updateAvailable
-						? 'Update available'
-						: 'Settings'
-			}
-		/>
+		<ActionTooltip label={label} shortcut={null} delay={800} dismissOnClick>
+			{(describedBy) => (
+				<InlineAction
+					variant={null}
+					onClick={openModal}
+					renderAction={updateAvailable ? renderUpdateIcon : renderGearIcon}
+					unhoveredColor={hasBugfixesAvailable ? WARNING_COLOR : WHITE_ALPHA_80}
+					title=""
+					aria-label={label}
+					aria-describedby={describedBy}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -8,8 +8,12 @@ import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
-import {useKeyboardShortcutLabel} from '../helpers/use-keyboard-shortcut-label';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {SidebarContext} from '../state/sidebar';
+import {ActionTooltip} from './ActionTooltip';
 import type {RenderInlineAction} from './InlineAction';
 import {InlineAction} from './InlineAction';
 import {useResponsiveSidebarStatus} from './TopPanel';
@@ -154,17 +158,14 @@ export const SidebarCollapserControl: React.FC<{
 		};
 	}, [keybindings, side, toggleBoth, toggleLeft, toggleRight]);
 
-	const leftShortcut = useKeyboardShortcutLabel('toggleLeftSidebar');
-	const rightShortcut = useKeyboardShortcutLabel('toggleRightSidebar');
-	const toggleLeftTooltip =
-		areKeyboardShortcutsDisabled() || leftShortcut === ''
-			? 'Toggle Left Sidebar'
-			: `Toggle Left Sidebar (${leftShortcut})`;
-
-	const toggleRightTooltip =
-		areKeyboardShortcutsDisabled() || rightShortcut === ''
-			? 'Toggle Right Sidebar'
-			: `Toggle Right Sidebar (${rightShortcut})`;
+	const action = side === 'left' ? 'toggleLeftSidebar' : 'toggleRightSidebar';
+	const shortcut = useKeyboardShortcutLabel(action);
+	const ariaShortcut = useKeyboardShortcutAriaKeyShortcuts(action);
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
+	const expanded =
+		(side === 'left' ? leftSidebarStatus : sidebarCollapsedStateRight) ===
+			'expanded' && sidebarCollapsedDuringDrag !== side;
+	const label = `${expanded ? 'Collapse' : 'Expand'} ${side} sidebar`;
 
 	const colorStyle = useCallback((color: string): React.CSSProperties => {
 		return {
@@ -176,49 +177,46 @@ export const SidebarCollapserControl: React.FC<{
 	const toggleLeftAction: RenderInlineAction = useCallback(
 		(color) => {
 			return (
-				<div
-					data-sidebar-toggle="left"
-					style={colorStyle(color)}
-					title={toggleLeftTooltip}
-				>
+				<div data-sidebar-toggle="left" style={colorStyle(color)}>
 					<div style={leftIcon(color)} />
 				</div>
 			);
 		},
-		[colorStyle, leftIcon, toggleLeftTooltip],
+		[colorStyle, leftIcon],
 	);
 
 	const toggleRightAction: RenderInlineAction = useCallback(
 		(color) => {
 			return (
-				<div
-					data-sidebar-toggle="right"
-					style={colorStyle(color)}
-					title={toggleRightTooltip}
-				>
+				<div data-sidebar-toggle="right" style={colorStyle(color)}>
 					<div style={rightIcon(color)} />
 				</div>
 			);
 		},
-		[colorStyle, rightIcon, toggleRightTooltip],
+		[colorStyle, rightIcon],
 	);
 
-	if (side === 'left') {
-		return (
-			<InlineAction
-				variant={null}
-				onClick={toggleLeft}
-				renderAction={toggleLeftAction}
-				style={{marginRight: 4}}
-			/>
-		);
-	}
-
 	return (
-		<InlineAction
-			variant={null}
-			onClick={toggleRight}
-			renderAction={toggleRightAction}
-		/>
+		<ActionTooltip
+			label={label}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick
+		>
+			{(describedBy) => (
+				<InlineAction
+					variant={null}
+					onClick={side === 'left' ? toggleLeft : toggleRight}
+					renderAction={side === 'left' ? toggleLeftAction : toggleRightAction}
+					style={side === 'left' ? {marginRight: 4} : undefined}
+					aria-label={label}
+					aria-describedby={describedBy}
+					aria-expanded={expanded}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaShortcut || undefined
+					}
+				/>
+			)}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SidebarCollapserControls.tsx
+++ b/packages/studio/src/components/SidebarCollapserControls.tsx
@@ -203,20 +203,17 @@ export const SidebarCollapserControl: React.FC<{
 			delay={800}
 			dismissOnClick
 		>
-			{(describedBy) => (
-				<InlineAction
-					variant={null}
-					onClick={side === 'left' ? toggleLeft : toggleRight}
-					renderAction={side === 'left' ? toggleLeftAction : toggleRightAction}
-					style={side === 'left' ? {marginRight: 4} : undefined}
-					aria-label={label}
-					aria-describedby={describedBy}
-					aria-expanded={expanded}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaShortcut || undefined
-					}
-				/>
-			)}
+			<InlineAction
+				variant={null}
+				onClick={side === 'left' ? toggleLeft : toggleRight}
+				renderAction={side === 'left' ? toggleLeftAction : toggleRightAction}
+				style={side === 'left' ? {marginRight: 4} : undefined}
+				aria-label={label}
+				aria-expanded={expanded}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaShortcut || undefined
+				}
+			/>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SizeSelector.tsx
+++ b/packages/studio/src/components/SizeSelector.tsx
@@ -54,7 +54,7 @@ export const getPreviewSizeLabel = (previewSize: PreviewSize) => {
 	return `${(previewSize.size * 100).toFixed(0)}%`;
 };
 
-const accessibilityLabel = 'Preview Size';
+const accessibilityLabel = 'Zoom';
 
 export const getUniqueSizes = (size: PreviewSize) => {
 	const customPreviewSizes = [size, ...commonPreviewSizes];
@@ -156,6 +156,7 @@ export const SizeSelector: React.FC = () => {
 	return (
 		<TimelineCombobox
 			title={accessibilityLabel}
+			tooltipDelay={800}
 			selectedId={selectedId}
 			values={items}
 			renderLeftItem={(color) =>

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -32,27 +32,24 @@ export const SnappingToggle: React.FC = () => {
 			delay={800}
 			dismissOnClick={false}
 		>
-			{(describedBy) => (
-				<ControlButton
-					title=""
-					aria-label={accessibilityLabel}
-					aria-describedby={describedBy}
-					aria-pressed={editorSnapping}
-					aria-keyshortcuts={
-						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
-					}
-					onClick={onClick}
-				>
-					{(color) => (
-						<MagnetIcon
-							style={{width: 18, height: 18, transform: 'translateY(1px)'}}
-							color={editorSnapping ? BLUE : color}
-							aria-hidden="true"
-							focusable="false"
-						/>
-					)}
-				</ControlButton>
-			)}
+			<ControlButton
+				title=""
+				aria-label={accessibilityLabel}
+				aria-pressed={editorSnapping}
+				aria-keyshortcuts={
+					shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+				}
+				onClick={onClick}
+			>
+				{(color) => (
+					<MagnetIcon
+						style={{width: 18, height: 18, transform: 'translateY(1px)'}}
+						color={editorSnapping ? BLUE : color}
+						aria-hidden="true"
+						focusable="false"
+					/>
+				)}
+			</ControlButton>
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/SnappingToggle.tsx
+++ b/packages/studio/src/components/SnappingToggle.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useContext} from 'react';
-import {NoReactInternals} from 'remotion/no-react';
 import {BLUE} from '../helpers/colors';
 import {areKeyboardShortcutsDisabled} from '../helpers/use-keybinding';
 import {
@@ -8,6 +7,7 @@ import {
 } from '../helpers/use-keyboard-shortcut-label';
 import {MagnetIcon} from '../icons/magnet';
 import {EditorSnappingContext} from '../state/editor-snapping';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
 
 export const SnappingToggle: React.FC = () => {
@@ -20,29 +20,39 @@ export const SnappingToggle: React.FC = () => {
 	const ariaKeyShortcuts =
 		useKeyboardShortcutAriaKeyShortcuts('toggleSnapping');
 
-	const accessibilityLabel = [
-		editorSnapping ? 'Disable snapping' : 'Enable snapping',
-		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
-	]
-		.filter(NoReactInternals.truthy)
-		.join(' ');
+	const accessibilityLabel = editorSnapping
+		? 'Disable snapping'
+		: 'Enable snapping';
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 
 	return (
-		<ControlButton
-			title={accessibilityLabel}
-			aria-label={accessibilityLabel}
-			aria-pressed={editorSnapping}
-			aria-keyshortcuts={ariaKeyShortcuts || undefined}
-			onClick={onClick}
+		<ActionTooltip
+			label={accessibilityLabel}
+			shortcut={shortcutsDisabled ? null : shortcut}
+			delay={800}
+			dismissOnClick={false}
 		>
-			{(color) => (
-				<MagnetIcon
-					style={{width: 18, height: 18, transform: 'translateY(1px)'}}
-					color={editorSnapping ? BLUE : color}
-					aria-hidden="true"
-					focusable="false"
-				/>
+			{(describedBy) => (
+				<ControlButton
+					title=""
+					aria-label={accessibilityLabel}
+					aria-describedby={describedBy}
+					aria-pressed={editorSnapping}
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : ariaKeyShortcuts || undefined
+					}
+					onClick={onClick}
+				>
+					{(color) => (
+						<MagnetIcon
+							style={{width: 18, height: 18, transform: 'translateY(1px)'}}
+							color={editorSnapping ? BLUE : color}
+							aria-hidden="true"
+							focusable="false"
+						/>
+					)}
+				</ControlButton>
 			)}
-		</ControlButton>
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -13,6 +13,7 @@ import {useIsVideoComposition} from '../../helpers/is-current-selected-still';
 import {CanvasZoomIcon, CanvasZoomOutIcon} from '../../icons/canvas-zoom';
 import {TimelineZoomCtx} from '../../state/timeline-zoom';
 import {useZIndex} from '../../state/z-index';
+import {ActionTooltip} from '../ActionTooltip';
 import {ControlButton} from '../ControlButton';
 import {Spacing} from '../layout';
 import {scrollableRef} from './timeline-refs';
@@ -136,15 +137,25 @@ const TimelineZoomControlsInner: React.FC<{
 
 	return (
 		<div style={container}>
-			<ControlButton
-				onClick={onMinusClicked}
-				style={buttonStyle}
-				title="Zoom out timeline"
-				role={'ControlButton'}
-				type="button"
+			<ActionTooltip
+				label="Zoom out timeline"
+				shortcut={null}
+				delay={800}
+				dismissOnClick
 			>
-				{(color) => <CanvasZoomOutIcon color={color} />}
-			</ControlButton>
+				{(describedBy) => (
+					<ControlButton
+						onClick={onMinusClicked}
+						style={buttonStyle}
+						title=""
+						aria-label="Zoom out timeline"
+						aria-describedby={describedBy}
+						type="button"
+					>
+						{(color) => <CanvasZoomOutIcon color={color} />}
+					</ControlButton>
+				)}
+			</ActionTooltip>
 			<Spacing x={0.5} />
 			<TimelineZoomSlider
 				maxWidth={sliderMaxWidth}
@@ -152,15 +163,25 @@ const TimelineZoomControlsInner: React.FC<{
 				timelineViewportWidth={timelineViewportWidth}
 			/>
 			<Spacing x={0.5} />
-			<ControlButton
-				onClick={onPlusClicked}
-				style={buttonStyle}
-				title="Zoom in timeline"
-				role={'button'}
-				type="button"
+			<ActionTooltip
+				label="Zoom in timeline"
+				shortcut={null}
+				delay={800}
+				dismissOnClick
 			>
-				{(color) => <CanvasZoomIcon color={color} />}
-			</ControlButton>
+				{(describedBy) => (
+					<ControlButton
+						onClick={onPlusClicked}
+						style={buttonStyle}
+						title=""
+						aria-label="Zoom in timeline"
+						aria-describedby={describedBy}
+						type="button"
+					>
+						{(color) => <CanvasZoomIcon color={color} />}
+					</ControlButton>
+				)}
+			</ActionTooltip>
 		</div>
 	);
 };

--- a/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
+++ b/packages/studio/src/components/Timeline/TimelineZoomControls.tsx
@@ -143,18 +143,15 @@ const TimelineZoomControlsInner: React.FC<{
 				delay={800}
 				dismissOnClick
 			>
-				{(describedBy) => (
-					<ControlButton
-						onClick={onMinusClicked}
-						style={buttonStyle}
-						title=""
-						aria-label="Zoom out timeline"
-						aria-describedby={describedBy}
-						type="button"
-					>
-						{(color) => <CanvasZoomOutIcon color={color} />}
-					</ControlButton>
-				)}
+				<ControlButton
+					onClick={onMinusClicked}
+					style={buttonStyle}
+					title=""
+					aria-label="Zoom out timeline"
+					type="button"
+				>
+					{(color) => <CanvasZoomOutIcon color={color} />}
+				</ControlButton>
 			</ActionTooltip>
 			<Spacing x={0.5} />
 			<TimelineZoomSlider
@@ -169,18 +166,15 @@ const TimelineZoomControlsInner: React.FC<{
 				delay={800}
 				dismissOnClick
 			>
-				{(describedBy) => (
-					<ControlButton
-						onClick={onPlusClicked}
-						style={buttonStyle}
-						title=""
-						aria-label="Zoom in timeline"
-						aria-describedby={describedBy}
-						type="button"
-					>
-						{(color) => <CanvasZoomIcon color={color} />}
-					</ControlButton>
-				)}
+				<ControlButton
+					onClick={onPlusClicked}
+					style={buttonStyle}
+					title=""
+					aria-label="Zoom in timeline"
+					type="button"
+				>
+					{(color) => <CanvasZoomIcon color={color} />}
+				</ControlButton>
 			</ActionTooltip>
 		</div>
 	);

--- a/packages/studio/src/components/TimelineCombobox.tsx
+++ b/packages/studio/src/components/TimelineCombobox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {LIGHT_TEXT} from '../helpers/colors';
 import {CaretDown} from '../icons/caret';
+import {ActionTooltip} from './ActionTooltip';
 import type {RenderInlineAction} from './InlineAction';
 import {Spacing} from './layout';
 import type {ComboboxValue} from './NewComposition/ComboBox';
@@ -29,6 +30,7 @@ export const TimelineCombobox: React.FC<{
 	readonly values: ComboboxValue[];
 	readonly selectedId: string | number;
 	readonly title: string;
+	readonly tooltipDelay: number | null;
 	readonly labelWidth?: number;
 	readonly renderLeftItem?: RenderInlineAction;
 	readonly unhoveredIconColor?: string;
@@ -36,6 +38,7 @@ export const TimelineCombobox: React.FC<{
 	values,
 	selectedId,
 	title,
+	tooltipDelay,
 	labelWidth = 32,
 	renderLeftItem,
 	unhoveredIconColor = LIGHT_TEXT,
@@ -62,7 +65,9 @@ export const TimelineCombobox: React.FC<{
 					{selected ? (
 						<div
 							title={
-								typeof selected.label === 'string' ? selected.label : undefined
+								tooltipDelay === null && typeof selected.label === 'string'
+									? selected.label
+									: undefined
 							}
 							style={{...label, width: labelWidth}}
 						>
@@ -76,17 +81,30 @@ export const TimelineCombobox: React.FC<{
 			segmentId: 'selector',
 			selectedId,
 			style: {fontFamily: 'inherit', padding: '0 4px'},
-			title,
+			title: tooltipDelay === null ? title : null,
 			type: 'menu',
 			values,
 		},
 	];
 
-	return (
+	const button = (
 		<SegmentedButton
 			segments={segments}
 			style={segmentedButtonStyle}
 			title={null}
 		/>
+	);
+
+	return tooltipDelay === null ? (
+		button
+	) : (
+		<ActionTooltip
+			label={title}
+			shortcut={null}
+			delay={tooltipDelay}
+			dismissOnClick
+		>
+			{() => button}
+		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/TimelineCombobox.tsx
+++ b/packages/studio/src/components/TimelineCombobox.tsx
@@ -104,7 +104,7 @@ export const TimelineCombobox: React.FC<{
 			delay={tooltipDelay}
 			dismissOnClick
 		>
-			{() => button}
+			{button}
 		</ActionTooltip>
 	);
 };

--- a/packages/studio/src/components/TimelineInOutToggle.tsx
+++ b/packages/studio/src/components/TimelineInOutToggle.tsx
@@ -307,28 +307,25 @@ export const TimelineInOutPointToggle: React.FC = () => {
 				delay={800}
 				dismissOnClick
 			>
-				{(describedBy) => (
-					<ControlButton
-						title=""
-						aria-label="In point"
-						aria-description="Right click to clear"
-						aria-describedby={describedBy}
-						aria-keyshortcuts={
-							shortcutsDisabled ? undefined : inAriaShortcut || undefined
-						}
-						style={buttonStyle}
-						onClick={onInMark}
-						onContextMenu={clearInMark}
-						disabled={!videoConfig || isFirstFrame}
-					>
-						{(color) => (
-							<TimelineInPointer
-								color={inFrame === null ? color : BLUE}
-								style={style}
-							/>
-						)}
-					</ControlButton>
-				)}
+				<ControlButton
+					title=""
+					aria-label="In point"
+					aria-description="Right click to clear"
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : inAriaShortcut || undefined
+					}
+					style={buttonStyle}
+					onClick={onInMark}
+					onContextMenu={clearInMark}
+					disabled={!videoConfig || isFirstFrame}
+				>
+					{(color) => (
+						<TimelineInPointer
+							color={inFrame === null ? color : BLUE}
+							style={style}
+						/>
+					)}
+				</ControlButton>
 			</ActionTooltip>
 			<ActionTooltip
 				label="Out point"
@@ -336,28 +333,25 @@ export const TimelineInOutPointToggle: React.FC = () => {
 				delay={800}
 				dismissOnClick
 			>
-				{(describedBy) => (
-					<ControlButton
-						title=""
-						aria-label="Out point"
-						aria-description="Right click to clear"
-						aria-describedby={describedBy}
-						aria-keyshortcuts={
-							shortcutsDisabled ? undefined : outAriaShortcut || undefined
-						}
-						style={buttonStyle}
-						onClick={onOutMark}
-						onContextMenu={clearOutMark}
-						disabled={!videoConfig || isLastFrame}
-					>
-						{(color) => (
-							<TimelineOutPointer
-								color={outFrame === null ? color : BLUE}
-								style={style}
-							/>
-						)}
-					</ControlButton>
-				)}
+				<ControlButton
+					title=""
+					aria-label="Out point"
+					aria-description="Right click to clear"
+					aria-keyshortcuts={
+						shortcutsDisabled ? undefined : outAriaShortcut || undefined
+					}
+					style={buttonStyle}
+					onClick={onOutMark}
+					onContextMenu={clearOutMark}
+					disabled={!videoConfig || isLastFrame}
+				>
+					{(color) => (
+						<TimelineOutPointer
+							color={outFrame === null ? color : BLUE}
+							style={style}
+						/>
+					)}
+				</ControlButton>
 			</ActionTooltip>
 		</>
 	);

--- a/packages/studio/src/components/TimelineInOutToggle.tsx
+++ b/packages/studio/src/components/TimelineInOutToggle.tsx
@@ -6,13 +6,15 @@ import React, {
 	useImperativeHandle,
 } from 'react';
 import {Internals} from 'remotion';
-import {NoReactInternals} from 'remotion/no-react';
-import {useStudioConfigRevision} from '../helpers/client-id';
 import {BLUE} from '../helpers/colors';
 import {
 	areKeyboardShortcutsDisabled,
 	useKeybinding,
 } from '../helpers/use-keybinding';
+import {
+	useKeyboardShortcutAriaKeyShortcuts,
+	useKeyboardShortcutLabel,
+} from '../helpers/use-keyboard-shortcut-label';
 import {
 	TimelineInPointer,
 	TimelineOutPointer,
@@ -22,22 +24,8 @@ import {
 	useTimelineInOutFramePosition,
 	useTimelineSetInOutFramePosition,
 } from '../state/in-out';
+import {ActionTooltip} from './ActionTooltip';
 import {ControlButton} from './ControlButton';
-import {getKeyboardShortcutLabel} from './keyboard-shortcuts';
-
-const getTooltipText = (
-	pointType: string,
-	action: 'setInPoint' | 'setOutPoint',
-) => {
-	const shortcut = getKeyboardShortcutLabel(action);
-	return [
-		`Mark ${pointType}`,
-		areKeyboardShortcutsDisabled() || shortcut === '' ? null : `(${shortcut})`,
-		'- right click to clear',
-	]
-		.filter(NoReactInternals.truthy)
-		.join(' ');
-};
 
 const style: React.CSSProperties = {
 	width: 17,
@@ -57,7 +45,11 @@ export const inOutHandles = createRef<{
 export const defaultInOutValue: InOutValue = {inFrame: null, outFrame: null};
 
 export const TimelineInOutPointToggle: React.FC = () => {
-	useStudioConfigRevision();
+	const inShortcut = useKeyboardShortcutLabel('setInPoint');
+	const outShortcut = useKeyboardShortcutLabel('setOutPoint');
+	const inAriaShortcut = useKeyboardShortcutAriaKeyShortcuts('setInPoint');
+	const outAriaShortcut = useKeyboardShortcutAriaKeyShortcuts('setOutPoint');
+	const shortcutsDisabled = areKeyboardShortcutsDisabled();
 	const {inFrame, outFrame} = useTimelineInOutFramePosition();
 	const {setInAndOutFrames} = useTimelineSetInOutFramePosition();
 	const videoConfig = Internals.useUnsafeVideoConfig();
@@ -309,36 +301,64 @@ export const TimelineInOutPointToggle: React.FC = () => {
 
 	return (
 		<>
-			<ControlButton
-				title={getTooltipText('In', 'setInPoint')}
-				aria-label={getTooltipText('In', 'setInPoint')}
-				style={buttonStyle}
-				onClick={onInMark}
-				onContextMenu={clearInMark}
-				disabled={!videoConfig || isFirstFrame}
+			<ActionTooltip
+				label="In point"
+				shortcut={shortcutsDisabled ? null : inShortcut}
+				delay={800}
+				dismissOnClick
 			>
-				{(color) => (
-					<TimelineInPointer
-						color={inFrame === null ? color : BLUE}
-						style={style}
-					/>
+				{(describedBy) => (
+					<ControlButton
+						title=""
+						aria-label="In point"
+						aria-description="Right click to clear"
+						aria-describedby={describedBy}
+						aria-keyshortcuts={
+							shortcutsDisabled ? undefined : inAriaShortcut || undefined
+						}
+						style={buttonStyle}
+						onClick={onInMark}
+						onContextMenu={clearInMark}
+						disabled={!videoConfig || isFirstFrame}
+					>
+						{(color) => (
+							<TimelineInPointer
+								color={inFrame === null ? color : BLUE}
+								style={style}
+							/>
+						)}
+					</ControlButton>
 				)}
-			</ControlButton>
-			<ControlButton
-				title={getTooltipText('Out', 'setOutPoint')}
-				aria-label={getTooltipText('Out', 'setOutPoint')}
-				style={buttonStyle}
-				onClick={onOutMark}
-				onContextMenu={clearOutMark}
-				disabled={!videoConfig || isLastFrame}
+			</ActionTooltip>
+			<ActionTooltip
+				label="Out point"
+				shortcut={shortcutsDisabled ? null : outShortcut}
+				delay={800}
+				dismissOnClick
 			>
-				{(color) => (
-					<TimelineOutPointer
-						color={outFrame === null ? color : BLUE}
-						style={style}
-					/>
+				{(describedBy) => (
+					<ControlButton
+						title=""
+						aria-label="Out point"
+						aria-description="Right click to clear"
+						aria-describedby={describedBy}
+						aria-keyshortcuts={
+							shortcutsDisabled ? undefined : outAriaShortcut || undefined
+						}
+						style={buttonStyle}
+						onClick={onOutMark}
+						onContextMenu={clearOutMark}
+						disabled={!videoConfig || isLastFrame}
+					>
+						{(color) => (
+							<TimelineOutPointer
+								color={outFrame === null ? color : BLUE}
+								style={style}
+							/>
+						)}
+					</ControlButton>
 				)}
-			</ControlButton>
+			</ActionTooltip>
 		</>
 	);
 };

--- a/packages/studio/src/components/keyboard-shortcuts.ts
+++ b/packages/studio/src/components/keyboard-shortcuts.ts
@@ -35,11 +35,13 @@ export const defaultKeyboardShortcuts: Record<
 	readonly StudioKeyboardShortcut[]
 > = {
 	playPause: [{key: 'Space'}],
+	toggleMute: [{key: 'm', shift: false}],
+	toggleLoop: [{key: 'l', shift: true}],
 	jumpToBeginning: [{key: 'a'}],
 	jumpToEnd: [{key: 'e'}],
 	reversePlayback: [{key: 'j'}],
 	pausePlayback: [{key: 'k'}],
-	playForward: [{key: 'l'}],
+	playForward: [{key: 'l', shift: false}],
 	goToFrame: [{key: 'g'}],
 	pauseAndReturnToPlaybackStart: [{key: 'Enter'}],
 	toggleLeftSidebar: [{key: 'b', commandOrControl: true}],
@@ -47,14 +49,16 @@ export const defaultKeyboardShortcuts: Record<
 	toggleBothSidebars: [{key: 'g', commandOrControl: true}],
 	enterFullscreen: [{key: 'f'}],
 	toggleSnapping: [{key: 'm', shift: true}],
+	toggleOutlines: [{key: 'o', shift: true}],
+	toggleRulersAndGuides: [{key: 'r', shift: true}],
 	previousComposition: [{key: 'PageUp'}],
 	nextComposition: [{key: 'PageDown'}],
 	showKeyboardShortcuts: [{key: '?', shift: true}],
 	quickSwitcher: [{key: 'k', commandOrControl: true}],
-	render: [{key: 'r'}],
+	render: [{key: 'r', shift: false}],
 	toggleCheckerboard: [{key: 't'}],
 	setInPoint: [{key: 'i'}],
-	setOutPoint: [{key: 'o'}],
+	setOutPoint: [{key: 'o', shift: false}],
 	clearInOutPoints: [{key: 'x'}],
 	zoomIn: [{key: '+', shift: true}, {key: '+'}],
 	zoomOut: [{key: '-'}],
@@ -67,7 +71,7 @@ export const defaultKeyboardShortcuts: Record<
 	selectAllSequenceRows: [{key: 'a', commandOrControl: true}],
 	selectTranslateProp: [{key: 'p'}],
 	selectOpacityProp: [{key: 't'}],
-	selectRotateProp: [{key: 'r'}],
+	selectRotateProp: [{key: 'r', shift: false}],
 	selectScaleProp: [{key: 's'}],
 	duplicateSequences: [{key: 'd', commandOrControl: true}],
 	copyEffectsAndValues: [{key: 'c', commandOrControl: true}],
@@ -91,6 +95,8 @@ export const keyboardShortcutGroups: readonly KeyboardShortcutGroup[] = [
 				'Context-sensitive timeline control',
 			),
 			shortcut('Play / Pause', 'playPause'),
+			shortcut('Mute / Unmute', 'toggleMute'),
+			shortcut('Loop', 'toggleLoop'),
 			fixedShortcut(
 				'Next frame',
 				[['→']],
@@ -127,6 +133,8 @@ export const keyboardShortcutGroups: readonly KeyboardShortcutGroup[] = [
 			shortcut('Enter fullscreen', 'enterFullscreen'),
 			fixedShortcut('Exit fullscreen', [['Esc']], 'Handled by the browser'),
 			shortcut('Enable snapping', 'toggleSnapping'),
+			shortcut('Outlines', 'toggleOutlines'),
+			shortcut('Rulers and guides', 'toggleRulersAndGuides'),
 		],
 	},
 	{
@@ -239,8 +247,8 @@ export const keyboardEventMatchesShortcut = ({
 		event.key.toLowerCase() === normalizeKey(value.key).toLowerCase() &&
 		commandOrControl === (value.commandOrControl ?? false) &&
 		(isMac ? !event.ctrlKey : !event.metaKey) &&
-		(!value.shift || event.shiftKey) &&
-		(!value.alt || event.altKey)
+		(value.shift === undefined || event.shiftKey === value.shift) &&
+		(value.alt === undefined || event.altKey === value.alt)
 	);
 };
 
@@ -249,7 +257,13 @@ export const keyboardShortcutsOverlap = (
 	second: StudioKeyboardShortcut,
 ) =>
 	first.key.toLowerCase() === second.key.toLowerCase() &&
-	(first.commandOrControl ?? false) === (second.commandOrControl ?? false);
+	(first.commandOrControl ?? false) === (second.commandOrControl ?? false) &&
+	(first.shift === undefined ||
+		second.shift === undefined ||
+		first.shift === second.shift) &&
+	(first.alt === undefined ||
+		second.alt === undefined ||
+		first.alt === second.alt);
 
 export const keyboardEventMatchesAction = (
 	event: KeyboardEvent,
@@ -315,7 +329,7 @@ export const shortcutFromKeyboardEvent = (
 		...((isMac ? event.metaKey : event.ctrlKey)
 			? {commandOrControl: true}
 			: {}),
-		...(event.shiftKey ? {shift: true} : {}),
-		...(event.altKey ? {alt: true} : {}),
+		shift: event.shiftKey,
+		alt: event.altKey,
 	};
 };

--- a/packages/studio/src/helpers/colors.ts
+++ b/packages/studio/src/helpers/colors.ts
@@ -34,6 +34,7 @@ export const WHITE_ALPHA_60 = 'rgba(255, 255, 255, 0.6)';
 export const WHITE_ALPHA_70 = 'rgba(255, 255, 255, 0.7)';
 export const WHITE_ALPHA_72 = 'rgba(255, 255, 255, 0.72)';
 export const WHITE_ALPHA_80 = 'rgba(255, 255, 255, 0.8)';
+export const WHITE_ALPHA_90 = 'rgba(255, 255, 255, 0.9)';
 export const BLACK_ALPHA_10 = 'rgba(0, 0, 0, 0.1)';
 export const BLACK_ALPHA_28 = 'rgba(0, 0, 0, 0.28)';
 export const BLACK_ALPHA_30 = 'rgba(0, 0, 0, 0.3)';

--- a/packages/studio/src/test/keyboard-shortcuts.test.ts
+++ b/packages/studio/src/test/keyboard-shortcuts.test.ts
@@ -5,6 +5,7 @@ import {
 	formatKeyboardShortcutForAria,
 	keyboardEventMatchesShortcut,
 	keyboardShortcutsOverlap,
+	shortcutFromKeyboardEvent,
 } from '../components/keyboard-shortcuts';
 import {isMac} from '../helpers/is-mac';
 
@@ -89,6 +90,49 @@ test('detects overlapping shortcuts', () => {
 	expect(
 		keyboardShortcutsOverlap({key: 'a'}, {commandOrControl: true, key: 'a'}),
 	).toBe(false);
+});
+
+test('keeps shifted shortcuts distinct from their plain-key actions', () => {
+	for (const [key, plainAction, shiftedAction] of [
+		['m', 'toggleMute', 'toggleSnapping'],
+		['l', 'playForward', 'toggleLoop'],
+		['o', 'setOutPoint', 'toggleOutlines'],
+		['r', 'render', 'toggleRulersAndGuides'],
+		['r', 'selectRotateProp', 'toggleRulersAndGuides'],
+	] as const) {
+		const plainShortcut = defaultKeyboardShortcuts[plainAction][0];
+		const shiftedShortcut = defaultKeyboardShortcuts[shiftedAction][0];
+		for (const shiftKey of [false, true]) {
+			const keyEvent = event({
+				key: shiftKey ? key.toUpperCase() : key,
+				shiftKey,
+			});
+			expect(
+				keyboardEventMatchesShortcut({
+					event: keyEvent,
+					shortcut: plainShortcut,
+				}),
+			).toBe(!shiftKey);
+			expect(
+				keyboardEventMatchesShortcut({
+					event: keyEvent,
+					shortcut: shiftedShortcut,
+				}),
+			).toBe(shiftKey);
+		}
+
+		expect(keyboardShortcutsOverlap(plainShortcut, shiftedShortcut)).toBe(
+			false,
+		);
+		const recorded = shortcutFromKeyboardEvent(event({key}))!;
+		expect(keyboardShortcutsOverlap(recorded, shiftedShortcut)).toBe(false);
+		expect(
+			keyboardEventMatchesShortcut({
+				event: event({key, altKey: true}),
+				shortcut: recorded,
+			}),
+		).toBe(false);
+	}
 });
 
 test('formats a shortcut for display', () => {


### PR DESCRIPTION
## What

Toolbar buttons in the Studio now show a tooltip with their label and keyboard shortcut on hover/focus, via a new `ActionTooltip` component.

Also adds keyboard shortcuts for actions that previously had none:
- `M` — Mute / Unmute
- `Shift+L` — Loop
- `Shift+O` — Toggle outlines
- `Shift+R` — Toggle rulers and guides

Shortcut matching for `shift`/`alt` modifiers is now exact (previously `shift: true` required the key but didn't forbid it when unset, and unset meant "don't care"), so shortcuts that overload a key with/without Shift (e.g. plain `l` for play-forward vs. `Shift+L` for loop) no longer conflict.

`ActionTooltip` takes regular React children rather than an `aria-describedby` render prop. That keeps tooltip visibility from re-rendering the control (a11y vs. performance).

## Test plan
- `bun run build`
- `bun run stylecheck`
- Updated/added unit tests in `keyboard-shortcuts.test.ts`
- Updated e2e test in `packages/example/e2e/studio.test.mts`

## Preview
- [Keyboard shortcuts](https://remotion-git-codex-studio-toolbar-tooltips-remotion.vercel.app/docs/studio/shortcuts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8F1PURkS6MCr1MjYQzY3i
