### PR TITLE
Recorder: require selected media devices

### DIFF
--- a/packages/template-recorder/src/Stream.tsx
+++ b/packages/template-recorder/src/Stream.tsx
@@ -26,7 +26,7 @@ export const Stream: React.FC<{
   setResolution: React.Dispatch<React.SetStateAction<ResolutionAndFps | null>>;
   recordAudio: boolean;
   selectedVideoSource: SelectedSource | null;
-  selectedAudioSource: ConstrainDOMString | null;
+  selectedAudioSource: string | null;
   preferPortrait: boolean;
   mirror: boolean;
   clear: () => void;

--- a/packages/template-recorder/src/helpers/get-video-stream.ts
+++ b/packages/template-recorder/src/helpers/get-video-stream.ts
@@ -51,6 +51,22 @@ export const getCameraStreamConstraints = (
   return video;
 };
 
+export const getAudioStreamConstraints = ({
+  recordAudio,
+  selectedAudioSource,
+}: {
+  recordAudio: boolean;
+  selectedAudioSource: string | null;
+}): MediaTrackConstraints | undefined => {
+  if (!recordAudio || !selectedAudioSource) {
+    return undefined;
+  }
+
+  // A string constraint is only an "ideal" preference. Use an exact
+  // constraint so Chrome cannot silently substitute the default microphone.
+  return { deviceId: { exact: selectedAudioSource } };
+};
+
 const getCameraStram = ({
   selectedVideoSource,
   preferPortrait,
@@ -69,10 +85,7 @@ const getCameraStram = ({
 
   const mediaStreamConstraints: MediaStreamConstraints = {
     video: video ?? undefined,
-    audio:
-      recordAudio && selectedAudioSource
-        ? { deviceId: { exact: selectedAudioSource } }
-        : undefined,
+    audio: getAudioStreamConstraints({ recordAudio, selectedAudioSource }),
   };
 
   return window.navigator.mediaDevices.getUserMedia(mediaStreamConstraints);
@@ -96,7 +109,7 @@ export const getVideoStream = async ({
     const displayStream = await getDisplayStream(selectedVideoSource);
     if (recordAudio && selectedAudioSource) {
       const audioStream = await window.navigator.mediaDevices.getUserMedia({
-        audio: { deviceId: { exact: selectedAudioSource } },
+        audio: getAudioStreamConstraints({ recordAudio, selectedAudioSource }),
       });
       return new MediaStream([
         ...displayStream.getVideoTracks(),

--- a/packages/template-recorder/src/helpers/get-video-stream.ts
+++ b/packages/template-recorder/src/helpers/get-video-stream.ts
@@ -31,7 +31,9 @@ export const getCameraStreamConstraints = (
     return null;
   }
   const video: MediaTrackConstraints = {
-    deviceId: selectedVideoSource.deviceId,
+    // A string constraint is only an "ideal" preference. Use an exact
+    // constraint so Chrome cannot silently substitute the default webcam.
+    deviceId: { exact: selectedVideoSource.deviceId },
     width: preferPortrait
       ? undefined
       : selectedVideoSource.maxWidth
@@ -58,7 +60,7 @@ const getCameraStram = ({
   selectedVideoSource: SelectedSource;
   preferPortrait: boolean;
   recordAudio: boolean;
-  selectedAudioSource: ConstrainDOMString | null;
+  selectedAudioSource: string | null;
 }): Promise<MediaStream> => {
   if (selectedVideoSource.type !== "camera") {
     throw new Error("Unknown video source type");
@@ -69,7 +71,7 @@ const getCameraStram = ({
     video: video ?? undefined,
     audio:
       recordAudio && selectedAudioSource
-        ? { deviceId: selectedAudioSource }
+        ? { deviceId: { exact: selectedAudioSource } }
         : undefined,
   };
 
@@ -85,7 +87,7 @@ export const getVideoStream = async ({
   selectedVideoSource: SelectedSource;
   preferPortrait: boolean;
   recordAudio: boolean;
-  selectedAudioSource: ConstrainDOMString | null;
+  selectedAudioSource: string | null;
 }): Promise<MediaStream> => {
   if (selectedVideoSource.type === "display-with-audio") {
     return getDisplayStream(selectedVideoSource);
@@ -94,7 +96,7 @@ export const getVideoStream = async ({
     const displayStream = await getDisplayStream(selectedVideoSource);
     if (recordAudio && selectedAudioSource) {
       const audioStream = await window.navigator.mediaDevices.getUserMedia({
-        audio: { deviceId: selectedAudioSource },
+        audio: { deviceId: { exact: selectedAudioSource } },
       });
       return new MediaStream([
         ...displayStream.getVideoTracks(),

--- a/packages/template-recorder/tests/get-video-stream.test.ts
+++ b/packages/template-recorder/tests/get-video-stream.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { getCameraStreamConstraints } from "../src/helpers/get-video-stream";
+
+test("requires the selected camera instead of accepting the browser default", () => {
+  expect(
+    getCameraStreamConstraints(
+      {
+        type: "camera",
+        deviceId: "camo-camera-id",
+        maxWidth: 1920,
+        maxHeight: 1080,
+        minFps: 30,
+      },
+      false,
+    ),
+  ).toMatchObject({
+    deviceId: { exact: "camo-camera-id" },
+  });
+});

--- a/packages/template-recorder/tests/get-video-stream.test.ts
+++ b/packages/template-recorder/tests/get-video-stream.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import { getCameraStreamConstraints } from "../src/helpers/get-video-stream";
+import {
+  getAudioStreamConstraints,
+  getCameraStreamConstraints,
+} from "../src/helpers/get-video-stream";
 
 test("requires the selected camera instead of accepting the browser default", () => {
   expect(
@@ -16,4 +19,24 @@ test("requires the selected camera instead of accepting the browser default", ()
   ).toMatchObject({
     deviceId: { exact: "camo-camera-id" },
   });
+});
+
+test("requires the selected microphone instead of accepting the browser default", () => {
+  expect(
+    getAudioStreamConstraints({
+      recordAudio: true,
+      selectedAudioSource: "camo-microphone-id",
+    }),
+  ).toEqual({
+    deviceId: { exact: "camo-microphone-id" },
+  });
+});
+
+test("does not request a microphone when audio recording is disabled", () => {
+  expect(
+    getAudioStreamConstraints({
+      recordAudio: false,
+      selectedAudioSource: "camo-microphone-id",
+    }),
+  ).toBeUndefined();
 });


### PR DESCRIPTION
## Summary

Recorder showed the selected Camo camera and microphone while Chrome could capture the default MacBook devices instead. A bare string `deviceId` is an ideal preference in Media Constraints, so the browser may silently substitute another device.

This makes the selected camera and microphone constraints exact, and narrows the internal selected-audio type to the actual stored device ID.

## Verification

- Reproduced with Camo Camera and Camo Microphone: the UI selection previously captured the MacBook defaults.
- Confirmed the fix requested the selected Camo video and audio tracks by exact device ID.
- `bun test tests` in `packages/template-recorder`: 30 passing tests, including the new regression test.

This supersedes remotion-dev/recorder#149, which was opened against the standalone mirror.