### PR TITLE
Elements: Simplify editorial starter designs

### DIFF
--- a/packages/docs/elements/storytelling/polaroid-pictures/polaroid-pictures.tsx
+++ b/packages/docs/elements/storytelling/polaroid-pictures/polaroid-pictures.tsx
@@ -46,9 +46,9 @@ export const PolaroidPictures = () => {
 			<Interactive.Div
 				name="Photo 1 card"
 				style={{
-					backgroundColor: '#f8f1e5',
+					backgroundColor: '#fffdfa',
 					boxShadow:
-						'0 44px 78px rgba(8, 5, 3, 0.34), 0 8px 20px rgba(8, 5, 3, 0.2), inset 0 0 0 1px rgba(80, 62, 46, 0.08)',
+						'0 24px 52px rgba(8, 5, 3, 0.16), 0 4px 12px rgba(8, 5, 3, 0.08), inset 0 0 0 1px rgba(80, 62, 46, 0.05)',
 					boxSizing: 'border-box',
 					height: 520,
 					left: 100,
@@ -69,15 +69,26 @@ export const PolaroidPictures = () => {
 						[8, 34, durationInFrames - 30, durationInFrames - 1],
 						['-20deg', '-8deg', '-8deg', '-18deg'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
 					),
 					scale: interpolate(
 						frame,
-						[8, 30, 36, durationInFrames - 30, durationInFrames - 1],
-						[0.84, 1.035, 1, 1, 1.08],
+						[durationInFrames - 30, durationInFrames - 1],
+						[1, 1.08],
 						{
 							easing: Easing.bezier(0.16, 1, 0.3, 1),
 							extrapolateLeft: 'clamp',
@@ -91,7 +102,18 @@ export const PolaroidPictures = () => {
 						[8, 34, durationInFrames - 30, durationInFrames - 1],
 						['-620px 260px', '0px 0px', '0px 0px', '-760px -120px'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
@@ -129,9 +151,8 @@ export const PolaroidPictures = () => {
 					<Img
 						name="Photo 1"
 						alt=""
-						src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?fm=jpg&fit=crop&w=1400&q=85"
+						src="https://remotion.media/transition-bg-blue.jpg"
 						style={{
-							filter: 'saturate(0.94) contrast(1.03)',
 							height: '100%',
 							objectFit: 'cover',
 							width: '100%',
@@ -139,17 +160,20 @@ export const PolaroidPictures = () => {
 					/>
 					<div
 						style={{
-							backgroundColor: '#f4e8d2',
+							alignItems: 'center',
+							color: 'white',
+							display: 'flex',
+							fontFamily: 'sans-serif',
+							fontSize: 160,
+							fontWeight: 900,
 							inset: 0,
-							opacity: interpolate(frame, [8, 30, 44], [0.82, 0.82, 0], {
-								easing: Easing.out(Easing.cubic),
-								extrapolateLeft: 'clamp',
-								extrapolateRight: 'clamp',
-							}),
-							pointerEvents: 'none',
+							justifyContent: 'center',
 							position: 'absolute',
+							textShadow: '0 4px 30px rgba(0, 0, 0, 0.55)',
 						}}
-					/>
+					>
+						A
+					</div>
 				</div>
 				<Interactive.Div
 					name="Photo 1 caption"
@@ -167,16 +191,16 @@ export const PolaroidPictures = () => {
 						textAlign: 'center',
 					}}
 				>
-					first stop · 08:42
+					scene A
 				</Interactive.Div>
 			</Interactive.Div>
 
 			<Interactive.Div
 				name="Photo 2 card"
 				style={{
-					backgroundColor: '#f8f1e5',
+					backgroundColor: '#fffdfa',
 					boxShadow:
-						'0 48px 86px rgba(8, 5, 3, 0.38), 0 9px 22px rgba(8, 5, 3, 0.2), inset 0 0 0 1px rgba(80, 62, 46, 0.08)',
+						'0 28px 58px rgba(8, 5, 3, 0.18), 0 5px 14px rgba(8, 5, 3, 0.08), inset 0 0 0 1px rgba(80, 62, 46, 0.05)',
 					boxSizing: 'border-box',
 					height: 520,
 					left: 530,
@@ -197,15 +221,26 @@ export const PolaroidPictures = () => {
 						[20, 46, durationInFrames - 28, durationInFrames - 1],
 						['16deg', '6deg', '6deg', '15deg'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
 					),
 					scale: interpolate(
 						frame,
-						[20, 42, 48, durationInFrames - 28, durationInFrames - 1],
-						[0.86, 1.04, 1, 1, 1.1],
+						[durationInFrames - 28, durationInFrames - 1],
+						[1, 1.1],
 						{
 							easing: Easing.bezier(0.16, 1, 0.3, 1),
 							extrapolateLeft: 'clamp',
@@ -219,7 +254,18 @@ export const PolaroidPictures = () => {
 						[20, 46, durationInFrames - 28, durationInFrames - 1],
 						['340px -620px', '0px 0px', '0px 0px', '280px -720px'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
@@ -256,9 +302,8 @@ export const PolaroidPictures = () => {
 					<Img
 						name="Photo 2"
 						alt=""
-						src="https://images.unsplash.com/photo-1529156069898-49953e39b3ac?fm=jpg&fit=crop&w=1400&q=85"
+						src="https://remotion.media/transition-bg-pink.jpg"
 						style={{
-							filter: 'saturate(0.94) contrast(1.03)',
 							height: '100%',
 							objectFit: 'cover',
 							width: '100%',
@@ -266,17 +311,20 @@ export const PolaroidPictures = () => {
 					/>
 					<div
 						style={{
-							backgroundColor: '#f4e8d2',
+							alignItems: 'center',
+							color: 'white',
+							display: 'flex',
+							fontFamily: 'sans-serif',
+							fontSize: 160,
+							fontWeight: 900,
 							inset: 0,
-							opacity: interpolate(frame, [20, 42, 56], [0.82, 0.82, 0], {
-								easing: Easing.out(Easing.cubic),
-								extrapolateLeft: 'clamp',
-								extrapolateRight: 'clamp',
-							}),
-							pointerEvents: 'none',
+							justifyContent: 'center',
 							position: 'absolute',
+							textShadow: '0 4px 30px rgba(0, 0, 0, 0.55)',
 						}}
-					/>
+					>
+						B
+					</div>
 				</div>
 				<Interactive.Div
 					name="Photo 2 caption"
@@ -294,16 +342,16 @@ export const PolaroidPictures = () => {
 						textAlign: 'center',
 					}}
 				>
-					golden hour
+					scene B
 				</Interactive.Div>
 			</Interactive.Div>
 
 			<Interactive.Div
 				name="Photo 3 card"
 				style={{
-					backgroundColor: '#f8f1e5',
+					backgroundColor: '#fffdfa',
 					boxShadow:
-						'0 52px 92px rgba(8, 5, 3, 0.42), 0 10px 24px rgba(8, 5, 3, 0.22), inset 0 0 0 1px rgba(80, 62, 46, 0.08)',
+						'0 32px 64px rgba(8, 5, 3, 0.2), 0 6px 16px rgba(8, 5, 3, 0.09), inset 0 0 0 1px rgba(80, 62, 46, 0.05)',
 					boxSizing: 'border-box',
 					height: 520,
 					left: 960,
@@ -324,15 +372,26 @@ export const PolaroidPictures = () => {
 						[32, 58, durationInFrames - 26, durationInFrames - 1],
 						['15deg', '-3deg', '-3deg', '10deg'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
 					),
 					scale: interpolate(
 						frame,
-						[32, 54, 60, durationInFrames - 26, durationInFrames - 1],
-						[0.88, 1.035, 1, 1, 1.12],
+						[durationInFrames - 26, durationInFrames - 1],
+						[1, 1.12],
 						{
 							easing: Easing.bezier(0.16, 1, 0.3, 1),
 							extrapolateLeft: 'clamp',
@@ -346,7 +405,18 @@ export const PolaroidPictures = () => {
 						[32, 58, durationInFrames - 26, durationInFrames - 1],
 						['680px 380px', '0px 0px', '0px 0px', '820px 240px'],
 						{
-							easing: Easing.bezier(0.16, 1, 0.3, 1),
+							easing: [
+								Easing.bezier(0.16, 1, 0.3, 1),
+								Easing.spring({
+									damping: 200,
+									mass: 1,
+									stiffness: 100,
+									allowTail: true,
+									durationRestThreshold: 0.02,
+									overshootClamping: false,
+								}),
+								Easing.bezier(0.16, 1, 0.3, 1),
+							],
 							extrapolateLeft: 'clamp',
 							extrapolateRight: 'clamp',
 						},
@@ -383,9 +453,9 @@ export const PolaroidPictures = () => {
 					<Img
 						name="Photo 3"
 						alt=""
-						src="https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?fm=jpg&fit=crop&w=1400&q=85"
+						src="https://remotion.media/transition-bg-blue.jpg"
 						style={{
-							filter: 'saturate(0.94) contrast(1.03)',
+							filter: 'hue-rotate(-65deg)',
 							height: '100%',
 							objectFit: 'cover',
 							width: '100%',
@@ -393,17 +463,20 @@ export const PolaroidPictures = () => {
 					/>
 					<div
 						style={{
-							backgroundColor: '#f4e8d2',
+							alignItems: 'center',
+							color: 'white',
+							display: 'flex',
+							fontFamily: 'sans-serif',
+							fontSize: 160,
+							fontWeight: 900,
 							inset: 0,
-							opacity: interpolate(frame, [32, 54, 68], [0.82, 0.82, 0], {
-								easing: Easing.out(Easing.cubic),
-								extrapolateLeft: 'clamp',
-								extrapolateRight: 'clamp',
-							}),
-							pointerEvents: 'none',
+							justifyContent: 'center',
 							position: 'absolute',
+							textShadow: '0 4px 30px rgba(0, 0, 0, 0.55)',
 						}}
-					/>
+					>
+						C
+					</div>
 				</div>
 				<Interactive.Div
 					name="Photo 3 caption"
@@ -421,7 +494,7 @@ export const PolaroidPictures = () => {
 						textAlign: 'center',
 					}}
 				>
-					one more memory
+					scene C
 				</Interactive.Div>
 			</Interactive.Div>
 		</div>

--- a/packages/docs/elements/text/news-article-highlight/news-article-highlight.tsx
+++ b/packages/docs/elements/text/news-article-highlight/news-article-highlight.tsx
@@ -48,241 +48,133 @@ export const NewsArticleHighlight: React.FC = () => {
 		<AbsoluteFill
 			style={{
 				alignItems: 'center',
-				backgroundColor: '#ffffff',
 				display: 'flex',
 				justifyContent: 'center',
 				overflow: 'hidden',
-				perspective: 1800,
 			}}
 		>
 			<Interactive.Div
 				name="Container"
 				style={{
-					filter: `blur(${interpolate(frame, [0, 30, 125, 149], [16, 0, 0, 8], {
-						easing: Easing.bezier(0.16, 1, 0.3, 1),
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-					})}px)`,
-					height: 760,
+					height: 458,
 					opacity: interpolate(frame, [125, 149], [1, 0], {
 						easing: Easing.in(Easing.cubic),
 						extrapolateLeft: 'clamp',
 						extrapolateRight: 'clamp',
 					}),
-					scale: interpolate(frame, [0, 149], [1, 1.045], {
-						easing: Easing.inOut(Easing.quad),
-						extrapolateLeft: 'clamp',
-						extrapolateRight: 'clamp',
-					}),
-					transformOrigin: '50% 50%',
 					width: 1420,
-					willChange: 'filter, opacity, transform',
+					willChange: 'opacity',
 				}}
 			>
-				<div
+				<article
 					style={{
-						backfaceVisibility: 'hidden',
+						boxSizing: 'border-box',
+						color: '#181816',
+						display: 'flex',
+						flexDirection: 'column',
 						height: '100%',
-						rotate: `x ${interpolate(frame, [0, 149], [7.5, -7.5], {
-							easing: Easing.inOut(Easing.quad),
-							extrapolateLeft: 'clamp',
-							extrapolateRight: 'clamp',
-						})}deg`,
-						transformStyle: 'preserve-3d',
+						padding: '54px 84px 0',
 						width: '100%',
-						willChange: 'transform',
 					}}
 				>
-					<div
+					<Interactive.Div
+						name="Article category"
 						style={{
-							backfaceVisibility: 'hidden',
-							height: '100%',
-							rotate: `y ${interpolate(frame, [0, 149], [-7.5, 7.5], {
-								easing: Easing.inOut(Easing.quad),
-								extrapolateLeft: 'clamp',
-								extrapolateRight: 'clamp',
-							})}deg`,
-							transformStyle: 'preserve-3d',
-							width: '100%',
-							willChange: 'transform',
+							color: '#a0432d',
+							fontFamily: 'Arial, Helvetica, sans-serif',
+							fontSize: 15,
+							fontWeight: 700,
+							letterSpacing: 2.6,
+							textTransform: 'uppercase',
 						}}
 					>
-						<article
-							style={{
-								backfaceVisibility: 'hidden',
-								backgroundColor: '#ffffff',
-								border: '1px solid #d9d9d6',
-								boxShadow: '0 32px 80px rgba(24, 24, 20, 0.13)',
-								boxSizing: 'border-box',
-								color: '#181816',
-								display: 'flex',
-								flexDirection: 'column',
-								height: '100%',
-								padding: '54px 84px 62px',
-								transform: 'translateZ(0)',
-								width: '100%',
-								willChange: 'transform',
-							}}
+						Politics
+					</Interactive.Div>
+
+					<h1
+						style={{
+							fontFamily: "Georgia, 'Times New Roman', serif",
+							fontSize: 70,
+							fontWeight: 700,
+							letterSpacing: -2.8,
+							lineHeight: 1.04,
+							margin: '14px 0 18px',
+							overflowWrap: 'break-word',
+							textWrap: 'balance',
+						}}
+					>
+						<Interactive.Span name="Headline opening">
+							Markets brace for a
+						</Interactive.Span>{' '}
+						<Highlight
+							name="Highlight 1 · word 1"
+							progress={getWordProgress(firstHighlightProgress, 0)}
+							bowing={0}
+							color="rgba(255, 224, 76, 0.62)"
+							maxRandomnessOffset={7}
+							padding={{left: 4, right: 4}}
+							roughness={2.1}
+							seed={1}
 						>
-							<header
-								style={{
-									alignItems: 'center',
-									borderBottom: '2px solid #181816',
-									display: 'flex',
-									fontFamily: 'Arial, Helvetica, sans-serif',
-									justifyContent: 'space-between',
-									paddingBottom: 18,
-								}}
-							>
-								<Interactive.Div
-									name="Publication name"
-									style={{
-										fontSize: 18,
-										fontWeight: 700,
-										letterSpacing: 3.8,
-									}}
-								>
-									THE MORNING REPORT
-								</Interactive.Div>
-								<Interactive.Div
-									name="Issue details"
-									style={{
-										color: '#696965',
-										fontSize: 14,
-										fontWeight: 600,
-										letterSpacing: 1.7,
-										textTransform: 'uppercase',
-									}}
-								>
-									Tuesday · National affairs
-								</Interactive.Div>
-							</header>
+							government
+						</Highlight>{' '}
+						<Highlight
+							name="Highlight 1 · word 2"
+							progress={getWordProgress(firstHighlightProgress, 1)}
+							bowing={0}
+							color="rgba(255, 224, 76, 0.62)"
+							maxRandomnessOffset={7}
+							padding={{left: 4, right: 4}}
+							roughness={2.1}
+							seed={2}
+						>
+							shutdown
+						</Highlight>{' '}
+						<Interactive.Span name="Headline middle">
+							as Congress confronts fresh
+						</Interactive.Span>{' '}
+						<Highlight
+							name="Highlight 2 · word 1"
+							progress={getWordProgress(secondHighlightProgress, 0)}
+							bowing={0}
+							color="rgba(255, 224, 76, 0.62)"
+							maxRandomnessOffset={7}
+							padding={{left: 4, right: 4}}
+							roughness={2.1}
+							seed={11}
+						>
+							funding
+						</Highlight>{' '}
+						<Highlight
+							name="Highlight 2 · word 2"
+							progress={getWordProgress(secondHighlightProgress, 1)}
+							bowing={0}
+							color="rgba(255, 224, 76, 0.62)"
+							maxRandomnessOffset={7}
+							padding={{left: 4, right: 4}}
+							roughness={2.1}
+							seed={12}
+						>
+							lapses
+						</Highlight>
+					</h1>
 
-							<Interactive.Div
-								name="Article category"
-								style={{
-									color: '#a0432d',
-									fontFamily: 'Arial, Helvetica, sans-serif',
-									fontSize: 15,
-									fontWeight: 700,
-									letterSpacing: 2.6,
-									marginTop: 32,
-									textTransform: 'uppercase',
-								}}
-							>
-								Politics
-							</Interactive.Div>
-
-							<h1
-								style={{
-									fontFamily: "Georgia, 'Times New Roman', serif",
-									fontSize: 70,
-									fontWeight: 700,
-									letterSpacing: -2.8,
-									lineHeight: 1.04,
-									margin: '14px 0 18px',
-									overflowWrap: 'break-word',
-									textWrap: 'balance',
-								}}
-							>
-								<Interactive.Span name="Headline opening">
-									Markets brace for a
-								</Interactive.Span>{' '}
-								<Highlight
-									name="Highlight 1 · word 1"
-									progress={getWordProgress(firstHighlightProgress, 0)}
-									bowing={0}
-									color="rgba(255, 224, 76, 0.62)"
-									maxRandomnessOffset={7}
-									padding={{left: 4, right: 4}}
-									roughness={2.1}
-									seed={1}
-								>
-									government
-								</Highlight>{' '}
-								<Highlight
-									name="Highlight 1 · word 2"
-									progress={getWordProgress(firstHighlightProgress, 1)}
-									bowing={0}
-									color="rgba(255, 224, 76, 0.62)"
-									maxRandomnessOffset={7}
-									padding={{left: 4, right: 4}}
-									roughness={2.1}
-									seed={2}
-								>
-									shutdown
-								</Highlight>{' '}
-								<Interactive.Span name="Headline middle">
-									as Congress confronts fresh
-								</Interactive.Span>{' '}
-								<Highlight
-									name="Highlight 2 · word 1"
-									progress={getWordProgress(secondHighlightProgress, 0)}
-									bowing={0}
-									color="rgba(255, 224, 76, 0.62)"
-									maxRandomnessOffset={7}
-									padding={{left: 4, right: 4}}
-									roughness={2.1}
-									seed={11}
-								>
-									funding
-								</Highlight>{' '}
-								<Highlight
-									name="Highlight 2 · word 2"
-									progress={getWordProgress(secondHighlightProgress, 1)}
-									bowing={0}
-									color="rgba(255, 224, 76, 0.62)"
-									maxRandomnessOffset={7}
-									padding={{left: 4, right: 4}}
-									roughness={2.1}
-									seed={12}
-								>
-									lapses
-								</Highlight>
-							</h1>
-
-							<Interactive.P
-								name="Summary"
-								style={{
-									color: '#4c4c48',
-									fontFamily: "Georgia, 'Times New Roman', serif",
-									fontSize: 25,
-									lineHeight: 1.42,
-									margin: 0,
-									maxWidth: 1080,
-								}}
-							>
-								{
-									'Negotiators returned to the Capitol with the deadline\napproaching, but leaders remained divided over a short-term spending agreement.'
-								}
-							</Interactive.P>
-
-							<div
-								style={{
-									alignItems: 'center',
-									borderTop: '1px solid #d9d9d6',
-									color: '#696965',
-									display: 'flex',
-									fontFamily: 'Arial, Helvetica, sans-serif',
-									fontSize: 14,
-									fontWeight: 600,
-									justifyContent: 'space-between',
-									letterSpacing: 1.3,
-									marginTop: 'auto',
-									paddingTop: 22,
-									textTransform: 'uppercase',
-								}}
-							>
-								<Interactive.Span name="Byline">
-									By Elena Ward · Washington
-								</Interactive.Span>
-								<Interactive.Span name="Reading time">
-									6 minute read
-								</Interactive.Span>
-							</div>
-						</article>
-					</div>
-				</div>
+					<Interactive.P
+						name="Summary"
+						style={{
+							color: '#4c4c48',
+							fontFamily: "Georgia, 'Times New Roman', serif",
+							fontSize: 25,
+							lineHeight: 1.42,
+							margin: 0,
+							maxWidth: 1080,
+						}}
+					>
+						{
+							'Negotiators returned to the Capitol with the deadline\napproaching, but leaders remained divided over a short-term spending agreement.'
+						}
+					</Interactive.P>
+				</article>
 			</Interactive.Div>
 		</AbsoluteFill>
 	);

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -711,8 +711,7 @@ const elementImplementations = [
 		slug: 'text/news-article-highlight',
 		component: NewsArticleHighlight,
 		contributors: [],
-		description:
-			'A framed news article with camera movement, blur, and animated passage highlights.',
+		description: 'A centered news headline with animated passage highlights.',
 		dependencies: [{name: '@remotion/rough-notation', version: null}],
 		durationInFrames: 150,
 		elementHeight: null,


### PR DESCRIPTION
## Summary
- simplify the Polaroid Pictures composition and motion
- simplify News Article Highlight while retaining animated passage emphasis
- update the article Element description

## Test plan
- [x] Run `bun test src/test/elements.test.ts` on this stack layer (239 tests)
- [x] Run `bun run build` on the complete stack
- [x] Run `bun run stylecheck` on the complete stack
