### PR TITLE
Docs: Add progress slider to tear effect demo

### DIFF
--- a/packages/docs/components/effects-demos/registry.ts
+++ b/packages/docs/components/effects-demos/registry.ts
@@ -306,7 +306,10 @@ export const effectsDemos: EffectsDemoType[] = [
 		effectName: 'tear',
 		effectImportPath: '@remotion/effects/tear',
 		comp: EffectsTearPreview,
-		schema: tear().definition.schema,
+		schema: {
+			...tear().definition.schema,
+			progress: {...tear().definition.schema.progress, max: 2},
+		},
 	},
 	{
 		...defaults,


### PR DESCRIPTION
## Summary

- show the tear effect demo's progress control as a slider from `0` to `2`
- keep the public `tear()` progress range unchanged by applying the limit only to the docs demo

Closes #11203

## Verification

- `bun run build`
- `bun run stylecheck`
