### PR TITLE
`@remotion/studio`: Slugify composition IDs before saving

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1865,12 +1865,12 @@ test.describe('visual mode', () => {
 	});
 
 	test('should navigate to a newly created composition', async ({page}) => {
-		const compositionId = 'NewlyCreatedComposition';
+		const compositionName = 'Newly Created Composition';
+		const compositionId = 'Newly-Created-Composition';
 		const rootFile = path.join(exampleDir, 'src', 'E2eTestRoot.tsx');
 		const compositionFile = path.join(
 			exampleDir,
-			'src',
-			`${compositionId}.tsx`,
+			'src/NewlyCreatedComposition.tsx',
 		);
 
 		try {
@@ -1883,7 +1883,10 @@ test.describe('visual mode', () => {
 				.click();
 			await page
 				.getByRole('textbox', {name: 'Composition ID'})
-				.fill(compositionId);
+				.fill(compositionName);
+			await expect(
+				page.getByText(`Will be created as ${compositionId}`),
+			).toBeVisible();
 			await page.getByTitle('Folder').click();
 			const schemaFolderOption = page
 				.getByRole('button', {name: 'Schema', exact: true})
@@ -3303,9 +3306,7 @@ export const SequenceShiftRepro = () => {
 				.toBe(contextForAgents);
 			await page.getByRole('button', {name: 'Go to beginning'}).click();
 			for (let i = 0; i < 3; i++) {
-				await page
-					.getByRole('button', {name: 'Go forward 1 frame'})
-					.click();
+				await page.getByRole('button', {name: 'Go forward 1 frame'}).click();
 			}
 			await expect
 				.poll(() =>

--- a/packages/studio/src/components/ElementInstallConfirmation.tsx
+++ b/packages/studio/src/components/ElementInstallConfirmation.tsx
@@ -524,6 +524,7 @@ export const ElementInstallConfirmation: React.FC<{
 	}, [folderCompositionFile, newPlan, request.element, selectedFolderStack]);
 
 	const {
+		compositionId: newCompositionId,
 		createComposition,
 		heightValidationMessage,
 		nameValidationMessage,
@@ -755,9 +756,7 @@ export const ElementInstallConfirmation: React.FC<{
 					? selectedPlan.compositionFile
 					: request.compositionFile,
 			compositionId:
-				mode === 'new-composition'
-					? newCompositionValues.id
-					: request.compositionId,
+				mode === 'new-composition' ? newCompositionId : request.compositionId,
 			element: request.element,
 			// The insert operation revalidates this even if the name preflight is pending.
 			expectedFileState: activePlan?.expectedFileState ?? {exists: false},
@@ -781,7 +780,7 @@ export const ElementInstallConfirmation: React.FC<{
 		createComposition,
 		folderSymbolicatedStack,
 		mode,
-		newCompositionValues.id,
+		newCompositionId,
 		onClose,
 		request,
 		selectedFolderStack,
@@ -885,6 +884,7 @@ export const ElementInstallConfirmation: React.FC<{
 							aria-label="New composition settings"
 						>
 							<NewCompositionFields
+								compositionId={newCompositionId}
 								heightValidationMessage={heightValidationMessage}
 								inputRef={inputRef}
 								nameValidationMessage={

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -118,6 +118,7 @@ export type NewCompositionFormValues = {
 };
 
 export const NewCompositionFields: React.FC<{
+	readonly compositionId: string;
 	readonly heightValidationMessage: string | null;
 	readonly inputRef: RefObject<HTMLInputElement | null>;
 	readonly nameValidationMessage: string | null;
@@ -125,6 +126,7 @@ export const NewCompositionFields: React.FC<{
 	readonly values: NewCompositionFormValues;
 	readonly widthValidationMessage: string | null;
 }> = ({
+	compositionId,
 	heightValidationMessage,
 	inputRef,
 	nameValidationMessage,
@@ -329,6 +331,17 @@ export const NewCompositionFields: React.FC<{
 							status="ok"
 							rightAlign
 						/>
+						{compositionId && compositionId !== values.id ? (
+							<>
+								<Spacing y={1} block />
+								<div
+									aria-live="polite"
+									style={{fontSize: 12, color: LIGHT_TEXT}}
+								>
+									Will be created as {compositionId}
+								</div>
+							</>
+						) : null}
 						{nameValidationMessage ? (
 							<>
 								<Spacing y={1} block />
@@ -473,6 +486,7 @@ const NewCompositionLoaded: React.FC<{
 
 	const {
 		codemod,
+		compositionId,
 		createComposition,
 		heightValidationMessage,
 		nameValidationMessage,
@@ -546,6 +560,7 @@ const NewCompositionLoaded: React.FC<{
 			<form onSubmit={onSubmit}>
 				<div style={content}>
 					<NewCompositionFields
+						compositionId={compositionId}
 						heightValidationMessage={heightValidationMessage}
 						inputRef={inputRef}
 						nameValidationMessage={nameValidationMessage}

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -7,6 +7,7 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
+import {LIGHT_TEXT} from '../../helpers/colors';
 import {useRenameComposition} from '../../helpers/use-rename-composition';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -60,6 +61,7 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 
 	const {
 		codemod,
+		compositionId,
 		renameComposition,
 		valid,
 		validationMessage: compNameErrMessage,
@@ -92,6 +94,17 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 									status="ok"
 									rightAlign
 								/>
+								{compositionId && compositionId !== newId ? (
+									<>
+										<Spacing y={1} block />
+										<div
+											aria-live="polite"
+											style={{fontSize: 12, color: LIGHT_TEXT}}
+										>
+											Will be renamed to {compositionId}
+										</div>
+									</>
+								) : null}
 								{compNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/helpers/use-create-composition.ts
+++ b/packages/studio/src/helpers/use-create-composition.ts
@@ -7,6 +7,7 @@ import {useCallback, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {useSelectComposition} from '../components/InitialCompositionLoader';
 import {applyCodemod} from '../components/RenderQueue/actions';
+import {slugifyName} from './slugify-name';
 import {
 	validateCompositionDimension,
 	validateCompositionName,
@@ -73,11 +74,17 @@ export const useCreateComposition = ({
 	} | null;
 }) => {
 	const selectComposition = useSelectComposition();
-	const componentName = useMemo(() => toPascalCase(newId), [newId]);
+	const compositionId = slugifyName(newId);
+	const componentName = useMemo(
+		() => toPascalCase(compositionId),
+		[compositionId],
+	);
 
 	const nameValidationMessage = useMemo(() => {
-		return validateCompositionName(newId, compositions);
-	}, [compositions, newId]);
+		return compositionId
+			? validateCompositionName(compositionId, compositions)
+			: 'Enter an ID containing letters or numbers.';
+	}, [compositionId, compositions]);
 
 	const widthValidationMessage = useMemo(() => {
 		return validateCompositionDimension('Width', size.width);
@@ -94,7 +101,7 @@ export const useCreateComposition = ({
 			newFps: Number(selectedFrameRate),
 			newHeight: Number(size.height),
 			newWidth: Number(size.width),
-			newId,
+			newId: compositionId,
 			componentName,
 			componentImportPath: `./${componentName}`,
 			folderName,
@@ -113,9 +120,9 @@ export const useCreateComposition = ({
 	}, [
 		canvasCapture,
 		componentName,
+		compositionId,
 		durationInFrames,
 		folderName,
-		newId,
 		parentName,
 		selectedFrameRate,
 		size.height,
@@ -145,7 +152,7 @@ export const useCreateComposition = ({
 			if (result.success) {
 				selectComposition(
 					{
-						id: newId,
+						id: compositionId,
 						folderName,
 						parentFolderName: parentName,
 					},
@@ -155,11 +162,12 @@ export const useCreateComposition = ({
 
 			return result;
 		},
-		[codemod, folderName, newId, parentName, selectComposition],
+		[codemod, compositionId, folderName, parentName, selectComposition],
 	);
 
 	return {
 		codemod,
+		compositionId,
 		createComposition,
 		heightValidationMessage,
 		nameValidationMessage,

--- a/packages/studio/src/helpers/use-rename-composition.ts
+++ b/packages/studio/src/helpers/use-rename-composition.ts
@@ -5,6 +5,7 @@ import type {
 import {useCallback, useMemo} from 'react';
 import type {_InternalTypes} from 'remotion';
 import {applyCodemod} from '../components/RenderQueue/actions';
+import {slugifyName} from './slugify-name';
 import {pushUrl} from './url-state';
 import {validateCompositionName} from './validate-new-comp-data';
 
@@ -19,11 +20,14 @@ export const useRenameComposition = ({
 }) => {
 	const getValidationMessage = useCallback(
 		(value: string) => {
-			if (value === currentId) {
+			const slug = slugifyName(value);
+			if (slug === currentId) {
 				return null;
 			}
 
-			return validateCompositionName(value, compositions);
+			return slug
+				? validateCompositionName(slug, compositions)
+				: 'Enter an ID containing letters or numbers.';
 		},
 		[compositions, currentId],
 	);
@@ -33,12 +37,13 @@ export const useRenameComposition = ({
 			return {
 				type: 'rename-composition',
 				idToRename: currentId,
-				newId: value,
+				newId: slugifyName(value),
 			};
 		},
 		[currentId],
 	);
 
+	const compositionId = slugifyName(newId);
 	const validationMessage = useMemo(() => {
 		return getValidationMessage(newId);
 	}, [getValidationMessage, newId]);
@@ -47,7 +52,7 @@ export const useRenameComposition = ({
 		return getCodemod(newId);
 	}, [getCodemod, newId]);
 
-	const valid = validationMessage === null && currentId !== newId;
+	const valid = validationMessage === null && currentId !== compositionId;
 
 	const renameComposition = useCallback(
 		async ({
@@ -67,7 +72,7 @@ export const useRenameComposition = ({
 			});
 
 			if (result.success) {
-				pushUrl(`/${newCompositionId}`);
+				pushUrl(`/${slugifyName(newCompositionId)}`);
 			}
 
 			return result;
@@ -77,6 +82,7 @@ export const useRenameComposition = ({
 
 	return {
 		codemod,
+		compositionId,
 		getValidationMessage,
 		renameComposition,
 		valid,


### PR DESCRIPTION
Follow-up to #11164. Base PR in stack #11228.

Slugifies human-readable composition IDs before creating or renaming compositions in Studio. The resulting ID is previewed in the dialogs, validated for collisions, and used consistently for generated source, navigation, inline renames, and Element installation.

## Verification

- `bunx turbo run make --filter='@remotion/studio'`
- `cd packages/studio && bun run lint` (passes with existing warnings)
- `bunx oxfmt ... --check`
- `cd packages/example && bunx playwright test e2e/studio.test.mts --grep "should navigate to a newly created composition"`
- Red/green verification of the focused Playwright test
