### PR TITLE
fix(recorder): use latest takes for existing scenes

### DIFF
--- a/packages/template-recorder/remotion/calculate-metadata/get-camera.ts
+++ b/packages/template-recorder/remotion/calculate-metadata/get-camera.ts
@@ -101,6 +101,17 @@ const getCameras = (compositionId: string) => {
   return mappedCameras.sort((a, b) => a.timestamp - b.timestamp);
 };
 
+export const selectLatestCamerasForScenes = <T>(
+  cameras: T[],
+  numberOfVideoScenes: number,
+): T[] => {
+  if (numberOfVideoScenes <= 0) {
+    return [];
+  }
+
+  return cameras.slice(-numberOfVideoScenes);
+};
+
 export const getAllCameras = ({
   compositionId,
   scenes,
@@ -109,6 +120,10 @@ export const getAllCameras = ({
   scenes: SelectableScene[];
 }) => {
   const allCameras = getCameras(compositionId);
+  const camerasForScenes = selectLatestCamerasForScenes(
+    allCameras,
+    scenes.filter((scene) => scene.type === "videoscene").length,
+  );
   let videoIndex = -1;
 
   const scenesWithCameras = scenes.map((scene): CamerasAndScene => {
@@ -117,7 +132,7 @@ export const getAllCameras = ({
     }
 
     videoIndex += 1;
-    return { scene, cameras: allCameras[videoIndex] as Cameras };
+    return { scene, cameras: camerasForScenes[videoIndex] as Cameras };
   });
 
   const hasAtLeast1Camera = allCameras.length > 0;

--- a/packages/template-recorder/remotion/calculate-metadata/get-camera.ts
+++ b/packages/template-recorder/remotion/calculate-metadata/get-camera.ts
@@ -109,6 +109,9 @@ export const selectLatestCamerasForScenes = <T>(
     return [];
   }
 
+  // This supports the current one-scene retake workflow. Retakes for an
+  // arbitrary earlier scene need per-scene take metadata rather than relying
+  // on the chronological position of the recorded files.
   return cameras.slice(-numberOfVideoScenes);
 };
 

--- a/packages/template-recorder/tests/select-latest-cameras.test.ts
+++ b/packages/template-recorder/tests/select-latest-cameras.test.ts
@@ -1,0 +1,21 @@
+import { expect, mock, test } from "bun:test";
+
+mock.module("remotion", () => ({
+  getStaticFiles: () => [],
+}));
+
+const { selectLatestCamerasForScenes } = await import(
+  "../remotion/calculate-metadata/get-camera"
+);
+
+test("uses the newest take when one scene has multiple recordings", () => {
+  expect(selectLatestCamerasForScenes([1, 2], 1)).toEqual([2]);
+});
+
+test("keeps the latest takes in chronological order for multiple scenes", () => {
+  expect(selectLatestCamerasForScenes([1, 2, 3], 2)).toEqual([2, 3]);
+});
+
+test("does not select takes without a video scene", () => {
+  expect(selectLatestCamerasForScenes([1, 2], 0)).toEqual([]);
+});


### PR DESCRIPTION
## Summary

When a composition has more recorded take sets than video scenes, Recorder currently sorts the takes oldest-first and assigns from index zero. Recording again into an existing composition therefore leaves Studio showing the stale, earliest take.

This selects the newest required take sets while preserving chronological order when there are multiple video scenes.

## Verification

- Reproduced in `test2` with an initial 5.2-second take followed by a 70.2-second retake. Before the fix, Studio loaded the 5.2-second files; after the fix it loaded the 70.2-second webcam, display, and caption set.
- `bun test tests` in `packages/template-recorder`: 32 passing tests, including three regression cases for latest-take selection.

## Scope

This is a focused repair for the existing one-scene workflow. A future UX improvement could explicitly offer Retake versus Add new scene, rather than infer a new scene from an additional recording.

This supersedes remotion-dev/recorder#150, which was opened against the standalone mirror.