### PR TITLE
Elements: Simplify Element Library appearance

### DIFF
--- a/packages/docs/src/components/Elements/ElementLibrary.module.css
+++ b/packages/docs/src/components/Elements/ElementLibrary.module.css
@@ -32,15 +32,12 @@
 	min-width: 0;
 	flex-direction: column;
 	overflow: hidden;
-	border: 1px solid var(--ifm-color-emphasis-300);
-	border-radius: min(3vw, 12px);
-	background: var(--ifm-background-surface-color);
+	background: transparent;
 	color: var(--ifm-font-color-base);
 	text-decoration: none;
 }
 
 .library .card:hover {
-	border-color: var(--ifm-color-primary);
 	color: var(--ifm-font-color-base);
 	text-decoration: none;
 }
@@ -55,6 +52,7 @@
 	position: relative;
 	aspect-ratio: 16 / 9;
 	overflow: hidden;
+	border-radius: 8px;
 }
 
 .previewMedia {
@@ -69,27 +67,16 @@
 
 .content {
 	min-width: 0;
-	padding: 18px;
+	padding: 18px 0;
 }
 
 .title {
 	display: block;
 	margin: 0;
+	font-family: 'GTPlanar';
 	font-size: 1.125rem;
-	font-weight: 500;
+	font-weight: 400;
 	text-wrap: balance;
-}
-
-.description {
-	margin: 10px 0 0;
-	color: var(--ifm-color-emphasis-800);
-	font-size: 1rem;
-	line-height: 1.6;
-	text-wrap: pretty;
-}
-
-.card:hover .title {
-	color: var(--ifm-color-primary);
 }
 
 @container element-library (min-width: 600px) {
@@ -99,15 +86,11 @@
 	}
 
 	.content {
-		padding: 16px;
+		padding: 16px 0;
 	}
 
 	.title {
 		font-size: 1rem;
-	}
-
-	.description {
-		font-size: 0.9375rem;
 	}
 }
 

--- a/packages/docs/src/components/Elements/ElementLibrary.tsx
+++ b/packages/docs/src/components/Elements/ElementLibrary.tsx
@@ -135,7 +135,6 @@ const ElementCard: React.FC<{
 				</div>
 				<div className={styles.content}>
 					<span className={styles.title}>{definition.displayName}</span>
-					<p className={styles.description}>{definition.description}</p>
 				</div>
 			</a>
 		</li>

--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -375,7 +375,7 @@ describe('Element library', () => {
 			).toHaveLength(2);
 			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h2>`);
 			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h3>`);
-			expect(overviewMarkup).toContain(definition.description);
+			expect(overviewMarkup).not.toContain(definition.description);
 			expect(overviewMarkup).toContain(definition.preview.posterUrl);
 			expect(overviewMarkup).toContain(getElementDocumentationUrl(definition));
 		}


### PR DESCRIPTION
## Summary
- simplify Element Library cards by removing their border and surface background
- move rounding to the preview media and streamline card typography
- remove card descriptions from the library listing

## Test plan
- [x] Verify the combined stack diff matches the original PR exactly
