### PR TITLE
Internal: Remove implementation-detail Element tests

### DIFF
--- a/packages/docs/src/test/elements.test.ts
+++ b/packages/docs/src/test/elements.test.ts
@@ -19,21 +19,14 @@ import {
 	getElementDocumentationUrl,
 	getElementLibrarySections,
 } from '../components/Elements/element-library-data';
-import {
-	elementCategories,
-	elementRegistry,
-} from '../components/Elements/element-registry';
+import {elementRegistry} from '../components/Elements/element-registry';
 import {
 	getElementCompositionId,
 	getElementDefinition,
 	getElementDimensionsLabel,
 } from '../components/Elements/element-utils';
 import {ElementLibrary} from '../components/Elements/ElementLibrary';
-import {ElementPreview} from '../components/Elements/ElementPreview';
-import {
-	ElementPreviewComposition,
-	getElementPreviewDimensions,
-} from '../components/Elements/ElementPreviewComposition';
+import {getElementPreviewDimensions} from '../components/Elements/ElementPreviewComposition';
 import {Seo} from '../components/Seo';
 
 const elementsRoot = path.join(__dirname, '..', '..', 'elements');
@@ -87,22 +80,19 @@ const findElements = (root: string): Element[] => {
 	return elements;
 };
 
-const getRelativeTsxPath = (tsxPath: string, mdxPath: string) => {
-	const relative = path.relative(path.dirname(mdxPath), tsxPath);
-	return relative.startsWith('.') ? relative : `./${relative}`;
-};
-
 const productionElements = findElements(elementsRoot);
 const allElements = [...productionElements, ...findElements(templateRoot)];
 
 describe('Elements must follow the colocated single-file format', () => {
-	test('at least one element exists', () => {
-		expect(allElements.length).toBeGreaterThan(0);
-	});
-
 	test('remark plugin nests source inside ElementPage', () => {
 		const element = allElements[0];
-		const sourceFile = getRelativeTsxPath(element.tsxPath, element.mdxPath);
+		const relativeSourceFile = path.relative(
+			path.dirname(element.mdxPath),
+			element.tsxPath,
+		);
+		const sourceFile = relativeSourceFile.startsWith('.')
+			? relativeSourceFile
+			: `./${relativeSourceFile}`;
 		const elementPage = {
 			type: 'mdxJsxFlowElement',
 			name: 'ElementPage',
@@ -161,32 +151,6 @@ describe('Elements must follow the colocated single-file format', () => {
 			const tsx = readFileSync(element.tsxPath, 'utf8');
 			const mdx = readFileSync(element.mdxPath, 'utf8');
 
-			test('source file is an Element, not a composition', () => {
-				expect(tsx).not.toContain('export const durationInFrames');
-				expect(tsx).not.toContain('export const fps');
-				expect(tsx).not.toContain('export const width');
-				expect(tsx).not.toContain('export const height');
-				expect(tsx).not.toContain('export const RemotionRoot');
-				expect(tsx).not.toMatch(/<Composition(?:\s|\/?>)/);
-			});
-
-			test('MDX uses the ElementPage template', () => {
-				expect(mdx).toContain('ElementPage');
-			});
-
-			test('MDX references the source file from ElementPage', () => {
-				const relativeTsxPath = getRelativeTsxPath(
-					element.tsxPath,
-					element.mdxPath,
-				);
-
-				expect(mdx).toContain(`sourceFile="${relativeTsxPath}"`);
-				expect(mdx).not.toContain('<ElementSource');
-				expect(mdx).not.toContain('<RemotionElementSource');
-				expect(mdx).not.toContain('remotion-element-source');
-				expect(mdx).not.toContain(tsx.trim());
-			});
-
 			test('ElementPage sourceFile expands to the source file', () => {
 				const expanded = expandElementSourceReferences({
 					raw: mdx,
@@ -196,31 +160,6 @@ describe('Elements must follow the colocated single-file format', () => {
 				expect(expanded).toContain(
 					`\`\`\`tsx twoslash title="${path.basename(element.tsxPath)}"\n${tsx.trim()}\n\`\`\``,
 				);
-			});
-
-			test('MDX does not duplicate source metadata for drag payloads', () => {
-				expect(mdx).not.toContain('?raw');
-				expect(mdx).not.toContain('sourceCode=');
-				expect(mdx).not.toContain('componentName=');
-				expect(mdx).not.toMatch(/export const \w+Source = /);
-			});
-
-			test('Element drag file name is derived from the definition slug', () => {
-				expect(mdx).not.toContain('fileName=');
-
-				if (element.mdxPath.startsWith(templateRoot)) {
-					return;
-				}
-
-				const definition = elementDefinitionList.find(
-					(entry) => entry.slug === element.name,
-				);
-				expect(definition).toBeDefined();
-
-				const lastSlugSegment = definition?.slug.split('/').at(-1);
-				expect(lastSlugSegment).toBeTruthy();
-				expect(lastSlugSegment).toBe(lastSlugSegment?.toLowerCase());
-				expect(lastSlugSegment).not.toContain('..');
 			});
 		});
 	}
@@ -359,7 +298,7 @@ describe('Element library', () => {
 		).toThrow('Missing source pages: missing/source.');
 	});
 
-	test('renders draggable cards and filters the real category entry points', () => {
+	test('renders cards and filters the real category entry points', () => {
 		const sourceCodeBySlug = getRemotionElementSourceMap({elementsRoot});
 		const overviewMarkup = renderToStaticMarkup(
 			React.createElement(ElementLibrary, {
@@ -370,21 +309,10 @@ describe('Element library', () => {
 		const sections = getElementLibrarySections(null);
 
 		for (const definition of elementDefinitionList) {
-			expect(
-				overviewMarkup.split(`>${definition.displayName}</span>`),
-			).toHaveLength(2);
-			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h2>`);
-			expect(overviewMarkup).not.toContain(`>${definition.displayName}</h3>`);
-			expect(overviewMarkup).not.toContain(definition.description);
+			expect(overviewMarkup).toContain(definition.displayName);
 			expect(overviewMarkup).toContain(definition.preview.posterUrl);
 			expect(overviewMarkup).toContain(getElementDocumentationUrl(definition));
 		}
-
-		expect(overviewMarkup).not.toContain('.mp4');
-		expect(overviewMarkup).toContain('>YouTube</h2>');
-		expect(overviewMarkup.match(/draggable="true"/g)).toHaveLength(
-			elementDefinitionList.length,
-		);
 
 		for (const section of sections) {
 			const categoryMarkup = renderToStaticMarkup(
@@ -401,24 +329,6 @@ describe('Element library', () => {
 			expect(categoryIndex).toContain(
 				`<ElementLibrary category="${section.category}" />`,
 			);
-
-			if (section.category === 'backgrounds') {
-				const backgroundNames = [
-					'Notebook Paper',
-					'Paper Texture',
-					'Rotating Starburst',
-					'Liquid Contours',
-				];
-				for (let index = 1; index < backgroundNames.length; index++) {
-					expect(
-						categoryMarkup.indexOf(backgroundNames[index - 1]),
-					).toBeLessThan(categoryMarkup.indexOf(backgroundNames[index]));
-				}
-			}
-
-			if (section.category === 'captions') {
-				expect(section.definitions[0].slug).toBe('captions/basic-captions');
-			}
 
 			for (const definition of elementDefinitionList) {
 				if (definition.category === section.category) {
@@ -515,159 +425,38 @@ describe('Element social previews', () => {
 });
 
 describe('Elements sidebar', () => {
-	test('lists every registered Element exactly once in deterministic order', () => {
+	test('lists every registered Element exactly once', () => {
 		const sidebar = elementSidebars.elementsSidebar;
 		if (!Array.isArray(sidebar)) {
 			throw new Error('Elements sidebar must be an array');
 		}
 
-		expect(sidebar).toHaveLength(1);
 		const elementsCategory = sidebar[0];
 		if (
 			typeof elementsCategory !== 'object' ||
 			elementsCategory === null ||
-			elementsCategory.type !== 'category'
+			elementsCategory.type !== 'category' ||
+			!Array.isArray(elementsCategory.items)
 		) {
 			throw new Error('Elements sidebar must have an Elements root category');
 		}
 
-		expect(elementsCategory).toMatchObject({
-			type: 'category',
-			label: 'Elements',
-			className: 'elements-sidebar-root',
-			link: {type: 'doc', id: 'index'},
-			collapsible: true,
-			collapsed: false,
+		const listedElementPages = elementsCategory.items.flatMap((item) => {
+			if (
+				typeof item !== 'object' ||
+				item === null ||
+				item.type !== 'category' ||
+				!Array.isArray(item.items)
+			) {
+				return [];
+			}
+
+			return item.items.filter((child) => typeof child === 'string');
 		});
-		if (!Array.isArray(elementsCategory.items)) {
-			throw new Error('Elements root category must contain sidebar items');
-		}
-
-		expect(elementsCategory.items.slice(0, 3)).toEqual([
-			'libraries',
-			'contributing',
-			{
-				type: 'html',
-				value:
-					'<hr style="margin-top: 4px; margin-bottom: 4px; border-bottom: none"/>',
-				defaultStyle: true,
-			},
-		]);
-
-		const categories = elementsCategory.items.slice(3);
-		const expectedCategories = [
-			{
-				category: 'audio',
-				label: 'Audio',
-				items: [
-					'audio/oscilloscope/index',
-					'audio/waveform-progress/index',
-					'audio/mirrored-spectrum/index',
-				],
-			},
-			{
-				category: 'backgrounds',
-				label: 'Backgrounds',
-				items: [
-					'backgrounds/liquid-contours/index',
-					'backgrounds/notebook-paper/index',
-					'backgrounds/paper-texture/index',
-					'backgrounds/rotating-starburst/index',
-				],
-			},
-			{
-				category: 'captions',
-				label: 'Captions',
-				items: [
-					'captions/basic-captions/index',
-					'captions/moving-pill-captions/index',
-					'captions/popping-word-captions/index',
-					'captions/word-highlight-captions/index',
-				],
-			},
-			{
-				category: 'data',
-				label: 'Charts & Data',
-				items: [
-					'data/horizontal-bar-chart/index',
-					'data/line-chart/index',
-					'data/number-counter/index',
-					'data/pie-chart/index',
-					'data/vertical-bar-chart/index',
-				],
-			},
-			{
-				category: 'commerce',
-				label: 'Commerce',
-				items: [
-					'commerce/product-collection/index',
-					'commerce/product-discount-callout/index',
-					'commerce/product-offer/index',
-				],
-			},
-			{
-				category: 'maps',
-				label: 'Maps',
-				items: ['maps/map-flyover/index', 'maps/watercolor-map/index'],
-			},
-			{
-				category: 'overlays',
-				label: 'Overlays',
-				items: [
-					'overlays/location-lower-third/index',
-					'overlays/name-lower-third/index',
-					'overlays/social-safe-zones/index',
-				],
-			},
-			{
-				category: 'storytelling',
-				label: 'Storytelling',
-				items: [
-					'text/news-article-highlight/index',
-					'storytelling/on-screen-messages/index',
-					'storytelling/polaroid-pictures/index',
-				],
-			},
-			{
-				category: 'text',
-				label: 'Text Effects',
-				items: [
-					'text/circle-marker/index',
-					'text/crossed-off/index',
-					'text/spinning-text-wheel/index',
-					'text/strike-through/index',
-					'text/text-marker/index',
-				],
-			},
-			{
-				category: 'youtube',
-				label: 'YouTube',
-				items: [
-					'youtube/youtube-comment-highlight/index',
-					'youtube/youtube-end-card/index',
-					'youtube/youtube-subscribe-nudge/index',
-				],
-			},
-		] as const;
-
-		expect(categories).toEqual(
-			expectedCategories.map(({category, label, items}) => ({
-				type: 'category',
-				label,
-				link: {type: 'doc', id: `${category}/index`},
-				collapsible: true,
-				collapsed: true,
-				items,
-			})),
-		);
-		expect(elementCategories).toEqual(
-			expectedCategories.map(({category, label}) => ({category, label})),
-		);
-
-		const listedElementPages = expectedCategories.flatMap(({items}) => items);
 		const registeredElementPages = Object.keys(elementRegistry).map(
 			(slug) => `${slug}/index`,
 		);
+
 		expect([...listedElementPages].sort()).toEqual(
 			registeredElementPages.sort(),
 		);
@@ -705,88 +494,6 @@ describe('Element preview definitions', () => {
 
 		expect(definitionSlugs).toEqual(elementSlugs);
 		expect(new Set(definitionSlugs).size).toBe(definitionSlugs.length);
-	});
-
-	test('publishes caption treatments as separate Elements', () => {
-		const captionSlugs = elementDefinitionList
-			.map((definition) => definition.slug)
-			.filter((slug) => slug.startsWith('captions/'))
-			.sort();
-
-		expect(captionSlugs).toEqual([
-			'captions/basic-captions',
-			'captions/moving-pill-captions',
-			'captions/popping-word-captions',
-			'captions/word-highlight-captions',
-		]);
-
-		for (const slug of captionSlugs) {
-			const element = productionElements.find((entry) => entry.name === slug);
-			if (!element) {
-				throw new Error(`Missing caption Element for ${slug}`);
-			}
-
-			const definition = getElementDefinition(slug);
-			const initialProps = definition.initialProps as {
-				captions: Array<{text: string}>;
-				combineTokensWithinMilliseconds: number;
-				height: number;
-				width: number;
-			};
-			const source = readFileSync(element.tsxPath, 'utf8');
-			const payload = createElementPayloadFromDefinition({
-				definition,
-				sourceCode: source,
-			});
-			expect(initialProps.captions.length).toBeGreaterThan(0);
-			expect(initialProps.width).toBe(definition.elementWidth);
-			expect(initialProps.height).toBe(definition.elementHeight);
-			expect(payload.element.initialProps).toEqual(initialProps);
-			expect(source).not.toContain('timestampMs:');
-			expect(source).not.toContain('defaultCaptions');
-			expect(source).not.toContain('readonly mode');
-			expect(source).not.toContain('TimedCaptionsMode');
-			expect(source).not.toContain("translate: '109.5px -36px'");
-		}
-	});
-
-	test('keeps Basic Captions static and limited to two lines', () => {
-		const source = readFileSync(
-			path.join(elementsRoot, 'captions/basic-captions/basic-captions.tsx'),
-			'utf8',
-		);
-
-		expect(source).toContain("color: '#ffffff'");
-		expect(source).toContain("backgroundColor: 'rgba(64, 64, 64, 0.75)'");
-		expect(source).toContain('fontWeight: 400');
-		expect(source).toContain('WebkitLineClamp: 2');
-		expect(source).not.toContain('borderRadius');
-		expect(source).not.toContain('interpolate');
-		expect(source).not.toContain('spring');
-	});
-
-	test('only Elements with one interactive timeline item own their Sequence', () => {
-		const componentOwnedSequenceSlugs = new Set([
-			'audio/oscilloscope',
-			'audio/waveform-progress',
-			'audio/mirrored-spectrum',
-			'captions/basic-captions',
-			'captions/moving-pill-captions',
-			'captions/popping-word-captions',
-			'captions/word-highlight-captions',
-			'maps/map-flyover',
-			'maps/watercolor-map',
-			'overlays/social-safe-zones',
-			'text/spinning-text-wheel',
-		]);
-
-		for (const definition of elementDefinitionList) {
-			expect(definition.installationMode).toBe(
-				componentOwnedSequenceSlugs.has(definition.slug)
-					? 'component-owned-sequence'
-					: 'wrapped',
-			);
-		}
 	});
 
 	test('declares every external source dependency centrally with a valid version', () => {
@@ -872,67 +579,6 @@ describe('Element preview definitions', () => {
 		});
 	});
 
-	test('dimensionless Solid backgrounds use composition dimensions', () => {
-		for (const slug of [
-			'backgrounds/paper-texture',
-			'backgrounds/rotating-starburst',
-		] as const) {
-			const definition = getElementDefinition(slug);
-			const element = productionElements.find((entry) => entry.name === slug);
-			if (!element) {
-				throw new Error(`Could not find Element source for ${slug}`);
-			}
-
-			const source = readFileSync(element.tsxPath, 'utf8');
-			expect(definition.elementWidth).toBe(null);
-			expect(definition.elementHeight).toBe(null);
-			expect(source).toContain('useVideoConfig()');
-			expect(source).not.toContain(`width={${definition.width}}`);
-			expect(source).not.toContain(`height={${definition.height}}`);
-		}
-	});
-
-	test('Social Safe Zones keeps its calibrated 9:16 dimensions in Studio and the docs preview', () => {
-		const slug = 'overlays/social-safe-zones';
-		const definition = getElementDefinition(slug);
-		const element = productionElements.find((entry) => entry.name === slug);
-		if (!element) {
-			throw new Error(`Could not find Element source for ${slug}`);
-		}
-
-		const source = readFileSync(element.tsxPath, 'utf8');
-		const payload = createElementPayloadFromDefinition({
-			definition,
-			sourceCode: source,
-		});
-		const preview = renderToStaticMarkup(
-			React.createElement(ElementPreview, {
-				component: () =>
-					React.createElement(ElementPreviewComposition, {definition}),
-				durationInFrames: definition.durationInFrames,
-				elementHeight: definition.elementHeight,
-				elementWidth: definition.elementWidth,
-				fps: definition.fps,
-				previewLayout: definition.preview.previewLayout,
-				safeArea: definition.safeArea,
-			}),
-		);
-
-		expect(definition.elementWidth).toBe(1080);
-		expect(definition.elementHeight).toBe(1920);
-		expect(payload.element.dimensions).toEqual({width: 1080, height: 1920});
-		expect(definition.preview.previewLayout).toBe('vertical');
-		expect(preview).toContain('aspect-ratio:1920 / 1080');
-		expect(preview).toContain('width:31.640625%');
-		expect(preview).toContain('height:1080px;position:relative;width:607.5px');
-		expect(preview).toContain(
-			'transform:scale(0.5625);transform-origin:top left',
-		);
-		expect(source).not.toContain('useVideoConfig');
-		expect(source).toContain('width: 1080');
-		expect(source).toContain('height: 1920');
-	});
-
 	test('uses stable composition IDs and valid review or published preview paths', () => {
 		const compositionIds = elementDefinitionList.map((definition) =>
 			getElementCompositionId(definition.slug),
@@ -994,27 +640,5 @@ describe('Element preview definitions', () => {
 				expect(existsSync(videoPath)).toBe(false);
 			}
 		}
-	});
-
-	test('the Element template includes explicit defaults and local preview URLs', () => {
-		const template = readFileSync(path.join(templateRoot, 'index.mdx'), 'utf8');
-		expect(template).toContain("installationMode: 'wrapped'");
-		expect(template).toContain(
-			'image: /elements/category-element-title-preview.png',
-		);
-		expect(template).toContain(
-			"posterUrl: '/elements/category-element-title-preview.png'",
-		);
-		expect(template).toContain(
-			"videoUrl: '/elements/category-element-title-preview.mp4'",
-		);
-	});
-
-	test('registers Element compositions in a Folder', () => {
-		const root = readFileSync(
-			path.join(__dirname, '..', 'remotion', 'Root.tsx'),
-			'utf8',
-		);
-		expect(root).toContain('<Folder name="elements">');
 	});
 });


### PR DESCRIPTION
## Summary

- remove Element tests that only assert source-code, CSS, or markup implementation details
- retain behavior-oriented coverage for MDX expansion, library filtering, drag payloads, metadata, dependencies, and preview assets
- simplify sidebar coverage to verify that every registered Element is listed exactly once

## Verification

- `bun test packages/docs/src/test/elements.test.ts`
- `bun run build`
- `bun run stylecheck`
