### PR TITLE
Elements: Simplify commerce starter designs

### DIFF
--- a/packages/docs/elements/commerce/product-collection/index.mdx
+++ b/packages/docs/elements/commerce/product-collection/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Product Collection
-description: A rotating product-card carousel that adapts to variable catalog content.
+title: Rotating Cards
+description: Three cards which each take center once.
 image: https://remotion.media/elements/commerce-product-collection-preview.png
 ---
 
 import {ElementPage} from '@site/src/components/Elements/ElementPage';
 import {getElementDefinition} from '@site/src/components/Elements/element-utils';
 
-# Product Collection
+# Rotating Cards
 
 <ElementPage definition={getElementDefinition('commerce/product-collection')} sourceFile="./product-collection.tsx" />

--- a/packages/docs/elements/commerce/product-collection/product-collection.tsx
+++ b/packages/docs/elements/commerce/product-collection/product-collection.tsx
@@ -23,43 +23,17 @@ export const productCollectionDurationInFrames = 150;
 type ProductCardProps = InteractiveBaseProps &
 	Omit<InteractiveTransformProps, 'style'> & {
 		readonly count: number;
-		readonly discount: string;
-		readonly image: string;
 		readonly index: number;
-		readonly originalPrice: string;
-		readonly price: string;
+		readonly label: string;
 		readonly style: React.CSSProperties | null;
-		readonly title: string;
 	};
 
 const productCardSchema = {
 	...Interactive.baseSchema,
-	title: {
+	label: {
 		type: 'text-content',
-		default: 'Product title',
-		description: 'Product title',
-	},
-	image: {
-		type: 'asset',
-		assetType: 'image',
-		default:
-			'https://remotion.media/elements/product-collection-cloudline-runner.png',
-		description: 'Product image',
-	},
-	price: {
-		type: 'text-content',
-		default: '$100',
-		description: 'Current price',
-	},
-	originalPrice: {
-		type: 'text-content',
-		default: '',
-		description: 'Original price (leave empty to hide)',
-	},
-	discount: {
-		type: 'text-content',
-		default: '',
-		description: 'Promotion (leave empty to hide)',
+		default: 'A',
+		description: 'Card label',
 	},
 	count: {type: 'hidden'},
 	index: {type: 'hidden'},
@@ -69,274 +43,147 @@ const productCardSchema = {
 const ProductCardInner = forwardRef<
 	HTMLDivElement,
 	ProductCardProps & {readonly controls: SequenceControls | undefined}
->(
-	(
+>(({controls, count, index, label, name, style, ...sequenceProps}, ref) => {
+	const outlineRef = useRef<HTMLDivElement>(null);
+	const frame = useCurrentFrame();
+	const lastProductIndex = Math.max(0, count - 1);
+	const rawScrollPosition = interpolate(
+		frame,
+		[24, productCollectionDurationInFrames - 28],
+		[0, lastProductIndex],
 		{
-			controls,
-			count,
-			discount,
-			image,
-			index,
-			name,
-			originalPrice,
-			price,
-			style,
-			title,
-			...sequenceProps
+			extrapolateLeft: 'clamp',
+			extrapolateRight: 'clamp',
 		},
-		ref,
-	) => {
-		const outlineRef = useRef<HTMLDivElement>(null);
-		const frame = useCurrentFrame();
-		const lastProductIndex = Math.max(0, count - 1);
-		const rawScrollPosition = interpolate(
-			frame,
-			[24, productCollectionDurationInFrames - 28],
-			[0, lastProductIndex],
-			{
-				extrapolateLeft: 'clamp',
-				extrapolateRight: 'clamp',
-			},
-		);
-		const transitionIndex = Math.min(
-			Math.floor(rawScrollPosition),
-			Math.max(0, lastProductIndex - 1),
-		);
-		const transitionProgress = interpolate(
-			rawScrollPosition - transitionIndex,
-			[0.18, 0.82],
-			[0, 1],
-			{
-				easing: Easing.inOut(Easing.cubic),
-				extrapolateLeft: 'clamp',
-				extrapolateRight: 'clamp',
-			},
-		);
-		const scrollPosition = transitionIndex + transitionProgress;
-		const unwrappedSlotPosition = index - scrollPosition;
-		const slotPosition =
-			count <= 2
-				? unwrappedSlotPosition
-				: ((((unwrappedSlotPosition + count / 2) % count) + count) % count) -
-					count / 2;
-		const distanceFromCenter = Math.abs(slotPosition);
-		const visibility = interpolate(distanceFromCenter, [1.02, 1.18], [1, 0], {
+	);
+	const transitionIndex = Math.min(
+		Math.floor(rawScrollPosition),
+		Math.max(0, lastProductIndex - 1),
+	);
+	const transitionProgress = interpolate(
+		rawScrollPosition - transitionIndex,
+		[0.18, 0.82],
+		[0, 1],
+		{
+			easing: Easing.inOut(Easing.cubic),
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-		});
-		const entryStart = 8 + Math.min(index, 1) * 5;
-		const entryProgress = interpolate(
-			frame,
-			[entryStart, entryStart + 18],
-			[0, 1],
-			{
-				easing: Easing.bezier(0.16, 1, 0.3, 1),
-				extrapolateLeft: 'clamp',
-				extrapolateRight: 'clamp',
-			},
-		);
-		const x = slotPosition * 270;
-		const y =
-			Math.min(distanceFromCenter, 1.3) * 36 + (1 - entryProgress) * 180;
-		const rotation = slotPosition * 5.5;
-		const cardScale = interpolate(distanceFromCenter, [0, 1.5], [1.02, 0.84], {
+		},
+	);
+	const scrollPosition = transitionIndex + transitionProgress;
+	const unwrappedSlotPosition = index - scrollPosition;
+	const slotPosition =
+		count <= 2
+			? unwrappedSlotPosition
+			: ((((unwrappedSlotPosition + count / 2) % count) + count) % count) -
+				count / 2;
+	const distanceFromCenter = Math.abs(slotPosition);
+	const visibility = interpolate(distanceFromCenter, [1.02, 1.18], [1, 0], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+	});
+	const entryStart = 8 + Math.min(index, 1) * 5;
+	const entryProgress = interpolate(
+		frame,
+		[entryStart, entryStart + 18],
+		[0, 1],
+		{
+			easing: Easing.bezier(0.16, 1, 0.3, 1),
 			extrapolateLeft: 'clamp',
 			extrapolateRight: 'clamp',
-		});
-		const obscuredSidePadding = interpolate(
-			distanceFromCenter,
-			[0.5, 1],
-			[22, 48],
-			{
-				extrapolateLeft: 'clamp',
-				extrapolateRight: 'clamp',
-			},
-		);
+		},
+	);
+	const x = slotPosition * 270;
+	const y = Math.min(distanceFromCenter, 1.3) * 36 + (1 - entryProgress) * 180;
+	const rotation = slotPosition * 5.5;
+	const cardScale = interpolate(distanceFromCenter, [0, 1.5], [1.02, 0.84], {
+		extrapolateLeft: 'clamp',
+		extrapolateRight: 'clamp',
+	});
 
-		useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
+	useImperativeHandle(ref, () => outlineRef.current as HTMLDivElement, []);
 
-		return (
-			<Sequence
-				layout="none"
-				{...sequenceProps}
-				controls={controls}
-				name={name ?? '<ProductCard>'}
-				outlineRef={outlineRef}
+	return (
+		<Sequence
+			layout="none"
+			{...sequenceProps}
+			controls={controls}
+			name={name ?? '<ProductCard>'}
+			outlineRef={outlineRef}
+		>
+			<div
+				style={{
+					height: 560,
+					left: 300,
+					top: 40,
+					opacity: visibility * entryProgress,
+					position: 'absolute',
+					rotate: `${rotation}deg`,
+					scale: cardScale * (0.86 + entryProgress * 0.14),
+					transform: 'perspective(100px)',
+					translate: `${x}px ${y}px`,
+					width: 300,
+					willChange: 'transform, opacity',
+					zIndex: 100 - Math.round(distanceFromCenter * 20),
+				}}
 			>
 				<div
+					ref={outlineRef}
 					style={{
-						height: 560,
-						left: 300,
-						top: 40,
-						opacity: visibility * entryProgress,
-						position: 'absolute',
-						rotate: `${rotation}deg`,
-						scale: cardScale * (0.86 + entryProgress * 0.14),
-						transform: 'perspective(100px)',
-						translate: `${x}px ${y}px`,
-						width: 300,
-						willChange: 'transform, opacity',
-						zIndex: 100 - Math.round(distanceFromCenter * 20),
+						...style,
+						backgroundColor: '#ffffff',
+						borderRadius: 6,
+						boxShadow: '0 2px 6px rgba(29, 29, 25, 0.12)',
+						boxSizing: 'border-box',
+						color: '#1d1d19',
+						display: 'flex',
+						flexDirection: 'column',
+						height: '100%',
+						overflow: 'hidden',
+						width: '100%',
 					}}
 				>
-					<div
-						ref={outlineRef}
+					<Interactive.Div
+						name="Card label"
 						style={{
-							...style,
-							backgroundColor: '#ffffff',
-							borderRadius: 6,
-							boxShadow: '0 2px 6px rgba(29, 29, 25, 0.12)',
-							boxSizing: 'border-box',
-							color: '#1d1d19',
+							alignItems: 'center',
+							color: '#ffffff',
 							display: 'flex',
-							flexDirection: 'column',
+							fontFamily: 'sans-serif',
+							fontSize: 160,
+							fontWeight: 900,
 							height: '100%',
+							justifyContent: 'center',
+							letterSpacing: -8,
 							overflow: 'hidden',
-							width: '100%',
+							position: 'relative',
+							textShadow: '0 4px 30px rgba(0, 0, 0, 0.55)',
 						}}
 					>
-						<div
+						<Img
+							alt=""
+							name="Card background"
+							showInTimeline={false}
+							src={
+								index === 1
+									? 'https://remotion.media/transition-bg-pink.jpg'
+									: 'https://remotion.media/transition-bg-blue.jpg'
+							}
 							style={{
-								height: 335,
-								overflow: 'hidden',
-								position: 'relative',
+								filter: index === 2 ? 'hue-rotate(-65deg)' : 'none',
+								height: '100%',
+								objectFit: 'cover',
+								position: 'absolute',
 								width: '100%',
 							}}
-						>
-							<Img
-								alt={title}
-								name="Product image"
-								showInTimeline={false}
-								src={image}
-								style={{
-									height: '100%',
-									objectFit: 'cover',
-									objectPosition: '50% 50%',
-									scale: interpolate(
-										frame,
-										[0, productCollectionDurationInFrames - 1],
-										[1.06, 1.01],
-										{
-											easing: Easing.inOut(Easing.quad),
-											extrapolateLeft: 'clamp',
-											extrapolateRight: 'clamp',
-										},
-									),
-									transform: 'perspective(100px)',
-									width: '100%',
-									willChange: 'transform',
-								}}
-							/>
-
-							{discount.trim() === '' ? null : (
-								<div
-									style={{
-										backgroundColor: '#1d1d19',
-										color: '#f7c900',
-										fontSize: 20,
-										fontWeight: 700,
-										letterSpacing: -0.3,
-										lineHeight: 1,
-										maxWidth: 132,
-										overflow: 'hidden',
-										padding: '10px 12px',
-										position: 'absolute',
-										right: 0,
-										textOverflow: 'ellipsis',
-										textTransform: 'uppercase',
-										top: 0,
-										whiteSpace: 'nowrap',
-									}}
-								>
-									{discount}
-								</div>
-							)}
-						</div>
-
-						<div
-							style={{
-								boxSizing: 'border-box',
-								display: 'flex',
-								flex: 1,
-								flexDirection: 'column',
-								paddingBottom: 24,
-								paddingLeft: slotPosition > 0 ? obscuredSidePadding : 22,
-								paddingRight: slotPosition < 0 ? obscuredSidePadding : 22,
-								paddingTop: 22,
-							}}
-						>
-							<h3
-								style={{
-									WebkitBoxOrient: 'vertical',
-									WebkitLineClamp: 3,
-									display: '-webkit-box',
-									fontSize: 32,
-									fontWeight: 700,
-									height: 98,
-									letterSpacing: -1.4,
-									lineHeight: 0.98,
-									margin: 0,
-									overflow: 'hidden',
-									overflowWrap: 'anywhere',
-									textTransform: 'uppercase',
-									textWrap: 'balance',
-									width: 230,
-								}}
-							>
-								{title}
-							</h3>
-
-							<div
-								style={{
-									alignItems: 'baseline',
-									display: 'flex',
-									fontVariantNumeric: 'tabular-nums',
-									gap: 10,
-									height: 48,
-									marginTop: 'auto',
-									minWidth: 0,
-								}}
-							>
-								<div
-									style={{
-										fontSize: 48,
-										fontWeight: 700,
-										letterSpacing: -2.3,
-										lineHeight: 1,
-										maxWidth: 148,
-										overflow: 'hidden',
-										textOverflow: 'ellipsis',
-										whiteSpace: 'nowrap',
-									}}
-								>
-									{price}
-								</div>
-
-								{originalPrice.trim() === '' ? null : (
-									<div
-										style={{
-											color: '#7b776e',
-											fontSize: 22,
-											fontWeight: 500,
-											maxWidth: 74,
-											overflow: 'hidden',
-											textDecoration: 'line-through',
-											textDecorationThickness: 1.5,
-											textOverflow: 'ellipsis',
-											whiteSpace: 'nowrap',
-										}}
-									>
-										{originalPrice}
-									</div>
-								)}
-							</div>
-						</div>
-					</div>
+						/>
+						<div style={{position: 'relative'}}>{label}</div>
+					</Interactive.Div>
 				</div>
-			</Sequence>
-		);
-	},
-);
+			</div>
+		</Sequence>
+	);
+});
 
 const ProductCard = Interactive.withSchema({
 	Component: ProductCardInner,
@@ -414,59 +261,25 @@ export const ProductCollection = () => {
 			}}
 		>
 			<ProductCard
-				count={5}
-				discount="20% off"
-				image="https://remotion.media/elements/product-collection-cloudline-runner.png"
+				count={3}
 				index={0}
-				name="Cloudline Runner card"
-				originalPrice="$148"
-				price="$118"
+				label="A"
+				name="Card A"
 				style={{translate: '0px 0px'}}
-				title="Cloudline Runner"
 			/>
 			<ProductCard
-				count={5}
-				discount=""
-				image="https://remotion.media/elements/product-collection-minimal-steel-watch.png"
+				count={3}
 				index={1}
-				name="Minimal Steel Watch card"
-				originalPrice=""
-				price="$185"
+				label="B"
+				name="Card B"
 				style={{translate: '0px 0px'}}
-				title="Minimal Steel Watch"
 			/>
 			<ProductCard
-				count={5}
-				discount="Save $31"
-				image="https://images.unsplash.com/photo-1511499767150-a48a237f0083?fm=jpg&fit=crop&w=900&q=90"
+				count={3}
 				index={2}
-				name="Studio Sunglasses card"
-				originalPrice="$125"
-				price="$94"
+				label="C"
+				name="Card C"
 				style={{translate: '0px 0px'}}
-				title="Studio Sunglasses"
-			/>
-			<ProductCard
-				count={5}
-				discount="New"
-				image="https://images.unsplash.com/photo-1505740420928-5e560c06d30e?fm=jpg&fit=crop&w=900&q=90"
-				index={3}
-				name="Studio Headset card"
-				originalPrice=""
-				price="$179"
-				style={{translate: '0px 0px'}}
-				title="Studio Headset"
-			/>
-			<ProductCard
-				count={5}
-				discount=""
-				image="https://images.unsplash.com/photo-1507473885765-e6ed057f782c?fm=jpg&fit=crop&w=900&q=90"
-				index={4}
-				name="Sculptural Table Lamp card"
-				originalPrice=""
-				price="$149"
-				style={{translate: '0px 0px'}}
-				title="Sculptural Table Lamp"
 			/>
 		</Interactive.Div>
 	);

--- a/packages/docs/elements/commerce/product-discount-callout/index.mdx
+++ b/packages/docs/elements/commerce/product-discount-callout/index.mdx
@@ -1,14 +1,12 @@
 ---
-title: Product Discount Callout
-description: An animated product cutout with pricing and a hinged discount callout.
+title: Wiggling Callout
+description: An attention-grabbing speech bubble.
 image: https://remotion.media/elements/commerce-product-discount-callout-preview.png
 ---
 
 import {ElementPage} from '@site/src/components/Elements/ElementPage';
 import {getElementDefinition} from '@site/src/components/Elements/element-utils';
 
-# Product Discount Callout
+# Wiggling Callout
 
 <ElementPage definition={getElementDefinition('commerce/product-discount-callout')} sourceFile="./product-discount-callout.tsx" />
-
-The default product image is adapted from [a photo by Andrey Matveev on Pexels](https://www.pexels.com/photo/gray-shoe-on-gray-background-27361691/) under the [Pexels license](https://www.pexels.com/license/). The background was removed.

--- a/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
+++ b/packages/docs/elements/commerce/product-discount-callout/product-discount-callout.tsx
@@ -1,31 +1,23 @@
 import {loadFont} from '@remotion/google-fonts/Inter';
 import {makeCallout} from '@remotion/shapes';
 import React from 'react';
-import {
-	CanvasImage,
-	Easing,
-	Interactive,
-	interpolate,
-	useCurrentFrame,
-	useVideoConfig,
-} from 'remotion';
+import {Easing, Interactive, interpolate, useCurrentFrame} from 'remotion';
 
 loadFont('normal', {
 	subsets: ['latin'],
-	weights: ['500', '600', '700'],
+	weights: ['500', '600', '700', '800'],
 });
 
 export const ProductDiscountCallout = () => {
 	const frame = useCurrentFrame();
-	const {durationInFrames} = useVideoConfig();
 	const discountCallout = makeCallout({
-		width: 260,
-		height: 86,
-		pointerLength: 24,
-		pointerBaseWidth: 42,
+		width: 600,
+		height: 300,
+		pointerLength: 70,
+		pointerBaseWidth: 130,
 		pointerPosition: 0.5,
 		pointerDirection: 'down',
-		cornerRadius: 14,
+		cornerRadius: 45,
 	});
 
 	return (
@@ -33,65 +25,23 @@ export const ProductDiscountCallout = () => {
 			name="Container"
 			style={{
 				WebkitFontSmoothing: 'antialiased',
-				color: '#161714',
 				fontFamily: 'Inter',
 				height: '100%',
 				isolation: 'isolate',
-				opacity: interpolate(
-					frame,
-					[0, 8, durationInFrames - 14, durationInFrames - 1],
-					[0, 1, 1, 0],
-					{
-						easing: Easing.bezier(0.16, 1, 0.3, 1),
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-					},
-				),
 				overflow: 'hidden',
 				position: 'relative',
-				translate: interpolate(
-					frame,
-					[0, 16, durationInFrames - 16, durationInFrames - 1],
-					['-150px 0px', '0px 0px', '0px 0px', '110px 0px'],
-					{
-						easing: Easing.bezier(0.16, 1, 0.3, 1),
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-					},
-				),
 				width: '100%',
-				willChange: 'transform, opacity',
 			}}
 		>
-			<CanvasImage
-				fit="contain"
-				height={430}
-				name="Product image"
-				src="https://remotion.media/elements/product-discount-callout-gray-runner.png"
-				style={{
-					filter: 'drop-shadow(0px 28px 20px rgba(22, 23, 20, 0.18))',
-					left: 50,
-					position: 'absolute',
-					scale: interpolate(frame, [0, 18], [0.98, 1], {
-						easing: Easing.bezier(0.16, 1, 0.3, 1),
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-						output: 'perceptual-scale',
-					}),
-					top: 0,
-					willChange: 'transform',
-				}}
-				width={800}
-			/>
 			<Interactive.Div
 				name="Discount callout"
 				style={{
-					height: 110,
-					left: 150,
+					height: 370,
+					left: 80,
 					position: 'absolute',
 					rotate: interpolate(
 						frame,
-						[50, 57, 64, 70, 76],
+						[0, 7, 14, 20, 26],
 						['0deg', '10deg', '-7deg', '3deg', '0deg'],
 						{
 							easing: Easing.inOut(Easing.quad),
@@ -99,15 +49,14 @@ export const ProductDiscountCallout = () => {
 							extrapolateRight: 'clamp',
 						},
 					),
-					top: 360,
+					top: 195,
 					transformOrigin: '50% 100%',
-					width: 260,
+					width: 600,
 					willChange: 'transform',
 				}}
 			>
 				<svg
 					style={{
-						filter: 'drop-shadow(0px 9px 8px rgba(22, 23, 20, 0.16))',
 						height: '100%',
 						overflow: 'visible',
 						position: 'absolute',
@@ -116,107 +65,26 @@ export const ProductDiscountCallout = () => {
 					viewBox={`0 0 ${discountCallout.width} ${discountCallout.height}`}
 					xmlns="http://www.w3.org/2000/svg"
 				>
-					<path d={discountCallout.path} fill="#d8ff52" />
+					<path d={discountCallout.path} fill="#2563eb" />
 				</svg>
 				<Interactive.Div
 					name="Discount text"
 					style={{
 						alignItems: 'center',
+						color: '#ffffff',
 						display: 'flex',
-						fontSize: 43,
-						fontWeight: 700,
-						height: 86,
+						fontSize: 180,
+						fontWeight: 800,
+						height: 300,
 						justifyContent: 'center',
-						letterSpacing: -1.8,
+						letterSpacing: -7,
 						lineHeight: 1,
 						position: 'relative',
 					}}
 				>
-					20% OFF
+					-20%
 				</Interactive.Div>
 			</Interactive.Div>
-			<Interactive.Div
-				name="Current price"
-				style={{
-					fontSize: 104,
-					fontVariantNumeric: 'tabular-nums',
-					fontWeight: 700,
-					left: 150,
-					letterSpacing: -6,
-					lineHeight: 0.86,
-					maxWidth: 270,
-					overflow: 'hidden',
-					position: 'absolute',
-					textOverflow: 'ellipsis',
-					top: 490,
-					whiteSpace: 'nowrap',
-				}}
-			>
-				$79
-			</Interactive.Div>
-			<Interactive.Div
-				name="Original price"
-				style={{
-					color: '#6f736a',
-					fontSize: 28,
-					fontWeight: 600,
-					left: 154,
-					lineHeight: 1,
-					maxWidth: 245,
-					overflow: 'hidden',
-					position: 'absolute',
-					textDecoration: 'line-through',
-					textDecorationThickness: 2,
-					textOverflow: 'ellipsis',
-					top: 590,
-					whiteSpace: 'nowrap',
-				}}
-			>
-				$99
-			</Interactive.Div>
-			<div
-				style={{
-					backgroundColor: '#c9cdc4',
-					height: 118,
-					left: 444,
-					position: 'absolute',
-					top: 493,
-					width: 2,
-				}}
-			/>
-			<div
-				style={{
-					left: 474,
-					maxWidth: 400,
-					overflow: 'hidden',
-					position: 'absolute',
-					top: 492,
-				}}
-			>
-				<Interactive.Div
-					name="Product name"
-					style={{
-						fontSize: 38,
-						fontWeight: 700,
-						letterSpacing: -1.4,
-						lineHeight: 1.05,
-					}}
-				>
-					Everyday Runner
-				</Interactive.Div>
-				<Interactive.Div
-					name="Product description"
-					style={{
-						color: '#5e6259',
-						fontSize: 23,
-						fontWeight: 500,
-						lineHeight: 1.3,
-						marginTop: 12,
-					}}
-				>
-					Lightweight comfort for daily miles.
-				</Interactive.Div>
-			</div>
 		</Interactive.Div>
 	);
 };

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -383,15 +383,14 @@ const elementImplementations = [
 		slug: 'commerce/product-collection',
 		component: ProductCollection,
 		contributors: [],
-		description:
-			'An animated product carousel that adapts to changing catalog images, titles, prices, and promotions.',
+		description: 'Three cards which each take center once.',
 		dependencies: [{name: '@remotion/google-fonts', version: null}],
 		durationInFrames: productCollectionDurationInFrames,
 		elementHeight: 1020,
 		elementWidth: 1020,
 		fps: 30,
 		height: 1080,
-		posterFrame: 90,
+		posterFrame: 73,
 		preview: {
 			previewLayout: 'composition',
 			posterUrl:
@@ -408,15 +407,14 @@ const elementImplementations = [
 		slug: 'commerce/product-discount-callout',
 		component: ProductDiscountCallout,
 		contributors: [],
-		description:
-			'An animated product cutout with pricing and a hinged discount callout.',
+		description: 'An attention-grabbing speech bubble.',
 		dependencies: [
 			{name: '@remotion/google-fonts', version: null},
 			{name: '@remotion/shapes', version: null},
 		],
 		durationInFrames: 120,
-		elementHeight: 650,
-		elementWidth: 900,
+		elementHeight: 760,
+		elementWidth: 760,
 		fps: 30,
 		height: 1080,
 		posterFrame: 57,

--- a/packages/docs/src/components/Elements/element-registry.ts
+++ b/packages/docs/src/components/Elements/element-registry.ts
@@ -60,11 +60,11 @@ export const elementRegistry = {
 	},
 	'commerce/product-collection': {
 		category: 'commerce',
-		displayName: 'Product Collection',
+		displayName: 'Rotating Cards',
 	},
 	'commerce/product-discount-callout': {
 		category: 'commerce',
-		displayName: 'Product Discount Callout',
+		displayName: 'Wiggling Callout',
 	},
 	'commerce/product-offer': {
 		category: 'commerce',


### PR DESCRIPTION
## Summary
- simplify the Product Collection animation into rotating product cards
- simplify Product Discount Callout into a focused speech-bubble treatment
- update their gallery metadata and documentation

## Test plan
- [x] Run `bun test src/test/elements.test.ts` on this stack layer (239 tests)
- [x] Run `bun run build` on the complete stack
- [x] Run `bun run stylecheck` on the complete stack

## Preview
- [Rotating Cards](https://remotion-git-elements-commerce-refresh-remotion.vercel.app/elements/commerce/product-collection/)
- [Wiggling Callout](https://remotion-git-elements-commerce-refresh-remotion.vercel.app/elements/commerce/product-discount-callout/)
