### PR TITLE
Add Angles to Products resources

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -194,6 +194,7 @@ See the [Showcase](/showcase) for videos made with Remotion.
 - [CutSnap — AI video editor with auto-captions](https://cutsnap.ai)
 - [MapAnimate - Travel Map Animation Generator](https://mapanimate.app)
 - [Captioner - AI Video Translator](https://captioner.io)
+- [Angles - Multi-angle promo videos from a product page](https://angles.video)
 
 ## See also
 


### PR DESCRIPTION
Adds Angles to the Products list on the Resources page.

Angles turns a product page, screen recording, or brief into distinct selling angles, each an editable video with its own hook, script, voice-over, and captions. The whole rendering pipeline is built on Remotion — compositions are rendered through @remotion/lambda, and the in-app preview uses @remotion/player so what the user previews is what gets rendered.

Site: https://angles.video