### PR TITLE
Elements: Add moving background designs

### DIFF
--- a/packages/docs/elements/backgrounds/moving-waves/index.mdx
+++ b/packages/docs/elements/backgrounds/moving-waves/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Moving Waves
+description: A seamless wave background that flows upward.
+image: https://remotion.media/elements/backgrounds-moving-waves-preview.png
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {getElementDefinition} from '@site/src/components/Elements/element-utils';
+
+# Moving Waves
+
+<ElementPage definition={getElementDefinition('backgrounds/moving-waves')} sourceFile="./moving-waves.tsx" />

--- a/packages/docs/elements/backgrounds/moving-waves/moving-waves.tsx
+++ b/packages/docs/elements/backgrounds/moving-waves/moving-waves.tsx
@@ -1,0 +1,29 @@
+import {waves} from '@remotion/effects/waves';
+import React from 'react';
+import {Solid, useCurrentFrame, useVideoConfig} from 'remotion';
+
+export const MovingWaves: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames, height, width} = useVideoConfig();
+
+	return (
+		<Solid
+			color="#dff4ff"
+			width={width}
+			height={height}
+			effects={[
+				waves({
+					colors: ['#dff4ff', '#7cc6ff'],
+					direction: 'horizontal',
+					thickness: 56,
+					gap: 0,
+					angle: 0,
+					offset: (frame / durationInFrames) * 448,
+					amplitude: 24,
+					wavelength: 160,
+					phase: 0,
+				}),
+			]}
+		/>
+	);
+};

--- a/packages/docs/elements/backgrounds/moving-zigzags/index.mdx
+++ b/packages/docs/elements/backgrounds/moving-zigzags/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Moving Zigzags
+description: A seamless zigzag background that flows upward.
+image: https://remotion.media/elements/backgrounds-moving-zigzags-preview.png
+---
+
+import {ElementPage} from '@site/src/components/Elements/ElementPage';
+import {getElementDefinition} from '@site/src/components/Elements/element-utils';
+
+# Moving Zigzags
+
+<ElementPage definition={getElementDefinition('backgrounds/moving-zigzags')} sourceFile="./moving-zigzags.tsx" />

--- a/packages/docs/elements/backgrounds/moving-zigzags/moving-zigzags.tsx
+++ b/packages/docs/elements/backgrounds/moving-zigzags/moving-zigzags.tsx
@@ -1,0 +1,28 @@
+import {zigzag} from '@remotion/effects/zigzag';
+import React from 'react';
+import {Solid, useCurrentFrame, useVideoConfig} from 'remotion';
+
+export const MovingZigzags: React.FC = () => {
+	const frame = useCurrentFrame();
+	const {durationInFrames, height, width} = useVideoConfig();
+
+	return (
+		<Solid
+			color="#dff4ff"
+			width={width}
+			height={height}
+			effects={[
+				zigzag({
+					colors: ['#dff4ff', '#7cc6ff'],
+					direction: 'horizontal',
+					thickness: 40,
+					gap: 0,
+					angle: 0,
+					offset: (frame / durationInFrames) * 480,
+					amplitude: 40,
+					wavelength: 160,
+				}),
+			]}
+		/>
+	);
+};

--- a/packages/docs/src/components/Elements/element-definitions.ts
+++ b/packages/docs/src/components/Elements/element-definitions.ts
@@ -8,6 +8,8 @@ import {MirroredAudioSpectrum} from '../../../elements/audio/mirrored-spectrum/m
 import {AudioOscilloscope} from '../../../elements/audio/oscilloscope/audio-oscilloscope';
 import {AudioWaveformProgress} from '../../../elements/audio/waveform-progress/audio-waveform-progress';
 import {LiquidContours} from '../../../elements/backgrounds/liquid-contours/liquid-contours';
+import {MovingWaves} from '../../../elements/backgrounds/moving-waves/moving-waves';
+import {MovingZigzags} from '../../../elements/backgrounds/moving-zigzags/moving-zigzags';
 import {NotebookPaper} from '../../../elements/backgrounds/notebook-paper/notebook-paper';
 import {PaperTexture} from '../../../elements/backgrounds/paper-texture/paper-texture';
 import {RotatingStarburst} from '../../../elements/backgrounds/rotating-starburst/rotating-starburst';
@@ -238,6 +240,54 @@ const elementImplementations = [
 				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.png',
 			videoUrl:
 				'https://remotion.media/elements/backgrounds-rotating-starburst-preview.mp4',
+		},
+		safeArea: 0,
+		initialProps: null,
+		installationMode: 'wrapped',
+		width: 1920,
+	},
+	{
+		slug: 'backgrounds/moving-waves',
+		component: MovingWaves,
+		contributors: [],
+		description: 'A seamless wave background that flows upward.',
+		dependencies: [{name: '@remotion/effects', version: null}],
+		durationInFrames: 240,
+		elementHeight: null,
+		elementWidth: null,
+		fps: 30,
+		height: 1080,
+		posterFrame: 120,
+		preview: {
+			previewLayout: 'composition',
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-moving-waves-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-moving-waves-preview.mp4',
+		},
+		safeArea: 0,
+		initialProps: null,
+		installationMode: 'wrapped',
+		width: 1920,
+	},
+	{
+		slug: 'backgrounds/moving-zigzags',
+		component: MovingZigzags,
+		contributors: [],
+		description: 'A seamless zigzag background that flows upward.',
+		dependencies: [{name: '@remotion/effects', version: null}],
+		durationInFrames: 240,
+		elementHeight: null,
+		elementWidth: null,
+		fps: 30,
+		height: 1080,
+		posterFrame: 120,
+		preview: {
+			previewLayout: 'composition',
+			posterUrl:
+				'https://remotion.media/elements/backgrounds-moving-zigzags-preview.png',
+			videoUrl:
+				'https://remotion.media/elements/backgrounds-moving-zigzags-preview.mp4',
 		},
 		safeArea: 0,
 		initialProps: null,

--- a/packages/docs/src/components/Elements/element-registry.ts
+++ b/packages/docs/src/components/Elements/element-registry.ts
@@ -30,6 +30,14 @@ export const elementRegistry = {
 		category: 'backgrounds',
 		displayName: 'Liquid Contours',
 	},
+	'backgrounds/moving-waves': {
+		category: 'backgrounds',
+		displayName: 'Moving Waves',
+	},
+	'backgrounds/moving-zigzags': {
+		category: 'backgrounds',
+		displayName: 'Moving Zigzags',
+	},
 	'backgrounds/notebook-paper': {
 		category: 'backgrounds',
 		displayName: 'Notebook Paper',


### PR DESCRIPTION
## Summary
- add Moving Waves as a seamless animated background Element
- add Moving Zigzags as a seamless animated background Element
- register both Elements with their docs, previews, and sidebar coverage

## Test plan
- [x] Run `bun test src/test/elements.test.ts` on this stack layer (251 tests)
- [x] Run `bun run build` on the complete stack
- [x] Run `bun run stylecheck` on the complete stack

## Preview
- [Moving Waves](https://remotion-git-elements-moving-backgrounds-remotion.vercel.app/elements/backgrounds/moving-waves/)
- [Moving Zigzags](https://remotion-git-elements-moving-backgrounds-remotion.vercel.app/elements/backgrounds/moving-zigzags/)
