### PR TITLE
Elements: Preserve initial props when inserting components in Browser Studio

### DIFF
--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -2044,6 +2044,33 @@ export const createBrowserStudioOperations = ({
 			),
 		insertElement: async (request) => {
 			try {
+				const installationMode = request.element.installationMode ?? 'wrapped';
+				const componentOwnsSequence =
+					installationMode === 'component-owned-sequence';
+				if (
+					componentOwnsSequence &&
+					request.element.initialProps !== null &&
+					['from', 'durationInFrames', 'name'].some((prop) =>
+						Object.hasOwn(request.element.initialProps ?? {}, prop),
+					)
+				) {
+					throw new Error(
+						'Component-owned Element initial props must not override from, durationInFrames, or name',
+					);
+				}
+
+				if (
+					componentOwnsSequence &&
+					request.element.initialProps?.style !== undefined &&
+					(request.element.initialProps.style === null ||
+						typeof request.element.initialProps.style !== 'object' ||
+						Array.isArray(request.element.initialProps.style))
+				) {
+					throw new Error(
+						'Component-owned Element initial style must be an object',
+					);
+				}
+
 				const project = getProject();
 				const plan = await getElementInstallPlanForProject({
 					installationName: request.installationName,
@@ -2092,9 +2119,6 @@ export const createBrowserStudioOperations = ({
 				const installedDependencies = await resolveElementDependencies(
 					request.element.dependencies,
 				);
-				const installationMode = request.element.installationMode ?? 'wrapped';
-				const componentOwnsSequence =
-					installationMode === 'component-owned-sequence';
 				const durationInFrames = request.element.durationInFrames ?? null;
 				const insertion =
 					await insertJsxElementIntoProjectWithNodePathRemappings({

--- a/packages/browser-studio/src/browser-studio-operations.ts
+++ b/packages/browser-studio/src/browser-studio-operations.ts
@@ -2107,19 +2107,22 @@ export const createBrowserStudioOperations = ({
 								importName: plan.componentName,
 								importPath: plan.importPath,
 								position: componentOwnsSequence ? request.position : null,
-								props: componentOwnsSequence
-									? [
-											...(durationInFrames === null
-												? []
-												: [
-														{
-															name: 'durationInFrames',
-															value: durationInFrames,
-														},
-													]),
-											{name: 'name', value: request.element.displayName},
-										]
-									: [],
+								props: [
+									...Object.entries(request.element.initialProps ?? {}).map(
+										([name, value]) => ({name, value}),
+									),
+									...(componentOwnsSequence && durationInFrames !== null
+										? [
+												{
+													name: 'durationInFrames',
+													value: durationInFrames,
+												},
+											]
+										: []),
+									...(componentOwnsSequence
+										? [{name: 'name', value: request.element.displayName}]
+										: []),
+								],
 								type: 'component',
 							},
 							from: componentOwnsSequence ? request.from : null,

--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -400,7 +400,7 @@ test('imports an Element with pinned Remotion dependencies as one undoable mutat
 		dimensions: {width: 640, height: 180},
 		displayName: 'Lower Third',
 		durationInFrames: 90,
-		initialProps: null,
+		initialProps: {label: 'Starter'},
 		installationMode: 'wrapped' as const,
 		slug: 'titles/lower-third',
 		sourceCode: `import {Rect} from '@remotion/shapes';
@@ -470,6 +470,9 @@ export const LowerThird = () => <Rect width={640} height={180} />;
 	expect(project.files['/project/src/Composition.tsx']).toContain('from={12}');
 	expect(project.files['/project/src/Composition.tsx']).toContain(
 		'name="Lower Third"',
+	);
+	expect(project.files['/project/src/Composition.tsx']).toContain(
+		'label="Starter"',
 	);
 	expect(project.files['/project/src/Composition.tsx']).toContain(
 		'translate: "24px 48px"',
@@ -553,6 +556,84 @@ export const LowerThird = () => <Rect width={640} height={180} />;
 	expect(project.files['/project/src/speaker-name.element.tsx']).toBe(
 		element.sourceCode,
 	);
+});
+
+test('installs component-owned Element timing and initial props', async () => {
+	let project = createBlankTemplateProject();
+	const operations = createBrowserStudioOperations({
+		dependencyVersions: {},
+		getStaticFiles: null,
+		getProject: () => project,
+		initialElement: null,
+		onProjectChange: (nextProject) => {
+			project = nextProject;
+		},
+		resolveDependencies: null,
+	});
+	const element = {
+		dependencies: [],
+		dimensions: {width: 640, height: 180},
+		displayName: 'Captions',
+		durationInFrames: 90,
+		initialProps: {
+			captions: [{text: 'Starter', startMs: 0, endMs: 1000}],
+			style: {
+				color: 'red',
+				position: 'relative',
+				translate: '1px 2px',
+			},
+			width: 640,
+		},
+		installationMode: 'component-owned-sequence' as const,
+		slug: 'captions',
+		sourceCode: 'export const Captions = () => <div />;\n',
+	} satisfies ElementDragData['element'];
+	const preflight = await operations.prepareElementInstall({
+		installationName: null,
+		destination: {
+			type: 'current-composition',
+			compositionFile: '/project/src/Composition.tsx',
+			compositionId: 'MyComp',
+		},
+		element,
+	});
+	if (!preflight.success) {
+		throw new Error(preflight.reason);
+	}
+
+	const inserted = await operations.insertElement({
+		installationName: null,
+		compositionFile: '/project/src/Composition.tsx',
+		compositionId: 'MyComp',
+		element,
+		expectedFileState: preflight.plan.expectedFileState,
+		from: 30,
+		overwriteExisting: false,
+		position: {x: 24, y: 48},
+	});
+	if (!inserted.success) {
+		throw new Error(
+			inserted.type === 'error' ? inserted.reason : 'Unexpected file conflict',
+		);
+	}
+
+	expect(project.files['/project/src/captions.element.tsx']).toBe(
+		element.sourceCode,
+	);
+	const composition = project.files['/project/src/Composition.tsx'];
+	expect(composition).not.toContain('<Sequence');
+	expect(composition).toContain('<Captions');
+	expect(composition).toContain('captions={[');
+	expect(composition).toContain('text: "Starter"');
+	expect(composition).toContain('width={640}');
+	expect(composition).toContain('durationInFrames={90}');
+	expect(composition).toContain('from={30}');
+	expect(composition).toContain('name="Captions"');
+	expect(composition).toContain('color: "red"');
+	expect(composition).toContain('position: "absolute"');
+	expect(composition).toContain('translate: "24px 48px"');
+	expect(composition).not.toContain('translate: "1px 2px"');
+	expect(composition.match(/\bstyle=/g)).toHaveLength(1);
 });
 
 test('installs packages as an undoable project mutation and reports structured failures', async () => {

--- a/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
+++ b/packages/browser-studio/src/test/browser-studio-project-operations.test.ts
@@ -636,6 +636,74 @@ test('installs component-owned Element timing and initial props', async () => {
 	expect(composition.match(/\bstyle=/g)).toHaveLength(1);
 });
 
+test('rejects contradictory component-owned Element initial props', async () => {
+	const initialProject = createBlankTemplateProject();
+	let project = initialProject;
+	const operations = createBrowserStudioOperations({
+		dependencyVersions: {},
+		getStaticFiles: null,
+		getProject: () => project,
+		initialElement: null,
+		onProjectChange: (nextProject) => {
+			project = nextProject;
+		},
+		resolveDependencies: null,
+	});
+	const invalidCases: Array<{
+		initialProps: ElementDragData['element']['initialProps'];
+		reason: string;
+	}> = [
+		{
+			initialProps: {from: 10},
+			reason:
+				'Component-owned Element initial props must not override from, durationInFrames, or name',
+		},
+		{
+			initialProps: {durationInFrames: 10},
+			reason:
+				'Component-owned Element initial props must not override from, durationInFrames, or name',
+		},
+		{
+			initialProps: {name: 'Override'},
+			reason:
+				'Component-owned Element initial props must not override from, durationInFrames, or name',
+		},
+		{
+			initialProps: {style: 'color: red'},
+			reason: 'Component-owned Element initial style must be an object',
+		},
+	];
+
+	for (const {initialProps, reason} of invalidCases) {
+		const response = await operations.insertElement({
+			installationName: null,
+			compositionFile: '/project/src/Composition.tsx',
+			compositionId: 'MyComp',
+			element: {
+				dependencies: [],
+				dimensions: {width: 640, height: 180},
+				displayName: 'Captions',
+				durationInFrames: 90,
+				initialProps,
+				installationMode: 'component-owned-sequence',
+				slug: 'captions',
+				sourceCode: 'export const Captions = () => <div />;\n',
+			},
+			expectedFileState: null,
+			from: 30,
+			overwriteExisting: false,
+			position: {x: 24, y: 48},
+		});
+
+		expect(response).toMatchObject({
+			success: false,
+			type: 'error',
+			reason,
+		});
+		expect(project).toBe(initialProject);
+	}
+});
+
 test('installs packages as an undoable project mutation and reports structured failures', async () => {
 	const initialProject = createBlankTemplateProject();
 	let project = initialProject;


### PR DESCRIPTION
## Summary

- pass Element `initialProps` into generated component insertions
- retain component-owned timing and naming props alongside the initial values
- merge inserted positioning into an existing initial `style` prop without duplicating it

## Verification

- `bun test packages/browser-studio/src/test/browser-studio-project-operations.test.ts --test-name-pattern 'installs component-owned Element timing and initial props|imports an Element with pinned Remotion dependencies as one undoable mutation'`
- red/green regression verification: the component-owned insertion test fails when the production wiring is reverted and passes when restored
- `bun run build`
- `bun run stylecheck`
