### PR TITLE
Docs: Prevent content hash collisions from corrupting bundles

### DIFF
--- a/packages/docs/build-docs.ts
+++ b/packages/docs/build-docs.ts
@@ -143,6 +143,9 @@ await run(
 	docusaurusBuild.args,
 	docusaurusEnv,
 );
+await run('validate generated JavaScript', 'bun', [
+	'validate-built-javascript.ts',
+]);
 await run('build standalone Browser Studio', 'bun', [
 	'build-browser-studio-standalone.ts',
 ]);

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import type {Config} from '@docusaurus/types';
 import elementSourceDependencies from './plugins/element-source-dependencies.js';
+import longContentHashes from './plugins/long-content-hashes.js';
 import remarkElementSource from './plugins/remark-element-source.js';
 import remarkExportRaw from './plugins/remark-export-raw.js';
 import {elementRegistry} from './src/components/Elements/element-registry';
@@ -348,6 +349,7 @@ const config: Config = {
 	],
 	plugins: [
 		elementSourceDependencies,
+		longContentHashes,
 		[
 			'@docusaurus/plugin-content-docs',
 			{

--- a/packages/docs/plugins/long-content-hashes.js
+++ b/packages/docs/plugins/long-content-hashes.js
@@ -1,0 +1,39 @@
+// Rspack's RealContentHashPlugin globally replaces preliminary hashes in all
+// assets. An eight-character hash can occur in source data and corrupt a
+// bundle: https://github.com/web-infra-dev/rspack/issues/8474
+const shortContentHash = '[contenthash:8]';
+const longContentHash = '[contenthash:12]';
+
+export default function longContentHashes() {
+	return {
+		name: 'long-content-hashes',
+		configureWebpack(config, isServer) {
+			if (isServer || config.mode !== 'production') {
+				return {};
+			}
+
+			for (const key of ['filename', 'chunkFilename']) {
+				const value = config.output?.[key];
+				if (typeof value === 'string') {
+					config.output[key] = value.replace(shortContentHash, longContentHash);
+				}
+			}
+
+			for (const plugin of config.plugins ?? []) {
+				const options = plugin?.options;
+				if (!options) {
+					continue;
+				}
+
+				for (const key of ['filename', 'chunkFilename']) {
+					const value = options[key];
+					if (typeof value === 'string') {
+						options[key] = value.replace(shortContentHash, longContentHash);
+					}
+				}
+			}
+
+			return {};
+		},
+	};
+}

--- a/packages/docs/validate-built-javascript.ts
+++ b/packages/docs/validate-built-javascript.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+const buildDirectory = path.join(import.meta.dir, 'build');
+const transpiler = new Bun.Transpiler({loader: 'js'});
+let filesChecked = 0;
+
+for await (const relativePath of new Bun.Glob('**/*.js').scan({
+	cwd: buildDirectory,
+	onlyFiles: true,
+})) {
+	const file = path.join(buildDirectory, relativePath);
+	try {
+		transpiler.scan(await Bun.file(file).text());
+	} catch (error) {
+		throw new Error(`Generated invalid JavaScript in ${relativePath}`, {
+			cause: error,
+		});
+	}
+
+	filesChecked++;
+}
+
+console.log(`Validated ${filesChecked} generated JavaScript files.`);

--- a/packages/docs/validate-built-javascript.ts
+++ b/packages/docs/validate-built-javascript.ts
@@ -2,7 +2,35 @@ import path from 'path';
 
 const buildDirectory = path.join(import.meta.dir, 'build');
 const transpiler = new Bun.Transpiler({loader: 'js'});
+const contentHashLength = 12;
 let filesChecked = 0;
+
+for (const {relativeDirectory, extension} of [
+	{relativeDirectory: 'assets/js', extension: 'js'},
+	{relativeDirectory: 'assets/css', extension: 'css'},
+]) {
+	let assetsFound = 0;
+	const expectedFilename = new RegExp(
+		`\\.[0-9a-f]{${contentHashLength}}\\.${extension}$`,
+	);
+
+	for await (const filename of new Bun.Glob(`*.${extension}`).scan({
+		cwd: path.join(buildDirectory, relativeDirectory),
+		onlyFiles: true,
+	})) {
+		if (!expectedFilename.test(filename)) {
+			throw new Error(
+				`Expected a ${contentHashLength}-character content hash in ${relativeDirectory}/${filename}`,
+			);
+		}
+
+		assetsFound++;
+	}
+
+	if (assetsFound === 0) {
+		throw new Error(`No generated ${extension.toUpperCase()} assets found`);
+	}
+}
 
 for await (const relativePath of new Bun.Glob('**/*.js').scan({
 	cwd: buildDirectory,
@@ -10,6 +38,8 @@ for await (const relativePath of new Bun.Glob('**/*.js').scan({
 })) {
 	const file = path.join(buildDirectory, relativePath);
 	try {
+		// This catches syntax corruption, but not hash replacements that leave
+		// syntactically valid JavaScript. Longer hashes make both cases less likely.
 		transpiler.scan(await Bun.file(file).text());
 	} catch (error) {
 		throw new Error(`Generated invalid JavaScript in ${relativePath}`, {


### PR DESCRIPTION
## What

Prevents Rspack's `RealContentHashPlugin` from corrupting generated docs JavaScript when an eight-character preliminary content hash also occurs in source data.

The production Elements bundle hit this collision: `32268938` inside a floating-point literal was replaced with a hexadecimal hash, leaving the route chunk syntactically invalid. The server-rendered page remained visible, but client hydration and Element preview interactions failed.

## How

- increases production JavaScript and CSS content hashes from 8 to 12 characters;
- verifies that generated JavaScript and CSS asset filenames use 12-character content hashes, catching configuration regressions;
- validates every generated JavaScript file with Bun after the Docusaurus build, so malformed bundles fail the deployment instead of reaching production.

Rspack issue: https://github.com/web-infra-dev/rspack/issues/8474

## Verification

- `bun run build`
- `bun run stylecheck`
- `cd packages/docs && VERCEL=1 REMOTION_DOCS_LOW_MEMORY_BUILD=1 DOCUSAURUS_IGNORE_SSG_WARNINGS=true DOCUSAURUS_NO_PERSISTENT_CACHE=true NODE_OPTIONS='--max-old-space-size=3072' node build-docusaurus-low-memory.cjs`
- `cd packages/docs && bun validate-built-javascript.ts`
- `cd packages/docs && bun test src/test/elements.test.ts`
- Red/green: changing a generated CSS asset to an 8-character content hash makes the validator fail with the expected error.
