### PR TITLE
`@remotion/studio`: Fix hidden Captions Inspector for missing props

### DIFF
--- a/packages/example/e2e/captions-inspector.test.mts
+++ b/packages/example/e2e/captions-inspector.test.mts
@@ -22,16 +22,27 @@ const elementCallSiteFile = path.join(
 	'src',
 	'MovingPillCaptionsComposition.tsx',
 );
+const missingCaptionsCallSiteFile = path.join(
+	exampleDir,
+	'src',
+	'CaptionsTester',
+	'MissingCaptionsComposition.tsx',
+);
 
 test.describe('captions inspector', () => {
 	let inlineSourceBefore: string;
 	let elementSourceBefore: string;
 	let elementCallSiteSourceBefore: string;
+	let missingCaptionsCallSiteSourceBefore: string;
 
 	test.beforeEach(async () => {
 		inlineSourceBefore = fs.readFileSync(inlineCaptionsFile, 'utf-8');
 		elementSourceBefore = fs.readFileSync(elementCaptionsFile, 'utf-8');
 		elementCallSiteSourceBefore = fs.readFileSync(elementCallSiteFile, 'utf-8');
+		missingCaptionsCallSiteSourceBefore = fs.readFileSync(
+			missingCaptionsCallSiteFile,
+			'utf-8',
+		);
 		await startStudio();
 	});
 
@@ -40,6 +51,10 @@ test.describe('captions inspector', () => {
 		fs.writeFileSync(inlineCaptionsFile, inlineSourceBefore);
 		fs.writeFileSync(elementCaptionsFile, elementSourceBefore);
 		fs.writeFileSync(elementCallSiteFile, elementCallSiteSourceBefore);
+		fs.writeFileSync(
+			missingCaptionsCallSiteFile,
+			missingCaptionsCallSiteSourceBefore,
+		);
 	});
 
 	test('persists caption edits at their inline definitions', async ({page}) => {
@@ -173,5 +188,53 @@ test.describe('captions inspector', () => {
 				);
 			})
 			.toBe(true);
+	});
+
+	test('imports captions when the schema-declared prop is missing', async ({
+		page,
+	}) => {
+		await page.goto(`${STUDIO_URL}/missing-captions-inspector-e2e`);
+		await expect(page).toHaveURL(/missing-captions-inspector-e2e/, {
+			timeout: 15_000,
+		});
+		await page.waitForFunction(
+			() => !document.body.innerText.includes('Loading...'),
+			{timeout: 30_000},
+		);
+
+		const captionsSequence = page
+			.getByText('<MissingCaptions>', {exact: true})
+			.first();
+		const importCaptionsButton = page.getByRole('button', {
+			name: 'Import captions',
+			exact: true,
+		});
+		await expect(async () => {
+			await captionsSequence.click();
+			await expect(importCaptionsButton).toBeVisible({timeout: 1_000});
+		}).toPass({timeout: 30_000});
+
+		await page.getByLabel('Import captions file').setInputFiles({
+			name: 'captions.json',
+			mimeType: 'application/json',
+			buffer: Buffer.from(
+				JSON.stringify([
+					{
+						text: 'Materialized',
+						startMs: 0,
+						endMs: 1000,
+						timestampMs: 500,
+						confidence: null,
+					},
+				]),
+			),
+		});
+
+		await expect(page.getByRole('textbox', {name: 'Caption 1'})).toHaveValue(
+			'Materialized',
+		);
+		await expect
+			.poll(() => fs.readFileSync(missingCaptionsCallSiteFile, 'utf-8'))
+			.toMatch(/<MissingCaptions[\s\S]*captions=\{\[[\s\S]*Materialized/);
 	});
 });

--- a/packages/example/src/CaptionsTester/MissingCaptionsComposition.tsx
+++ b/packages/example/src/CaptionsTester/MissingCaptionsComposition.tsx
@@ -1,0 +1,29 @@
+import type {Caption} from '@remotion/captions';
+import React from 'react';
+import {Interactive, Sequence, type SequenceControls} from 'remotion';
+
+type MissingCaptionsProps = {
+	readonly captions: Caption[] | undefined;
+};
+
+const MissingCaptionsInner: React.FC<
+	MissingCaptionsProps & {readonly controls: SequenceControls | undefined}
+> = ({controls}) => {
+	return (
+		<Sequence controls={controls} name="Missing Captions">
+			<div>Import captions in the inspector</div>
+		</Sequence>
+	);
+};
+
+const MissingCaptions = Interactive.withSchema({
+	Component: MissingCaptionsInner,
+	componentName: '<MissingCaptions>',
+	schema: Interactive.captionsSchema,
+	supportsEffects: false,
+});
+
+export const MissingCaptionsComposition: React.FC = () => {
+	// @ts-expect-error This fixture intentionally omits the schema-declared prop.
+	return <MissingCaptions />;
+};

--- a/packages/example/src/E2eTestRoot.tsx
+++ b/packages/example/src/E2eTestRoot.tsx
@@ -6,6 +6,7 @@ import {
 	CAPTIONS_HEIGHT,
 } from './CaptionsTester/AnimatedCaptions';
 import {AnimatedCaptionsComposition} from './CaptionsTester/AnimatedCaptionsComposition';
+import {MissingCaptionsComposition} from './CaptionsTester/MissingCaptionsComposition';
 import {EffectKeyframeE2e} from './EffectKeyframeE2e';
 import {
 	ErrorOverlayRepro,
@@ -116,6 +117,14 @@ export const E2eTestRoot: React.FC = () => {
 				id="default-captions-inspector-e2e"
 				component={MovingPillCaptionsComposition}
 				durationInFrames={210}
+				fps={30}
+				width={1920}
+				height={1080}
+			/>
+			<Composition
+				id="missing-captions-inspector-e2e"
+				component={MissingCaptionsComposition}
+				durationInFrames={30}
 				fps={30}
 				width={1920}
 				height={1080}

--- a/packages/studio/src/components/InspectorSequenceSection.tsx
+++ b/packages/studio/src/components/InspectorSequenceSection.tsx
@@ -707,12 +707,11 @@ export const InspectorSequenceSection: React.FC<{
 		sequencePropStatuses,
 		getDragOverrides(nodePathInfo.sequenceSubscriptionKey),
 	);
-	const inlineCaptionValue =
-		schema.captions?.type === 'remotion-captions'
-			? runtimeValues.captions
-			: null;
-	const inlineCaptions = Array.isArray(inlineCaptionValue)
-		? (inlineCaptionValue as Caption[])
+	const hasCaptionsSchema = schema.captions?.type === 'remotion-captions';
+	const inlineCaptions = hasCaptionsSchema
+		? Array.isArray(runtimeValues.captions)
+			? (runtimeValues.captions as Caption[])
+			: []
 		: null;
 	const showEffectsSection =
 		nodePathInfo.supportsEffects || effectRows.length > 0;


### PR DESCRIPTION
## Summary

- show the Captions Inspector when `Interactive.withSchema()` declares `Interactive.captionsSchema`, even if the runtime captions value is missing
- treat missing captions as an empty inspector value so importing captions materializes the prop at the interactive component call site
- add an end-to-end regression workflow covering inspector visibility, import, and persisted source output

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/example && bunx playwright test e2e/captions-inspector.test.mts`
- red/green regression verification

## Limitation

Default caption values applied inside the wrapped component or declared only in the schema remain unavailable to the wrapper when the runtime prop is absent. The inspector starts empty until captions are imported; this change does not add a `defaultProps` API.
