### PR TITLE
Recorder: Replace Media Parser with Mediabunny

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2443,7 +2443,6 @@
         "@remotion/lambda": "workspace:*",
         "@remotion/layout-utils": "workspace:*",
         "@remotion/media": "workspace:*",
-        "@remotion/media-parser": "workspace:*",
         "@remotion/media-utils": "workspace:*",
         "@remotion/renderer": "workspace:*",
         "@remotion/shapes": "workspace:*",

--- a/packages/template-recorder/package.json
+++ b/packages/template-recorder/package.json
@@ -24,7 +24,6 @@
     "@remotion/install-whisper-cpp": "workspace:*",
     "@remotion/lambda": "workspace:*",
     "@remotion/layout-utils": "workspace:*",
-    "@remotion/media-parser": "workspace:*",
     "@remotion/media-utils": "workspace:*",
     "@remotion/renderer": "workspace:*",
     "@remotion/shapes": "workspace:*",

--- a/packages/template-recorder/remotion/calculate-metadata/add-metadata-to-scene.ts
+++ b/packages/template-recorder/remotion/calculate-metadata/add-metadata-to-scene.ts
@@ -1,4 +1,3 @@
-import { parseMedia } from "@remotion/media-parser";
 import { CanvasLayout } from "../../config/layout";
 import {
   Cameras,
@@ -7,6 +6,7 @@ import {
   SelectableScene,
 } from "../../config/scenes";
 import { calculateSrt } from "../captions/srt/helpers/calculate-srt";
+import { getVideoMetadata } from "../helpers/get-video-metadata";
 import { getBRollDimensions } from "../layout/get-broll-dimensions";
 import { getVideoSceneLayout } from "../layout/get-layout";
 import { PLACEHOLDER_DURATION_IN_FRAMES } from "./empty-place-holder";
@@ -49,13 +49,9 @@ export const addMetadataToScene = async ({
     };
   }
 
-  const webcamMetadata = await parseMedia({
+  const webcamMetadata = await getVideoMetadata({
     src: cameras.webcam.src,
-    fields: {
-      durationInSeconds: true,
-      dimensions: true,
-    },
-    acknowledgeRemotionLicense: true,
+    includeDuration: true,
   });
 
   if (!webcamMetadata.dimensions) {
@@ -66,10 +62,9 @@ export const addMetadataToScene = async ({
   }
 
   const displayMetadata = cameras.display
-    ? await parseMedia({
+    ? await getVideoMetadata({
         src: cameras.display.src,
-        fields: { dimensions: true, durationInSeconds: true },
-        acknowledgeRemotionLicense: true,
+        includeDuration: false,
       })
     : null;
 

--- a/packages/template-recorder/remotion/helpers/get-video-metadata.ts
+++ b/packages/template-recorder/remotion/helpers/get-video-metadata.ts
@@ -1,0 +1,43 @@
+import { ALL_FORMATS, Input, UrlSource } from "mediabunny";
+
+export const getVideoMetadata = async ({
+  src,
+  includeDuration,
+}: {
+  src: string;
+  includeDuration: boolean;
+}) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src),
+  });
+
+  try {
+    const [videoTrack, durationInSeconds] = await Promise.all([
+      input.getPrimaryVideoTrack(),
+      includeDuration
+        ? input
+            .getDurationFromMetadata(undefined, { skipLiveWait: true })
+            .then(
+              (duration) =>
+                duration ??
+                input.computeDuration(undefined, { skipLiveWait: true }),
+            )
+        : null,
+    ]);
+
+    const dimensions = videoTrack
+      ? {
+          width: await videoTrack.getDisplayWidth(),
+          height: await videoTrack.getDisplayHeight(),
+        }
+      : null;
+
+    return {
+      dimensions,
+      durationInSeconds,
+    };
+  } finally {
+    input.dispose();
+  }
+};

--- a/packages/template-recorder/remotion/layout/get-broll-dimensions.ts
+++ b/packages/template-recorder/remotion/layout/get-broll-dimensions.ts
@@ -1,6 +1,6 @@
-import { parseMedia } from "@remotion/media-parser";
 import { getImageDimensions } from "@remotion/media-utils";
 import type { BRoll, BRollWithDimensions } from "../../config/scenes";
+import { getVideoMetadata } from "../helpers/get-video-metadata";
 
 const imageFileExtensions = [
   "jpg",
@@ -33,10 +33,9 @@ export const getBRollDimensions = async (
   if (
     videoFileExtensions.some((ext) => bRoll.source.toLowerCase().endsWith(ext))
   ) {
-    const metadata = await parseMedia({
+    const metadata = await getVideoMetadata({
       src: bRoll.source,
-      fields: { dimensions: true },
-      acknowledgeRemotionLicense: true,
+      includeDuration: false,
     });
     if (!metadata.dimensions) {
       throw new Error("No dimensions found for bRoll: " + bRoll.source);


### PR DESCRIPTION
## Summary

- Replace Template Recorder's Media Parser metadata reads with Mediabunny
- Dispose each Mediabunny input after reading video dimensions and duration
- Remove the unused `@remotion/media-parser` dependency

## Test plan

- `bun run build`
- `bun run stylecheck`
- `bun run test` in `packages/template-recorder`
