### PR TITLE
Docs: Clarify Element Sequence ownership and editing

### DIFF
--- a/packages/docs/docs/studio-protocol/create-element-payload.mdx
+++ b/packages/docs/docs/studio-protocol/create-element-payload.mdx
@@ -72,9 +72,11 @@ The preferred duration shown while dragging. It must be a positive integer.
 
 Controls how Studio installs the Element. The default is `'wrapped'`.
 
-Use `'wrapped'` for a regular visual component. Studio generates a [`<Sequence>`](/docs/sequence) around the component to provide its timing, name, dimensions, and position.
+With `'wrapped'`, Studio generates a [`<Sequence>`](/docs/sequence) around the component to provide its timing, name, dimensions, and position.
 
-Use `'component-owned-sequence'` only if the component already owns the one Sequence that should appear in the timeline and be editable in Studio. The component must accept and forward `from`, `durationInFrames`, `name`, and `style` to that Sequence and its rendered outline. It must also define its own rendered dimensions. Studio places timing and absolute positioning props directly on the component call instead of generating an outer Sequence.
+With `'component-owned-sequence'`, Studio puts timing, name, and absolute positioning props on the component call without adding an outer Sequence. The component must provide its own Studio-editable Sequence and rendered dimensions.
+
+See [Design it for composition](/elements/contributing#design-it-for-composition) for guidance on choosing a mode and wiring the component.
 
 ## Return value
 

--- a/packages/docs/elements/contributing.mdx
+++ b/packages/docs/elements/contributing.mdx
@@ -81,11 +81,22 @@ The caption Elements show the distinction: moving a pill between words, popping 
 
 ### Design it for composition
 
-Size the Element to its smallest useful bounding box. By default, let the [`<Sequence>`](/docs/sequence) generated during installation control its placement and duration. Set both dimensions to `null` if it adapts to the composition.
+Prefer the default `installationMode: 'wrapped'` and keep the Element's layers inspectable so users can edit and remix them. The [`<Sequence>`](/docs/sequence) generated during installation controls placement and duration. Size the Element to its smallest useful bounding box, or set both dimensions to `null` if it adapts to the composition.
 
-An Element that already owns the one interactive Sequence users should edit may set `installationMode: 'component-owned-sequence'` in its central definition. In this mode, the public component must accept and forward `from`, `durationInFrames`, `name`, and `style` to its Sequence and rendered outline. It must also define its own rendered dimensions because Element metadata dimensions are not passed as component props.
+For an analyzer or generative effect such as the [audio oscilloscope](/elements/audio/oscilloscope), editing individual generated parts is less useful. A public interface can expose the useful controls while keeping the implementation behind them. Use `installationMode: 'component-owned-sequence'` for this approach if the exported component has its own Studio-editable `<Sequence>`.
 
-Do not use the component-owned mode merely to remove markup: The Element needs to remain movable and trimmable through its component-owned Sequence. Do not add internal padding only to improve the gallery preview.
+Export [`Interactive.withSchema()`](/docs/interactive-with-schema) directly and connect its props:
+
+- Include [`Interactive.baseSchema`](/docs/interactive#interactivebaseschema) in the schema and forward `controls` unchanged to the owned `<Sequence>`.
+- Forward `from`, `durationInFrames`, `trimBefore`, `freeze`, and `name` to that Sequence.
+- Forward `style` and the ref to the rendered outline, and pass [`outlineRef`](/docs/sequence#outlineref) to the Sequence when using `layout="none"`. Set dimensions in the component; it does not receive dimensions from Element metadata.
+- Put frame-dependent animation in a child component below the Sequence so [`useCurrentFrame()`](/docs/use-current-frame) respects `from`, `trimBefore`, and `freeze`. Calling it in the component that returns the Sequence reads the parent clock.
+
+Avoid a plain forwarding wrapper around the schema-enabled component. It can make Studio target internal JSX with computed spread props instead of editable timing at the call site. The [oscilloscope](/elements/audio/oscilloscope), [waveform progress](/elements/audio/waveform-progress), and [mirrored spectrum](/elements/audio/mirrored-spectrum) Elements show the direct-export pattern.
+
+A Sequence can group inspectable children; you do not need to limit the subtree to one timeline row. Check that the exported instance can be moved and trimmed in Studio. The default `'wrapped'` mode adds an outer Sequence but does not fix these wiring problems.
+
+Choose the mode based on which component owns the editable Sequence, not to remove markup. Do not add padding only for the gallery preview.
 
 ### Animate temporary Elements in and out
 
@@ -99,7 +110,7 @@ Animate properties within the Element, such as translation, scale, and opacity; 
 
 Elements are source-code copies designed for direct editing, not managed dependencies. Expose useful Studio controls in the Element's `Interactive` schema, but there is no need to mirror every implementation detail as a public prop.
 
-Use [`Interactive.withSchema()`](/docs/interactive-with-schema) when you intentionally want an instance-level API. Controls should meaningfully edit the treatment; they may tune details but must not switch between unrelated visual styles.
+Reserve [`Interactive.withSchema()`](/docs/interactive-with-schema) for Elements that benefit more from a public interface than from editing their layers. Controls should meaningfully edit the treatment; they may tune details but must not switch between unrelated visual styles.
 
 Give editable objects clear names, using a generic name such as `Container` for the main object and child controls only for separate editing targets.
 


### PR DESCRIPTION
## Summary

Prefer wrapped Elements with inspectable, remixable layers. Explain when a public interface fits an analyzer or generative effect, using the audio oscilloscope as an example.

Document direct `Interactive.withSchema()` exports, controls and timing forwarding, outline wiring, and animation below the owned Sequence. Keep the installation API reference focused on behavior and link to the contribution guide rather than repeating the guidance.

Docs only; no Element implementations or installation metadata changed.

## Verification

- `bun run build` passed.
- `bun run stylecheck` passed.
- Both edited pages compiled with the MDX compiler.
- `git diff --check` passed.
- Checked the guidance against the implementation and the oscilloscope, waveform-progress, and mirrored-spectrum Elements.

Oxfmt rewrote an existing MDX comment; that unrelated rewrite was restored before committing.

## Preview

- [Contributing an Element](https://remotion-git-docs-component-owned-sequence-remotion.vercel.app/elements/contributing)
- [createElementPayload()](https://remotion-git-docs-component-owned-sequence-remotion.vercel.app/docs/studio-protocol/create-element-payload)
