### PR TITLE
`@remotion/bundler`: Fix Rspack bundles without optional Studio dependencies

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -367,6 +367,13 @@ export const internalBundle = async (
 		}
 	}
 
+	const bundleOutput = path.join(outDir, NoReactInternals.bundleName);
+	if (!fs.existsSync(bundleOutput)) {
+		throw new Error(
+			`The bundler completed without emitting ${NoReactInternals.bundleName}.`,
+		);
+	}
+
 	const publicPath = getBundlePublicPath(actualArgs.publicPath);
 	const staticHash = getBundleStaticHash(publicPath);
 

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -83,6 +83,12 @@ export const rspackConfig = async ({
 	const sharedBaseConfig = getBaseConfig(environment, poll);
 	const baseConfig = {
 		...sharedBaseConfig,
+		optimization: {
+			...sharedBaseConfig.optimization,
+			// The optional dependency plugin removes expected resolution errors after
+			// compilation. Rspack must emit their throwing fallback chunks first.
+			emitOnErrors: true,
+		},
 		experiments: {
 			...sharedBaseConfig.experiments,
 			...(environment === 'development'

--- a/packages/bundler/src/test/rspack-optional-dependencies.test.ts
+++ b/packages/bundler/src/test/rspack-optional-dependencies.test.ts
@@ -1,0 +1,119 @@
+import {expect, test} from 'bun:test';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {bundle} from '../bundle';
+
+test(
+	'Rspack emits a bundle when optional Studio dependencies are missing',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-optional-dependency-'),
+		);
+		const studioDirectory = path.join(
+			fixtureDirectory,
+			'node_modules',
+			'@remotion',
+			'studio',
+		);
+		const entryPoint = path.join(studioDirectory, 'entry.js');
+		const outputDirectory = path.join(fixtureDirectory, 'build');
+		mkdirSync(studioDirectory, {recursive: true});
+		writeFileSync(
+			entryPoint,
+			"void import('@remotion/whisper-webgpu');\n",
+			'utf8',
+		);
+
+		try {
+			const output = await bundle({
+				enableCaching: false,
+				entryPoint,
+				ignoreRegisterRootWarning: true,
+				outDir: outputDirectory,
+				rootDir: fixtureDirectory,
+				rspack: true,
+			});
+
+			expect(output).toBe(outputDirectory);
+			const bundlePath = path.join(output, 'bundle.js');
+			expect(existsSync(bundlePath)).toBe(true);
+			expect(readFileSync(bundlePath, 'utf8').length).toBeGreaterThan(0);
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'bundle fails if Rspack does not emit bundle.js',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-missing-output-'),
+		);
+		const entryPoint = path.join(fixtureDirectory, 'entry.js');
+		writeFileSync(entryPoint, 'globalThis.remotion_entry = true;\n', 'utf8');
+
+		try {
+			await expect(
+				bundle({
+					enableCaching: false,
+					entryPoint,
+					ignoreRegisterRootWarning: true,
+					outDir: path.join(fixtureDirectory, 'build'),
+					rootDir: fixtureDirectory,
+					rspack: true,
+					rspackOverride: (configuration) => ({
+						...configuration,
+						output: {
+							...configuration.output,
+							filename: 'unexpected.js',
+						},
+					}),
+				}),
+			).rejects.toThrow('The bundler completed without emitting bundle.js.');
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'Rspack still fails for missing user dependencies',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-missing-user-dependency-'),
+		);
+		const entryPoint = path.join(fixtureDirectory, 'entry.js');
+		writeFileSync(
+			entryPoint,
+			"import 'definitely-not-an-installed-package';\n",
+			'utf8',
+		);
+
+		try {
+			await expect(
+				bundle({
+					enableCaching: false,
+					entryPoint,
+					ignoreRegisterRootWarning: true,
+					outDir: path.join(fixtureDirectory, 'build'),
+					rootDir: fixtureDirectory,
+					rspack: true,
+				}),
+			).rejects.toThrow("Can't resolve 'definitely-not-an-installed-package'");
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);


### PR DESCRIPTION
## Summary

- Emit Rspack's throwing fallback chunks for narrowly ignored optional Studio dependencies.
- Fail bundling explicitly if the required `bundle.js` output is missing.
- Cover optional dependencies, missing output, and ordinary missing user dependencies through the public `bundle()` API.

## Testing

- `bunx turbo run lint test --filter='@remotion/bundler'`
- `bun run build`
- `bun run stylecheck`
- Red/green verified by removing `emitOnErrors` and observing the optional-dependency integration test fail because `bundle.js` was not emitted.

Closes #11244
