### PR TITLE
Elements: Remove sticky listing card tooltip

### DIFF
--- a/packages/docs/src/components/Elements/ElementLibrary.tsx
+++ b/packages/docs/src/components/Elements/ElementLibrary.tsx
@@ -104,7 +104,6 @@ const ElementCard: React.FC<{
 				}}
 				onPointerEnter={activateFromPointer}
 				onPointerLeave={() => setIsPointerOver(false)}
-				title="Click to view details, or drag this Element into Remotion Studio"
 			>
 				<div
 					aria-hidden="true"

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -385,9 +385,6 @@ describe('Element library', () => {
 		expect(overviewMarkup.match(/draggable="true"/g)).toHaveLength(
 			elementDefinitionList.length,
 		);
-		expect(overviewMarkup).toContain(
-			'title="Click to view details, or drag this Element into Remotion Studio"',
-		);
 
 		for (const section of sections) {
 			const categoryMarkup = renderToStaticMarkup(


### PR DESCRIPTION
## Summary

Removes the native browser tooltip from Element gallery cards. The tooltip could remain visible while moving between cards and obstruct the gallery.

Cards remain clickable and draggable into Remotion Studio.

## Verification

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`
