### PR TITLE
`@remotion/studio`: Preserve number field display precision

### DIFF
--- a/packages/example/e2e/effect-keyframes.test.mts
+++ b/packages/example/e2e/effect-keyframes.test.mts
@@ -127,6 +127,71 @@ test.describe('effect keyframes', () => {
 			{timeout: 30_000},
 		);
 
+		const originalContent = fs.readFileSync(effectKeyframeE2eFile, 'utf-8');
+		const factorDragger = page.getByRole('button', {name: '0.75', exact: true});
+		await expect(async () => {
+			await page
+				.getByTitle('Effect scale precision', {exact: true})
+				.first()
+				.click();
+			await expect(page.getByText('Factor', {exact: true})).toBeVisible({
+				timeout: 1_000,
+			});
+		}).toPass({timeout: 15_000});
+		await expect(factorDragger).toBeVisible();
+
+		await factorDragger.click();
+		const factorInput = page.getByRole('textbox');
+		await expect(factorInput).toHaveValue('0.75');
+		await factorInput.press('Enter');
+		await expect(factorDragger).toBeVisible();
+		expect(fs.readFileSync(effectKeyframeE2eFile, 'utf-8')).toBe(
+			originalContent,
+		);
+
+		await factorDragger.click();
+		await factorInput.fill('0.625');
+		await factorInput.press('ArrowUp');
+		await expect(factorInput).toHaveValue('0.725');
+		await factorInput.press('ArrowDown');
+		await expect(factorInput).toHaveValue('0.625');
+		await factorInput.press('Enter');
+		await expect
+			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
+			.toContain('scale({scale: 0.625})');
+
+		const preciseFactorDragger = page.getByRole('button', {
+			name: '0.625',
+			exact: true,
+		});
+		await expect(preciseFactorDragger).toBeVisible();
+		await preciseFactorDragger.click();
+		await expect(factorInput).toHaveValue('0.625');
+		await factorInput.press('Enter');
+
+		// Dragging still increments and snaps to the effect's 0.1 step.
+		const factorBounds = await preciseFactorDragger.boundingBox();
+		assert(factorBounds);
+		const factorX = factorBounds.x + factorBounds.width / 2;
+		const factorY = factorBounds.y + factorBounds.height / 2;
+		await page.mouse.move(factorX, factorY);
+		await page.mouse.down();
+		await page.mouse.move(factorX + 5, factorY);
+		await page.mouse.up();
+		await expect
+			.poll(() => fs.readFileSync(effectKeyframeE2eFile, 'utf-8'))
+			.toContain('scale({scale: 0.8})');
+		await page.reload();
+		await expect(async () => {
+			await page
+				.getByTitle('Effect scale precision', {exact: true})
+				.first()
+				.click();
+			await expect(
+				page.getByRole('button', {name: '0.8', exact: true}),
+			).toBeVisible({timeout: 1_000});
+		}).toPass({timeout: 15_000});
+
 		const timelineExpansionLabel = page
 			.getByText('Timeline expansion', {exact: true})
 			.last();
@@ -264,6 +329,10 @@ test.describe('effect keyframes', () => {
 			)
 			.toBe(true);
 
+		await expect(
+			page.getByRole('button', {name: '0.005', exact: true}),
+		).toBeVisible();
+
 		await selectScalePrecisionAndWaitFor({page, locator: waveRow});
 		await waveRow.click();
 
@@ -295,5 +364,8 @@ test.describe('effect keyframes', () => {
 				},
 			)
 			.toBe(true);
+		await expect(
+			page.getByRole('button', {name: '60.525', exact: true}),
+		).toBeVisible();
 	});
 });

--- a/packages/example/src/EffectKeyframeE2e.tsx
+++ b/packages/example/src/EffectKeyframeE2e.tsx
@@ -4,6 +4,7 @@ import {Video} from '@remotion/media';
 import React from 'react';
 import {
 	AbsoluteFill,
+	CanvasImage,
 	interpolate,
 	Solid,
 	staticFile,
@@ -33,6 +34,15 @@ export const EffectKeyframeE2e: React.FC = () => {
 					wave({}),
 					scale({scale: 1, horizontal: true, vertical: true}),
 				]}
+			/>
+			<CanvasImage
+				name="Effect scale precision"
+				src={staticFile('1.jpg')}
+				width={1280}
+				height={720}
+				fit="cover"
+				style={{position: 'absolute'}}
+				effects={[scale({scale: 0.75})]}
 			/>
 			<Solid
 				name="Timeline expansion"

