### PR TITLE
Elements: Fix Social Safe Zones transform editing

### DIFF
--- a/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
+++ b/packages/docs/elements/overlays/social-safe-zones/social-safe-zones.tsx
@@ -44,6 +44,7 @@ const socialSafeZonesSchema = {
 		hiddenFromList: false,
 		keyframable: false,
 	},
+	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
 const SocialSafeZonesInner = forwardRef<
@@ -93,7 +94,7 @@ const SocialSafeZonesInner = forwardRef<
 				layout="none"
 				{...sequenceProps}
 				controls={controls}
-				name={name ?? '<SocialSafeZones>'}
+				name={name ?? 'Social Safe Zones'}
 				outlineRef={outlineRef}
 			>
 				<div
@@ -152,6 +153,7 @@ const SocialSafeZonesInner = forwardRef<
 							aria-hidden="true"
 							fit="contain"
 							height={1920}
+							showInTimeline={false}
 							src={
 								platform === 'tiktok'
 									? 'https://remotion.media/elements/social-safe-zones/tiktok-interface.png'


### PR DESCRIPTION
## Summary

- Expose transform controls for Social Safe Zones so it can be moved and scaled in Studio.
- Keep component-owned Sequence installation and a single timeline item by hiding the internal interface image from the timeline.
- Use "Social Safe Zones" as the fallback timeline name.

The existing platform, interface visibility, and unsafe-area opacity controls, fixed 1080×1920 calibration, and normal rendering behavior are unchanged. Playground test installations were removed.

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/docs/src/test/elements.test.ts` — 239 passed
- `git diff --check`
- User confirmed movement works after reinstalling the Element.

No new tests were added, as requested.
