### PR TITLE
Internal: Stop local dev servers from opening browsers

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
 		"formatting": "oxfmt src standalone --check",
 		"format": "oxfmt src standalone",
 		"docusaurus": "docusaurus",
-		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && bun prepare-browser-studio-workspace.ts && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0",
+		"start": "bun copy-raw-docs.ts && bun fetch-prompt-submissions.ts && bun update-prompt.ts && cd .. && bun run build && cd docs && bun prepare-browser-studio-workspace.ts && if [ \"$REMOTION_DOCS_ENABLE_TWOSLASH\" = \"1\" ]; then echo \"🧪 Twoslash is enabled in development.\"; else echo \"⚡ Twoslash is disabled in development for faster startup.\"; echo \"   Enable it with: REMOTION_DOCS_ENABLE_TWOSLASH=1 bun run start\"; fi && REMOTION_DOCS_DISABLE_TWOSLASH=1 docusaurus start --host 0.0.0.0 --no-open",
 		"build-docs": "bun build-docs.ts",
 		"build-browser-studio": "bun prepare-browser-studio-workspace.ts && bun build-browser-studio-standalone.ts",
 		"swizzle": "docusaurus swizzle",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,9 +14,9 @@
 	"scripts": {
 		"formatting": "oxfmt src --check",
 		"format": "oxfmt src",
-		"dev": "remotion studio --props src/my-props.json",
-		"start-bun": "PATCH_BUN_DEVELOPMENT=true bun --bun remotion studio",
-		"start-js": "remotion preview src/entry.jsx",
+		"dev": "remotion studio --props src/my-props.json --no-open",
+		"start-bun": "PATCH_BUN_DEVELOPMENT=true bun --bun remotion studio --no-open",
+		"start-js": "remotion preview src/entry.jsx --no-open",
 		"comps": "remotion compositions",
 		"clean": "rm -rf build && rm -rf build-testbed && rm -rf out",
 		"lint": "eslint src",


### PR DESCRIPTION
## Summary

- prevent the example Studio scripts from opening a system browser automatically
- prevent the docs development server from opening a system browser automatically
- keep local server URLs available for integrated browser tooling to open explicitly

## Verification

- `bunx oxfmt packages/docs/package.json packages/example/package.json --write`
- `bun run build`
- `bun run stylecheck`
- `git diff --check`
