### PR TITLE
`@remotion/studio`: Share slug preview logic

### DIFF
--- a/packages/example/e2e/studio.test.mts
+++ b/packages/example/e2e/studio.test.mts
@@ -1881,12 +1881,14 @@ test.describe('visual mode', () => {
 			await page
 				.getByRole('button', {name: 'New composition...', exact: true})
 				.click();
-			await page
-				.getByRole('textbox', {name: 'Composition ID'})
-				.fill(compositionName);
-			await expect(
-				page.getByText(`Will be created as ${compositionId}`),
-			).toBeVisible();
+			const compositionIdInput = page.getByRole('textbox', {
+				name: 'Composition ID',
+			});
+			const slugPreview = page.getByText(`Will be created as ${compositionId}`);
+			await compositionIdInput.fill(`${compositionId} `);
+			await expect(slugPreview).toBeHidden();
+			await compositionIdInput.fill(compositionName);
+			await expect(slugPreview).toBeVisible();
 			await page.getByTitle('Folder').click();
 			const schemaFolderOption = page
 				.getByRole('button', {name: 'Schema', exact: true})

--- a/packages/studio/src/components/NewComposition/NewComposition.tsx
+++ b/packages/studio/src/components/NewComposition/NewComposition.tsx
@@ -40,6 +40,7 @@ import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {InputDragger} from './InputDragger';
 import {NewCompDuration} from './NewCompDuration';
 import {RemotionInput} from './RemInput';
+import {SlugPreview} from './SlugPreview';
 import {ValidationMessage} from './ValidationMessage';
 
 const content: React.CSSProperties = {
@@ -331,17 +332,12 @@ export const NewCompositionFields: React.FC<{
 							status="ok"
 							rightAlign
 						/>
-						{compositionId && compositionId !== values.id ? (
-							<>
-								<Spacing y={1} block />
-								<div
-									aria-live="polite"
-									style={{fontSize: 12, color: LIGHT_TEXT}}
-								>
-									Will be created as {compositionId}
-								</div>
-							</>
-						) : null}
+						<SlugPreview
+							action="create"
+							currentName={null}
+							input={values.id}
+							slug={compositionId}
+						/>
 						{nameValidationMessage ? (
 							<>
 								<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/NewFolder.tsx
+++ b/packages/studio/src/components/NewComposition/NewFolder.tsx
@@ -9,7 +9,6 @@ import React, {
 	useState,
 } from 'react';
 import {Internals, type _InternalTypes} from 'remotion';
-import {LIGHT_TEXT} from '../../helpers/colors';
 import {slugifyName} from '../../helpers/slugify-name';
 import {validateNewFolderName} from '../../helpers/validate-new-folder-name';
 import {Spacing} from '../layout';
@@ -21,6 +20,7 @@ import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
+import {SlugPreview} from './SlugPreview';
 import {ValidationMessage} from './ValidationMessage';
 
 const content: React.CSSProperties = {
@@ -117,17 +117,12 @@ export const NewFolder: React.FC<{
 									status="ok"
 									rightAlign
 								/>
-								{folderName && folderName !== newName ? (
-									<>
-										<Spacing y={1} block />
-										<div
-											aria-live="polite"
-											style={{fontSize: 12, color: LIGHT_TEXT}}
-										>
-											Will be created as {folderName}
-										</div>
-									</>
-								) : null}
+								<SlugPreview
+									action="create"
+									currentName={null}
+									input={newName}
+									slug={folderName}
+								/>
 								{folderNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/RenameComposition.tsx
+++ b/packages/studio/src/components/NewComposition/RenameComposition.tsx
@@ -7,7 +7,6 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
-import {LIGHT_TEXT} from '../../helpers/colors';
 import {useRenameComposition} from '../../helpers/use-rename-composition';
 import {Spacing} from '../layout';
 import {ModalFooterContainer} from '../ModalFooter';
@@ -21,6 +20,7 @@ import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
+import {SlugPreview} from './SlugPreview';
 import {ValidationMessage} from './ValidationMessage';
 
 const content: React.CSSProperties = {
@@ -94,17 +94,12 @@ const RenameCompositionLoaded: React.FC<{}> = () => {
 									status="ok"
 									rightAlign
 								/>
-								{compositionId && compositionId !== newId ? (
-									<>
-										<Spacing y={1} block />
-										<div
-											aria-live="polite"
-											style={{fontSize: 12, color: LIGHT_TEXT}}
-										>
-											Will be renamed to {compositionId}
-										</div>
-									</>
-								) : null}
+								<SlugPreview
+									action="rename"
+									currentName={resolved.result.id}
+									input={newId}
+									slug={compositionId}
+								/>
 								{compNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/RenameFolder.tsx
+++ b/packages/studio/src/components/NewComposition/RenameFolder.tsx
@@ -9,7 +9,6 @@ import React, {
 	useState,
 } from 'react';
 import {Internals} from 'remotion';
-import {LIGHT_TEXT} from '../../helpers/colors';
 import {getFolderId} from '../../helpers/get-folder-id';
 import {slugifyName} from '../../helpers/slugify-name';
 import {validateFolderRename} from '../../helpers/validate-folder-rename';
@@ -22,6 +21,7 @@ import {CodemodFooter} from './CodemodFooter';
 import {DismissableModal} from './DismissableModal';
 import {InputAndValidationContainer} from './InputAndValidationContainer';
 import {RemotionInput} from './RemInput';
+import {SlugPreview} from './SlugPreview';
 import {ValidationMessage} from './ValidationMessage';
 
 const content: React.CSSProperties = {
@@ -100,17 +100,12 @@ export const RenameFolder: React.FC<{
 									status="ok"
 									rightAlign
 								/>
-								{slug && slug !== newName ? (
-									<>
-										<Spacing y={1} block />
-										<div
-											aria-live="polite"
-											style={{fontSize: 12, color: LIGHT_TEXT}}
-										>
-											Will be renamed to {slug}
-										</div>
-									</>
-								) : null}
+								<SlugPreview
+									action="rename"
+									currentName={folderName}
+									input={newName}
+									slug={slug}
+								/>
 								{folderNameErrMessage ? (
 									<>
 										<Spacing y={1} block />

--- a/packages/studio/src/components/NewComposition/SlugPreview.tsx
+++ b/packages/studio/src/components/NewComposition/SlugPreview.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {LIGHT_TEXT} from '../../helpers/colors';
+import {Spacing} from '../layout';
+
+export const SlugPreview: React.FC<{
+	readonly action: 'create' | 'rename';
+	readonly currentName: string | null;
+	readonly input: string;
+	readonly slug: string;
+}> = ({action, currentName, input, slug}) => {
+	if (
+		!slug ||
+		slug === input ||
+		slug === input.trim() ||
+		slug === currentName
+	) {
+		return null;
+	}
+
+	return (
+		<>
+			<Spacing y={1} block />
+			<div aria-live="polite" style={{fontSize: 12, color: LIGHT_TEXT}}>
+				Will be {action === 'create' ? 'created as' : 'renamed to'} {slug}
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
Depends on #11225 in stack #11228. Follow-up to #11164 and its Pullfrog review.

Shares slug preview rendering and visibility logic across folder and composition creation and rename dialogs. Previews are hidden when normalization only trims surrounding whitespace, or when a rename resolves to the current name, so inputs such as `Jonny ` no longer display the redundant “Will be created as Jonny” message.

## Verification

- `bunx turbo run make --filter='@remotion/studio'`
- `cd packages/studio && bun run lint` (passes with existing warnings)
- `bunx oxfmt ... --check`
- `cd packages/example && bunx playwright test e2e/studio.test.mts --grep "should navigate to a newly created composition"`
