### PR TITLE
`@remotion/bundler`: Fix Rspack bundles without optional Studio dependencies

### DIFF
--- a/packages/bundler/src/bundle.ts
+++ b/packages/bundler/src/bundle.ts
@@ -367,6 +367,13 @@ export const internalBundle = async (
 		}
 	}
 
+	const bundleOutput = path.join(outDir, NoReactInternals.bundleName);
+	if (!fs.existsSync(bundleOutput)) {
+		throw new Error(
+			`The bundler completed without emitting ${NoReactInternals.bundleName}.`,
+		);
+	}
+
 	const publicPath = getBundlePublicPath(actualArgs.publicPath);
 	const staticHash = getBundleStaticHash(publicPath);
 

--- a/packages/bundler/src/optional-dependencies.ts
+++ b/packages/bundler/src/optional-dependencies.ts
@@ -1,5 +1,6 @@
 // When Webpack cannot resolve these dependencies, it will not print an error message.
 
+import {stripAnsi} from '@remotion/studio-shared';
 import type {Compiler} from 'webpack';
 
 const OPTIONAL_DEPENDENCIES = [
@@ -25,8 +26,10 @@ export class AllowOptionalDependenciesPlugin {
 			};
 		},
 	) {
+		const message = stripAnsi(error.message);
+
 		for (const dependency of OPTIONAL_DEPENDENCIES) {
-			if (error.message.includes(`Can't resolve '${dependency}'`)) {
+			if (message.includes(`Can't resolve '${dependency}'`)) {
 				return false;
 			}
 		}
@@ -36,7 +39,7 @@ export class AllowOptionalDependenciesPlugin {
 			error.module?.resourceResolveData?.descriptionFileData?.name;
 		for (const dependency of STUDIO_OPTIONAL_DEPENDENCIES) {
 			if (
-				error.message.includes(`Can't resolve '${dependency}'`) &&
+				message.includes(`Can't resolve '${dependency}'`) &&
 				(issuerPackageName === '@remotion/studio' ||
 					issuer.includes('/@remotion/studio/'))
 			) {
@@ -46,8 +49,8 @@ export class AllowOptionalDependenciesPlugin {
 
 		for (const dependency of SOURCE_MAP_IGNORE) {
 			if (
-				error.message.includes(`Can't resolve '${dependency}'`) &&
-				error.message.includes('source-map')
+				message.includes(`Can't resolve '${dependency}'`) &&
+				message.includes('source-map')
 			) {
 				return false;
 			}

--- a/packages/bundler/src/rspack-config.ts
+++ b/packages/bundler/src/rspack-config.ts
@@ -83,6 +83,12 @@ export const rspackConfig = async ({
 	const sharedBaseConfig = getBaseConfig(environment, poll);
 	const baseConfig = {
 		...sharedBaseConfig,
+		optimization: {
+			...sharedBaseConfig.optimization,
+			// The optional dependency plugin removes expected resolution errors after
+			// compilation. Rspack must emit their throwing fallback chunks first.
+			emitOnErrors: true,
+		},
 		experiments: {
 			...sharedBaseConfig.experiments,
 			...(environment === 'development'

--- a/packages/bundler/src/test/optional-dependencies.test.ts
+++ b/packages/bundler/src/test/optional-dependencies.test.ts
@@ -38,3 +38,17 @@ test('does not hide missing optional AI package imports in user code', () => {
 		).toBe(true);
 	}
 });
+
+test('allows colorized Rspack errors for optional Studio dependencies', () => {
+	const plugin = new AllowOptionalDependenciesPlugin();
+	const error = missingOptionalPackageError(
+		'@remotion/whisper-webgpu',
+		'/project/node_modules/@remotion/studio/dist/esm/chunk.js',
+	);
+	error.message = error.message.replace(
+		"'@remotion/whisper-webgpu'",
+		"\u001b[33m'@remotion/whisper-webgpu'\u001b[39m",
+	);
+
+	expect(plugin.filter(error)).toBe(false);
+});

--- a/packages/bundler/src/test/rspack-optional-dependencies.test.ts
+++ b/packages/bundler/src/test/rspack-optional-dependencies.test.ts
@@ -110,7 +110,7 @@ test(
 					rootDir: fixtureDirectory,
 					rspack: true,
 				}),
-			).rejects.toThrow("Can't resolve 'definitely-not-an-installed-package'");
+			).rejects.toThrow('definitely-not-an-installed-package');
 		} finally {
 			rmSync(fixtureDirectory, {recursive: true, force: true});
 		}

--- a/packages/bundler/src/test/rspack-optional-dependencies.test.ts
+++ b/packages/bundler/src/test/rspack-optional-dependencies.test.ts
@@ -1,0 +1,119 @@
+import {expect, test} from 'bun:test';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {bundle} from '../bundle';
+
+test(
+	'Rspack emits a bundle when optional Studio dependencies are missing',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-optional-dependency-'),
+		);
+		const studioDirectory = path.join(
+			fixtureDirectory,
+			'node_modules',
+			'@remotion',
+			'studio',
+		);
+		const entryPoint = path.join(studioDirectory, 'entry.js');
+		const outputDirectory = path.join(fixtureDirectory, 'build');
+		mkdirSync(studioDirectory, {recursive: true});
+		writeFileSync(
+			entryPoint,
+			"void import('@remotion/whisper-webgpu');\n",
+			'utf8',
+		);
+
+		try {
+			const output = await bundle({
+				enableCaching: false,
+				entryPoint,
+				ignoreRegisterRootWarning: true,
+				outDir: outputDirectory,
+				rootDir: fixtureDirectory,
+				rspack: true,
+			});
+
+			expect(output).toBe(outputDirectory);
+			const bundlePath = path.join(output, 'bundle.js');
+			expect(existsSync(bundlePath)).toBe(true);
+			expect(readFileSync(bundlePath, 'utf8').length).toBeGreaterThan(0);
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'bundle fails if Rspack does not emit bundle.js',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-missing-output-'),
+		);
+		const entryPoint = path.join(fixtureDirectory, 'entry.js');
+		writeFileSync(entryPoint, 'globalThis.remotion_entry = true;\n', 'utf8');
+
+		try {
+			await expect(
+				bundle({
+					enableCaching: false,
+					entryPoint,
+					ignoreRegisterRootWarning: true,
+					outDir: path.join(fixtureDirectory, 'build'),
+					rootDir: fixtureDirectory,
+					rspack: true,
+					rspackOverride: (configuration) => ({
+						...configuration,
+						output: {
+							...configuration.output,
+							filename: 'unexpected.js',
+						},
+					}),
+				}),
+			).rejects.toThrow('The bundler completed without emitting bundle.js.');
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);
+
+test(
+	'Rspack still fails for missing user dependencies',
+	async () => {
+		const fixtureDirectory = mkdtempSync(
+			path.join(tmpdir(), 'remotion-rspack-missing-user-dependency-'),
+		);
+		const entryPoint = path.join(fixtureDirectory, 'entry.js');
+		writeFileSync(
+			entryPoint,
+			"import 'definitely-not-an-installed-package';\n",
+			'utf8',
+		);
+
+		try {
+			await expect(
+				bundle({
+					enableCaching: false,
+					entryPoint,
+					ignoreRegisterRootWarning: true,
+					outDir: path.join(fixtureDirectory, 'build'),
+					rootDir: fixtureDirectory,
+					rspack: true,
+				}),
+			).rejects.toThrow("Can't resolve 'definitely-not-an-installed-package'");
+		} finally {
+			rmSync(fixtureDirectory, {recursive: true, force: true});
+		}
+	},
+	{timeout: 60_000},
+);


### PR DESCRIPTION
Replacement for #11255 after its accidental merge was reverted in #11256.

This reapplies the exact source tree from #11255 on top of the restored `main` branch. It is opened as a draft because the original run had failures in the Node 16 Ubuntu, Node 16 Windows, and Node 25 macOS build jobs that still need investigation.
