### PR TITLE
Elements: Add `initialProps` to the `component-owned-sequence` installs

### DIFF
--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -400,6 +400,7 @@ test('imports an Element with pinned Remotion dependencies as one undoable mutat
 		dimensions: {width: 640, height: 180},
 		displayName: 'Lower Third',
 		durationInFrames: 90,
+		initialProps: null,
 		installationMode: 'wrapped' as const,
 		slug: 'titles/lower-third',
 		sourceCode: `import {Rect} from '@remotion/shapes';

--- a/packages/docs/docs/studio-protocol/component-library-integration.mdx
+++ b/packages/docs/docs/studio-protocol/component-library-integration.mdx
@@ -27,7 +27,7 @@ Show each component in a [`<Player>`](/docs/player). The preview lets users exam
 
 Import the component normally for the preview. The website bundler then compiles the component.
 
-Use the same dimensions and duration in the Player and the Element payload. Use the same initial values in the preview and the source code. This configuration helps the installed Element match the preview.
+Use the same dimensions and duration in the Player and the Element payload. For a `component-owned-sequence` Element with replaceable starter content, set [`initialProps`](/docs/studio-protocol/create-element-payload#initialprops) in the payload and pass the same object to the Player as `inputProps`.
 
 ## Reuse component code
 

--- a/packages/docs/docs/studio-protocol/create-element-payload.mdx
+++ b/packages/docs/docs/studio-protocol/create-element-payload.mdx
@@ -68,6 +68,16 @@ Studio uses these dimensions for the drag preview, drop position, and the genera
 
 The preferred duration shown while dragging. It must be a positive integer.
 
+### initialProps?<AvailableFrom v="4.0.524" />
+
+Use `initialProps` when a `component-owned-sequence` Element needs replaceable starter content. Studio writes each property onto the installed component. The default is `null`.
+
+Use JSON-compatible values and valid JSX attribute names. For `component-owned-sequence`, omit `from`, `durationInFrames`, and `name` because Studio supplies them. In this mode, `style` must be an object.
+
+Pass the same props to the component preview. Element dimensions are not passed as component props, so include `width` and `height` when the component needs them.
+
+In `'wrapped'` mode, Studio also passes `initialProps` to the component inside the generated Sequence. Most wrapped Elements do not need this because their editable values can stay on internal `Interactive` call sites in the copied source.
+
 ### installationMode?<AvailableFrom v="4.0.506" />
 
 Controls how Studio installs the Element. The default is `'wrapped'`.

--- a/packages/docs/docs/studio-protocol/install-in-studio.mdx
+++ b/packages/docs/docs/studio-protocol/install-in-studio.mdx
@@ -49,7 +49,7 @@ When [the library](/docs/studio-protocol/component-library-integration) is embed
 
 ### payload
 
-The value returned by [`createElementPayload()`](/docs/studio-protocol/create-element-payload).
+The value returned by [`createElementPayload()`](/docs/studio-protocol/create-element-payload). For a `component-owned-sequence` Element with replaceable starter content, set [`initialProps`](/docs/studio-protocol/create-element-payload#initialprops) when creating the payload.
 
 ## Return value
 

--- a/packages/docs/elements/captions/basic-captions/basic-captions.tsx
+++ b/packages/docs/elements/captions/basic-captions/basic-captions.tsx
@@ -16,38 +16,13 @@ import {
 type BasicCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions?: Caption[];
+		readonly captions: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
 const defaultCombineTokensWithinMilliseconds = 2000;
 const defaultWidth = 900;
 const defaultHeight = 220;
-const defaultCaptions: Caption[] = [
-	{
-		text: 'Simple captions,ready for every video.',
-		startMs: 0,
-		endMs: 2200,
-		timestampMs: 1100,
-		confidence: null,
-		pageBreakAfter: true,
-	},
-	{
-		text: 'No animation,\njust clear text.',
-		startMs: 2200,
-		endMs: 4400,
-		timestampMs: 3300,
-		confidence: null,
-		pageBreakAfter: true,
-	},
-	{
-		text: 'Easy to read,\nand easy to customize.',
-		startMs: 4400,
-		endMs: 7000,
-		timestampMs: 5700,
-		confidence: null,
-	},
-];
 
 const basicCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -136,7 +111,7 @@ const BasicCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions = defaultCaptions,
+			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
 			height = defaultHeight,

--- a/packages/docs/elements/captions/basic-captions/basic-captions.tsx
+++ b/packages/docs/elements/captions/basic-captions/basic-captions.tsx
@@ -16,11 +16,38 @@ import {
 type BasicCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions: Caption[];
+		readonly captions?: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
 const defaultCombineTokensWithinMilliseconds = 2000;
+const defaultWidth = 900;
+const defaultHeight = 220;
+const defaultCaptions: Caption[] = [
+	{
+		text: 'Simple captions,ready for every video.',
+		startMs: 0,
+		endMs: 2200,
+		timestampMs: 1100,
+		confidence: null,
+		pageBreakAfter: true,
+	},
+	{
+		text: 'No animation,\njust clear text.',
+		startMs: 2200,
+		endMs: 4400,
+		timestampMs: 3300,
+		confidence: null,
+		pageBreakAfter: true,
+	},
+	{
+		text: 'Easy to read,\nand easy to customize.',
+		startMs: 4400,
+		endMs: 7000,
+		timestampMs: 5700,
+		confidence: null,
+	},
+];
 
 const basicCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -109,13 +136,13 @@ const BasicCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions,
+			captions = defaultCaptions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
+			height = defaultHeight,
 			name,
 			style,
-			width,
-			height,
+			width = defaultWidth,
 			...interactiveProps
 		},
 		ref,
@@ -161,36 +188,4 @@ const BasicCaptionsLayer = Interactive.withSchema({
 	supportsEffects: false,
 }) as React.FC<BasicCaptionsProps>;
 
-export const BasicCaptions: React.FC = () => {
-	return (
-		<BasicCaptionsLayer
-			captions={[
-				{
-					text: 'Simple captions,ready for every video.',
-					startMs: 0,
-					endMs: 2200,
-					timestampMs: 1100,
-					confidence: null,
-					pageBreakAfter: true,
-				},
-				{
-					text: 'No animation,\njust clear text.',
-					startMs: 2200,
-					endMs: 4400,
-					timestampMs: 3300,
-					confidence: null,
-					pageBreakAfter: true,
-				},
-				{
-					text: 'Easy to read,\nand easy to customize.',
-					startMs: 4400,
-					endMs: 7000,
-					timestampMs: 5700,
-					confidence: null,
-				},
-			]}
-			height={220}
-			width={900}
-		/>
-	);
-};
+export const BasicCaptions = BasicCaptionsLayer;

--- a/packages/docs/elements/captions/basic-captions/initial-props.ts
+++ b/packages/docs/elements/captions/basic-captions/initial-props.ts
@@ -1,0 +1,33 @@
+import type {ComponentProps} from 'react';
+import type {BasicCaptions} from './basic-captions';
+
+export const basicCaptionsInitialProps = {
+	captions: [
+		{
+			text: 'Simple captions,ready for every video.',
+			startMs: 0,
+			endMs: 2200,
+			timestampMs: 1100,
+			confidence: null,
+			pageBreakAfter: true,
+		},
+		{
+			text: 'No animation,\njust clear text.',
+			startMs: 2200,
+			endMs: 4400,
+			timestampMs: 3300,
+			confidence: null,
+			pageBreakAfter: true,
+		},
+		{
+			text: 'Easy to read,\nand easy to customize.',
+			startMs: 4400,
+			endMs: 7000,
+			timestampMs: 5700,
+			confidence: null,
+		},
+	],
+	combineTokensWithinMilliseconds: 2000,
+	width: 900,
+	height: 220,
+} satisfies ComponentProps<typeof BasicCaptions>;

--- a/packages/docs/elements/captions/moving-pill-captions/initial-props.ts
+++ b/packages/docs/elements/captions/moving-pill-captions/initial-props.ts
@@ -1,0 +1,59 @@
+import type {ComponentProps} from 'react';
+import type {MovingPillCaptions} from './moving-pill-captions';
+
+export const movingPillCaptionsInitialProps = {
+	captions: [
+		{
+			text: 'Captions',
+			startMs: 0,
+			endMs: 800,
+			timestampMs: 400,
+			confidence: null,
+		},
+		{
+			text: ' can',
+			startMs: 800,
+			endMs: 1500,
+			timestampMs: 1150,
+			confidence: null,
+		},
+		{
+			text: ' move',
+			startMs: 1500,
+			endMs: 2300,
+			timestampMs: 1900,
+			confidence: null,
+		},
+		{
+			text: ' with',
+			startMs: 2300,
+			endMs: 3100,
+			timestampMs: 2700,
+			confidence: null,
+		},
+		{
+			text: ' every',
+			startMs: 3100,
+			endMs: 4000,
+			timestampMs: 3550,
+			confidence: null,
+		},
+		{
+			text: ' spoken',
+			startMs: 4000,
+			endMs: 5100,
+			timestampMs: 4550,
+			confidence: null,
+		},
+		{
+			text: ' word.',
+			startMs: 5100,
+			endMs: 6500,
+			timestampMs: 5800,
+			confidence: null,
+		},
+	],
+	combineTokensWithinMilliseconds: 800,
+	width: 682,
+	height: 252,
+} satisfies ComponentProps<typeof MovingPillCaptions>;

--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -29,7 +29,7 @@ import {
 type MovingPillCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions: Caption[];
+		readonly captions?: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -42,6 +42,59 @@ const pillVerticalPadding = 12;
 const pillBorderRadius = 10;
 const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
+const defaultWidth = 682;
+const defaultHeight = 252;
+const defaultCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const movingPillCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -376,13 +429,13 @@ const MovingPillCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions,
+			captions = defaultCaptions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
+			height = defaultHeight,
 			name,
 			style,
-			width,
-			height,
+			width = defaultWidth,
 			...interactiveProps
 		},
 		ref,
@@ -440,62 +493,4 @@ const MovingPillCaptionsLayer = Interactive.withSchema({
 	supportsEffects: false,
 }) as React.FC<MovingPillCaptionsProps>;
 
-export const MovingPillCaptions: React.FC = () => {
-	return (
-		<MovingPillCaptionsLayer
-			captions={[
-				{
-					text: 'Captions',
-					startMs: 0,
-					endMs: 800,
-					timestampMs: 400,
-					confidence: null,
-				},
-				{
-					text: ' can',
-					startMs: 800,
-					endMs: 1500,
-					timestampMs: 1150,
-					confidence: null,
-				},
-				{
-					text: ' move',
-					startMs: 1500,
-					endMs: 2300,
-					timestampMs: 1900,
-					confidence: null,
-				},
-				{
-					text: ' with',
-					startMs: 2300,
-					endMs: 3100,
-					timestampMs: 2700,
-					confidence: null,
-				},
-				{
-					text: ' every',
-					startMs: 3100,
-					endMs: 4000,
-					timestampMs: 3550,
-					confidence: null,
-				},
-				{
-					text: ' spoken',
-					startMs: 4000,
-					endMs: 5100,
-					timestampMs: 4550,
-					confidence: null,
-				},
-				{
-					text: ' word.',
-					startMs: 5100,
-					endMs: 6500,
-					timestampMs: 5800,
-					confidence: null,
-				},
-			]}
-			width={682}
-			height={252}
-		/>
-	);
-};
+export const MovingPillCaptions = MovingPillCaptionsLayer;

--- a/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
+++ b/packages/docs/elements/captions/moving-pill-captions/moving-pill-captions.tsx
@@ -29,7 +29,7 @@ import {
 type MovingPillCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions?: Caption[];
+		readonly captions: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -44,57 +44,6 @@ const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
 const defaultWidth = 682;
 const defaultHeight = 252;
-const defaultCaptions: Caption[] = [
-	{
-		text: 'Captions',
-		startMs: 0,
-		endMs: 800,
-		timestampMs: 400,
-		confidence: null,
-	},
-	{
-		text: ' can',
-		startMs: 800,
-		endMs: 1500,
-		timestampMs: 1150,
-		confidence: null,
-	},
-	{
-		text: ' move',
-		startMs: 1500,
-		endMs: 2300,
-		timestampMs: 1900,
-		confidence: null,
-	},
-	{
-		text: ' with',
-		startMs: 2300,
-		endMs: 3100,
-		timestampMs: 2700,
-		confidence: null,
-	},
-	{
-		text: ' every',
-		startMs: 3100,
-		endMs: 4000,
-		timestampMs: 3550,
-		confidence: null,
-	},
-	{
-		text: ' spoken',
-		startMs: 4000,
-		endMs: 5100,
-		timestampMs: 4550,
-		confidence: null,
-	},
-	{
-		text: ' word.',
-		startMs: 5100,
-		endMs: 6500,
-		timestampMs: 5800,
-		confidence: null,
-	},
-];
 
 const movingPillCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -429,7 +378,7 @@ const MovingPillCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions = defaultCaptions,
+			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
 			height = defaultHeight,

--- a/packages/docs/elements/captions/popping-word-captions/initial-props.ts
+++ b/packages/docs/elements/captions/popping-word-captions/initial-props.ts
@@ -1,0 +1,59 @@
+import type {ComponentProps} from 'react';
+import type {PoppingWordCaptions} from './popping-word-captions';
+
+export const poppingWordCaptionsInitialProps = {
+	captions: [
+		{
+			text: 'Captions',
+			startMs: 0,
+			endMs: 800,
+			timestampMs: 400,
+			confidence: null,
+		},
+		{
+			text: ' can',
+			startMs: 800,
+			endMs: 1500,
+			timestampMs: 1150,
+			confidence: null,
+		},
+		{
+			text: ' move',
+			startMs: 1500,
+			endMs: 2300,
+			timestampMs: 1900,
+			confidence: null,
+		},
+		{
+			text: ' with',
+			startMs: 2300,
+			endMs: 3100,
+			timestampMs: 2700,
+			confidence: null,
+		},
+		{
+			text: ' every',
+			startMs: 3100,
+			endMs: 4000,
+			timestampMs: 3550,
+			confidence: null,
+		},
+		{
+			text: ' spoken',
+			startMs: 4000,
+			endMs: 5100,
+			timestampMs: 4550,
+			confidence: null,
+		},
+		{
+			text: ' word.',
+			startMs: 5100,
+			endMs: 6500,
+			timestampMs: 5800,
+			confidence: null,
+		},
+	],
+	combineTokensWithinMilliseconds: 800,
+	width: 682,
+	height: 252,
+} satisfies ComponentProps<typeof PoppingWordCaptions>;

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -28,7 +28,7 @@ import {
 type PoppingWordCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions: Caption[];
+		readonly captions?: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -38,6 +38,59 @@ const textColor = '#ffffff';
 const highlightColor = '#4da3ff';
 const activeWordScale = 1.03;
 const defaultCombineTokensWithinMilliseconds = 800;
+const defaultWidth = 682;
+const defaultHeight = 252;
+const defaultCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const poppingWordCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -287,13 +340,13 @@ const PoppingWordCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions,
+			captions = defaultCaptions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
+			height = defaultHeight,
 			name,
 			style,
-			width,
-			height,
+			width = defaultWidth,
 			...interactiveProps
 		},
 		ref,
@@ -351,62 +404,4 @@ const PoppingWordCaptionsLayer = Interactive.withSchema({
 	supportsEffects: false,
 }) as React.FC<PoppingWordCaptionsProps>;
 
-export const PoppingWordCaptions: React.FC = () => {
-	return (
-		<PoppingWordCaptionsLayer
-			captions={[
-				{
-					text: 'Captions',
-					startMs: 0,
-					endMs: 800,
-					timestampMs: 400,
-					confidence: null,
-				},
-				{
-					text: ' can',
-					startMs: 800,
-					endMs: 1500,
-					timestampMs: 1150,
-					confidence: null,
-				},
-				{
-					text: ' move',
-					startMs: 1500,
-					endMs: 2300,
-					timestampMs: 1900,
-					confidence: null,
-				},
-				{
-					text: ' with',
-					startMs: 2300,
-					endMs: 3100,
-					timestampMs: 2700,
-					confidence: null,
-				},
-				{
-					text: ' every',
-					startMs: 3100,
-					endMs: 4000,
-					timestampMs: 3550,
-					confidence: null,
-				},
-				{
-					text: ' spoken',
-					startMs: 4000,
-					endMs: 5100,
-					timestampMs: 4550,
-					confidence: null,
-				},
-				{
-					text: ' word.',
-					startMs: 5100,
-					endMs: 6500,
-					timestampMs: 5800,
-					confidence: null,
-				},
-			]}
-			width={682}
-			height={252}
-		/>
-	);
-};
+export const PoppingWordCaptions = PoppingWordCaptionsLayer;

--- a/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
+++ b/packages/docs/elements/captions/popping-word-captions/popping-word-captions.tsx
@@ -28,7 +28,7 @@ import {
 type PoppingWordCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions?: Caption[];
+		readonly captions: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -40,57 +40,6 @@ const activeWordScale = 1.03;
 const defaultCombineTokensWithinMilliseconds = 800;
 const defaultWidth = 682;
 const defaultHeight = 252;
-const defaultCaptions: Caption[] = [
-	{
-		text: 'Captions',
-		startMs: 0,
-		endMs: 800,
-		timestampMs: 400,
-		confidence: null,
-	},
-	{
-		text: ' can',
-		startMs: 800,
-		endMs: 1500,
-		timestampMs: 1150,
-		confidence: null,
-	},
-	{
-		text: ' move',
-		startMs: 1500,
-		endMs: 2300,
-		timestampMs: 1900,
-		confidence: null,
-	},
-	{
-		text: ' with',
-		startMs: 2300,
-		endMs: 3100,
-		timestampMs: 2700,
-		confidence: null,
-	},
-	{
-		text: ' every',
-		startMs: 3100,
-		endMs: 4000,
-		timestampMs: 3550,
-		confidence: null,
-	},
-	{
-		text: ' spoken',
-		startMs: 4000,
-		endMs: 5100,
-		timestampMs: 4550,
-		confidence: null,
-	},
-	{
-		text: ' word.',
-		startMs: 5100,
-		endMs: 6500,
-		timestampMs: 5800,
-		confidence: null,
-	},
-];
 
 const poppingWordCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -340,7 +289,7 @@ const PoppingWordCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions = defaultCaptions,
+			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
 			height = defaultHeight,

--- a/packages/docs/elements/captions/word-highlight-captions/initial-props.ts
+++ b/packages/docs/elements/captions/word-highlight-captions/initial-props.ts
@@ -1,0 +1,59 @@
+import type {ComponentProps} from 'react';
+import type {WordHighlightCaptions} from './word-highlight-captions';
+
+export const wordHighlightCaptionsInitialProps = {
+	captions: [
+		{
+			text: 'Captions',
+			startMs: 0,
+			endMs: 800,
+			timestampMs: 400,
+			confidence: null,
+		},
+		{
+			text: ' can',
+			startMs: 800,
+			endMs: 1500,
+			timestampMs: 1150,
+			confidence: null,
+		},
+		{
+			text: ' move',
+			startMs: 1500,
+			endMs: 2300,
+			timestampMs: 1900,
+			confidence: null,
+		},
+		{
+			text: ' with',
+			startMs: 2300,
+			endMs: 3100,
+			timestampMs: 2700,
+			confidence: null,
+		},
+		{
+			text: ' every',
+			startMs: 3100,
+			endMs: 4000,
+			timestampMs: 3550,
+			confidence: null,
+		},
+		{
+			text: ' spoken',
+			startMs: 4000,
+			endMs: 5100,
+			timestampMs: 4550,
+			confidence: null,
+		},
+		{
+			text: ' word.',
+			startMs: 5100,
+			endMs: 6500,
+			timestampMs: 5800,
+			confidence: null,
+		},
+	],
+	combineTokensWithinMilliseconds: 800,
+	width: 682,
+	height: 252,
+} satisfies ComponentProps<typeof WordHighlightCaptions>;

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -26,7 +26,7 @@ import {
 type WordHighlightCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions?: Caption[];
+		readonly captions: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -37,57 +37,6 @@ const highlightColor = '#4da3ff';
 const defaultCombineTokensWithinMilliseconds = 800;
 const defaultWidth = 682;
 const defaultHeight = 252;
-const defaultCaptions: Caption[] = [
-	{
-		text: 'Captions',
-		startMs: 0,
-		endMs: 800,
-		timestampMs: 400,
-		confidence: null,
-	},
-	{
-		text: ' can',
-		startMs: 800,
-		endMs: 1500,
-		timestampMs: 1150,
-		confidence: null,
-	},
-	{
-		text: ' move',
-		startMs: 1500,
-		endMs: 2300,
-		timestampMs: 1900,
-		confidence: null,
-	},
-	{
-		text: ' with',
-		startMs: 2300,
-		endMs: 3100,
-		timestampMs: 2700,
-		confidence: null,
-	},
-	{
-		text: ' every',
-		startMs: 3100,
-		endMs: 4000,
-		timestampMs: 3550,
-		confidence: null,
-	},
-	{
-		text: ' spoken',
-		startMs: 4000,
-		endMs: 5100,
-		timestampMs: 4550,
-		confidence: null,
-	},
-	{
-		text: ' word.',
-		startMs: 5100,
-		endMs: 6500,
-		timestampMs: 5800,
-		confidence: null,
-	},
-];
 
 const wordHighlightCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -298,7 +247,7 @@ const WordHighlightCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions = defaultCaptions,
+			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
 			height = defaultHeight,

--- a/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
+++ b/packages/docs/elements/captions/word-highlight-captions/word-highlight-captions.tsx
@@ -26,7 +26,7 @@ import {
 type WordHighlightCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions: Caption[];
+		readonly captions?: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
 
@@ -35,6 +35,59 @@ const fontWeight = '700';
 const textColor = '#ffffff';
 const highlightColor = '#4da3ff';
 const defaultCombineTokensWithinMilliseconds = 800;
+const defaultWidth = 682;
+const defaultHeight = 252;
+const defaultCaptions: Caption[] = [
+	{
+		text: 'Captions',
+		startMs: 0,
+		endMs: 800,
+		timestampMs: 400,
+		confidence: null,
+	},
+	{
+		text: ' can',
+		startMs: 800,
+		endMs: 1500,
+		timestampMs: 1150,
+		confidence: null,
+	},
+	{
+		text: ' move',
+		startMs: 1500,
+		endMs: 2300,
+		timestampMs: 1900,
+		confidence: null,
+	},
+	{
+		text: ' with',
+		startMs: 2300,
+		endMs: 3100,
+		timestampMs: 2700,
+		confidence: null,
+	},
+	{
+		text: ' every',
+		startMs: 3100,
+		endMs: 4000,
+		timestampMs: 3550,
+		confidence: null,
+	},
+	{
+		text: ' spoken',
+		startMs: 4000,
+		endMs: 5100,
+		timestampMs: 4550,
+		confidence: null,
+	},
+	{
+		text: ' word.',
+		startMs: 5100,
+		endMs: 6500,
+		timestampMs: 5800,
+		confidence: null,
+	},
+];
 
 const wordHighlightCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -245,13 +298,13 @@ const WordHighlightCaptionsInner = forwardRef<
 >(
 	(
 		{
-			captions,
+			captions = defaultCaptions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
+			height = defaultHeight,
 			name,
 			style,
-			width,
-			height,
+			width = defaultWidth,
 			...interactiveProps
 		},
 		ref,
@@ -309,62 +362,4 @@ const WordHighlightCaptionsLayer = Interactive.withSchema({
 	supportsEffects: false,
 }) as React.FC<WordHighlightCaptionsProps>;
 
-export const WordHighlightCaptions: React.FC = () => {
-	return (
-		<WordHighlightCaptionsLayer
-			captions={[
-				{
-					text: 'Captions',
-					startMs: 0,
-					endMs: 800,
-					timestampMs: 400,
-					confidence: null,
-				},
-				{
-					text: ' can',
-					startMs: 800,
-					endMs: 1500,
-					timestampMs: 1150,
-					confidence: null,
-				},
-				{
-					text: ' move',
-					startMs: 1500,
-					endMs: 2300,
-					timestampMs: 1900,
-					confidence: null,
-				},
-				{
-					text: ' with',
-					startMs: 2300,
-					endMs: 3100,
-					timestampMs: 2700,
-					confidence: null,
-				},
-				{
-					text: ' every',
-					startMs: 3100,
-					endMs: 4000,
-					timestampMs: 3550,
-					confidence: null,
-				},
-				{
-					text: ' spoken',
-					startMs: 4000,
-					endMs: 5100,
-					timestampMs: 4550,
-					confidence: null,
-				},
-				{
-					text: ' word.',
-					startMs: 5100,
-					endMs: 6500,
-					timestampMs: 5800,
-					confidence: null,
-				},
-			]}
-			width={682}
-			height={252}
-		/>
-	);
-};
+export const WordHighlightCaptions = WordHighlightCaptionsLayer;

--- a/packages/docs/elements/contributing.mdx
+++ b/packages/docs/elements/contributing.mdx
@@ -79,31 +79,13 @@ The caption Elements show the distinction: moving a pill between words, popping 
 - Minimize dependencies. [Remotion Effects](/docs/effects) are an acceptable exception.
 - Declare every external dependency in the central Element definition, except `react`, `react-dom`, and `remotion`. Every non-Remotion package must use an exact semantic version; version ranges and tags are not accepted. Remotion packages use `version: null` and are installed at the project's Remotion version.
 
-### Separate implementation from instance values
-
-An Element source file is a reusable implementation. The JSX inserted into the composition is an instance of that implementation and owns its content and configuration.
-
-When an Element needs starter values:
-
-1. Keep `elements/<category>/<slug>/<slug>.tsx` portable and limited to one named component export. Do not import starter data into this file.
-2. Add `elements/<category>/<slug>/initial-props.ts`. Type the object with `satisfies ComponentProps<typeof Component>`.
-3. Set `initialProps` in `element-definitions.ts`. Use `null` when the Element does not need installation props.
-
-`initialProps` must contain JSON-compatible values. The gallery preview, rendered previews, drag payload, and Studio installation all use this object. Studio serializes every top-level value as an explicit JSX attribute; it does not evaluate source code or insert an opaque spread.
-
-For `component-owned-sequence`, do not put `from`, `durationInFrames`, or `name` in `initialProps`. Studio owns those values so the current playhead, chosen duration, and installation name take precedence. An initial `style` must be an object. Studio preserves its other properties, then sets `position: 'absolute'` and the drop translation. Element dimensions are metadata only; add `width` and `height` to `initialProps` when the component needs them.
-
-The installed Interactive JSX call is the source-edit target for timing, transforms, captions, and other props. The copied `.element.tsx` file remains the implementation-edit target. Do not add forwarding wrappers or redirect source locations between them.
-
-The code viewer shows the reusable implementation. Install the Element to also materialize its starter instance values in a composition.
-
 ### Design it for composition
 
 Prefer exposing the Element's layers so users can inspect and edit them with [Studio interactivity](/docs/studio/interactivity). Use one of the following installation modes based on what the user should see in Studio.
 
 #### Separate editable layers
 
-Use `installationMode: 'wrapped'` whenever the Element's layers can be edited separately. This is the default mode. Studio adds a [`<Sequence>`](/docs/sequence) that controls the Element's placement and duration. One installed top-level group may expose multiple child timeline rows. Independent named installations copy independent source files; reusing an existing source file is an explicit conflict decision.
+Use `installationMode: 'wrapped'` when the Element's layers can be edited separately. This is the default mode. Studio wraps the component in a [`<Sequence>`](/docs/sequence) for placement and duration. The top-level group may expose multiple child timeline rows. Editable values can stay on internal `Interactive` call sites in the copied source, where Studio edits them.
 
 Size the Element to its smallest useful bounding box. If it adapts to the composition, set both dimensions to `null`.
 
@@ -124,9 +106,19 @@ Export the schema-enabled component directly and wire up the common props:
 - Pass `style` and the ref to the rendered outline. When the Sequence uses `layout="none"`, pass [`outlineRef`](/docs/sequence#outlineref) to it. Set the dimensions in the component because Element metadata does not pass them as props.
 - Render frame-dependent animation in a child below the Sequence. This makes [`useCurrentFrame()`](/docs/use-current-frame) respect `from`, `trimBefore`, and `freeze`. If the component that returns the Sequence calls it, it reads the parent clock.
 
-Do not add a forwarding wrapper around the schema-enabled component. Studio may then target internal JSX with computed spread props instead of the editable timing props at the call site. The [oscilloscope](/elements/audio/oscilloscope), [waveform progress](/elements/audio/waveform-progress), and [mirrored spectrum](/elements/audio/mirrored-spectrum) Elements export the component directly.
+Export the schema-enabled component directly, without a forwarding wrapper. See the [oscilloscope](/elements/audio/oscilloscope), [waveform progress](/elements/audio/waveform-progress), and [mirrored spectrum](/elements/audio/mirrored-spectrum) Elements.
 
 Check in Studio that the exported instance appears as one layer and can be moved and trimmed. Do not use `component-owned-sequence` only to remove markup. Do not add padding only for the gallery preview.
+
+##### Initial props
+
+[`Interactive.withSchema()`](/docs/interactive-with-schema) makes a component's props editable in Studio. Content declared inside the component is not a prop, so users cannot edit it per instance.
+
+For a `component-owned-sequence` Element with replaceable starter content, put those values in `initial-props.ts`. Register them as `initialProps` with the component in `element-definitions.ts`, and type them with `satisfies ComponentProps<typeof YourComponent>`.
+
+Pass these props to the previews too. Studio writes them onto the installed component, and Inspector edits them there. Keep rendering and animation in the copied Element file.
+
+Studio supplies `from`, `durationInFrames`, and `name`. Pass `width` and `height` in `initialProps` when the component needs them. Element dimension metadata is not passed as component props.
 
 ### Animate temporary Elements in and out
 

--- a/packages/docs/elements/contributing.mdx
+++ b/packages/docs/elements/contributing.mdx
@@ -79,13 +79,31 @@ The caption Elements show the distinction: moving a pill between words, popping 
 - Minimize dependencies. [Remotion Effects](/docs/effects) are an acceptable exception.
 - Declare every external dependency in the central Element definition, except `react`, `react-dom`, and `remotion`. Every non-Remotion package must use an exact semantic version; version ranges and tags are not accepted. Remotion packages use `version: null` and are installed at the project's Remotion version.
 
+### Separate implementation from instance values
+
+An Element source file is a reusable implementation. The JSX inserted into the composition is an instance of that implementation and owns its content and configuration.
+
+When an Element needs starter values:
+
+1. Keep `elements/<category>/<slug>/<slug>.tsx` portable and limited to one named component export. Do not import starter data into this file.
+2. Add `elements/<category>/<slug>/initial-props.ts`. Type the object with `satisfies ComponentProps<typeof Component>`.
+3. Set `initialProps` in `element-definitions.ts`. Use `null` when the Element does not need installation props.
+
+`initialProps` must contain JSON-compatible values. The gallery preview, rendered previews, drag payload, and Studio installation all use this object. Studio serializes every top-level value as an explicit JSX attribute; it does not evaluate source code or insert an opaque spread.
+
+For `component-owned-sequence`, do not put `from`, `durationInFrames`, or `name` in `initialProps`. Studio owns those values so the current playhead, chosen duration, and installation name take precedence. An initial `style` must be an object. Studio preserves its other properties, then sets `position: 'absolute'` and the drop translation. Element dimensions are metadata only; add `width` and `height` to `initialProps` when the component needs them.
+
+The installed Interactive JSX call is the source-edit target for timing, transforms, captions, and other props. The copied `.element.tsx` file remains the implementation-edit target. Do not add forwarding wrappers or redirect source locations between them.
+
+The code viewer shows the reusable implementation. Install the Element to also materialize its starter instance values in a composition.
+
 ### Design it for composition
 
 Prefer exposing the Element's layers so users can inspect and edit them with [Studio interactivity](/docs/studio/interactivity). Use one of the following installation modes based on what the user should see in Studio.
 
 #### Separate editable layers
 
-Use `installationMode: 'wrapped'` whenever the Element's layers can be edited separately. This is the default mode. Studio adds a [`<Sequence>`](/docs/sequence) that controls the Element's placement and duration.
+Use `installationMode: 'wrapped'` whenever the Element's layers can be edited separately. This is the default mode. Studio adds a [`<Sequence>`](/docs/sequence) that controls the Element's placement and duration. One installed top-level group may expose multiple child timeline rows. Independent named installations copy independent source files; reusing an existing source file is an explicit conflict decision.
 
 Size the Element to its smallest useful bounding box. If it adapts to the composition, set both dimensions to `null`.
 

--- a/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
+++ b/packages/docs/src/components/Elements/ElementPreviewComposition.tsx
@@ -32,9 +32,13 @@ export const ElementPreviewComposition: React.FC<{
 	} = definition;
 	const {height, width} = useVideoConfig();
 	const hasElementDimensions = elementWidth !== null && elementHeight !== null;
+	const element = React.createElement(
+		Component as React.ComponentType<Record<string, unknown>>,
+		definition.initialProps ?? {},
+	);
 
 	if (!hasElementDimensions) {
-		return <Component />;
+		return element;
 	}
 
 	const scale = Math.min(
@@ -70,7 +74,7 @@ export const ElementPreviewComposition: React.FC<{
 							width: elementWidth,
 						}}
 					>
-						<Component />
+						{element}
 					</div>
 				</div>
 			</Sequence>

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -1,5 +1,6 @@
 import type {
 	ElementDependency,
+	ElementInitialProps,
 	ElementInstallationMode,
 } from '@remotion/studio-protocol';
 import type {ComponentType} from 'react';
@@ -11,8 +12,12 @@ import {NotebookPaper} from '../../../elements/backgrounds/notebook-paper/notebo
 import {PaperTexture} from '../../../elements/backgrounds/paper-texture/paper-texture';
 import {RotatingStarburst} from '../../../elements/backgrounds/rotating-starburst/rotating-starburst';
 import {BasicCaptions} from '../../../elements/captions/basic-captions/basic-captions';
+import {basicCaptionsInitialProps} from '../../../elements/captions/basic-captions/initial-props';
+import {movingPillCaptionsInitialProps} from '../../../elements/captions/moving-pill-captions/initial-props';
 import {MovingPillCaptions} from '../../../elements/captions/moving-pill-captions/moving-pill-captions';
+import {poppingWordCaptionsInitialProps} from '../../../elements/captions/popping-word-captions/initial-props';
 import {PoppingWordCaptions} from '../../../elements/captions/popping-word-captions/popping-word-captions';
+import {wordHighlightCaptionsInitialProps} from '../../../elements/captions/word-highlight-captions/initial-props';
 import {WordHighlightCaptions} from '../../../elements/captions/word-highlight-captions/word-highlight-captions';
 import {
 	ProductCollection,
@@ -62,7 +67,7 @@ export type ElementPreviewMetadata = {
 
 export type ElementDefinition = {
 	readonly category: ElementCategory;
-	readonly component: ComponentType<Record<string, never>>;
+	readonly component: ComponentType<never>;
 	readonly contributors: readonly Contributor[];
 	readonly dependencies: readonly ElementDependency[];
 	readonly description: string;
@@ -72,6 +77,7 @@ export type ElementDefinition = {
 	readonly elementWidth: number | null;
 	readonly fps: number;
 	readonly height: number;
+	readonly initialProps: ElementInitialProps | null;
 	readonly posterFrame: number;
 	readonly preview: ElementPreviewMetadata;
 	readonly safeArea: number;
@@ -106,6 +112,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/audio-oscilloscope-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -132,6 +139,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/audio-waveform-progress-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -159,6 +167,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/audio-mirrored-spectrum-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -182,6 +191,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/backgrounds-notebook-paper-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -206,6 +216,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/backgrounds-paper-texture-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -229,6 +240,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -253,6 +265,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/backgrounds-liquid-contours-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -277,6 +290,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/captions-basic-captions-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: basicCaptionsInitialProps,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -305,6 +319,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/captions-moving-pill-captions-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: movingPillCaptionsInitialProps,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -332,6 +347,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/captions-popping-word-captions-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: poppingWordCaptionsInitialProps,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -359,6 +375,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/captions-word-highlight-captions-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: wordHighlightCaptionsInitialProps,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -383,6 +400,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/commerce-product-collection-preview.mp4',
 		},
 		safeArea: 30,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1080,
 	},
@@ -410,6 +428,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/commerce-product-discount-callout-preview.mp4',
 		},
 		safeArea: 90,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1080,
 	},
@@ -434,6 +453,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/commerce-product-offer-preview.mp4',
 		},
 		safeArea: 90,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1080,
 	},
@@ -457,6 +477,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/data-horizontal-bar-chart-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -478,6 +499,7 @@ const elementImplementations = [
 			videoUrl: 'https://remotion.media/elements/data-line-chart-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -507,6 +529,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/data-number-counter-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -529,6 +552,7 @@ const elementImplementations = [
 			videoUrl: 'https://remotion.media/elements/data-pie-chart-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -553,6 +577,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/data-vertical-bar-chart-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -578,6 +603,7 @@ const elementImplementations = [
 			videoUrl: 'https://remotion.media/elements/maps-map-flyover-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -605,6 +631,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/maps-watercolor-map-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -628,6 +655,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/overlays-location-lower-third-preview.mp4',
 		},
 		safeArea: 300,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -652,6 +680,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/overlays-name-lower-third-preview.mp4',
 		},
 		safeArea: 300,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -676,6 +705,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/overlays-social-safe-zones-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1080,
 	},
@@ -700,6 +730,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/text-news-article-highlight-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -724,6 +755,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/storytelling-on-screen-messages-preview.mp4',
 		},
 		safeArea: 180,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -748,6 +780,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/storytelling-polaroid-pictures-preview.mp4',
 		},
 		safeArea: 220,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -775,6 +808,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/text-circle-marker-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -800,6 +834,7 @@ const elementImplementations = [
 			videoUrl: 'https://remotion.media/elements/text-crossed-off-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -824,6 +859,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/text-spinning-text-wheel-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'component-owned-sequence',
 		width: 1920,
 	},
@@ -851,6 +887,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/text-strike-through-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -876,6 +913,7 @@ const elementImplementations = [
 			videoUrl: 'https://remotion.media/elements/text-text-marker-preview.mp4',
 		},
 		safeArea: 120,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -899,6 +937,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/youtube-youtube-comment-highlight-preview.mp4',
 		},
 		safeArea: 200,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -923,6 +962,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/overlays-social-endcard-preview.mp4',
 		},
 		safeArea: 0,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},
@@ -951,6 +991,7 @@ const elementImplementations = [
 				'https://remotion.media/elements/youtube-youtube-subscribe-nudge-preview.mp4',
 		},
 		safeArea: 240,
+		initialProps: null,
 		installationMode: 'wrapped',
 		width: 1920,
 	},

--- a/packages/docs/src/components/Elements/element-drag-data.ts
+++ b/packages/docs/src/components/Elements/element-drag-data.ts
@@ -24,6 +24,7 @@ export const createElementPayloadFromDefinition = ({
 		dimensions,
 		displayName: definition.displayName,
 		durationInFrames: definition.durationInFrames,
+		initialProps: definition.initialProps,
 		installationMode: definition.installationMode,
 		slug: definition.slug,
 		sourceCode,

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -729,7 +729,24 @@ describe('Element preview definitions', () => {
 				throw new Error(`Missing caption Element for ${slug}`);
 			}
 
+			const definition = getElementDefinition(slug);
+			const initialProps = definition.initialProps as {
+				captions: Array<{text: string}>;
+				combineTokensWithinMilliseconds: number;
+				height: number;
+				width: number;
+			};
 			const source = readFileSync(element.tsxPath, 'utf8');
+			const payload = createElementPayloadFromDefinition({
+				definition,
+				sourceCode: source,
+			});
+			expect(initialProps.captions.length).toBeGreaterThan(0);
+			expect(initialProps.width).toBe(definition.elementWidth);
+			expect(initialProps.height).toBe(definition.elementHeight);
+			expect(payload.element.initialProps).toEqual(initialProps);
+			expect(source).not.toContain('timestampMs:');
+			expect(source).not.toContain('defaultCaptions');
 			expect(source).not.toContain('readonly mode');
 			expect(source).not.toContain('TimedCaptionsMode');
 			expect(source).not.toContain("translate: '109.5px -36px'");

--- a/packages/example/e2e/captions-inspector.test.mts
+++ b/packages/example/e2e/captions-inspector.test.mts
@@ -123,7 +123,7 @@ test.describe('captions inspector', () => {
 		await expect(importCaptionsButton).toBeVisible();
 
 		const sourceBeforeFailedImport = fs.readFileSync(
-			elementCaptionsFile,
+			elementCallSiteFile,
 			'utf-8',
 		);
 		await importCaptionsInput.setInputFiles({
@@ -145,7 +145,7 @@ test.describe('captions inspector', () => {
 				/broken\.json:.*captions\[0\]\.startMs must be a finite, non-negative number/,
 			),
 		).toBeVisible();
-		expect(fs.readFileSync(elementCaptionsFile, 'utf-8')).toBe(
+		expect(fs.readFileSync(elementCallSiteFile, 'utf-8')).toBe(
 			sourceBeforeFailedImport,
 		);
 
@@ -173,9 +173,12 @@ test.describe('captions inspector', () => {
 		});
 		await expect(defaultCaption).toHaveValue('Imported');
 		await expect
-			.poll(() => fs.readFileSync(elementCaptionsFile, 'utf-8'))
+			.poll(() => fs.readFileSync(elementCallSiteFile, 'utf-8'))
 			.toMatch(/text:\s*['"]Imported['"][\s\S]*startMs:\s*100/);
-		expect(fs.readFileSync(elementCallSiteFile, 'utf-8')).toBe(
+		expect(fs.readFileSync(elementCaptionsFile, 'utf-8')).toBe(
+			elementSourceBefore,
+		);
+		expect(fs.readFileSync(elementCallSiteFile, 'utf-8')).not.toBe(
 			elementCallSiteSourceBefore,
 		);
 
@@ -184,10 +187,13 @@ test.describe('captions inspector', () => {
 		await expect
 			.poll(() => {
 				return /text:\s*['"]Edited imported caption['"]/.test(
-					fs.readFileSync(elementCaptionsFile, 'utf-8'),
+					fs.readFileSync(elementCallSiteFile, 'utf-8'),
 				);
 			})
 			.toBe(true);
+		expect(fs.readFileSync(elementCaptionsFile, 'utf-8')).toBe(
+			elementSourceBefore,
+		);
 	});
 
 	test('imports captions when the schema-declared prop is missing', async ({

--- a/packages/example/src/MovingPillCaptionsComposition.tsx
+++ b/packages/example/src/MovingPillCaptionsComposition.tsx
@@ -6,12 +6,66 @@ export const MovingPillCaptionsComposition: React.FC = () => {
 	return (
 		<>
 			<MovingPillCaptions
+				captions={[
+					{
+						text: 'Captions',
+						startMs: 0,
+						endMs: 800,
+						timestampMs: 400,
+						confidence: null,
+					},
+					{
+						text: ' can',
+						startMs: 800,
+						endMs: 1500,
+						timestampMs: 1150,
+						confidence: null,
+					},
+					{
+						text: ' move',
+						startMs: 1500,
+						endMs: 2300,
+						timestampMs: 1900,
+						confidence: null,
+					},
+					{
+						text: ' with',
+						startMs: 2300,
+						endMs: 3100,
+						timestampMs: 2700,
+						confidence: null,
+					},
+					{
+						text: ' every',
+						startMs: 3100,
+						endMs: 4000,
+						timestampMs: 3550,
+						confidence: null,
+					},
+					{
+						text: ' spoken',
+						startMs: 4000,
+						endMs: 5100,
+						timestampMs: 4550,
+						confidence: null,
+					},
+					{
+						text: ' word.',
+						startMs: 5100,
+						endMs: 6500,
+						timestampMs: 5800,
+						confidence: null,
+					},
+				]}
+				combineTokensWithinMilliseconds={800}
 				durationInFrames={210}
+				height={252}
 				name="Moving Pill Captions"
 				style={{
 					position: 'absolute',
 					translate: '-12.2px -10.3px',
 				}}
+				width={682}
 			/>
 			<AudioOscilloscope
 				durationInFrames={271}

--- a/packages/example/src/moving-pill-captions.element.tsx
+++ b/packages/example/src/moving-pill-captions.element.tsx
@@ -29,17 +29,9 @@ import {
 type MovingPillCaptionsProps = InteractiveBaseProps &
 	InteractiveTransformProps &
 	Pick<SequenceProps, 'width' | 'height'> & {
-		readonly captions?: Caption[];
+		readonly captions: Caption[];
 		readonly combineTokensWithinMilliseconds?: number;
 	};
-
-type MovingPillCaptionsLayerProps = Omit<
-	MovingPillCaptionsProps,
-	'captions'
-> & {
-	readonly callerStyle: React.CSSProperties | null;
-	readonly captions: Caption[];
-};
 
 const desiredFontSize = 80;
 const maximumTextWidth = 800;
@@ -51,6 +43,8 @@ const pillVerticalPadding = 12;
 const pillBorderRadius = 10;
 const pillMoveDurationInFrames = 5;
 const defaultCombineTokensWithinMilliseconds = 800;
+const defaultWidth = 682;
+const defaultHeight = 252;
 
 const movingPillCaptionsSchema = {
 	...Interactive.baseSchema,
@@ -79,7 +73,6 @@ const movingPillCaptionsSchema = {
 		description: 'Time between caption pages',
 		hiddenFromList: false,
 	},
-	callerStyle: {type: 'hidden'},
 	...Interactive.transformSchema,
 } as const satisfies InteractivitySchema;
 
@@ -388,36 +381,25 @@ const MovingPillCaptionsContent: React.FC<{
 
 const MovingPillCaptionsInner = forwardRef<
 	HTMLDivElement,
-	MovingPillCaptionsLayerProps & {
+	MovingPillCaptionsProps & {
 		readonly controls: SequenceControls | undefined;
 	}
 >(
 	(
 		{
-			callerStyle,
 			captions,
 			combineTokensWithinMilliseconds = defaultCombineTokensWithinMilliseconds,
 			controls,
-			height,
+			height = defaultHeight,
 			name,
 			style,
-			width,
+			width = defaultWidth,
 			...interactiveProps
 		},
 		ref,
 	) => {
 		const outlineRef = useRef<HTMLDivElement>(null);
 		const [fontLoaded, setFontLoaded] = useState(false);
-		const {
-			rotate: callerRotate,
-			scale: callerScale,
-			transform: callerTransform,
-			transformBox: callerTransformBox,
-			transformOrigin: callerTransformOrigin,
-			transformStyle: callerTransformStyle,
-			translate: callerTranslate,
-			...callerContentStyle
-		} = callerStyle ?? {};
 
 		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
@@ -442,34 +424,20 @@ const MovingPillCaptionsInner = forwardRef<
 				outlineRef={outlineRef}
 			>
 				<div
+					ref={outlineRef}
 					style={{
-						height: height ?? '100%',
-						rotate: callerRotate,
-						scale: callerScale,
-						transform: callerTransform,
-						transformBox: callerTransformBox,
-						transformOrigin: callerTransformOrigin,
-						transformStyle: callerTransformStyle,
-						translate: callerTranslate,
-						width: width ?? '100%',
+						height,
+						marginInline: 'auto',
+						width,
+						...style,
 					}}
 				>
-					<div
-						ref={outlineRef}
-						style={{
-							height: '100%',
-							width: '100%',
-							...style,
-							...callerContentStyle,
-						}}
-					>
-						<MovingPillCaptionsContent
-							captionAreaWidth={width ?? null}
-							captions={captions}
-							combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
-							fontLoaded={fontLoaded}
-						/>
-					</div>
+					<MovingPillCaptionsContent
+						captionAreaWidth={width ?? null}
+						captions={captions}
+						combineTokensWithinMilliseconds={combineTokensWithinMilliseconds}
+						fontLoaded={fontLoaded}
+					/>
 				</div>
 			</Sequence>
 		);
@@ -481,92 +449,6 @@ const MovingPillCaptionsLayer = Interactive.withSchema({
 	componentName: '<MovingPillCaptions>',
 	schema: movingPillCaptionsSchema,
 	supportsEffects: false,
-}) as React.FC<MovingPillCaptionsLayerProps>;
+}) as React.FC<MovingPillCaptionsProps>;
 
-export const MovingPillCaptions: React.FC<MovingPillCaptionsProps> = ({
-	captions,
-	style,
-	...props
-}) => {
-	if (captions) {
-		return (
-			<MovingPillCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={captions}
-				style={{translate: '0px 0px'}}
-			/>
-		);
-	}
-
-	return (
-		<div
-			style={{
-				alignItems: 'center',
-				display: 'flex',
-				height: 180,
-				justifyContent: 'center',
-				width: 900,
-			}}
-		>
-			<MovingPillCaptionsLayer
-				{...props}
-				callerStyle={style ?? null}
-				captions={[
-					{
-						text: 'Captions',
-						startMs: 0,
-						endMs: 800,
-						timestampMs: 400,
-						confidence: null,
-					},
-					{
-						text: ' can',
-						startMs: 800,
-						endMs: 1500,
-						timestampMs: 1150,
-						confidence: null,
-					},
-					{
-						text: ' move',
-						startMs: 1500,
-						endMs: 2300,
-						timestampMs: 1900,
-						confidence: null,
-					},
-					{
-						text: ' with',
-						startMs: 2300,
-						endMs: 3100,
-						timestampMs: 2700,
-						confidence: null,
-					},
-					{
-						text: ' every',
-						startMs: 3100,
-						endMs: 4000,
-						timestampMs: 3550,
-						confidence: null,
-					},
-					{
-						text: ' spoken',
-						startMs: 4000,
-						endMs: 5100,
-						timestampMs: 4550,
-						confidence: null,
-					},
-					{
-						text: ' word.',
-						startMs: 5100,
-						endMs: 6500,
-						timestampMs: 5800,
-						confidence: null,
-					},
-				]}
-				width={props.width ?? 681}
-				height={props.height ?? 252}
-				style={{translate: '0px 0px'}}
-			/>
-		</div>
-	);
-};
+export const MovingPillCaptions = MovingPillCaptionsLayer;

--- a/packages/studio-codemods/src/insert-jsx-element.ts
+++ b/packages/studio-codemods/src/insert-jsx-element.ts
@@ -918,18 +918,6 @@ const createStringAttribute = (
 	);
 };
 
-const createBooleanAttribute = (
-	name: string,
-	value: boolean,
-): namedTypes.JSXAttribute => {
-	return recast.types.builders.jsxAttribute(
-		recast.types.builders.jsxIdentifier(name),
-		recast.types.builders.jsxExpressionContainer(
-			recast.types.builders.booleanLiteral(value),
-		),
-	);
-};
-
 const translateDecimalPlaces = 1;
 
 const roundTranslateCoordinate = (value: number): number => {
@@ -1026,15 +1014,16 @@ const createComponentProp = ({
 	name,
 	value,
 }: ComponentProp): namedTypes.JSXAttribute => {
-	if (typeof value === 'number') {
-		return createNumberAttribute(name, value);
+	if (typeof value === 'string') {
+		return createStringAttribute(name, value);
 	}
 
-	if (typeof value === 'boolean') {
-		return createBooleanAttribute(name, value);
-	}
-
-	return createStringAttribute(name, value);
+	return recast.types.builders.jsxAttribute(
+		recast.types.builders.jsxIdentifier(name),
+		recast.types.builders.jsxExpressionContainer(
+			parseValueExpression(value) as never,
+		),
+	) as unknown as namedTypes.JSXAttribute;
 };
 
 const createStringSrcAttribute = (src: string): namedTypes.JSXAttribute => {
@@ -1084,15 +1073,49 @@ const createComponentElement = ({
 	props: ComponentProp[];
 	position: InsertableCompositionElementPosition | null;
 }): namedTypes.JSXElement => {
+	const styleProp = props.find((prop) => prop.name === 'style');
+	const propsWithoutStyle = addPositionStyle
+		? props.filter((prop) => prop.name !== 'style')
+		: props;
+	let styleAttribute: namedTypes.JSXAttribute | null = null;
+	if (addPositionStyle) {
+		const styleExpression =
+			styleProp === undefined
+				? recast.types.builders.objectExpression([])
+				: parseValueExpression(styleProp.value);
+		if (styleExpression.type !== 'ObjectExpression') {
+			throw new Error('Component style must be an object to add a position');
+		}
+
+		styleExpression.properties = styleExpression.properties.filter(
+			(property) => {
+				if (property.type !== 'ObjectProperty') {
+					return true;
+				}
+
+				const key =
+					property.key.type === 'Identifier'
+						? property.key.name
+						: property.key.type === 'StringLiteral'
+							? property.key.value
+							: null;
+				return key !== 'position' && (position === null || key !== 'translate');
+			},
+		);
+		styleExpression.properties.push(...getPositionStyleProperties(position));
+		styleAttribute = recast.types.builders.jsxAttribute(
+			recast.types.builders.jsxIdentifier('style'),
+			recast.types.builders.jsxExpressionContainer(styleExpression as never),
+		) as unknown as namedTypes.JSXAttribute;
+	}
+
 	return recast.types.builders.jsxElement(
 		recast.types.builders.jsxOpeningElement(
 			recast.types.builders.jsxIdentifier(localName),
 			[
-				...props.map(createComponentProp),
+				...propsWithoutStyle.map(createComponentProp),
 				...(from === null ? [] : [createNumberAttribute('from', from)]),
-				...(addPositionStyle
-					? [createPositionAbsoluteStyleAttribute(position)]
-					: []),
+				...(styleAttribute === null ? [] : [styleAttribute]),
 			],
 			true,
 		),

--- a/packages/studio-protocol/src/drag-data.ts
+++ b/packages/studio-protocol/src/drag-data.ts
@@ -64,9 +64,13 @@ export type MakeEffectDragDataInput = EffectDragData['effect'] & {
 	readonly type: 'effect';
 };
 
-export type MakeElementDragDataInput = ElementDragData['element'] & {
+export type MakeElementDragDataInput = Omit<
+	ElementDragData['element'],
+	'initialProps'
+> & {
 	readonly type: 'element';
 	readonly durationInFrames: number;
+	readonly initialProps?: ElementDragData['element']['initialProps'];
 };
 
 export type MakeSfxDragDataInput = SfxDragData['sfx'] & {
@@ -234,6 +238,7 @@ export const makeDragData = ((
 					dimensions: input.dimensions,
 					displayName: input.displayName,
 					durationInFrames: input.durationInFrames,
+					initialProps: input.initialProps ?? null,
 					slug: input.slug,
 					sourceCode: input.sourceCode,
 					installationMode: input.installationMode,

--- a/packages/studio-protocol/src/element-drag-data.ts
+++ b/packages/studio-protocol/src/element-drag-data.ts
@@ -7,6 +7,18 @@ import {isValidPackageName} from './validation';
 
 export type ElementInstallationMode = 'wrapped' | 'component-owned-sequence';
 
+export type ElementInitialPropValue =
+	| string
+	| number
+	| boolean
+	| null
+	| readonly ElementInitialPropValue[]
+	| Readonly<object>;
+
+export type ElementInitialProps = Readonly<
+	Record<string, ElementInitialPropValue>
+>;
+
 export type ElementDependency =
 	| {
 			readonly name: `@remotion/${string}`;
@@ -23,6 +35,7 @@ export type ElementDragData = {
 	element: {
 		dependencies: ElementDependency[];
 		durationInFrames?: number;
+		initialProps: ElementInitialProps | null;
 		installationMode?: ElementInstallationMode;
 		slug: string;
 		displayName: string;
@@ -149,6 +162,7 @@ export const makeElementDragData = ({
 	dimensions,
 	displayName,
 	durationInFrames,
+	initialProps,
 	slug,
 	sourceCode,
 	installationMode,
@@ -173,6 +187,7 @@ export const makeElementDragData = ({
 			dimensions,
 			displayName,
 			...(durationInFrames === undefined ? {} : {durationInFrames}),
+			initialProps,
 			...(installationMode === undefined ? {} : {installationMode}),
 			slug,
 			sourceCode,
@@ -191,12 +206,90 @@ const elementInstallationModeSchema = z.union([
 const durationSchema = z
 	.number()
 	.check(z.int(), z.positive(), z.lte(100_000_000));
+const elementInitialPropsSchema = z.record(z.string(), z.unknown());
+const initialPropNameRegex = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+const componentOwnedInstallationProps = new Set([
+	'durationInFrames',
+	'from',
+	'name',
+]);
+
+const isJsonCompatibleValue = (
+	value: unknown,
+	seen: Set<object>,
+): value is ElementInitialPropValue => {
+	if (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'boolean'
+	) {
+		return true;
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value);
+	}
+
+	if (typeof value !== 'object' || seen.has(value)) {
+		return false;
+	}
+
+	seen.add(value);
+	const valid = Array.isArray(value)
+		? value.every((item) => isJsonCompatibleValue(item, seen))
+		: Object.getPrototypeOf(value) === Object.prototype &&
+			Object.values(value).every((item) => isJsonCompatibleValue(item, seen));
+	seen.delete(value);
+	return valid;
+};
+
+export const isElementInitialProps = (
+	value: unknown,
+): value is ElementInitialProps | null =>
+	value === null ||
+	(!Array.isArray(value) &&
+		typeof value === 'object' &&
+		value !== null &&
+		Object.keys(value).every((key) => initialPropNameRegex.test(key)) &&
+		isJsonCompatibleValue(value, new Set()));
+
+export const hasValidElementInitialPropsForInstallationMode = ({
+	initialProps,
+	installationMode,
+}: {
+	initialProps: ElementInitialProps | null;
+	installationMode: ElementInstallationMode | undefined;
+}) => {
+	if (
+		installationMode !== 'component-owned-sequence' ||
+		initialProps === null
+	) {
+		return true;
+	}
+
+	if (
+		Object.keys(initialProps).some((name) =>
+			componentOwnedInstallationProps.has(name),
+		)
+	) {
+		return false;
+	}
+
+	return (
+		initialProps.style === undefined ||
+		(initialProps.style !== null &&
+			typeof initialProps.style === 'object' &&
+			!Array.isArray(initialProps.style))
+	);
+};
+
 const elementDragDataSchema = z.object({
 	type: z.literal('remotion-element'),
 	version: z.literal(1),
 	element: z.object({
 		dependencies: z.array(z.unknown()).check(z.maxLength(100)),
 		durationInFrames: z.optional(durationSchema),
+		initialProps: z.optional(z.nullable(elementInitialPropsSchema)),
 		installationMode: z.optional(elementInstallationModeSchema),
 		slug: slugSchema,
 		displayName: z.string().check(z.minLength(1), z.maxLength(119)),
@@ -233,11 +326,23 @@ export const parseElementDragData = (value: string): ElementDragData | null => {
 			dependencies.push(dependency);
 		}
 
+		const initialProps = parsed.data.element.initialProps ?? null;
+		if (
+			!isElementInitialProps(initialProps) ||
+			!hasValidElementInitialPropsForInstallationMode({
+				initialProps,
+				installationMode: parsed.data.element.installationMode,
+			})
+		) {
+			return null;
+		}
+
 		return makeElementDragData({
 			dependencies,
 			dimensions: parsed.data.element.dimensions ?? null,
 			displayName: parsed.data.element.displayName,
 			durationInFrames: parsed.data.element.durationInFrames,
+			initialProps,
 			slug: parsed.data.element.slug,
 			sourceCode: parsed.data.element.sourceCode,
 			installationMode: parsed.data.element.installationMode,

--- a/packages/studio-protocol/src/element-payload.ts
+++ b/packages/studio-protocol/src/element-payload.ts
@@ -4,10 +4,13 @@ import {makeDragData} from './drag-data';
 import {
 	assertElementDependency,
 	getElementComponentNameFromSourceCode,
+	hasValidElementInitialPropsForInstallationMode,
+	isElementInitialProps,
 	makeElementFileNameFromSlug,
 	parseElementDragData,
 	type ElementDependency,
 	type ElementDragData,
+	type ElementInitialProps,
 	type ElementInstallationMode,
 } from './element-drag-data';
 
@@ -22,6 +25,7 @@ export type CreateElementPayloadInput = {
 	readonly dependencies: readonly ElementDependency[];
 	readonly dimensions: ComponentDimensions | null;
 	readonly durationInFrames: number;
+	readonly initialProps?: ElementInitialProps | null;
 	readonly installationMode?: ElementInstallationMode;
 };
 
@@ -87,6 +91,24 @@ const assertCreateElementPayloadInput = (
 			'installationMode must be "wrapped" or "component-owned-sequence"',
 		);
 	}
+
+	const initialProps = input.initialProps ?? null;
+	if (!isElementInitialProps(initialProps)) {
+		throw new TypeError(
+			'initialProps must be null or an object containing JSON-compatible values with valid JSX attribute names',
+		);
+	}
+
+	if (
+		!hasValidElementInitialPropsForInstallationMode({
+			initialProps,
+			installationMode: input.installationMode,
+		})
+	) {
+		throw new TypeError(
+			'component-owned-sequence initialProps must not define from, durationInFrames, or name, and style must be an object when provided',
+		);
+	}
 };
 
 export const createElementPayload = (
@@ -99,6 +121,7 @@ export const createElementPayload = (
 		dimensions: input.dimensions,
 		displayName: input.displayName,
 		durationInFrames: input.durationInFrames,
+		initialProps: input.initialProps ?? null,
 		slug: input.slug,
 		sourceCode: input.sourceCode,
 		installationMode: input.installationMode ?? 'wrapped',
@@ -122,13 +145,33 @@ export const parseStudioElementPayload = (
 		return null;
 	}
 
-	const element = parseElementDragData(
-		JSON.stringify({
+	if (
+		typeof parsed.data.element !== 'object' ||
+		parsed.data.element === null ||
+		Array.isArray(parsed.data.element)
+	) {
+		return null;
+	}
+
+	const rawInitialProps = Object.hasOwn(parsed.data.element, 'initialProps')
+		? (parsed.data.element as {initialProps: unknown}).initialProps
+		: null;
+	if (!isElementInitialProps(rawInitialProps)) {
+		return null;
+	}
+
+	let serializedElement: string;
+	try {
+		serializedElement = JSON.stringify({
 			type: parsed.data.type,
 			version: parsed.data.version,
 			element: parsed.data.element,
-		}),
-	);
+		});
+	} catch {
+		return null;
+	}
+
+	const element = parseElementDragData(serializedElement);
 	if (element === null) return null;
 	const payload: StudioElementPayload = {
 		...element,

--- a/packages/studio-protocol/src/index.ts
+++ b/packages/studio-protocol/src/index.ts
@@ -77,6 +77,8 @@ export type {
 export type {
 	ElementDependency,
 	ElementDragData,
+	ElementInitialProps,
+	ElementInitialPropValue,
 	ElementInstallationMode,
 } from './element-drag-data';
 export type {RenderOutputDragData} from './render-output-drag-data';

--- a/packages/studio-protocol/src/test/element-drag-data.test.ts
+++ b/packages/studio-protocol/src/test/element-drag-data.test.ts
@@ -7,6 +7,7 @@ const validElement = {
 	dependencies: [{name: '@remotion/google-fonts', version: null}],
 	slug: 'overlays/lower-third',
 	displayName: 'Lower Third',
+	initialProps: null,
 	sourceCode: 'export const LowerThird = () => null;',
 	dimensions: {width: 900, height: 260},
 } satisfies ElementInput;
@@ -49,6 +50,23 @@ test('parses element drag data', () => {
 		type: 'remotion-element',
 		version: 1,
 		element: {...validElement, durationInFrames: 120},
+	});
+});
+
+test('normalizes legacy drag data without initial props', () => {
+	const {initialProps: _initialProps, ...legacyElement} = validElement;
+	expect(
+		parseElementDragData(
+			JSON.stringify({
+				type: 'remotion-element',
+				version: 1,
+				element: {...legacyElement, durationInFrames: 120},
+			}),
+		),
+	).toEqual({
+		type: 'remotion-element',
+		version: 1,
+		element: {...legacyElement, durationInFrames: 120, initialProps: null},
 	});
 });
 
@@ -187,6 +205,26 @@ test('rejects invalid element drag data', () => {
 			}),
 		),
 	).toBe(null);
+	for (const initialProps of [
+		{'invalid-name': true},
+		{from: 10},
+		{style: 'red'},
+	]) {
+		expect(
+			parseElementDragData(
+				JSON.stringify({
+					type: 'remotion-element',
+					version: 1,
+					element: {
+						...validElement,
+						initialProps,
+						installationMode: 'component-owned-sequence',
+					},
+				}),
+			),
+		).toBe(null);
+	}
+
 	for (const dependencies of [
 		['@remotion/google-fonts'],
 		['--ignore-scripts'],

--- a/packages/studio-protocol/src/test/element-payload.test.ts
+++ b/packages/studio-protocol/src/test/element-payload.test.ts
@@ -16,6 +16,10 @@ const validInput = {
 	dimensions: {width: 800, height: 200},
 	displayName: 'Lower Third',
 	durationInFrames: 90,
+	initialProps: {
+		captions: [{text: 'Hello', startMs: 0, endMs: 1000}],
+		style: {color: 'red'},
+	},
 	slug: 'lower-third',
 	sourceCode: 'export const LowerThird = () => null;',
 	installationMode: 'component-owned-sequence',
@@ -38,6 +42,10 @@ test('creates one canonical Element payload for HTTP and drag transports', () =>
 			dimensions: {width: 800, height: 200},
 			displayName: 'Lower Third',
 			durationInFrames: 90,
+			initialProps: {
+				captions: [{text: 'Hello', startMs: 0, endMs: 1000}],
+				style: {color: 'red'},
+			},
 			installationMode: 'component-owned-sequence',
 			slug: 'lower-third',
 			sourceCode: 'export const LowerThird = () => null;',
@@ -75,6 +83,46 @@ test('defaults new Element payloads to wrapped installation', () => {
 	const {installationMode: _installationMode, ...input} = validInput;
 	const payload = createElementPayload(input);
 	expect(payload.element.installationMode).toBe('wrapped');
+});
+
+test('normalizes legacy payloads without initial props to null', () => {
+	const payload = createElementPayload(validInput);
+	const {initialProps: _initialProps, ...legacyElement} = payload.element;
+	expect(
+		parseStudioElementPayload({...payload, element: legacyElement}),
+	).toMatchObject({element: {initialProps: null}});
+});
+
+test('rejects invalid and reserved initial props', () => {
+	for (const initialProps of [
+		{invalid: undefined},
+		{invalid: Number.NaN},
+		{'not-an-attribute': true},
+		{captions: () => undefined},
+		{from: 10},
+		{style: 'color: red'},
+	]) {
+		expect(() => createInvalidPayload({...validInput, initialProps})).toThrow(
+			/initialProps|initial props/,
+		);
+	}
+
+	const payload = createElementPayload(validInput);
+	for (const initialProps of [
+		{invalid: undefined},
+		{invalid: Number.NaN},
+		{'not-an-attribute': true},
+		{captions: () => undefined},
+		{durationInFrames: 10},
+		{style: 'color: red'},
+	]) {
+		expect(
+			parseStudioElementPayload({
+				...payload,
+				element: {...payload.element, initialProps},
+			}),
+		).toBe(null);
+	}
 });
 
 test('rejects an invalid installation mode from Studio payloads', () => {

--- a/packages/studio-server/src/preview-server/routes/insert-element.ts
+++ b/packages/studio-server/src/preview-server/routes/insert-element.ts
@@ -79,6 +79,29 @@ export const insertElementHandler: ApiHandler<
 					: element.installationMode;
 			const componentOwnsSequence =
 				installationMode === 'component-owned-sequence';
+			if (
+				componentOwnsSequence &&
+				element.initialProps !== null &&
+				['from', 'durationInFrames', 'name'].some((prop) =>
+					Object.hasOwn(element.initialProps ?? {}, prop),
+				)
+			) {
+				throw new Error(
+					'Component-owned Element initial props must not override from, durationInFrames, or name',
+				);
+			}
+
+			if (
+				componentOwnsSequence &&
+				element.initialProps?.style !== undefined &&
+				(element.initialProps.style === null ||
+					typeof element.initialProps.style !== 'object' ||
+					Array.isArray(element.initialProps.style))
+			) {
+				throw new Error(
+					'Component-owned Element initial style must be an object',
+				);
+			}
 
 			RenderInternals.Log.trace(
 				{indent: false, logLevel},
@@ -146,19 +169,22 @@ export const insertElementHandler: ApiHandler<
 					componentName: plan.componentName,
 					importName: plan.componentName,
 					importPath: plan.importPath,
-					props: componentOwnsSequence
-						? [
-								...(element.durationInFrames === null
-									? []
-									: [
-											{
-												name: 'durationInFrames',
-												value: element.durationInFrames,
-											},
-										]),
-								{name: 'name', value: element.displayName},
-							]
-						: [],
+					props: [
+						...Object.entries(element.initialProps ?? {}).map(
+							([name, value]) => ({name, value}),
+						),
+						...(componentOwnsSequence && element.durationInFrames !== null
+							? [
+									{
+										name: 'durationInFrames',
+										value: element.durationInFrames,
+									},
+								]
+							: []),
+						...(componentOwnsSequence
+							? [{name: 'name', value: element.displayName}]
+							: []),
+					],
 					position: componentOwnsSequence ? position : null,
 				},
 				from: componentOwnsSequence ? from : null,

--- a/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
+++ b/packages/studio-server/src/preview-server/studio-protocol/handle-install.ts
@@ -46,6 +46,7 @@ const deliverElementInstall = ({
 		element: {
 			...element,
 			durationInFrames: element.durationInFrames ?? null,
+			initialProps: element.initialProps ?? null,
 			installationMode: element.installationMode ?? null,
 		},
 		from: null,

--- a/packages/studio-server/src/test/insert-element.test.ts
+++ b/packages/studio-server/src/test/insert-element.test.ts
@@ -51,10 +51,30 @@ const incomingElementSource =
 const existingElementSource =
 	'export const LowerThird = () => <div>Locally changed</div>;\n';
 
+const structuredInitialProps = {
+	captions: [
+		{
+			confidence: null,
+			endMs: 1000,
+			startMs: 0,
+			text: 'First copy',
+			timestampMs: 500,
+		},
+	],
+	style: {
+		color: 'red',
+		opacity: 0.8,
+		position: 'relative',
+		translate: '1px 2px',
+	},
+	width: 900,
+};
+
 const element: InsertElementRequest['element'] = {
 	dependencies: [],
 	dimensions: {width: 900, height: 260},
 	durationInFrames: 72,
+	initialProps: null,
 	installationMode: null,
 	displayName: 'Lower Third',
 	slug: 'overlays/lower-third',
@@ -297,21 +317,32 @@ test('creates a new Element file without an overwrite conflict', async () => {
 	}
 });
 
-test('installs an Element with a component-owned Sequence', async () => {
+test('installs structured initial props on a component-owned Sequence', async () => {
 	const fixture = makeFixture();
 	try {
 		const response = await fixture.callHandlerWithInput({
 			installationName: null,
 			compositionFile: 'Root.tsx',
 			compositionId: 'target',
-			element: {...element, installationMode: 'component-owned-sequence'},
+			element: {
+				...element,
+				initialProps: structuredInitialProps,
+				installationMode: 'component-owned-sequence',
+			},
 			expectedFileState: null,
 			from: 30,
 			overwriteExisting: false,
 			position: {x: 120, y: 80},
 		});
 
-		expect(response.success).toBe(true);
+		if (!response.success) {
+			throw new Error(
+				response.type === 'error'
+					? response.reason
+					: 'Unexpected file conflict',
+			);
+		}
+
 		expect(readFileSync(fixture.elementFile, 'utf-8')).toBe(
 			incomingElementSource,
 		);
@@ -321,8 +352,125 @@ test('installs an Element with a component-owned Sequence', async () => {
 		expect(composition).toContain('durationInFrames={72}');
 		expect(composition).toContain('from={30}');
 		expect(composition).toContain('name="Lower Third"');
+		expect(composition).toContain('captions={[');
+		expect(composition).toContain('text: "First copy"');
+		expect(composition).toContain('width={900}');
+		expect(composition).toContain('color: "red"');
+		expect(composition).toContain('opacity: 0.8');
 		expect(composition).toContain('position: "absolute"');
 		expect(composition).toContain('translate: "120px 80px"');
+		expect(composition).not.toContain('position: "relative"');
+		expect(composition).not.toContain('translate: "1px 2px"');
+		expect(composition.match(/\bstyle=/g)).toHaveLength(1);
+		expect(composition.match(/text: "First copy"/g)).toHaveLength(1);
+		expect(incomingElementSource).not.toContain('First copy');
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('rejects contradictory component-owned installation props', async () => {
+	const invalidInitialProps: Array<
+		NonNullable<InsertElementRequest['element']['initialProps']>
+	> = [{from: 10}, {style: 'color: red'}];
+	for (const initialProps of invalidInitialProps) {
+		const fixture = makeFixture();
+		try {
+			const response = await fixture.callHandlerWithInput({
+				installationName: null,
+				compositionFile: 'Root.tsx',
+				compositionId: 'target',
+				element: {
+					...element,
+					initialProps,
+					installationMode: 'component-owned-sequence',
+				},
+				expectedFileState: null,
+				from: 30,
+				overwriteExisting: false,
+				position: {x: 120, y: 80},
+			});
+			expect(response).toMatchObject({success: false, type: 'error'});
+			expect(readFileSync(fixture.compositionFile, 'utf-8')).toBe(
+				compositionSource,
+			);
+			expect(existsSync(fixture.elementFile)).toBe(false);
+		} finally {
+			fixture.cleanup();
+		}
+	}
+});
+
+test('keeps wrapped installation and passes initial props to its child', async () => {
+	const fixture = makeFixture();
+	try {
+		const response = await fixture.callHandlerWithInput({
+			installationName: null,
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element: {
+				...element,
+				initialProps: {label: 'Starter', style: {color: 'blue'}},
+			},
+			expectedFileState: null,
+			from: 12,
+			overwriteExisting: false,
+			position: {x: 40, y: 50},
+		});
+		if (!response.success) {
+			throw new Error(
+				response.type === 'error'
+					? response.reason
+					: 'Unexpected file conflict',
+			);
+		}
+
+		const composition = readFileSync(fixture.compositionFile, 'utf-8');
+		expect(composition).toContain('<Sequence');
+		expect(composition).toContain('from={12}');
+		expect(composition).toContain('translate: "40px 50px"');
+		expect(composition).toContain('label="Starter"');
+		expect(composition).toMatch(/style=\{\{\s*color: "blue"\s*\}\}/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('materializes independent props for two component-owned copies', async () => {
+	const fixture = makeFixture();
+	try {
+		const componentOwnedElement = {
+			...element,
+			initialProps: structuredInitialProps,
+			installationMode: 'component-owned-sequence' as const,
+		};
+		const first = await fixture.callHandlerWithInput({
+			installationName: null,
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element: componentOwnedElement,
+			expectedFileState: null,
+			from: 0,
+			overwriteExisting: false,
+			position: null,
+		});
+		expect(first.success).toBe(true);
+		const second = await fixture.callHandlerWithInput({
+			installationName: 'second-lower-third',
+			compositionFile: 'Root.tsx',
+			compositionId: 'target',
+			element: componentOwnedElement,
+			expectedFileState: {exists: false},
+			from: 30,
+			overwriteExisting: false,
+			position: null,
+		});
+		expect(second.success).toBe(true);
+
+		const composition = readFileSync(fixture.compositionFile, 'utf-8');
+		expect(composition.match(/captions=\{\[/g)).toHaveLength(2);
+		expect(composition.match(/text: "First copy"/g)).toHaveLength(2);
+		expect(composition).not.toContain('...structuredInitialProps');
 	} finally {
 		fixture.cleanup();
 	}

--- a/packages/studio-shared/src/api-requests.ts
+++ b/packages/studio-shared/src/api-requests.ts
@@ -45,9 +45,17 @@ import type {SymbolicatedStackFrame} from './stack-types';
 import type {EnumPath} from './stringify-default-props';
 import type {TerminalId} from './terminal';
 
+export type ComponentPropValue =
+	| string
+	| number
+	| boolean
+	| null
+	| readonly ComponentPropValue[]
+	| Readonly<object>;
+
 export type ComponentProp = {
 	name: string;
-	value: string | number | boolean;
+	value: ComponentPropValue;
 };
 
 export type EffectConfigValue =
@@ -83,6 +91,7 @@ export type ElementDependency =
 export type InstallableElement = {
 	dependencies: ElementDependency[];
 	durationInFrames: number | null;
+	initialProps: Readonly<Record<string, ComponentPropValue>> | null;
 	installationMode: ElementInstallationMode | null;
 	slug: string;
 	displayName: string;

--- a/packages/studio/src/components/Canvas.tsx
+++ b/packages/studio/src/components/Canvas.tsx
@@ -874,6 +874,7 @@ export const Canvas: React.FC<{
 						element: {
 							...payload.element,
 							durationInFrames: payload.element.durationInFrames ?? null,
+							initialProps: payload.element.initialProps ?? null,
 							installationMode: payload.element.installationMode ?? null,
 						},
 						from: null,

--- a/packages/studio/src/components/handle-drop.ts
+++ b/packages/studio/src/components/handle-drop.ts
@@ -140,6 +140,7 @@ export const handleDrop = async ({
 			element: {
 				...element.element,
 				durationInFrames: element.element.durationInFrames ?? null,
+				initialProps: element.element.initialProps ?? null,
 				installationMode: element.element.installationMode ?? null,
 			},
 			from: getFromForDrop({


### PR DESCRIPTION
Closes #11211

## What

Adds explicit JSON-compatible `initialProps` to the Remotion Element protocol and installation flow.

Element implementations remain reusable source files, while each installed JSX invocation receives its own starter content and configuration. Caption Elements now keep starter captions in typed `initial-props.ts` files and install them as explicit attributes on the component call site.

This standalone PR includes the direct-export caption wiring needed by the installation model and supersedes #11212. Unlike the later forwarding-wrapper approach in #11212, schema-enabled caption components are exported directly so Studio edits the actual installed call site.

## How

- validates and preserves `initialProps` across HTTP, drag, copy, and drop payloads, while normalizing legacy payloads to `null`;
- serializes structured values through the JSX AST without evaluating source or emitting opaque spreads;
- reserves Studio-owned timing and naming props, and merges placement into existing style props;
- uses the same initial props for Element previews and installation;
- migrates all caption Elements away from embedded starter caption defaults;
- directly exports `Interactive.withSchema()` caption components without forwarding wrappers;
- documents `initialProps` in the Studio Protocol and its use for component-owned installation mode.

## Verification

- `bun run build`
- `bun run stylecheck`
- `bun test packages/studio-protocol/src/test`
- `bun test packages/studio-server/src/test/insert-element.test.ts packages/studio-server/src/test/studio-protocol-routes.test.ts`
- `bun test packages/browser-studio/src/test/browser-studio-project-operations.test.ts`
- `cd packages/docs && bun test src/test/elements.test.ts`
- `cd packages/example && bunx playwright test e2e/captions-inspector.test.mts`

## Preview

- [Element contribution guide](https://remotion-git-elements-initial-props-remotion.vercel.app/elements/contributing)

