### PR TITLE
docs: add Lexington Motion to the resources page

### DIFF
--- a/packages/docs/docs/resources.mdx
+++ b/packages/docs/docs/resources.mdx
@@ -28,6 +28,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - Docker Build & Render ([Source code](https://github.com/scotthavird/remotion-docker-template))
 - [Template for deploying Remotion on Railway](https://railway.com/deploy/remotion-on-rails) ([Blog](https://medium.com/@viveknathani/remotion-on-rails-0852acc9595e))
 - [Multiple shared Remotion components in a Monorepo template](https://github.com/Takamasa045/remotion-studio-monorepo)
+- [Lexington Motion - Seamlessly looping promo templates for social media](https://lexingtonthemes.com/remotion)
 
 ## SaaS starter Kits
 


### PR DESCRIPTION
Adds Lexington Motion to the Templates section of the resources page.

It is a collection of seamlessly looping promo video templates for social media, built entirely with Remotion. Each template is a 15 second loop, and images and text are swapped by editing props in Remotion Studio.

Preview of all templates: https://lexingtonthemes.com/remotion

Jonny suggested over email that I send a PR to add it here. Thanks!