### PR TITLE
Internal: Stabilize transition registration range test

### DIFF
--- a/packages/transitions/src/test/transition-series-stack.test.tsx
+++ b/packages/transitions/src/test/transition-series-stack.test.tsx
@@ -214,7 +214,7 @@ test('TransitionSeries registers with its own visual mode identity', async () =>
 });
 
 test('TransitionSeries.Transition and Overlay register at their rendered timeline ranges', async () => {
-	const registeredSequences: RegisteredSequence[] = [];
+	const registeredSequences = new Map<string, RegisteredSequence>();
 	const div = document.createElement('div');
 	const root = createRoot(div);
 	const transitionStack = 'Error\n    at UserAuthoredTransition';
@@ -228,8 +228,13 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 	root.render(
 		<SequenceTestWrapper
 			onRegisterSequence={(sequence) => {
-				registeredSequences.push(sequence);
-				pendingRegistrationStacks.delete(sequence.getStack() ?? '');
+				const stack = sequence.getStack();
+				if (stack === null || !pendingRegistrationStacks.has(stack)) {
+					return;
+				}
+
+				registeredSequences.set(stack, sequence);
+				pendingRegistrationStacks.delete(stack);
 				if (pendingRegistrationStacks.size === 0) {
 					resolveRegistrations();
 				}
@@ -269,12 +274,8 @@ test('TransitionSeries.Transition and Overlay register at their rendered timelin
 
 	await registrations;
 
-	const transition = registeredSequences.find(
-		(sequence) => sequence.getStack() === transitionStack,
-	);
-	const overlay = registeredSequences.find(
-		(sequence) => sequence.getStack() === overlayStack,
-	);
+	const transition = registeredSequences.get(transitionStack);
+	const overlay = registeredSequences.get(overlayStack);
 
 	root.unmount();
 


### PR DESCRIPTION
## Summary

- capture transition and overlay registrations when their live stack identity is observed
- prevent asynchronous React updates from invalidating the registration lookup
- retain coverage for Studio timeline range and interactivity metadata

## Test plan

- `bun test src` in `packages/transitions`
- focused test repeated successfully 6,074 times
- `bun run build`
- `bun run stylecheck`
## Summary

- Rewrite the Mediabunny docs overview around current Remotion usage, `npx remotion add mediabunny`, and `npx remotion upgrade`
- Add a `remotion.dev/mediabunny` redirect to `/docs/mediabunny`

Closes #9128

## Test plan

- [ ] Open `/docs/mediabunny` and confirm the install and upgrade commands
- [ ] Confirm `remotion.dev/mediabunny` redirects to `/docs/mediabunny`

## Preview

- https://remotion-git-docs-rewrite-mediabunny-remotion.vercel.app/docs/mediabunny