--- a/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
+++ b/packages/studio/src/components/Timeline/timeline-field-display-utils.ts
@@ -137,11 +137,15 @@ const formatNumberTimelineFieldValueForDisplay = ({
 		return digits === 0 ? String(numericValue) : numericValue.toFixed(digits);
 	}
 
-	return formatTimelineNumber({
-		decimalPlaces: stepDecimals,
-		fixed: true,
-		value: numericValue,
-	});
+	// The step controls increments, not the precision of source or typed values.
+	// Keep finer values while trimming floating point noise.
+	const normalizedValue =
+		getDecimalPlaces(numericValue) > stepDecimals
+			? Number(numericValue.toPrecision(15))
+			: numericValue;
+	return getDecimalPlaces(normalizedValue) > stepDecimals
+		? String(normalizedValue)
+		: normalizedValue.toFixed(stepDecimals);
 };
 
 const formatRotationTimelineFieldValueForDisplay = ({

--- a/packages/studio/src/test/timeline-field-utils.test.ts
+++ b/packages/studio/src/test/timeline-field-utils.test.ts
@@ -51,19 +51,41 @@ test('formatTimelineNumber can omit unnecessary trailing zeroes', () => {
 	).toBe('10');
 });
 
-test('formatTimelineFieldValueForDisplay formats number fields based on step', () => {
-	expect(
-		formatTimelineFieldValueForDisplay({
-			fieldSchema: {
-				type: 'number',
-				default: 0,
-				hiddenFromList: false,
-				step: 0.01,
-			},
-			value: 1.2000000000000002,
-		}),
-	).toBe('1.20');
-});
+test.each([
+	{step: 0.1, value: 0.75, expected: '0.75'},
+	{step: 0.1, value: '0.625', expected: '0.625'},
+	{step: 0.1, value: 1, expected: '1.0'},
+	{step: 1, value: -60.525, expected: '-60.525'},
+	{step: 0.01, value: 0.005, expected: '0.005'},
+	{step: 0.01, value: 1.2000000000000002, expected: '1.20'},
+	{step: 0.1, value: 0.1 + 0.2, expected: '0.3'},
+	{step: 0.1, value: 0.123456789, expected: '0.123456789'},
+	{step: 0.1, value: 1.25e-7, expected: '1.25e-7'},
+	{step: 0.1, value: 1e-101, expected: '1e-101'},
+	{step: 1e-7, value: 1.25e-7, expected: '1.25e-7'},
+	{
+		step: 1e-16,
+		value: 1.2000000000000002,
+		expected: '1.2000000000000002',
+	},
+	{step: 1, value: Number.MAX_SAFE_INTEGER, expected: '9007199254740991'},
+	{step: undefined, value: 0.123456789, expected: '0.123456789'},
+])(
+	'displays $value with step $step as $expected',
+	({step, value, expected}) => {
+		expect(
+			formatTimelineFieldValueForDisplay({
+				fieldSchema: {
+					type: 'number',
+					default: 0,
+					hiddenFromList: false,
+					step,
+				},
+				value,
+			}),
+		).toBe(expected);
+	},
+);
 
 test('formatTimelineFieldValueForDisplay formats scale fields with fixed decimals', () => {
 	expect(


### PR DESCRIPTION
## Summary

Closes #11222.

The Effects panel displayed `scale({scale: 0.75})` as `0.8` because number fields rounded their display to the decimal places of the schema's step, despite accepting more precise source and typed values.

- Preserve number field display precision beyond the configured step while trimming floating-point noise and retaining step-based trailing zeros.
- Leave stored/runtime values, keyboard increments, drag snapping, and specialized rotation/CSS scale formatters unchanged.
- Extend the existing Studio precision workflow with the exact CanvasImage case, no-op confirmation, precise editing and persistence, arrow keys, drag snapping, and reload. Also verify crop and wave-amplitude displays and formatter edge cases.

## Verification

- Red/green verified through the real Studio E2E workflow, with no added mocks: the original formatter fails the `0.75` display assertion and the fix passes.
- 707 Studio tests and 9 relevant E2E workflows passed, including font weights, multi-selection, rotation keyframes, input focus, and inspector effects.
- `bun run build` and `bun run stylecheck` passed.
- Studio and example type checks, focused formatter tests, Oxfmt, and `git diff --check` passed.
- Visually confirmed the CanvasImage and Effects panel showing `0.75` in the existing Treeport browser.

E2E verification used an isolated temporary directory and a temporary port override to avoid interference with another worktree; the port override is not included in this PR. Two unrelated transcription tests failed during an initial concurrent run, then passed in isolation and in the final full Studio run.
